### PR TITLE
Fix CONFIG_x86 check

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -58,7 +58,7 @@ CONFIG_x86 := --arch=amd64 \
 
 HOST_ARCH := $(shell arch)
 BUILD_ARCH := ${DEB_HOST_MULTIARCH}
-ifeq ($(BUILD_ARCH),x86_64)
+ifeq ($(BUILD_ARCH),x86_64-linux-gnu)
     # Native amd64 build
     CONFIG += $(CONFIG_x86)
 endif


### PR DESCRIPTION
It seems the x86_64 check got broken with the addition of arm64
(Changing `HOST_ARCH` -> `BUILD_ARCH`)
```bash
$ arch
x86_64
$ dpkg-architecture -q DEB_HOST_MULTIARCH
x86_64-linux-gnu
```