### PR TITLE
Add patch fixing up segment muxer

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -11,7 +11,7 @@ ENV DEB_BUILD_OPTIONS=noddebs
 
 # Prepare Debian build environment
 RUN apt-get update \
- && yes | apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv equivs
+ && yes | apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv equivs git
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/docker-build.sh /docker-build.sh

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -107,6 +107,12 @@ apt -yf install
 # Move to source directory
 pushd ${SOURCE_DIR}
 
+# Apply Jellyfin-specific patches
+for patchname in jf-patches/*.patch
+do
+    git apply "$patchname"
+done
+
 # Install dependencies and build the deb
 yes | mk-build-deps -i ${DEP_ARCH_OPT}
 dpkg-buildpackage -b -rfakeroot -us -uc ${BUILD_ARCH_OPT}

--- a/jf-patches/01-segment-muxer-fix.patch
+++ b/jf-patches/01-segment-muxer-fix.patch
@@ -1,5 +1,5 @@
 diff --git a/libavformat/segment.c b/libavformat/segment.c
-index e308206..083d57b 100644
+index e308206..2478d8f 100644
 --- a/libavformat/segment.c
 +++ b/libavformat/segment.c
 @@ -87,6 +87,7 @@ typedef struct SegmentContext {
@@ -18,15 +18,18 @@ index e308206..083d57b 100644
          /* set default value if not specified */
          if (!seg->time_str)
              seg->time_str = av_strdup("2");
-@@ -914,7 +916,12 @@ calc_times:
+@@ -914,7 +916,15 @@ calc_times:
                  seg->cut_pending = 1;
              seg->last_val = wrapped_val;
          } else {
 -            end_pts = seg->time * (seg->segment_count + 1);
 +            if (seg->start_pts != -1) {
 +                end_pts = seg->start_pts + seg->time * (seg->segment_count + 1);
-+            } else if (pkt->pts != AV_NOPTS_VALUE) {
++            } else if (pkt->stream_index == seg->reference_stream_index && pkt->pts != AV_NOPTS_VALUE) {
++                // this is the first packet of the reference stream we see, initialize start point
 +                seg->start_pts = av_rescale_q(pkt->pts, st->time_base, AV_TIME_BASE_Q);
++                seg->cur_entry.start_time = (double)pkt->pts * av_q2d(st->time_base);
++                seg->cur_entry.start_pts = seg->start_pts;
 +                end_pts = seg->start_pts + seg->time * (seg->segment_count + 1);
 +            }
          }

--- a/jf-patches/01-segment-muxer-fix.patch
+++ b/jf-patches/01-segment-muxer-fix.patch
@@ -1,0 +1,34 @@
+diff --git a/libavformat/segment.c b/libavformat/segment.c
+index e308206..083d57b 100644
+--- a/libavformat/segment.c
++++ b/libavformat/segment.c
+@@ -87,6 +87,7 @@ typedef struct SegmentContext {
+     int64_t last_val;      ///< remember last time for wrap around detection
+     int cut_pending;
+     int header_written;    ///< whether we've already called avformat_write_header
++    int64_t start_pts;     ///< pts of the very first packet processed, used to compute correct segment length
+ 
+     char *entry_prefix;    ///< prefix to add to list entry filenames
+     int list_type;         ///< set the list type
+@@ -702,6 +703,7 @@ static int seg_init(AVFormatContext *s)
+         if ((ret = parse_frames(s, &seg->frames, &seg->nb_frames, seg->frames_str)) < 0)
+             return ret;
+     } else {
++        seg->start_pts = -1;
+         /* set default value if not specified */
+         if (!seg->time_str)
+             seg->time_str = av_strdup("2");
+@@ -914,7 +916,12 @@ calc_times:
+                 seg->cut_pending = 1;
+             seg->last_val = wrapped_val;
+         } else {
+-            end_pts = seg->time * (seg->segment_count + 1);
++            if (seg->start_pts != -1) {
++                end_pts = seg->start_pts + seg->time * (seg->segment_count + 1);
++            } else if (pkt->pts != AV_NOPTS_VALUE) {
++                seg->start_pts = av_rescale_q(pkt->pts, st->time_base, AV_TIME_BASE_Q);
++                end_pts = seg->start_pts + seg->time * (seg->segment_count + 1);
++            }
+         }
+     }
+ 


### PR DESCRIPTION
This should close https://github.com/jellyfin/jellyfin/issues/1694.
Also it provides us the means to add more patches in the future if we wanted to.

This patch was sent to upstream (so we won't have to maintain our custom `ffmpeg` forever), initial thread is here: http://ffmpeg.org/pipermail/ffmpeg-devel/2019-October/250920.html