### PR TITLE
 Add patch fixing up segment muxer

### DIFF
--- a/debian/patches/0001_fix-segment-muxer.patch
+++ b/debian/patches/0001_fix-segment-muxer.patch
@@ -1,0 +1,37 @@
+Index: jellyfin-ffmpeg/libavformat/segment.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/segment.c	2019-10-02 13:05:57.119005772 -0400
++++ jellyfin-ffmpeg/libavformat/segment.c	2019-10-02 13:06:11.367388679 -0400
+@@ -87,6 +87,7 @@
+     int64_t last_val;      ///< remember last time for wrap around detection
+     int cut_pending;
+     int header_written;    ///< whether we've already called avformat_write_header
++    int64_t start_pts;     ///< pts of the very first packet processed, used to compute correct segment length
+
+     char *entry_prefix;    ///< prefix to add to list entry filenames
+     int list_type;         ///< set the list type
+@@ -702,6 +703,7 @@
+         if ((ret = parse_frames(s, &seg->frames, &seg->nb_frames, seg->frames_str)) < 0)
+             return ret;
+     } else {
++        seg->start_pts = -1;
+         /* set default value if not specified */
+         if (!seg->time_str)
+             seg->time_str = av_strdup("2");
+@@ -914,7 +916,15 @@
+                 seg->cut_pending = 1;
+             seg->last_val = wrapped_val;
+         } else {
+-            end_pts = seg->time * (seg->segment_count + 1);
++            if (seg->start_pts != -1) {
++                end_pts = seg->start_pts + seg->time * (seg->segment_count + 1);
++            } else if (pkt->stream_index == seg->reference_stream_index && pkt->pts != AV_NOPTS_VALUE) {
++                // this is the first packet of the reference stream we see, initialize start point
++                seg->start_pts = av_rescale_q(pkt->pts, st->time_base, AV_TIME_BASE_Q);
++                seg->cur_entry.start_time = (double)pkt->pts * av_q2d(st->time_base);
++                seg->cur_entry.start_pts = seg->start_pts;
++                end_pts = seg->start_pts + seg->time * (seg->segment_count + 1);
++            }
+         }
+     }
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+0001_fix-segment-muxer.patch

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -316,8 +316,14 @@ RUN  \
         curl -sLO https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 && \
         tar -jx --strip-components=1 -f ffmpeg-${FFMPEG_VERSION}.tar.bz2
 
+COPY debian/patches/*.patch /tmp/ffmpeg/
+
 RUN \
         DIR=/tmp/ffmpeg && mkdir -p ${DIR} && cd ${DIR} && \
+        for patch in *.patch; do \
+            filename="$( grep '+++' ${patch} | awk '{ print $2 }' | sed 's|jellyfin-ffmpeg/||' )"; \
+            patch --verbose ${filename} ${patch}; \
+        done && \
         ./configure \
         --disable-debug \
         --disable-doc \


### PR DESCRIPTION
Closes #9 
Fixes jellyfin/jellyfin#1694

Re-implementation of #9 as a Debian source patch (rather than a manual patch). Also includes the porting of this patch to the Docker ffmpeg build.

Manual patch required until the relevant patch is accepted upstream. Tracking at http://ffmpeg.org/pipermail/ffmpeg-devel/2019-October/250920.html