### PR TITLE
Support Ubuntu Eoan

### DIFF
--- a/build
+++ b/build
@@ -10,6 +10,7 @@ usage() {
     echo -e " * bionic"
     echo -e " * cosmic"
     echo -e " * disco"
+    echo -e " * eoan"
 }
 
 if [[ -z ${1} ]]; then
@@ -41,6 +42,10 @@ case ${cli_release} in
     ;;
     'disco')
         release="ubuntu:disco"
+        gcc_version="7"
+    ;;
+    'eoan')
+        release="ubuntu:eoan"
         gcc_version="7"
     ;;
     *)

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "4.0.4-2"
+version: "4.2.1-2"
 packages:
   - stretch-amd64
   - stretch-armhf
@@ -19,3 +19,6 @@ packages:
   - disco-amd64
   - disco-armhf
   - disco-arm64
+  - eoan-amd64
+  - eoan-armhf
+  - eoan-arm64

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (4.2.1-2) unstable; urgency=medium
+
+  * Support Ubuntu Eoan (19.10)
+
+ -- Joshua Boniface <joshua@boniface.me>  Tue, 22 Oct 2019 14:01:54 -0400
+
 jellyfin-ffmpeg (4.2.1-1) unstable; urgency=medium
 
   * New upstream version 4.2.1


### PR DESCRIPTION
Adds Ubuntu Eoan (19.10) support to jellyfin-ffmpeg.