### PR TITLE
Add MMAL for armhf on Raspberry Pi

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (4.2.1-3) unstable; urgency=medium
+
+  * Support MMAL hardware acceleration on armhf (Raspbian)
+
+ -- Joshua Boniface <joshua@boniface.me>  Sat, 02 Nov 2019 21:40:48 -0400
+
 jellyfin-ffmpeg (4.2.1-2) unstable; urgency=medium
 
   * Support Ubuntu Eoan (19.10)

--- a/debian/rules
+++ b/debian/rules
@@ -46,7 +46,8 @@ CONFIG := --toolchain=hardened \
 	--enable-vaapi \
 	--enable-vdpau \
 
-CONFIG_ARM := --enable-cross-compile \
+CONFIG_ARM := --enable-mmal \
+	--enable-cross-compile \
 	--cross-prefix=/usr/bin/arm-linux-gnueabihf- \
 	--arch=armhf
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -41,6 +41,15 @@ EOF
     ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime
     yes | apt-get install -y gcc-${GCC_VER}-source libstdc++6-armhf-cross binutils-arm-linux-gnueabihf bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf liblttng-ust0:armhf libstdc++6:armhf
     popd
+
+    # Fetch RasPi headers to build MMAL support
+    pushd ${SOURCE_DIR}
+    git clone --depth=1 https://github.com/raspberrypi/firmware mmalheaders
+    git clone --depth=1 https://github.com/raspberrypi/userland piuserland
+    cp -a mmalheaders/opt/vc/include/* /usr/include/
+    cp -a mmalheaders/opt/vc/lib/* /usr/lib/
+    cp -a piuserland/interface/* /usr/include/
+    popd
 }
 prepare_crossbuild_env_arm64() {
     # Prepare the Ubuntu-specific cross-build requirements


### PR DESCRIPTION
Includes a download of the Raspberry Pi headers and GPU driver in the
armhf build process, in order to properly enable MMAL cross-compiling.
This is OK license wise both due to the licenses of these headers (LGPL
and MIT mostly) and since these are not included in the final binary
packages.