### PR TITLE
enable ffmpeg AMD AMF encoder on linux

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (4.2.1-4) unstable; urgency=medium
+
+  * Add support for AMD AMF encoding on amd64
+
+ -- nyanmisaka <nst799610810@gmail.com>  Thu, 16 Jan 2020 02:55:28 +0800
+
 jellyfin-ffmpeg (4.2.1-3) unstable; urgency=medium
 
   * Support MMAL hardware acceleration on armhf (Raspbian)

--- a/debian/rules
+++ b/debian/rules
@@ -45,6 +45,7 @@ CONFIG := --toolchain=hardened \
 	--enable-version3 \
 	--enable-vaapi \
 	--enable-vdpau \
+	--enable-amf \
 
 CONFIG_ARM := --enable-mmal \
 	--enable-cross-compile \

--- a/debian/rules
+++ b/debian/rules
@@ -45,7 +45,6 @@ CONFIG := --toolchain=hardened \
 	--enable-version3 \
 	--enable-vaapi \
 	--enable-vdpau \
-	--enable-amf \
 
 CONFIG_ARM := --enable-mmal \
 	--enable-cross-compile \
@@ -57,7 +56,7 @@ CONFIG_ARM64 := --enable-cross-compile \
 	--arch=arm64
 
 CONFIG_x86 := --arch=amd64 \
-	--enable-nvenc --enable-nvdec
+	--enable-nvenc --enable-nvdec --enable-amf
 
 HOST_ARCH := $(shell arch)
 BUILD_ARCH := ${DEB_HOST_MULTIARCH}

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #NVCH_VERSION="8.2.15.8-dmo1"
-NVCH_VERSION="9.0.18.1-dmo1"
+NVCH_VERSION="9.0.18.3-dmo1"
 
 # Builds the DEB inside the Docker container
 
@@ -112,6 +112,13 @@ esac
 wget -O nv-codec-headers.deb https://www.deb-multimedia.org/pool/main/n/nv-codec-headers-dmo/nv-codec-headers_${NVCH_VERSION}_all.deb
 dpkg -i nv-codec-headers.deb
 apt -yf install
+
+# Download and setup AMD AMF headers from AMD official github repo
+# https://www.ffmpeg.org/general.html#AMD-AMF_002fVCE
+wget -O amf_headers.zip https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/master.zip
+unzip amf_headers.zip -d amf_headers
+cd "amf_headers/AMF-master/amf/public/include/"
+mkdir -p "/usr/include/AMF/" && cp -r * "/usr/include/AMF/"
 
 # Move to source directory
 pushd ${SOURCE_DIR}


### PR DESCRIPTION
Refer https://github.com/jellyfin/jellyfin/pull/2251