### PR TITLE
Check for dependencies on start

### DIFF
--- a/build
+++ b/build
@@ -81,6 +81,11 @@ esac
 set -o xtrace
 set -o errexit
 
+# Check for dependencies
+for dep in docker make mmv; do
+    which $dep || { echo "The command 'make' is required."; exit 1; }
+done
+
 image_name="jellyfin-ffmpeg-build-${cli_release}"
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"

--- a/build
+++ b/build
@@ -83,7 +83,7 @@ set -o errexit
 
 # Check for dependencies
 for dep in docker make mmv; do
-    which ${dep} || { echo "The command '${dep}' is required."; exit 1; }
+    command -v ${dep} &>/dev/null || { echo "The command '${dep}' is required."; exit 1; }
 done
 
 image_name="jellyfin-ffmpeg-build-${cli_release}"

--- a/build
+++ b/build
@@ -83,7 +83,7 @@ set -o errexit
 
 # Check for dependencies
 for dep in docker make mmv; do
-    which $dep || { echo "The command 'make' is required."; exit 1; }
+    which ${dep} || { echo "The command '${dep}' is required."; exit 1; }
 done
 
 image_name="jellyfin-ffmpeg-build-${cli_release}"


### PR DESCRIPTION
Ensures all the dependencies exists before kicking off a build.