### PR TITLE
Remove nv-codec-headers dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,7 +53,9 @@ Build-Depends:
 # [!armhf] is needed otherwise mk-build-deps creates an invalid build
 # dep list, targeting armhf specifically when the packge is any.
 # The docker build guarantees this is installed for armhf crossbuild.
- nv-codec-headers [!armhf !arm64],
+# Disabled entirely as the install now happens via Git inside the
+# Docker build environment.
+# nv-codec-headers [!armhf !arm64],
 # used to detect libraries
  pkg-config,
 # HTML documentation


### PR DESCRIPTION
Due to the changes in #20, builds would fail on trying to install the dependencies, since this package did not exist. Remove it entirely (though commented out for reference) from the `debian/control` file.

This will negatively affect manual builds, but given our purpose that should not occur.