### PR TITLE
Don't build for the obsolete Cosmic Cuttlefish

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -16,9 +16,6 @@ packages:
   - bionic-amd64
   - bionic-armhf
   - bionic-arm64
-  - cosmic-amd64
-  - cosmic-armhf
-  - cosmic-arm64
   - disco-amd64
   - disco-armhf
   - disco-arm64


### PR DESCRIPTION
Repo requests fail with a 404, assuming it's dead now.