### PR TITLE
Intergrate free libva and intel-vaapi-driver into deb package

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -3,15 +3,23 @@ FROM DISTRO
 ARG SOURCE_DIR=/ffmpeg
 ARG ARTIFACT_DIR=/dist
 # Docker run environment
+ENV DEB_BUILD_OPTIONS=noddebs
+ENV DEBIAN_FRONTEND=noninteractive
 ENV ARCH=BUILD_ARCHITECTURE
 ENV GCC_VER=GCC_RELEASE_VERSION
 ENV SOURCE_DIR=/ffmpeg
 ENV ARTIFACT_DIR=/dist
-ENV DEB_BUILD_OPTIONS=noddebs
+ENV TARGET_DIR=/usr/lib/jellyfin-ffmpeg
+ENV PKG_CONFIG_PATH=${TARGET_DIR}/lib/pkgconfig:$PKG_CONFIG_PATH
+ENV LD_LIBRARY_PATH=${TARGET_DIR}/lib:${TARGET_DIR}/lib/mfx:${TARGET_DIR}/lib/xorg:${LD_LIBRARY_PATH}
+ENV LDFLAGS=-Wl,-rpath=${TARGET_DIR}/lib
+ENV CXXFLAGS="-I${TARGET_DIR}/include $CXXFLAGS"
+ENV CPPFLAGS="-I${TARGET_DIR}/include $CPPFLAGS"
+ENV CFLAGS="-I${TARGET_DIR}/include $CFLAGS"
 
 # Prepare Debian build environment
 RUN apt-get update \
- && yes | apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv equivs git
+ && yes | apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv equivs git cmake pkg-config subversion dh-autoreconf libdrm-dev libpciaccess-dev
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/docker-build.sh /docker-build.sh

--- a/build
+++ b/build
@@ -12,6 +12,7 @@ usage() {
     echo -e " * cosmic"
     echo -e " * disco"
     echo -e " * eoan"
+    echo -e " * focal"
 }
 
 if [[ -z ${1} ]]; then
@@ -52,6 +53,10 @@ case ${cli_release} in
     'eoan')
         release="ubuntu:eoan"
         gcc_version="7"
+    ;;
+    'focal')
+        release="ubuntu:focal"
+        gcc_version="9"
     ;;
     *)
         echo "Invalid release."

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "4.2.1-4"
+version: "4.2.1-7"
 packages:
   - stretch-amd64
   - stretch-armhf
@@ -22,3 +22,6 @@ packages:
   - eoan-amd64
   - eoan-armhf
   - eoan-arm64
+  - focal-amd64
+  - focal-armhf
+  - focal-arm64

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 jellyfin-ffmpeg (4.2.1-7) unstable; urgency=medium
 
-  * Integrate free libva and intel-vaapi-driver with MIT license in the deb package.
+  * Integrate free libva and intel-vaapi-driver with MIT license in the deb
+    package to enable full features of VAAPI transcoding without proprietary
+    drivers (see https://github.com/jellyfin/jellyfin-ffmpeg/pull/33).
 
  -- nyanmisaka <nst799610810@gmail.com>  Thu, 9 Apr 2020 12:54:22 +0800
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (4.2.1-7) unstable; urgency=medium
+
+  * Integrate free libva and intel-vaapi-driver with MIT license in the deb package.
+
+ -- nyanmisaka <nst799610810@gmail.com>  Thu, 9 Apr 2020 12:54:22 +0800
+
 jellyfin-ffmpeg (4.2.1-6) unstable; urgency=medium
 
   * Update AMD AMF files to support Linux

--- a/debian/control
+++ b/debian/control
@@ -45,10 +45,17 @@ Build-Depends:
  libzvbi-dev,
 # --enable-omx
  libomxil-bellagio-dev,
+# omx headers are fully included in raspberrypi/firmware.
+# libomxil-bellagio-dev is missing some functions required in ffmpeg 4.3+.
+# Drop this package when building ffmpeg 4.3+.
+#
 # --enable-vaapi
- libva-dev,
-# --enable-vdpau
- libvdpau-dev,
+# libva-dev is replaced by the libva build from source,
+# which will be shipped with jellyfin-ffmpeg package.
+# Vaapi currently only supports Intel and AMD gfx
+# and the drivers they provide only support x86/x64.
+# libva-dev [!armhf !arm64],
+#
 # --enable-nvenc/--enable-nvdec
 # [!armhf] is needed otherwise mk-build-deps creates an invalid build
 # dep list, targeting armhf specifically when the packge is any.
@@ -56,6 +63,7 @@ Build-Depends:
 # Disabled entirely as the install now happens via Git inside the
 # Docker build environment.
 # nv-codec-headers [!armhf !arm64],
+#
 # used to detect libraries
  pkg-config,
 # HTML documentation

--- a/debian/copyright
+++ b/debian/copyright
@@ -1009,6 +1009,18 @@ License: FSF
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
+Files: libva/*
+Copyright: 2007, Intel Corporation
+License: Expat
+Comment:
+  Libva is an implementation for VA-API (Video Acceleration API).
+
+Files: intel-vaapi-driver/*
+Copyright: 2011, Intel Corporation
+License: Expat
+Comment:
+  VA-API (Video Acceleration API) user mode driver for Intel GEN Graphics family.
+
 Files: debian/*
 Copyright:
   2014-2017, Andreas Cadhalpun <Andreas.Cadhalpun@googlemail.com>

--- a/debian/rules
+++ b/debian/rules
@@ -10,19 +10,18 @@ ifeq ($(VERSION_SUFFIX),testing)
 endif
 PACKAGEVERSION := "$(ORIG_VERSION)-$(VERSION_SUFFIX)"
 
-CONFIG := --toolchain=hardened \
-	--prefix=/usr \
+CONFIG := --prefix=${TARGET_DIR} \
 	--target-os=linux \
-	--enable-cross-compile \
-	--extra-cflags='--static' \
-	--enable-gpl \
-	--enable-static \
 	--disable-doc \
 	--disable-ffplay \
 	--disable-shared \
 	--disable-libxcb \
+	--disable-vdpau \
 	--disable-sdl2 \
 	--disable-xlib \
+	--enable-gpl \
+	--enable-version3 \
+	--enable-static \
 	--enable-libfontconfig \
 	--enable-fontconfig \
 	--enable-gmp \
@@ -40,23 +39,28 @@ CONFIG := --toolchain=hardened \
 	--enable-libx264 \
 	--enable-libx265 \
 	--enable-libzvbi \
+
+CONFIG_ARM := --arch=armhf \
+	--enable-mmal \
 	--enable-omx \
 	--enable-omx-rpi \
-	--enable-version3 \
-	--enable-vaapi \
-	--enable-vdpau \
-
-CONFIG_ARM := --enable-mmal \
 	--enable-cross-compile \
-	--cross-prefix=/usr/bin/arm-linux-gnueabihf- \
-	--arch=armhf
+	--toolchain=hardened \
+	--cross-prefix=/usr/bin/arm-linux-gnueabihf-
 
-CONFIG_ARM64 := --enable-cross-compile \
-	--cross-prefix=/usr/bin/aarch64-linux-gnu- \
-	--arch=arm64
+CONFIG_ARM64 := --arch=arm64 \
+	--enable-omx \
+	--enable-omx-rpi \
+	--enable-cross-compile \
+	--toolchain=hardened \
+	--cross-prefix=/usr/bin/aarch64-linux-gnu-
 
 CONFIG_x86 := --arch=amd64 \
-	--enable-nvenc --enable-nvdec --enable-amf
+	--enable-amf \
+	--enable-nvenc \
+	--enable-nvdec \
+	--enable-vaapi \
+#	--enable-libmfx # uncomment for non-free QSV
 
 HOST_ARCH := $(shell arch)
 BUILD_ARCH := ${DEB_HOST_MULTIARCH}

--- a/debian/rules
+++ b/debian/rules
@@ -40,20 +40,17 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-libx265 \
 	--enable-libzvbi \
 
+CONFIG_ARM_COMMON := --toolchain=hardened \
+	--enable-cross-compile \
+	--enable-omx \
+	--enable-omx-rpi \
+
 CONFIG_ARM := --arch=armhf \
 	--enable-mmal \
-	--enable-omx \
-	--enable-omx-rpi \
-	--enable-cross-compile \
-	--toolchain=hardened \
-	--cross-prefix=/usr/bin/arm-linux-gnueabihf-
+	--cross-prefix=/usr/bin/arm-linux-gnueabihf- \
 
 CONFIG_ARM64 := --arch=arm64 \
-	--enable-omx \
-	--enable-omx-rpi \
-	--enable-cross-compile \
-	--toolchain=hardened \
-	--cross-prefix=/usr/bin/aarch64-linux-gnu-
+	--cross-prefix=/usr/bin/aarch64-linux-gnu- \
 
 CONFIG_x86 := --arch=amd64 \
 	--enable-amf \
@@ -70,10 +67,12 @@ ifeq ($(BUILD_ARCH),x86_64-linux-gnu)
 endif
 ifeq ($(BUILD_ARCH),arm-linux-gnueabihf)
 	# Cross-building ARM on AMD64
+	CONFIG += $(CONFIG_ARM_COMMON)
 	CONFIG += $(CONFIG_ARM)
 endif
 ifeq ($(BUILD_ARCH),aarch64-linux-gnu)
 	# Cross-building ARM64 on AMD64
+	CONFIG += $(CONFIG_ARM_COMMON)
 	CONFIG += $(CONFIG_ARM64)
 endif
 

--- a/debian/rules
+++ b/debian/rules
@@ -45,11 +45,13 @@ CONFIG_ARM_COMMON := --toolchain=hardened \
 	--enable-omx \
 	--enable-omx-rpi \
 
-CONFIG_ARM := --arch=armhf \
+CONFIG_ARM := ${CONFIG_ARM_COMMON} \
 	--enable-mmal \
+	--arch=armhf \
 	--cross-prefix=/usr/bin/arm-linux-gnueabihf- \
 
-CONFIG_ARM64 := --arch=arm64 \
+CONFIG_ARM64 := ${CONFIG_ARM_COMMON} \
+	--arch=arm64 \
 	--cross-prefix=/usr/bin/aarch64-linux-gnu- \
 
 CONFIG_x86 := --arch=amd64 \
@@ -67,12 +69,10 @@ ifeq ($(BUILD_ARCH),x86_64-linux-gnu)
 endif
 ifeq ($(BUILD_ARCH),arm-linux-gnueabihf)
 	# Cross-building ARM on AMD64
-	CONFIG += $(CONFIG_ARM_COMMON)
 	CONFIG += $(CONFIG_ARM)
 endif
 ifeq ($(BUILD_ARCH),aarch64-linux-gnu)
 	# Cross-building ARM64 on AMD64
-	CONFIG += $(CONFIG_ARM_COMMON)
 	CONFIG += $(CONFIG_ARM64)
 endif
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -5,8 +5,8 @@
 set -o errexit
 set -o xtrace
 
-ARCHIVE_ADDR=https://archive.ubuntu.com/ubuntu/
-PORTS_ADDR=https://ports.ubuntu.com/
+ARCHIVE_ADDR=http://archive.ubuntu.com/ubuntu/
+PORTS_ADDR=http://ports.ubuntu.com/
 
 # Prepare HWA headers, libs and drivers for x86_64-linux-gnu
 prepare_hwa_amd64() {

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -5,6 +5,107 @@
 set -o errexit
 set -o xtrace
 
+ARCHIVE_ADDR=https://archive.ubuntu.com/ubuntu/
+PORTS_ADDR=https://ports.ubuntu.com/
+
+# Prepare HWA headers, libs and drivers for x86_64-linux-gnu
+prepare_hwa_amd64() {
+    # Download and install the nvidia headers
+    pushd ${SOURCE_DIR}
+    git clone --depth=1 https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
+    pushd nv-codec-headers
+    make
+    make install
+    popd
+    popd
+
+    # Download and setup AMD AMF headers
+    # https://www.ffmpeg.org/general.html#AMD-AMF_002fVCE
+    svn checkout https://github.com/GPUOpen-LibrariesAndSDKs/AMF/trunk/amf/public/include
+    pushd include
+    mkdir -p /usr/include/AMF
+    mv * /usr/include/AMF
+    popd
+
+    # Download and install libva
+    pushd ${SOURCE_DIR}
+    git clone -b v2.6-branch --depth=1 https://github.com/intel/libva
+    pushd libva
+    sed -i 's|getenv("LIBVA_DRIVERS_PATH")|"/usr/lib/jellyfin-ffmpeg/lib/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/dri:/usr/local/lib/dri"|g' va/va.c
+    sed -i 's|getenv("LIBVA_DRIVER_NAME")|NULL|g' va/va.c
+    ./autogen.sh
+    ./configure --prefix=${TARGET_DIR}
+    make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/intel
+    echo "intel${TARGET_DIR}/lib/libva.so* usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    echo "intel${TARGET_DIR}/lib/libva-drm.so* usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    popd
+    popd
+
+    # Download and install intel-vaapi-driver
+    pushd ${SOURCE_DIR}
+    git clone -b v2.4-branch --depth=1 https://github.com/intel/intel-vaapi-driver
+    pushd intel-vaapi-driver
+    ./autogen.sh
+    ./configure LIBVA_DRIVERS_PATH=${TARGET_DIR}/lib/dri
+    make -j$(nproc) && make install
+    mkdir -p ${SOURCE_DIR}/intel/dri
+    cp ${TARGET_DIR}/lib/dri/i965*.so ${SOURCE_DIR}/intel/dri
+    echo "intel/dri/i965*.so usr/lib/jellyfin-ffmpeg/lib/dri" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    popd
+    popd
+
+    # Uncomment for non-free QSV
+    # Download and install gmmlib
+    #pushd ${SOURCE_DIR}
+    #git clone -b intel-gmmlib-19.3.4.x --depth=1 https://github.com/intel/gmmlib
+    #pushd gmmlib
+    #mkdir build && pushd build
+    #cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
+    #make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/intel
+    #make install
+    #echo "intel${TARGET_DIR}/lib/libigdgmm.so* usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    #popd
+    #popd
+    #popd
+
+    # Uncomment for non-free QSV
+    # Download and install media-driver
+    # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
+    # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
+    #pushd ${SOURCE_DIR}
+    #git clone -b intel-media-19.4 --depth=1 https://github.com/intel/media-driver
+    #pushd media-driver
+    #mkdir build && pushd build
+    #cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
+    #      -DENABLE_KERNELS=ON \
+    #      -DENABLE_NONFREE_KERNELS=ON \
+    #      LIBVA_DRIVERS_PATH=${TARGET_DIR}/lib/dri \
+    #      ..
+    #make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/intel
+    #echo "intel${TARGET_DIR}/lib/libigfxcmrt.so* usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    #mkdir -p ${SOURCE_DIR}/intel/dri
+    #cp ${TARGET_DIR}/lib/dri/iHD*.so ${SOURCE_DIR}/intel/dri
+    #echo "intel/dri/iHD*.so usr/lib/jellyfin-ffmpeg/lib/dri" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    #popd
+    #popd
+    #popd
+
+    # Uncomment for non-free QSV
+    # Download and install MediaSDK
+    #pushd ${SOURCE_DIR}
+    #git clone -b intel-mediasdk-19.4 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
+    #pushd MediaSDK
+    #sed -i 's|MFX_PLUGINS_CONF_DIR "/plugins.cfg"|"/usr/lib/jellyfin-ffmpeg/lib/mfx/plugins.cfg"|g' api/mfx_dispatch/linux/mfxloader.cpp
+    #mkdir build && pushd build
+    #cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
+    #make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/intel
+    #echo "intel${TARGET_DIR}/lib/libmfx* usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    #echo "intel${TARGET_DIR}/lib/mfx/*.so usr/lib/jellyfin-ffmpeg/lib/mfx" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    #echo "intel${TARGET_DIR}/share/mfx/plugins.cfg usr/lib/jellyfin-ffmpeg/lib/mfx" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    #popd
+    #popd
+    #popd
+}
 # Prepare the cross-toolchain
 prepare_crossbuild_env_armhf() {
     # Prepare the Ubuntu-specific cross-build requirements
@@ -14,16 +115,16 @@ prepare_crossbuild_env_armhf() {
         rm /etc/apt/sources.list
         # Add arch-specific list files
         cat <<EOF > /etc/apt/sources.list.d/amd64.list
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME} main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-updates main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-backports main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-security main restricted universe multiverse
+deb [arch=amd64] ${ARCHIVE_ADDR} ${CODENAME} main restricted universe multiverse
+deb [arch=amd64] ${ARCHIVE_ADDR} ${CODENAME}-updates main restricted universe multiverse
+deb [arch=amd64] ${ARCHIVE_ADDR} ${CODENAME}-backports main restricted universe multiverse
+deb [arch=amd64] ${ARCHIVE_ADDR} ${CODENAME}-security main restricted universe multiverse
 EOF
         cat <<EOF > /etc/apt/sources.list.d/armhf.list
-deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME} main restricted universe multiverse
-deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME}-updates main restricted universe multiverse
-deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME}-backports main restricted universe multiverse
-deb [arch=armhf] http://ports.ubuntu.com/ ${CODENAME}-security main restricted universe multiverse
+deb [arch=armhf] ${PORTS_ADDR} ${CODENAME} main restricted universe multiverse
+deb [arch=armhf] ${PORTS_ADDR} ${CODENAME}-updates main restricted universe multiverse
+deb [arch=armhf] ${PORTS_ADDR} ${CODENAME}-backports main restricted universe multiverse
+deb [arch=armhf] ${PORTS_ADDR} ${CODENAME}-security main restricted universe multiverse
 EOF
     fi
     # Add armhf architecture
@@ -56,16 +157,16 @@ prepare_crossbuild_env_arm64() {
         rm /etc/apt/sources.list
         # Add arch-specific list files
         cat <<EOF > /etc/apt/sources.list.d/amd64.list
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME} main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-updates main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-backports main restricted universe multiverse
-deb [arch=amd64] http://archive.ubuntu.com/ubuntu/ ${CODENAME}-security main restricted universe multiverse
+deb [arch=amd64] ${ARCHIVE_ADDR} ${CODENAME} main restricted universe multiverse
+deb [arch=amd64] ${ARCHIVE_ADDR} ${CODENAME}-updates main restricted universe multiverse
+deb [arch=amd64] ${ARCHIVE_ADDR} ${CODENAME}-backports main restricted universe multiverse
+deb [arch=amd64] ${ARCHIVE_ADDR} ${CODENAME}-security main restricted universe multiverse
 EOF
         cat <<EOF > /etc/apt/sources.list.d/arm64.list
-deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME} main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-updates main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-backports main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ ${CODENAME}-security main restricted universe multiverse
+deb [arch=arm64] ${PORTS_ADDR} ${CODENAME} main restricted universe multiverse
+deb [arch=arm64] ${PORTS_ADDR} ${CODENAME}-updates main restricted universe multiverse
+deb [arch=arm64] ${PORTS_ADDR} ${CODENAME}-backports main restricted universe multiverse
+deb [arch=arm64] ${PORTS_ADDR} ${CODENAME}-security main restricted universe multiverse
 EOF
     fi
     # Add armhf architecture
@@ -85,6 +186,7 @@ EOF
 # Set the architecture-specific options
 case ${ARCH} in
     'amd64')
+        prepare_hwa_amd64
         CONFIG_SITE=""
         DEP_ARCH_OPT=""
         BUILD_ARCH_OPT=""
@@ -104,22 +206,6 @@ case ${ARCH} in
         BUILD_ARCH_OPT="-aarm64"
     ;;
 esac
-
-# Download and install the nvidia headers from deb-multimedia
-git clone --depth=1 https://git.videolan.org/git/ffmpeg/nv-codec-headers.git
-pushd nv-codec-headers
-make
-make install
-popd
-
-# Download and setup AMD AMF headers from AMD official github repo
-# https://www.ffmpeg.org/general.html#AMD-AMF_002fVCE
-apt-get update
-yes | apt-get install subversion
-svn checkout https://github.com/GPUOpen-LibrariesAndSDKs/AMF/trunk/amf/public/include
-pushd include
-mkdir -p /usr/include/AMF && mv * /usr/include/AMF
-popd
 
 # Move to source directory
 pushd ${SOURCE_DIR}


### PR DESCRIPTION
**Changes**
- Intergrate free [libva](https://github.com/intel/libva) and [intel-vaapi-driver](https://github.com/intel/intel-vaapi-driver) with MIT license into deb package.
(I am not sure whether the format of the changes in debian/copyright is accurate.)

- Avoid downloading unnecessary amd64 headers when building armhf/arm64 arch.

- Drop the unused VDPAU libs which has almost been replaced by NVENC/NVDEC.

- You can uncomment the parts of `gmmlib`, `media-driver`, and `MediaSDK` in `docker-build.sh` to get a deb package that supports all QSV HWA functions.
> It is commented out by default, as the full-featured version is non-free and cannot be distributed. In addition, the transcoding function of the non-full-featured version is incomplete, so it is better to use VAAPI.

**Issues**

https://github.com/jellyfin/jellyfin/issues/2726

https://github.com/jellyfin/jellyfin/issues/2724

https://github.com/jellyfin/jellyfin-ffmpeg/issues/16