### PR TITLE
Add AV1 decoding support with dav1d

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -19,7 +19,7 @@ ENV CFLAGS="-I${TARGET_DIR}/include $CFLAGS"
 
 # Prepare Debian build environment
 RUN apt-get update \
- && yes | apt-get install -y apt-transport-https debhelper gnupg wget devscripts mmv equivs git cmake pkg-config subversion dh-autoreconf libdrm-dev libpciaccess-dev
+ && yes | apt-get install -y apt-transport-https meson ninja-build debhelper gnupg wget devscripts mmv equivs git nasm cmake pkg-config subversion dh-autoreconf libdrm-dev libpciaccess-dev
 
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/docker-build.sh /docker-build.sh

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -19,8 +19,10 @@ ENV CFLAGS="-I${TARGET_DIR}/include $CFLAGS"
 
 # Prepare Debian build environment
 RUN apt-get update \
- && yes | apt-get install -y apt-transport-https meson ninja-build debhelper gnupg wget devscripts mmv equivs git nasm cmake pkg-config subversion dh-autoreconf libdrm-dev libpciaccess-dev
+ && yes | apt-get install -y apt-transport-https ninja-build debhelper gnupg wget devscripts mmv equivs git nasm cmake pkg-config subversion dh-autoreconf libdrm-dev libpciaccess-dev python3-pip
 
+#Install meson
+RUN pip3 install meson
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/docker-build.sh /docker-build.sh
 

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,9 @@ endif
 PACKAGEVERSION := "$(ORIG_VERSION)-$(VERSION_SUFFIX)"
 
 CONFIG := --prefix=${TARGET_DIR} \
+	--pkg-config-flags="--static" \
+	--extra-cflags="-I${TARGET_DIR}/include"
+	--extra-ldflags="-L${TARGET_DIR}/lib"
 	--target-os=linux \
 	--disable-doc \
 	--disable-ffplay \

--- a/debian/rules
+++ b/debian/rules
@@ -11,9 +11,8 @@ endif
 PACKAGEVERSION := "$(ORIG_VERSION)-$(VERSION_SUFFIX)"
 
 CONFIG := --prefix=${TARGET_DIR} \
-	--pkg-config-flags="--static" \
 	--extra-cflags="-I${TARGET_DIR}/include"
-	--extra-ldflags="-L${TARGET_DIR}/lib"
+	--extra-ldflags="-static -L${TARGET_DIR}/lib -Wl,-Bynamic"
 	--target-os=linux \
 	--disable-doc \
 	--disable-ffplay \

--- a/debian/rules
+++ b/debian/rules
@@ -39,6 +39,7 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-libx264 \
 	--enable-libx265 \
 	--enable-libzvbi \
+	--enable-libdav1d
 
 CONFIG_ARM_COMMON := --toolchain=hardened \
 	--enable-cross-compile \

--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,6 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-libx264 \
 	--enable-libx265 \
 	--enable-libzvbi \
-	--enable-libdav1d
 
 CONFIG_ARM_COMMON := --toolchain=hardened \
 	--enable-cross-compile \
@@ -60,6 +59,7 @@ CONFIG_x86 := --arch=amd64 \
 	--enable-nvenc \
 	--enable-nvdec \
 	--enable-vaapi \
+	--enable-libdav1d
 #	--enable-libmfx # uncomment for non-free QSV
 
 HOST_ARCH := $(shell arch)

--- a/debian/rules
+++ b/debian/rules
@@ -11,8 +11,6 @@ endif
 PACKAGEVERSION := "$(ORIG_VERSION)-$(VERSION_SUFFIX)"
 
 CONFIG := --prefix=${TARGET_DIR} \
-	--extra-cflags="-I${TARGET_DIR}/include"
-	--extra-ldflags="-static -L${TARGET_DIR}/lib -Wl,-Bynamic"
 	--target-os=linux \
 	--disable-doc \
 	--disable-ffplay \

--- a/debian/rules
+++ b/debian/rules
@@ -86,6 +86,9 @@ override_dh_gencontrol:
 override_dh_auto_configure:
 	./configure $(CONFIG)
 
+override_dh_shlibdeps:
+	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info
+
 override_dh_auto_clean:
 	dh_auto_clean || true
 

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -25,7 +25,7 @@ prepare_hwa_amd64() {
     pushd dav1d
     mkdir build
     pushd build
-    meson --prefix=${TARGET_DIR} ..
+    meson -Ddefault_library=static --prefix=${TARGET_DIR} ..
     ninja
     popd
     popd

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -25,8 +25,14 @@ prepare_hwa_amd64() {
     pushd dav1d
     mkdir build
     pushd build
-    meson -Ddefault_library=static --prefix=${TARGET_DIR} ..
+    meson -Ddefault_library=shared --prefix=${TARGET_DIR} ..
     ninja
+    meson install
+    echo ${LD_LIBRARY_PATH}
+    echo $(find ${TARGET_DIR}/lib/x86_64-linux-gnu)
+    cp ${TARGET_DIR}/lib/x86_64-linux-gnu/pkgconfig/dav1d.pc  /usr/lib/pkgconfig/
+    cp ${TARGET_DIR}/lib/x86_64-linux-gnu/*dav1d* ${SOURCE_DIR}/dav1d
+    echo "dav1d/*dav1d* /usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
     popd
     popd
     popd

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -19,6 +19,20 @@ prepare_hwa_amd64() {
     popd
     popd
 
+    # Download and install dav1d
+    pushd ${SOURCE_DIR}
+    git clone --depth=1 https://code.videolan.org/videolan/dav1d.git && \
+    pushd dav1d
+    mkdir build
+    pushd build
+    meson ..
+    ninja
+    meson install
+    popd
+    popd
+    popd
+
+
     # Download and setup AMD AMF headers
     # https://www.ffmpeg.org/general.html#AMD-AMF_002fVCE
     svn checkout https://github.com/GPUOpen-LibrariesAndSDKs/AMF/trunk/amf/public/include

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -25,9 +25,8 @@ prepare_hwa_amd64() {
     pushd dav1d
     mkdir build
     pushd build
-    meson ..
+    meson --prefix=${TARGET_DIR} ..
     ninja
-    meson install
     popd
     popd
     popd

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -25,11 +25,16 @@ prepare_hwa_amd64() {
     pushd dav1d
     mkdir build
     pushd build
-    meson -Ddefault_library=shared --prefix=${TARGET_DIR} ..
+    nasmver="$(nasm -v | cut -d ' ' -f3)"
+    nasmavx512ver="2.14.0"
+    if [ "$(printf '%s\n' "$nasmavx512ver" "$nasmver" | sort -V | head -n1)" = "$nasmavx512ver" ]; then 
+	    avx512=true
+    else
+	    avx512=false
+    fi
+    meson -Denable_asm=true -Denable_avx512=$avx512 -Ddefault_library=shared --prefix=${TARGET_DIR} ..
     ninja
     meson install
-    echo ${LD_LIBRARY_PATH}
-    echo $(find ${TARGET_DIR}/lib/x86_64-linux-gnu)
     cp ${TARGET_DIR}/lib/x86_64-linux-gnu/pkgconfig/dav1d.pc  /usr/lib/pkgconfig/
     cp ${TARGET_DIR}/lib/x86_64-linux-gnu/*dav1d* ${SOURCE_DIR}/dav1d
     echo "dav1d/*dav1d* /usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -75,15 +75,32 @@ RUN      buildDeps="autoconf \
                     libtool \
                     make \
                     nasm \
+		    ninja-build \
                     perl \
                     pkg-config \
                     python \
+		    python3-setuptools \
+                    python3-pip \
                     libgnutls28-dev \
                     yasm \
                     libva-dev \
                     zlib1g-dev" && \
         apt-get -yqq update && \
         apt-get install -yq --no-install-recommends ${buildDeps}
+## dav1d https://code.videolan.org/videolan/dav1d
+RUN \ 
+	pip3 install meson && \
+	DIR=/tmp/dav1d && \
+	mkdir -p ${DIR} && \
+	cd ${DIR} && \
+	git clone --depth=1 https://code.videolan.org/videolan/dav1d.git && \
+	cd dav1d && \
+        mkdir build && \
+        cd build && \
+        meson -Denable_asm=true -Denable_avx512=false -Ddefault_library=shared --prefix=${PREFIX} .. && \
+    	ninja && \
+    	meson install
+
 ## opencore-amr https://sourceforge.net/projects/opencore-amr/
 RUN \
         DIR=/tmp/opencore-amr && \
@@ -373,6 +390,7 @@ RUN \
         --enable-postproc \
         --enable-version3 \
         --enable-rpath \
+	--enable-libdav1d \ 
         --extra-cflags="-I${PREFIX}/include" \
         --extra-ldflags="-L${PREFIX}/lib" \
         --extra-libs=-ldl \


### PR DESCRIPTION
Adds dav1d library support to jellyfin-ffmpeg. This will allow jellyfin-ffmpeg to transcode AV1 files to other codecs such as H.264. This Fixes #39. I'm not experienced with debian packaging.

Note that this pull request does NOT allow transcoding to AV1, encoders for AV1 are not in a viable state currently. This allows playback of AV1 files by transcoding them from AV1 to another format.

(EX AV1 file -> dav1d -> x264 -> Jellyfin client)

dav1d is pulled from upstream and built statically (EDIT: Now dynamically) against FFmpeg. I chose to do this because there are dav1d is relatively new and not packaged for many distributions. 