### PR TITLE
Add zscale filter to armhf/arm64 for HDR thumbnails extraction

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "4.3.1-2"
+version: "4.3.1-3"
 packages:
   - stretch-amd64
   - stretch-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (4.3.1-3) unstable; urgency=medium
+
+  * Add zscale filter to armhf/arm64 for HDR thumbnails extraction
+
+ -- nyanmisaka <nst799610810@gmail.com>  Wed, 02 Dec 2020 20:52:33 +0800
+
 jellyfin-ffmpeg (4.3.1-2) unstable; urgency=medium
   
   * Add support for Ubuntu Groovy (20.10)

--- a/debian/rules
+++ b/debian/rules
@@ -40,6 +40,7 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-libx264 \
 	--enable-libx265 \
 	--enable-libzvbi \
+        --enable-libzimg \
 
 CONFIG_ARM_COMMON := --toolchain=hardened \
 	--enable-cross-compile \
@@ -56,7 +57,6 @@ CONFIG_ARM64 := ${CONFIG_ARM_COMMON} \
 	--cross-prefix=/usr/bin/aarch64-linux-gnu- \
 
 CONFIG_x86 := --arch=amd64 \
-	--enable-libzimg \
 	--enable-opencl \
 	--enable-vaapi \
 	--enable-amf \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -19,7 +19,7 @@ prepare_extra_common() {
             CROSS_OPT=""
         ;;
         'armhf')
-            CROSS_OPT="--host=arm-linux-gnueabihf CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++"
+            CROSS_OPT="--host=armv7-linux-gnueabihf CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++"
         ;;
         'arm64')
             CROSS_OPT="--host=aarch64-linux-gnu CC=aarch64-linux-gnu-gcc CXX=aarch64-linux-gnu-g++"


### PR DESCRIPTION
**Changes**
- Build zscale filter for armhf/arm64 for HDR thumbnails extraction.
Related to https://github.com/jellyfin/jellyfin/pull/4610