### PR TITLE
Add fdk-aac-free

### DIFF
--- a/debian/patches/0035-remove-fdk-aac-from-nonfree.patch
+++ b/debian/patches/0035-remove-fdk-aac-from-nonfree.patch
@@ -1,0 +1,20 @@
+Index: jellyfin-ffmpeg/configure
+===================================================================
+--- jellyfin-ffmpeg.orig/configure
++++ jellyfin-ffmpeg/configure
+@@ -1730,7 +1730,6 @@ EXTERNAL_LIBRARY_GPL_LIST="
+ 
+ EXTERNAL_LIBRARY_NONFREE_LIST="
+     decklink
+-    libfdk_aac
+     openssl
+     libtls
+ "
+@@ -1771,6 +1770,7 @@ EXTERNAL_LIBRARY_LIST="
+     libdav1d
+     libdc1394
+     libdrm
++    libfdk_aac
+     libflite
+     libfontconfig
+     libfreetype

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -32,3 +32,4 @@
 0032-add-async-support-for-qsv-vpp.patch
 0033-add-fixes-for-corrupted-hevc-vaapi-on-tgl.patch
 0034-add-webp-support-for-id3v2.patch
+0035-remove-fdk-aac-from-nonfree.patch

--- a/debian/rules
+++ b/debian/rules
@@ -42,6 +42,7 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-libx265 \
 	--enable-libzvbi \
 	--enable-libzimg \
+	--enable-libfdk-aac \
 
 CONFIG_ARM_COMMON := --toolchain=hardened \
 	--enable-cross-compile \

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -437,6 +437,21 @@ meson install
 popd
 popd
 
+# FDK-AAC-STRIPPED
+git clone -b stripped4 --depth=1 https://gitlab.freedesktop.org/wtaymans/fdk-aac-stripped.git
+pushd fdk-aac-stripped
+./autogen.sh
+./configure \
+    --prefix=${FF_DEPS_PREFIX} \
+    --host=${FF_TOOLCHAIN} \
+    --disable-{silent-rules,shared} \
+    --enable-static \
+    CFLAGS="-O3 -DNDEBUG" \
+    CXXFLAGS="-O3 -DNDEBUG"
+make -j$(nproc)
+make install
+popd
+
 # OpenCL headers
 git clone --depth=1 https://github.com/KhronosGroup/OpenCL-Headers
 pushd OpenCL-Headers/CL
@@ -544,6 +559,7 @@ fi
     --enable-libx264 \
     --enable-libx265 \
     --enable-libdav1d \
+    --enable-libfdk-aac \
     --enable-opencl \
     --enable-dxva2 \
     --enable-d3d11va \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -71,6 +71,17 @@ prepare_extra_common() {
     popd
     popd
     popd
+
+    # Download and install fdk-aac-stripped
+    pushd ${SOURCE_DIR}
+    git clone -b stripped4 --depth=1 https://gitlab.freedesktop.org/wtaymans/fdk-aac-stripped.git
+    pushd fdk-aac-stripped
+    ./autogen.sh
+    ./configure --disable-silent-rules --disable-static --prefix=${TARGET_DIR} CFLAGS="-O3 -DNDEBUG" CXXFLAGS="-O3 -DNDEBUG" ${CROSS_OPT}
+    make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/fdk-aac-stripped
+    echo "fdk-aac-stripped${TARGET_DIR}/lib/libfdk-aac.so* usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    popd
+    popd
 }
 
 # Prepare extra headers, libs and drivers for x86_64-linux-gnu


### PR DESCRIPTION
Fedora maintains a fork of libfdk-aac stripped of all AAC modes except for MPEG-2 AAC-LC, patents of which should now be expired. Their legal team greenlighted it, so it should be fine to redistribute such binaries. I'd like this encoder to replace the default LAME encoder that is in Jellyfin, because:
1. AAC is far more common on the Internet (less potential browser bugs)
2. better compression
3. Don't know if this is also in the mpegts muxer, but mp3 with variable bitrate couldn't seek accurately on some platforms. For Jellyfin, we could simply use fdk-aac VBR preset 5 or 4 instead of a fixed bitrate and save some bandwidth without sacrificing quality.

If this gets merged I'm planning to create a PR to the main Jellyfin repository to swap LAME for FDK-AAC.

Related links:
https://bugzilla.redhat.com/show_bug.cgi?id=1501522
https://frederickding.gitlab.io/HandBrake/