### PR TITLE
Do not link against GnuTLS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,8 +13,6 @@ Build-Depends:
  debhelper,
 # for build-profile support
  dpkg-dev,
-# --enable-gnutls
- libgnutls28-dev | libgnutls-dev,
 # --enable-libass
  libass-dev,
 # --enable-libbluray

--- a/debian/rules
+++ b/debian/rules
@@ -25,7 +25,6 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-libfontconfig \
 	--enable-fontconfig \
 	--enable-gmp \
-	--enable-gnutls \
 	--enable-libass \
 	--enable-libbluray \
 	--enable-libdrm \


### PR DESCRIPTION
It's not needed for Jellyfin.