### PR TITLE
Drop support for Debian stretch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,6 @@ jobs:
         release:
           - bullseye
           - buster
-          - stretch
           - groovy
           - focal
           - bionic

--- a/build
+++ b/build
@@ -4,10 +4,9 @@ usage() {
     echo -e "Build Jellyfin FFMPEG packages"
     echo -e " $0 <release> <arch>"
     echo -e "Releases:          Arches:"
-    echo -e " * stretch          * amd64"
-    echo -e " * buster           * armhf"
-    echo -e " * bullseye         * arm64"
-    echo -e " * xenial"
+    echo -e " * buster          * amd64"
+    echo -e " * bullseye        * armhf"
+    echo -e " * xenial          * arm64"
     echo -e " * bionic"
     echo -e " * cosmic"
     echo -e " * disco"
@@ -24,10 +23,6 @@ fi
 
 cli_release="${1}"
 case ${cli_release} in
-    'stretch')
-        release="debian:stretch"
-        gcc_version="6"
-    ;;
     'buster')
         release="debian:buster"
         gcc_version="8"

--- a/build.yaml
+++ b/build.yaml
@@ -3,9 +3,6 @@
 name: "jellyfin-ffmpeg"
 version: "4.4-1"
 packages:
-  - stretch-amd64
-  - stretch-armhf
-  - stretch-arm64
   - buster-amd64
   - buster-armhf
   - buster-arm64


### PR DESCRIPTION
Drop support for Debian Stretch because a dependency requires nasm 2.13.02 or later. Debian Stretch only has support for 2.12.01.

```
../meson.build:407:16: ERROR: Problem encountered: nasm 2.13.02 or later is required, found nasm 2.12.01
```