### PR TITLE
Add min nasm version check for x86 dav1d

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -35,7 +35,6 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-libopus \
 	--enable-libtheora \
 	--enable-libvorbis \
-	--enable-libdav1d \
 	--enable-libwebp \
 	--enable-libvpx \
 	--enable-libx264 \
@@ -45,6 +44,7 @@ CONFIG := --prefix=${TARGET_DIR} \
 
 CONFIG_ARM_COMMON := --toolchain=hardened \
 	--enable-cross-compile \
+	--enable-libdav1d \
 	--enable-omx \
 	--enable-omx-rpi \
 
@@ -70,8 +70,14 @@ CONFIG_x86 := --arch=amd64 \
 	--enable-nvdec \
 	--enable-ffnvcodec \
 
+CONFIG_DAV1D := --enable-libdav1d \
+
 HOST_ARCH := $(shell arch)
 BUILD_ARCH := ${DEB_HOST_MULTIARCH}
+
+ifeq ($(ENABLE_X86_DAV1D),true)
+	CONFIG_x86 += $(CONFIG_DAV1D)
+endif
 ifeq ($(BUILD_ARCH),x86_64-linux-gnu)
 	# Native amd64 build
 	CONFIG += $(CONFIG_x86)


### PR DESCRIPTION
- add min nasm version check for x86 dav1d

disable dav1d when nasm version < 2.13.02
https://code.videolan.org/videolan/dav1d/-/blob/0.9.1/meson.build#L406

Fixes: https://github.com/jellyfin/jellyfin-ffmpeg/issues/69