### PR TITLE
Allow partial DAV1D support on stretch and improve QSV OCL tonemap

### DIFF
--- a/debian/patches/0003-fix-for-the-broken-tonemap_vaapi-filter.patch
+++ b/debian/patches/0003-fix-for-the-broken-tonemap_vaapi-filter.patch
@@ -1,23 +1,61 @@
-# Fix for the broken tonemap_vaapi filter
-# avfilter/tonemap_vaapi: pass filter parameters to VA parameter buffer
-# avfilter: Add H2H support in tonemap_vaapi
 Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_vaapi.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavfilter/vf_tonemap_vaapi.c
 +++ jellyfin-ffmpeg/libavfilter/vf_tonemap_vaapi.c
-@@ -41,7 +41,11 @@ typedef struct HDRVAAPIContext {
+@@ -41,7 +41,13 @@ typedef struct HDRVAAPIContext {
      enum AVColorTransferCharacteristic color_transfer;
      enum AVColorSpace color_matrix;
  
-+    char *master_display;
-+    char *content_light;
++    char *in_master_display;
++    char *in_content_light;
++    char *out_master_display;
++    char *out_content_light;
 +
      VAHdrMetaDataHDR10  in_metadata;
 +    VAHdrMetaDataHDR10  out_metadata;
  
      AVFrameSideData    *src_display;
      AVFrameSideData    *src_light;
-@@ -148,6 +152,107 @@ static int tonemap_vaapi_save_metadata(A
+@@ -54,7 +60,7 @@ static int tonemap_vaapi_save_metadata(A
+     AVContentLightMetadata *light_meta;
+ 
+     if (input_frame->color_trc != AVCOL_TRC_SMPTE2084) {
+-        av_log(avctx, AV_LOG_WARNING, "Only support HDR10 as input for vaapi tone-mapping\n");
++        av_log(avctx, AV_LOG_DEBUG, "Only support HDR10 as input for vaapi tone-mapping\n");
+     }
+ 
+     ctx->src_display = av_frame_get_side_data(input_frame,
+@@ -62,8 +68,7 @@ static int tonemap_vaapi_save_metadata(A
+     if (ctx->src_display) {
+         hdr_meta = (AVMasteringDisplayMetadata *)ctx->src_display->data;
+         if (!hdr_meta) {
+-            av_log(avctx, AV_LOG_ERROR, "No mastering display data\n");
+-            return AVERROR(EINVAL);
++            av_log(avctx, AV_LOG_DEBUG, "No mastering display data\n");
+         }
+ 
+         if (hdr_meta->has_luminance) {
+@@ -120,8 +125,7 @@ static int tonemap_vaapi_save_metadata(A
+                    ctx->in_metadata.white_point_y);
+         }
+     } else {
+-        av_log(avctx, AV_LOG_ERROR, "No mastering display data from input\n");
+-        return AVERROR(EINVAL);
++        av_log(avctx, AV_LOG_DEBUG, "No mastering display data from input\n");
+     }
+ 
+     ctx->src_light = av_frame_get_side_data(input_frame,
+@@ -129,8 +133,7 @@ static int tonemap_vaapi_save_metadata(A
+     if (ctx->src_light) {
+         light_meta = (AVContentLightMetadata *)ctx->src_light->data;
+         if (!light_meta) {
+-            av_log(avctx, AV_LOG_ERROR, "No light metadata\n");
+-            return AVERROR(EINVAL);
++            av_log(avctx, AV_LOG_DEBUG, "No light metadata\n");
+         }
+ 
+         ctx->in_metadata.max_content_light_level = light_meta->MaxCLL;
+@@ -148,6 +151,107 @@ static int tonemap_vaapi_save_metadata(A
      return 0;
  }
  
@@ -125,7 +163,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_vaapi.c
  static int tonemap_vaapi_set_filter_params(AVFilterContext *avctx, AVFrame *input_frame)
  {
      VAAPIVPPContext *vpp_ctx   = avctx->priv;
-@@ -210,15 +315,26 @@ static int tonemap_vaapi_build_filter_pa
+@@ -210,15 +314,26 @@ static int tonemap_vaapi_build_filter_pa
          return AVERROR(EINVAL);
      }
  
@@ -161,7 +199,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_vaapi.c
      }
  
      hdrtm_param.type = VAProcFilterHighDynamicRangeToneMapping;
-@@ -243,6 +359,8 @@ static int tonemap_vaapi_filter_frame(AV
+@@ -243,6 +358,8 @@ static int tonemap_vaapi_filter_frame(AV
      VAProcPipelineParameterBuffer params;
      int err;
  
@@ -170,7 +208,22 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_vaapi.c
      av_log(avctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(input_frame->format),
             input_frame->width, input_frame->height, input_frame->pts);
-@@ -291,11 +409,26 @@ static int tonemap_vaapi_filter_frame(AV
+@@ -252,9 +369,11 @@ static int tonemap_vaapi_filter_frame(AV
+         return AVERROR(EINVAL);
+     }
+ 
+-    err = tonemap_vaapi_save_metadata(avctx, input_frame);
+-    if (err < 0)
+-        goto fail;
++    if (!ctx->in_master_display && !ctx->in_content_light) {
++        err = tonemap_vaapi_save_metadata(avctx, input_frame);
++        if (err < 0)
++            goto fail;
++    }
+ 
+     err = tonemap_vaapi_set_filter_params(avctx, input_frame);
+     if (err < 0)
+@@ -291,11 +410,26 @@ static int tonemap_vaapi_filter_frame(AV
      if (ctx->color_matrix != AVCOL_SPC_UNSPECIFIED)
          output_frame->colorspace = ctx->color_matrix;
  
@@ -197,59 +250,75 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_vaapi.c
      err = ff_vaapi_vpp_render_picture(avctx, &params, output_frame);
      if (err < 0)
          goto fail;
-@@ -355,6 +488,46 @@ static av_cold int tonemap_vaapi_init(AV
+@@ -355,6 +489,60 @@ static av_cold int tonemap_vaapi_init(AV
      STRING_OPTION(color_transfer,  color_transfer,  AVCOL_TRC_UNSPECIFIED);
      STRING_OPTION(color_matrix,    color_space,     AVCOL_SPC_UNSPECIFIED);
  
++#define READ_DISPLAY_OPTION(in_or_out) do { \
++        if (10 != sscanf(ctx->in_or_out ## _master_display, \
++                         "G(%hu|%hu)B(%hu|%hu)R(%hu|%hu)WP(%hu|%hu)L(%u|%u)", \
++                         &ctx->in_or_out ## _metadata.display_primaries_x[0], \
++                         &ctx->in_or_out ## _metadata.display_primaries_y[0], \
++                         &ctx->in_or_out ## _metadata.display_primaries_x[1], \
++                         &ctx->in_or_out ## _metadata.display_primaries_y[1], \
++                         &ctx->in_or_out ## _metadata.display_primaries_x[2], \
++                         &ctx->in_or_out ## _metadata.display_primaries_y[2], \
++                         &ctx->in_or_out ## _metadata.white_point_x, \
++                         &ctx->in_or_out ## _metadata.white_point_y, \
++                         &ctx->in_or_out ## _metadata.min_display_mastering_luminance, \
++                         &ctx->in_or_out ## _metadata.max_display_mastering_luminance)) { \
++            av_log(avctx, AV_LOG_ERROR, \
++                   "Option " #in_or_out "-mastering-display input invalid\n"); \
++            return AVERROR(EINVAL); \
++        } \
++    } while (0)
++
++#define READ_LIGHT_OPTION(in_or_out) do { \
++        if (2 != sscanf(ctx->in_or_out ## _content_light, \
++                        "CLL(%hu)FALL(%hu)", \
++                        &ctx->in_or_out ## _metadata.max_content_light_level, \
++                        &ctx->in_or_out ## _metadata.max_pic_average_light_level)) { \
++            av_log(avctx, AV_LOG_ERROR, \
++                   "Option " #in_or_out "-content-light input invalid\n"); \
++            return AVERROR(EINVAL); \
++        } \
++    } while (0)
++
++    if (ctx->in_master_display) {
++        READ_DISPLAY_OPTION(in);
++    }
++
++    if (ctx->in_content_light) {
++        READ_LIGHT_OPTION(in);
++    }
++
 +    if (ctx->color_transfer == AVCOL_TRC_SMPTE2084) {
-+        if (!ctx->master_display) {
++        if (!ctx->out_master_display) {
 +            av_log(avctx, AV_LOG_ERROR,
-+                   "Option mastering-display input invalid\n");
++                   "H2H tone-mapping requires valid out-mastering-display metadata\n");
 +            return AVERROR(EINVAL);
 +        }
++        READ_DISPLAY_OPTION(out);
 +
-+        if (10 != sscanf(ctx->master_display,
-+                         "G(%hu|%hu)B(%hu|%hu)R(%hu|%hu)WP(%hu|%hu)L(%u|%u)",
-+                         &ctx->out_metadata.display_primaries_x[0],
-+                         &ctx->out_metadata.display_primaries_y[0],
-+                         &ctx->out_metadata.display_primaries_x[1],
-+                         &ctx->out_metadata.display_primaries_y[1],
-+                         &ctx->out_metadata.display_primaries_x[2],
-+                         &ctx->out_metadata.display_primaries_y[2],
-+                         &ctx->out_metadata.white_point_x,
-+                         &ctx->out_metadata.white_point_y,
-+                         &ctx->out_metadata.min_display_mastering_luminance,
-+                         &ctx->out_metadata.max_display_mastering_luminance)) {
++        if (!ctx->out_content_light) {
 +            av_log(avctx, AV_LOG_ERROR,
-+                   "Option mastering-display input invalid\n");
++                   "H2H tone-mapping requires valid out-content-light metadata\n");
 +            return AVERROR(EINVAL);
 +        }
-+
-+        if (!ctx->content_light) {
-+            av_log(avctx, AV_LOG_ERROR,
-+                   "Option content-light input invalid\n");
-+            return AVERROR(EINVAL);
-+        }
-+
-+        if (2 != sscanf(ctx->content_light,
-+                        "CLL(%hu)FALL(%hu)",
-+                        &ctx->out_metadata.max_content_light_level,
-+                        &ctx->out_metadata.max_pic_average_light_level)) {
-+            av_log(avctx, AV_LOG_ERROR,
-+                   "Option content-light input invalid\n");
-+            return AVERROR(EINVAL);
-+        }
++        READ_LIGHT_OPTION(out);
 +    }
 +
      return 0;
  }
  
-@@ -380,10 +553,11 @@ static const AVOption tonemap_vaapi_opti
+@@ -380,10 +568,13 @@ static const AVOption tonemap_vaapi_opti
      { "t",        "Output color transfer characteristics set",
        OFFSET(color_transfer_string),  AV_OPT_TYPE_STRING,
        { .str = NULL }, .flags = FLAGS, "transfer" },
-+    { "display", "set master display",  OFFSET(master_display), AV_OPT_TYPE_STRING, {.str=NULL}, CHAR_MIN, CHAR_MAX, FLAGS },
-+    { "light",   "set content light",   OFFSET(content_light),  AV_OPT_TYPE_STRING, {.str=NULL}, CHAR_MIN, CHAR_MAX, FLAGS },
++    { "indisplay", "Set input mastering display",  OFFSET(in_master_display), AV_OPT_TYPE_STRING, { .str = NULL }, CHAR_MIN, CHAR_MAX, FLAGS },
++    { "inlight",   "Set input content light",   OFFSET(in_content_light),  AV_OPT_TYPE_STRING, { .str = NULL }, CHAR_MIN, CHAR_MAX, FLAGS },
++    { "outdisplay", "Set output mastering display for H2H",  OFFSET(out_master_display), AV_OPT_TYPE_STRING, { .str = NULL }, CHAR_MIN, CHAR_MAX, FLAGS },
++    { "outlight",   "Set output content light for H2H",   OFFSET(out_content_light),  AV_OPT_TYPE_STRING, { .str = NULL }, CHAR_MIN, CHAR_MAX, FLAGS },
      { NULL }
  };
  

--- a/debian/patches/0006-bt2390-and-fix-for-peak-detection-in-opencl-tonemap.patch
+++ b/debian/patches/0006-bt2390-and-fix-for-peak-detection-in-opencl-tonemap.patch
@@ -393,7 +393,7 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
  
      // Rescale the variables in order to bring it into a representation where
      // 1.0 represents the dst_peak. This is because all of the tone mapping
-@@ -178,30 +104,24 @@ float3 map_one_pixel_rgb(float3 rgb, flo
+@@ -178,95 +104,97 @@ float3 map_one_pixel_rgb(float3 rgb, flo
  
      float sig_old = sig;
  
@@ -430,21 +430,55 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
      c = lrgb2lrgb(c);
      return c;
  }
-@@ -210,7 +130,6 @@ __kernel void tonemap(__write_only image
+ 
++__constant sampler_t sampler = (CLK_NORMALIZED_COORDS_FALSE |
++                                CLK_ADDRESS_CLAMP_TO_EDGE   |
++                                CLK_FILTER_NEAREST);
++
+ __kernel void tonemap(__write_only image2d_t dst1,
                        __read_only  image2d_t src1,
                        __write_only image2d_t dst2,
                        __read_only  image2d_t src2,
 -                      global uint *util_buf,
++#ifdef NON_SEMI_PLANAR_OUT
++                      __write_only image2d_t dst3,
++#endif
++#ifdef NON_SEMI_PLANAR_IN
++                      __read_only  image2d_t src3,
++#endif
                        float peak
                        )
  {
-@@ -241,23 +160,17 @@ __kernel void tonemap(__write_only image
-     float sig3 = max(c3.x, max(c3.y, c3.z));
-     float sig = max(sig0, max(sig1, max(sig2, sig3)));
+-    __local uint sum_wg;
+-    const sampler_t sampler = (CLK_NORMALIZED_COORDS_FALSE |
+-                               CLK_ADDRESS_CLAMP_TO_EDGE   |
+-                               CLK_FILTER_NEAREST);
+     int xi = get_global_id(0);
+     int yi = get_global_id(1);
+     // each work item process four pixels
+     int x = 2 * xi;
+     int y = 2 * yi;
  
+-    float y0 = read_imagef(src1, sampler, (int2)(x,     y)).x;
+-    float y1 = read_imagef(src1, sampler, (int2)(x + 1, y)).x;
+-    float y2 = read_imagef(src1, sampler, (int2)(x,     y + 1)).x;
+-    float y3 = read_imagef(src1, sampler, (int2)(x + 1, y + 1)).x;
+-    float2 uv = read_imagef(src2, sampler, (int2)(xi,     yi)).xy;
+-
+-    float3 c0 = map_to_dst_space_from_yuv((float3)(y0, uv.x, uv.y), peak);
+-    float3 c1 = map_to_dst_space_from_yuv((float3)(y1, uv.x, uv.y), peak);
+-    float3 c2 = map_to_dst_space_from_yuv((float3)(y2, uv.x, uv.y), peak);
+-    float3 c3 = map_to_dst_space_from_yuv((float3)(y3, uv.x, uv.y), peak);
+-
+-    float sig0 = max(c0.x, max(c0.y, c0.z));
+-    float sig1 = max(c1.x, max(c1.y, c1.z));
+-    float sig2 = max(c2.x, max(c2.y, c2.z));
+-    float sig3 = max(c3.x, max(c3.y, c3.z));
+-    float sig = max(sig0, max(sig1, max(sig2, sig3)));
+-
 -    struct detection_result r = detect_peak_avg(util_buf, &sum_wg, sig, peak);
 -
-     float3 c0_old = c0, c1_old = c1, c2_old = c2;
+-    float3 c0_old = c0, c1_old = c1, c2_old = c2;
 -    c0 = map_one_pixel_rgb(c0, r.peak, r.average);
 -    c1 = map_one_pixel_rgb(c1, r.peak, r.average);
 -    c2 = map_one_pixel_rgb(c2, r.peak, r.average);
@@ -454,19 +488,69 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
 -    c1 = inverse_ootf(c1, target_peak);
 -    c2 = inverse_ootf(c2, target_peak);
 -    c3 = inverse_ootf(c3, target_peak);
-+    c0 = map_one_pixel_rgb(c0, peak);
-+    c1 = map_one_pixel_rgb(c1, peak);
-+    c2 = map_one_pixel_rgb(c2, peak);
-+    c3 = map_one_pixel_rgb(c3, peak);
- 
-     y0 = lrgb2y(c0);
-     y1 = lrgb2y(c1);
-     y2 = lrgb2y(c2);
-     y3 = lrgb2y(c3);
+-
+-    y0 = lrgb2y(c0);
+-    y1 = lrgb2y(c1);
+-    y2 = lrgb2y(c2);
+-    y3 = lrgb2y(c3);
+-    float3 chroma_c = get_chroma_sample(c0, c1, c2, c3);
+-    float3 chroma = lrgb2yuv(chroma_c);
+-
+     if (xi < get_image_width(dst2) && yi < get_image_height(dst2)) {
+-        write_imagef(dst1, (int2)(x, y), (float4)(y0, 0.0f, 0.0f, 1.0f));
+-        write_imagef(dst1, (int2)(x+1, y), (float4)(y1, 0.0f, 0.0f, 1.0f));
+-        write_imagef(dst1, (int2)(x, y+1), (float4)(y2, 0.0f, 0.0f, 1.0f));
+-        write_imagef(dst1, (int2)(x+1, y+1), (float4)(y3, 0.0f, 0.0f, 1.0f));
+-        write_imagef(dst2, (int2)(xi, yi),
+-                     (float4)(chroma.y, chroma.z, 0.0f, 1.0f));
++        float y0 = read_imagef(src1, sampler, (int2)(x,     y)).x;
++        float y1 = read_imagef(src1, sampler, (int2)(x + 1, y)).x;
++        float y2 = read_imagef(src1, sampler, (int2)(x,     y + 1)).x;
++        float y3 = read_imagef(src1, sampler, (int2)(x + 1, y + 1)).x;
++#ifdef NON_SEMI_PLANAR_IN
++        float u = read_imagef(src2, sampler, (int2)(xi, yi)).x;
++        float v = read_imagef(src3, sampler, (int2)(xi, yi)).x;
++        float2 uv = (float2)(u, v);
++#else
++        float2 uv = read_imagef(src2, sampler, (int2)(xi, yi)).xy;
++#endif
 +
-     float3 chroma_c = get_chroma_sample(c0, c1, c2, c3);
-     float3 chroma = lrgb2yuv(chroma_c);
- 
++        float3 c0 = map_to_dst_space_from_yuv((float3)(y0, uv.x, uv.y), peak);
++        float3 c1 = map_to_dst_space_from_yuv((float3)(y1, uv.x, uv.y), peak);
++        float3 c2 = map_to_dst_space_from_yuv((float3)(y2, uv.x, uv.y), peak);
++        float3 c3 = map_to_dst_space_from_yuv((float3)(y3, uv.x, uv.y), peak);
++
++        float sig0 = max(c0.x, max(c0.y, c0.z));
++        float sig1 = max(c1.x, max(c1.y, c1.z));
++        float sig2 = max(c2.x, max(c2.y, c2.z));
++        float sig3 = max(c3.x, max(c3.y, c3.z));
++        float sig = max(sig0, max(sig1, max(sig2, sig3)));
++
++        c0 = map_one_pixel_rgb(c0, peak);
++        c1 = map_one_pixel_rgb(c1, peak);
++        c2 = map_one_pixel_rgb(c2, peak);
++        c3 = map_one_pixel_rgb(c3, peak);
++
++        y0 = lrgb2y(c0);
++        y1 = lrgb2y(c1);
++        y2 = lrgb2y(c2);
++        y3 = lrgb2y(c3);
++
++        float3 chroma_c = get_chroma_sample(c0, c1, c2, c3);
++        float3 chroma = lrgb2yuv(chroma_c);
++
++        write_imagef(dst1, (int2)(x,     y), (float4)(y0, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst1, (int2)(x + 1, y), (float4)(y1, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst1, (int2)(x,     y + 1), (float4)(y2, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst1, (int2)(x + 1, y + 1), (float4)(y3, 0.0f, 0.0f, 1.0f));
++#ifdef NON_SEMI_PLANAR_OUT
++        write_imagef(dst2, (int2)(xi, yi), (float4)(chroma.y, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst3, (int2)(xi, yi), (float4)(chroma.z, 0.0f, 0.0f, 1.0f));
++#else
++        write_imagef(dst2, (int2)(xi, yi), (float4)(chroma.y, chroma.z, 0.0f, 1.0f));
++#endif
+     }
+ }
 Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavfilter/vf_tonemap_opencl.c
@@ -479,7 +563,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  #include <float.h>
  
  #include "libavutil/avassert.h"
-@@ -31,13 +32,6 @@
+@@ -31,12 +32,15 @@
  #include "video.h"
  #include "colorspace.h"
  
@@ -487,13 +571,20 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 -// - separate peak-detection from tone-mapping kernel to solve
 -//    one-frame-delay issue.
 -// - more format support
--
++#define OPENCL_SOURCE_NB 3
+ 
 -#define DETECTION_FRAMES 63
--
++static const enum AVPixelFormat supported_formats[] = {
++    AV_PIX_FMT_YUV420P,
++    AV_PIX_FMT_YUV420P16,
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_P016,
++};
+ 
  enum TonemapAlgorithm {
      TONEMAP_NONE,
-     TONEMAP_LINEAR,
-@@ -46,6 +40,7 @@ enum TonemapAlgorithm {
+@@ -46,6 +50,7 @@ enum TonemapAlgorithm {
      TONEMAP_REINHARD,
      TONEMAP_HABLE,
      TONEMAP_MOBIUS,
@@ -501,7 +592,17 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      TONEMAP_MAX,
  };
  
-@@ -68,12 +63,11 @@ typedef struct TonemapOpenCLContext {
+@@ -57,6 +62,9 @@ typedef struct TonemapOpenCLContext {
+     enum AVColorPrimaries primaries, primaries_in, primaries_out;
+     enum AVColorRange range, range_in, range_out;
+     enum AVChromaLocation chroma_loc;
++    enum AVPixelFormat in_fmt, out_fmt;
++    const AVPixFmtDescriptor *in_desc, *out_desc;
++    int in_planes, out_planes;
+ 
+     enum TonemapAlgorithm tonemap;
+     enum AVPixelFormat    format;
+@@ -68,12 +76,11 @@ typedef struct TonemapOpenCLContext {
      int                   initialised;
      cl_kernel             kernel;
      cl_command_queue      command_queue;
@@ -516,7 +617,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  };
  
  static const char *const delinearize_funcs[AVCOL_TRC_NB] = {
-@@ -99,6 +93,7 @@ static const char *const tonemap_func[TO
+@@ -99,6 +106,7 @@ static const char *const tonemap_func[TO
      [TONEMAP_REINHARD] = "reinhard",
      [TONEMAP_HABLE]    = "hable",
      [TONEMAP_MOBIUS]   = "mobius",
@@ -524,26 +625,33 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  };
  
  static void get_rgb2rgb_matrix(enum AVColorPrimaries in, enum AVColorPrimaries out,
-@@ -112,9 +107,6 @@ static void get_rgb2rgb_matrix(enum AVCo
+@@ -111,23 +119,16 @@ static void get_rgb2rgb_matrix(enum AVCo
+     ff_matrix_mul_3x3(rgb2rgb, rgb2xyz, xyz2rgb);
  }
  
- #define OPENCL_SOURCE_NB 3
+-#define OPENCL_SOURCE_NB 3
 -// Average light level for SDR signals. This is equal to a signal level of 0.5
 -// under a typical presentation gamma of about 2.0.
 -static const float sdr_avg = 0.25f;
- 
+-
  static int tonemap_opencl_init(AVFilterContext *avctx)
  {
-@@ -127,7 +119,7 @@ static int tonemap_opencl_init(AVFilterC
-     AVBPrint header;
-     const char *opencl_sources[OPENCL_SOURCE_NB];
- 
+     TonemapOpenCLContext *ctx = avctx->priv;
++    AVBPrint header;
++    const char *opencl_sources[OPENCL_SOURCE_NB];
+     int rgb2rgb_passthrough = 1;
+     double rgb2rgb[3][3], rgb2yuv[3][3], yuv2rgb[3][3];
+     const struct LumaCoefficients *luma_src, *luma_dst;
+     cl_int cle;
+     int err;
+-    AVBPrint header;
+-    const char *opencl_sources[OPENCL_SOURCE_NB];
+-
 -    av_bprint_init(&header, 1024, AV_BPRINT_SIZE_AUTOMATIC);
-+    av_bprint_init(&header, 2048, AV_BPRINT_SIZE_UNLIMITED);
  
      switch(ctx->tonemap) {
      case TONEMAP_GAMMA:
-@@ -149,18 +141,20 @@ static int tonemap_opencl_init(AVFilterC
+@@ -149,20 +150,20 @@ static int tonemap_opencl_init(AVFilterC
  
      // SDR peak is 1.0f
      ctx->target_peak = 1.0f;
@@ -564,40 +672,60 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 +    av_log(ctx, AV_LOG_DEBUG, "Mapping range from %s to %s\n",
             av_color_range_name(ctx->range_in),
             av_color_range_name(ctx->range_out));
+-    // checking valid value just because of limited implementaion
+-    // please remove when more functionalities are implemented
 +
-     // checking valid value just because of limited implementaion
-     // please remove when more functionalities are implemented
      av_assert0(ctx->trc_out == AVCOL_TRC_BT709 ||
-@@ -178,11 +172,9 @@ static int tonemap_opencl_init(AVFilterC
+                ctx->trc_out == AVCOL_TRC_BT2020_10);
+     av_assert0(ctx->trc_in == AVCOL_TRC_SMPTE2084||
+@@ -172,22 +173,36 @@ static int tonemap_opencl_init(AVFilterC
+     av_assert0(ctx->primaries_in == AVCOL_PRI_BT2020 ||
+                ctx->primaries_in == AVCOL_PRI_BT709);
+ 
+-    av_bprintf(&header, "__constant const float tone_param = %.4ff;\n",
++    av_bprint_init(&header, 2048, AV_BPRINT_SIZE_UNLIMITED);
++
++    av_bprintf(&header, "__constant float tone_param = %.4ff;\n",
+                ctx->param);
+-    av_bprintf(&header, "__constant const float desat_param = %.4ff;\n",
++    av_bprintf(&header, "__constant float desat_param = %.4ff;\n",
                 ctx->desat_param);
-     av_bprintf(&header, "__constant const float target_peak = %.4ff;\n",
+-    av_bprintf(&header, "__constant const float target_peak = %.4ff;\n",
++    av_bprintf(&header, "__constant float target_peak = %.4ff;\n",
                 ctx->target_peak);
 -    av_bprintf(&header, "__constant const float sdr_avg = %.4ff;\n", sdr_avg);
-     av_bprintf(&header, "__constant const float scene_threshold = %.4ff;\n",
+-    av_bprintf(&header, "__constant const float scene_threshold = %.4ff;\n",
++    av_bprintf(&header, "__constant float scene_threshold = %.4ff;\n",
                 ctx->scene_threshold);
++
      av_bprintf(&header, "#define TONE_FUNC %s\n", tonemap_func[ctx->tonemap]);
 -    av_bprintf(&header, "#define DETECTION_FRAMES %d\n", DETECTION_FRAMES);
++
++    if (ctx->in_planes > 2)
++        av_bprintf(&header, "#define NON_SEMI_PLANAR_IN\n");
++
++    if (ctx->out_planes > 2)
++        av_bprintf(&header, "#define NON_SEMI_PLANAR_OUT\n");
++
++    av_bprintf(&header, "#define powr native_powr\n");
++    av_bprintf(&header, "#define exp native_exp\n");
++    av_bprintf(&header, "#define log native_log\n");
++    av_bprintf(&header, "#define log10 native_log10\n");
++    av_bprintf(&header, "#define sqrt native_sqrt\n");
  
      if (ctx->primaries_out != ctx->primaries_in) {
          get_rgb2rgb_matrix(ctx->primaries_in, ctx->primaries_out, rgb2rgb);
-@@ -196,6 +188,16 @@ static int tonemap_opencl_init(AVFilterC
+         rgb2rgb_passthrough = 0;
+     }
++
+     if (ctx->range_in == AVCOL_RANGE_JPEG)
+         av_bprintf(&header, "#define FULL_RANGE_IN\n");
  
-     av_bprintf(&header, "#define chroma_loc %d\n", (int)ctx->chroma_loc);
- 
-+    av_bprintf(&header, "#define powr native_powr\n");
-+
-+    av_bprintf(&header, "#define exp native_exp\n");
-+
-+    av_bprintf(&header, "#define log native_log\n");
-+
-+    av_bprintf(&header, "#define log10 native_log10\n");
-+
-+    av_bprintf(&header, "#define sqrt native_sqrt\n");
-+
-     if (rgb2rgb_passthrough)
-         av_bprintf(&header, "#define RGB2RGB_PASSTHROUGH\n");
+@@ -201,11 +216,10 @@ static int tonemap_opencl_init(AVFilterC
      else
-@@ -205,7 +207,7 @@ static int tonemap_opencl_init(AVFilterC
+         ff_opencl_print_const_matrix_3x3(&header, "rgb2rgb", rgb2rgb);
+ 
+-
      luma_src = ff_get_luma_coefficients(ctx->colorspace_in);
      if (!luma_src) {
          err = AVERROR(EINVAL);
@@ -606,7 +734,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
                 ctx->colorspace_in, av_color_space_name(ctx->colorspace_in));
          goto fail;
      }
-@@ -213,7 +215,7 @@ static int tonemap_opencl_init(AVFilterC
+@@ -213,7 +227,7 @@ static int tonemap_opencl_init(AVFilterC
      luma_dst = ff_get_luma_coefficients(ctx->colorspace_out);
      if (!luma_dst) {
          err = AVERROR(EINVAL);
@@ -615,7 +743,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
                 ctx->colorspace_out, av_color_space_name(ctx->colorspace_out));
          goto fail;
      }
-@@ -225,21 +227,16 @@ static int tonemap_opencl_init(AVFilterC
+@@ -225,21 +239,16 @@ static int tonemap_opencl_init(AVFilterC
      ff_matrix_invert_3x3(rgb2yuv, yuv2rgb);
      ff_opencl_print_const_matrix_3x3(&header, "rgb_matrix", yuv2rgb);
  
@@ -641,7 +769,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
      opencl_sources[0] = header.str;
      opencl_sources[1] = ff_opencl_source_tonemap;
-@@ -259,19 +256,11 @@ static int tonemap_opencl_init(AVFilterC
+@@ -259,19 +268,11 @@ static int tonemap_opencl_init(AVFilterC
      ctx->kernel = clCreateKernel(ctx->ocf.program, "tonemap", &cle);
      CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create kernel %d.\n", cle);
  
@@ -661,49 +789,173 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      if (ctx->command_queue)
          clReleaseCommandQueue(ctx->command_queue);
      if (ctx->kernel)
-@@ -285,11 +274,11 @@ static int tonemap_opencl_config_output(
-     TonemapOpenCLContext *s = avctx->priv;
+@@ -279,23 +280,58 @@ fail:
+     return err;
+ }
+ 
++static int format_is_supported(enum AVPixelFormat fmt)
++{
++    for (int i = 0; i < FF_ARRAY_ELEMS(supported_formats); i++)
++        if (supported_formats[i] == fmt)
++            return 1;
++    return 0;
++}
++
+ static int tonemap_opencl_config_output(AVFilterLink *outlink)
+ {
+-    AVFilterContext *avctx = outlink->src;
+-    TonemapOpenCLContext *s = avctx->priv;
++    AVFilterContext    *avctx = outlink->src;
++    AVFilterLink      *inlink = avctx->inputs[0];
++    TonemapOpenCLContext *ctx = avctx->priv;
++    AVHWFramesContext *in_frames_ctx;
++    enum AVPixelFormat in_format;
++    enum AVPixelFormat out_format;
++    const AVPixFmtDescriptor *in_desc;
++    const AVPixFmtDescriptor *out_desc;
      int ret;
-     if (s->format == AV_PIX_FMT_NONE)
+-    if (s->format == AV_PIX_FMT_NONE)
 -        av_log(avctx, AV_LOG_WARNING, "format not set, use default format NV12\n");
-+        av_log(avctx, AV_LOG_WARNING, "Format not set, use default format NV12\n");
-     else {
-       if (s->format != AV_PIX_FMT_P010 &&
-           s->format != AV_PIX_FMT_NV12) {
+-    else {
+-      if (s->format != AV_PIX_FMT_P010 &&
+-          s->format != AV_PIX_FMT_NV12) {
 -        av_log(avctx, AV_LOG_ERROR, "unsupported output format,"
-+        av_log(avctx, AV_LOG_ERROR, "Unsupported output format,"
-                "only p010/nv12 supported now\n");
+-               "only p010/nv12 supported now\n");
++
++    if (!inlink->hw_frames_ctx)
          return AVERROR(EINVAL);
-       }
-@@ -315,8 +304,7 @@ static int launch_kernel(AVFilterContext
+-      }
+-    }
++    in_frames_ctx = (AVHWFramesContext*)inlink->hw_frames_ctx->data;
++    in_format     = in_frames_ctx->sw_format;
++    out_format    = (ctx->format == AV_PIX_FMT_NONE) ? in_format : ctx->format;
++    in_desc       = av_pix_fmt_desc_get(in_format);
++    out_desc      = av_pix_fmt_desc_get(out_format);
++
++    if (!format_is_supported(in_format)) {
++        av_log(ctx, AV_LOG_ERROR, "Unsupported input format: %s\n",
++               av_get_pix_fmt_name(in_format));
++        return AVERROR(ENOSYS);
++    }
++    if (!format_is_supported(out_format)) {
++        av_log(ctx, AV_LOG_ERROR, "Unsupported output format: %s\n",
++               av_get_pix_fmt_name(out_format));
++        return AVERROR(ENOSYS);
++    }
++    if (in_desc->comp[0].depth != 10 && in_desc->comp[0].depth != 16) {
++        av_log(ctx, AV_LOG_ERROR, "Unsupported input format depth: %d\n",
++               in_desc->comp[0].depth);
++        return AVERROR(ENOSYS);
++    }
++
++    ctx->in_fmt     = in_format;
++    ctx->out_fmt    = out_format;
++    ctx->in_desc    = in_desc;
++    ctx->out_desc   = out_desc;
++    ctx->in_planes  = av_pix_fmt_count_planes(in_format);
++    ctx->out_planes = av_pix_fmt_count_planes(out_format);
++    ctx->ocf.output_format = out_format;
+ 
+-    s->ocf.output_format = s->format == AV_PIX_FMT_NONE ? AV_PIX_FMT_NV12 : s->format;
+     ret = ff_opencl_filter_config_output(outlink);
+     if (ret < 0)
+         return ret;
+@@ -310,13 +346,36 @@ static int launch_kernel(AVFilterContext
+     size_t global_work[2];
+     size_t local_work[2];
+     cl_int cle;
++    int idx_arg;
++
++    if (!output->data[0] || !input->data[0] || !output->data[1] || !input->data[1]) {
++        err = AVERROR(EIO);
++        goto fail;
++    }
++
++    if (ctx->out_planes > 2 && !output->data[2]) {
++        err = AVERROR(EIO);
++        goto fail;
++    }
++
++    if (ctx->in_planes > 2 && !input->data[2]) {
++        err = AVERROR(EIO);
++        goto fail;
++    }
+ 
+     CL_SET_KERNEL_ARG(kernel, 0, cl_mem, &output->data[0]);
      CL_SET_KERNEL_ARG(kernel, 1, cl_mem, &input->data[0]);
      CL_SET_KERNEL_ARG(kernel, 2, cl_mem, &output->data[1]);
      CL_SET_KERNEL_ARG(kernel, 3, cl_mem, &input->data[1]);
 -    CL_SET_KERNEL_ARG(kernel, 4, cl_mem, &ctx->util_mem);
 -    CL_SET_KERNEL_ARG(kernel, 5, cl_float, &peak);
-+    CL_SET_KERNEL_ARG(kernel, 4, cl_float, &peak);
++
++    idx_arg = 4;
++    if (ctx->out_planes > 2)
++        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &output->data[2]);
++
++    if (ctx->in_planes > 2)
++        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &input->data[2]);
++
++    CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_float, &peak);
  
      local_work[0]  = 16;
      local_work[1]  = 16;
-@@ -390,13 +378,15 @@ static int tonemap_opencl_filter_frame(A
+@@ -343,10 +402,6 @@ static int tonemap_opencl_filter_frame(A
+     AVFrame *output = NULL;
+     cl_int cle;
+     int err;
+-    double peak = ctx->peak;
+-
+-    AVHWFramesContext *input_frames_ctx =
+-        (AVHWFramesContext*)input->hw_frames_ctx->data;
+ 
+     av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
+            av_get_pix_fmt_name(input->format),
+@@ -365,8 +420,8 @@ static int tonemap_opencl_filter_frame(A
+     if (err < 0)
+         goto fail;
+ 
+-    if (!peak)
+-        peak = ff_determine_signal_peak(input);
++    if (!ctx->peak)
++        ctx->peak = ff_determine_signal_peak(input);
+ 
+     if (ctx->trc != -1)
+         output->color_trc = ctx->trc;
+@@ -390,13 +445,8 @@ static int tonemap_opencl_filter_frame(A
      if (!ctx->initialised) {
          if (!(input->color_trc == AVCOL_TRC_SMPTE2084 ||
              input->color_trc == AVCOL_TRC_ARIB_STD_B67)) {
 -            av_log(ctx, AV_LOG_ERROR, "unsupported transfer function characteristic.\n");
+-            err = AVERROR(ENOSYS);
+-            goto fail;
+-        }
+-
+-        if (input_frames_ctx->sw_format != AV_PIX_FMT_P010) {
+-            av_log(ctx, AV_LOG_ERROR, "unsupported format in tonemap_opencl.\n");
 +            av_log(ctx, AV_LOG_ERROR, "Unsupported transfer function characteristic: %s\n",
 +                   av_color_transfer_name(input->color_trc));
              err = AVERROR(ENOSYS);
              goto fail;
          }
- 
-         if (input_frames_ctx->sw_format != AV_PIX_FMT_P010) {
--            av_log(ctx, AV_LOG_ERROR, "unsupported format in tonemap_opencl.\n");
-+            av_log(ctx, AV_LOG_ERROR, "Unsupported input format: %s\n",
-+                   av_get_pix_fmt_name(input_frames_ctx->sw_format));
-             err = AVERROR(ENOSYS);
+@@ -406,15 +456,9 @@ static int tonemap_opencl_filter_frame(A
              goto fail;
-         }
-@@ -423,31 +413,9 @@ static int tonemap_opencl_filter_frame(A
+     }
+ 
+-    switch(input_frames_ctx->sw_format) {
+-    case AV_PIX_FMT_P010:
+-        err = launch_kernel(avctx, ctx->kernel, output, input, peak);
+-        if (err < 0) goto fail;
+-        break;
+-    default:
+-        err = AVERROR(ENOSYS);
++    err = launch_kernel(avctx, ctx->kernel, output, input, ctx->peak);
++    if (err < 0)
+         goto fail;
+-    }
+ 
+     cle = clFinish(ctx->command_queue);
+     CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to finish command queue: %d.\n", cle);
+@@ -423,31 +467,9 @@ static int tonemap_opencl_filter_frame(A
  
      ff_update_hdr_metadata(output, ctx->target_peak);
  
@@ -736,7 +988,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  
      return ff_filter_frame(outlink, output);
  
-@@ -463,8 +431,6 @@ static av_cold void tonemap_opencl_unini
+@@ -463,8 +485,6 @@ static av_cold void tonemap_opencl_unini
      TonemapOpenCLContext *ctx = avctx->priv;
      cl_int cle;
  
@@ -745,11 +997,73 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      if (ctx->kernel) {
          cle = clReleaseKernel(ctx->kernel);
          if (cle != CL_SUCCESS)
-@@ -493,6 +459,7 @@ static const AVOption tonemap_opencl_opt
-     {     "reinhard", 0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_REINHARD},          0, 0, FLAGS, "tonemap" },
-     {     "hable",    0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_HABLE},             0, 0, FLAGS, "tonemap" },
-     {     "mobius",   0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_MOBIUS},            0, 0, FLAGS, "tonemap" },
-+    {     "bt2390",   0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_BT2390},            0, 0, FLAGS, "tonemap" },
-     { "transfer", "set transfer characteristic", OFFSET(trc), AV_OPT_TYPE_INT, {.i64 = AVCOL_TRC_BT709}, -1, INT_MAX, FLAGS, "transfer" },
-     { "t",        "set transfer characteristic", OFFSET(trc), AV_OPT_TYPE_INT, {.i64 = AVCOL_TRC_BT709}, -1, INT_MAX, FLAGS, "transfer" },
-     {     "bt709",            0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_TRC_BT709},         0, 0, FLAGS, "transfer" },
+@@ -485,37 +505,38 @@ static av_cold void tonemap_opencl_unini
+ #define OFFSET(x) offsetof(TonemapOpenCLContext, x)
+ #define FLAGS (AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_VIDEO_PARAM)
+ static const AVOption tonemap_opencl_options[] = {
+-    { "tonemap",      "tonemap algorithm selection", OFFSET(tonemap), AV_OPT_TYPE_INT, {.i64 = TONEMAP_NONE}, TONEMAP_NONE, TONEMAP_MAX - 1, FLAGS, "tonemap" },
+-    {     "none",     0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_NONE},              0, 0, FLAGS, "tonemap" },
+-    {     "linear",   0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_LINEAR},            0, 0, FLAGS, "tonemap" },
+-    {     "gamma",    0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_GAMMA},             0, 0, FLAGS, "tonemap" },
+-    {     "clip",     0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_CLIP},              0, 0, FLAGS, "tonemap" },
+-    {     "reinhard", 0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_REINHARD},          0, 0, FLAGS, "tonemap" },
+-    {     "hable",    0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_HABLE},             0, 0, FLAGS, "tonemap" },
+-    {     "mobius",   0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_MOBIUS},            0, 0, FLAGS, "tonemap" },
+-    { "transfer", "set transfer characteristic", OFFSET(trc), AV_OPT_TYPE_INT, {.i64 = AVCOL_TRC_BT709}, -1, INT_MAX, FLAGS, "transfer" },
+-    { "t",        "set transfer characteristic", OFFSET(trc), AV_OPT_TYPE_INT, {.i64 = AVCOL_TRC_BT709}, -1, INT_MAX, FLAGS, "transfer" },
+-    {     "bt709",            0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_TRC_BT709},         0, 0, FLAGS, "transfer" },
+-    {     "bt2020",           0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_TRC_BT2020_10},     0, 0, FLAGS, "transfer" },
+-    { "matrix", "set colorspace matrix", OFFSET(colorspace), AV_OPT_TYPE_INT, {.i64 = -1}, -1, INT_MAX, FLAGS, "matrix" },
+-    { "m",      "set colorspace matrix", OFFSET(colorspace), AV_OPT_TYPE_INT, {.i64 = -1}, -1, INT_MAX, FLAGS, "matrix" },
+-    {     "bt709",            0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_SPC_BT709},         0, 0, FLAGS, "matrix" },
+-    {     "bt2020",           0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_SPC_BT2020_NCL},    0, 0, FLAGS, "matrix" },
+-    { "primaries", "set color primaries", OFFSET(primaries), AV_OPT_TYPE_INT, {.i64 = -1}, -1, INT_MAX, FLAGS, "primaries" },
+-    { "p",         "set color primaries", OFFSET(primaries), AV_OPT_TYPE_INT, {.i64 = -1}, -1, INT_MAX, FLAGS, "primaries" },
+-    {     "bt709",            0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_PRI_BT709},         0, 0, FLAGS, "primaries" },
+-    {     "bt2020",           0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_PRI_BT2020},        0, 0, FLAGS, "primaries" },
+-    { "range",         "set color range", OFFSET(range), AV_OPT_TYPE_INT, {.i64 = -1}, -1, INT_MAX, FLAGS, "range" },
+-    { "r",             "set color range", OFFSET(range), AV_OPT_TYPE_INT, {.i64 = -1}, -1, INT_MAX, FLAGS, "range" },
+-    {     "tv",            0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_RANGE_MPEG},         0, 0, FLAGS, "range" },
+-    {     "pc",            0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_RANGE_JPEG},         0, 0, FLAGS, "range" },
+-    {     "limited",       0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_RANGE_MPEG},         0, 0, FLAGS, "range" },
+-    {     "full",          0,       0,                 AV_OPT_TYPE_CONST, {.i64 = AVCOL_RANGE_JPEG},         0, 0, FLAGS, "range" },
+-    { "format",    "output pixel format", OFFSET(format), AV_OPT_TYPE_PIXEL_FMT, {.i64 = AV_PIX_FMT_NONE}, AV_PIX_FMT_NONE, INT_MAX, FLAGS, "fmt" },
+-    { "peak",      "signal peak override", OFFSET(peak), AV_OPT_TYPE_DOUBLE, {.dbl = 0}, 0, DBL_MAX, FLAGS },
+-    { "param",     "tonemap parameter",   OFFSET(param), AV_OPT_TYPE_DOUBLE, {.dbl = NAN}, DBL_MIN, DBL_MAX, FLAGS },
+-    { "desat",     "desaturation parameter",   OFFSET(desat_param), AV_OPT_TYPE_DOUBLE, {.dbl = 0.5}, 0, DBL_MAX, FLAGS },
+-    { "threshold", "scene detection threshold",   OFFSET(scene_threshold), AV_OPT_TYPE_DOUBLE, {.dbl = 0.2}, 0, DBL_MAX, FLAGS },
++    { "tonemap",      "Tonemap algorithm selection", OFFSET(tonemap), AV_OPT_TYPE_INT, { .i64 = TONEMAP_NONE }, TONEMAP_NONE, TONEMAP_MAX - 1, FLAGS, "tonemap" },
++        { "none",     0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_NONE },              0, 0, FLAGS, "tonemap" },
++        { "linear",   0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_LINEAR },            0, 0, FLAGS, "tonemap" },
++        { "gamma",    0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_GAMMA },             0, 0, FLAGS, "tonemap" },
++        { "clip",     0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_CLIP },              0, 0, FLAGS, "tonemap" },
++        { "reinhard", 0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_REINHARD },          0, 0, FLAGS, "tonemap" },
++        { "hable",    0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_HABLE },             0, 0, FLAGS, "tonemap" },
++        { "mobius",   0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_MOBIUS },            0, 0, FLAGS, "tonemap" },
++        { "bt2390",   0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_BT2390 },            0, 0, FLAGS, "tonemap" },
++    { "transfer", "Set transfer characteristic", OFFSET(trc), AV_OPT_TYPE_INT, { .i64 = AVCOL_TRC_BT709 }, -1, INT_MAX, FLAGS, "transfer" },
++    { "t",        "Set transfer characteristic", OFFSET(trc), AV_OPT_TYPE_INT, { .i64 = AVCOL_TRC_BT709 }, -1, INT_MAX, FLAGS, "transfer" },
++        { "bt709",            0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_TRC_BT709 },         0, 0, FLAGS, "transfer" },
++        { "bt2020",           0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_TRC_BT2020_10 },     0, 0, FLAGS, "transfer" },
++    { "matrix", "Set colorspace matrix", OFFSET(colorspace), AV_OPT_TYPE_INT, { .i64 = AVCOL_SPC_BT709 }, -1, INT_MAX, FLAGS, "matrix" },
++    { "m",      "Set colorspace matrix", OFFSET(colorspace), AV_OPT_TYPE_INT, { .i64 = AVCOL_SPC_BT709 }, -1, INT_MAX, FLAGS, "matrix" },
++        { "bt709",            0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_SPC_BT709 },         0, 0, FLAGS, "matrix" },
++        { "bt2020",           0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_SPC_BT2020_NCL },    0, 0, FLAGS, "matrix" },
++    { "primaries", "Set color primaries", OFFSET(primaries), AV_OPT_TYPE_INT, { .i64 = AVCOL_PRI_BT709 }, -1, INT_MAX, FLAGS, "primaries" },
++    { "p",         "Set color primaries", OFFSET(primaries), AV_OPT_TYPE_INT, { .i64 = AVCOL_PRI_BT709 }, -1, INT_MAX, FLAGS, "primaries" },
++        { "bt709",            0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_PRI_BT709 },         0, 0, FLAGS, "primaries" },
++        { "bt2020",           0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_PRI_BT2020 },        0, 0, FLAGS, "primaries" },
++    { "range",         "Set color range", OFFSET(range), AV_OPT_TYPE_INT, { .i64 = AVCOL_RANGE_MPEG }, -1, INT_MAX, FLAGS, "range" },
++    { "r",             "Set color range", OFFSET(range), AV_OPT_TYPE_INT, { .i64 = AVCOL_RANGE_MPEG }, -1, INT_MAX, FLAGS, "range" },
++        { "tv",            0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_RANGE_MPEG },         0, 0, FLAGS, "range" },
++        { "pc",            0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_RANGE_JPEG },         0, 0, FLAGS, "range" },
++        { "limited",       0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_RANGE_MPEG },         0, 0, FLAGS, "range" },
++        { "full",          0,       0,                 AV_OPT_TYPE_CONST, { .i64 = AVCOL_RANGE_JPEG },         0, 0, FLAGS, "range" },
++    { "format",    "Output pixel format", OFFSET(format), AV_OPT_TYPE_PIXEL_FMT, { .i64 = AV_PIX_FMT_NONE }, AV_PIX_FMT_NONE, INT_MAX, FLAGS, "fmt" },
++    { "peak",      "Signal peak override", OFFSET(peak), AV_OPT_TYPE_DOUBLE, { .dbl = 0 }, 0, DBL_MAX, FLAGS },
++    { "param",     "Tonemap parameter",   OFFSET(param), AV_OPT_TYPE_DOUBLE, { .dbl = NAN }, DBL_MIN, DBL_MAX, FLAGS },
++    { "desat",     "Desaturation parameter",   OFFSET(desat_param), AV_OPT_TYPE_DOUBLE, { .dbl = 0.5}, 0, DBL_MAX, FLAGS },
++    { "threshold", "Scene detection threshold",   OFFSET(scene_threshold), AV_OPT_TYPE_DOUBLE, { .dbl = 0.2 }, 0, DBL_MAX, FLAGS },
+     { NULL }
+ };
+ 

--- a/debian/patches/0010-fix-for-qsv-opencl-derivation-mapping.patch
+++ b/debian/patches/0010-fix-for-qsv-opencl-derivation-mapping.patch
@@ -1,0 +1,43 @@
+# Fix for QSV-OpenCL derivation/mapping
+# avutils/hwcontext_qsv: set the source device in qsv_device_create
+# hwdevice: workaround disalbe qsv->vaapi->qsv derivation test
+Index: jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_qsv.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+@@ -1269,7 +1269,13 @@ static int qsv_device_create(AVHWDeviceC
+ 
+     impl = choose_implementation(device);
+ 
+-    return qsv_device_derive_from_child(ctx, impl, child_device, 0);
++    ret = qsv_device_derive_from_child(ctx, impl, child_device, 0);
++    if (ret == 0) {
++        ctx->internal->source_device = av_buffer_ref(priv->child_device_ctx);
++        if (!ctx->internal->source_device)
++            ret = AVERROR(ENOMEM);
++    }
++    return ret;
+ }
+ 
+ const HWContextType ff_hwcontext_type_qsv = {
+Index: jellyfin-ffmpeg/libavutil/tests/hwdevice.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/tests/hwdevice.c
++++ jellyfin-ffmpeg/libavutil/tests/hwdevice.c
+@@ -73,10 +73,12 @@ static int test_derivation(AVBufferRef *
+         }
+ 
+         if (back_ref->data != src_ref->data) {
+-            fprintf(stderr, "Derivation %s to %s succeeded, but derivation "
+-                    "back again did not return the original device.\n",
+-                   src_name, derived_name);
+-            goto fail;
++            if (!(derived_type == AV_HWDEVICE_TYPE_VAAPI && src_dev->type == AV_HWDEVICE_TYPE_QSV)) {
++                fprintf(stderr, "Derivation %s to %s succeeded, but derivation "
++                        "back again did not return the original device.\n",
++                       src_name, derived_name);
++                goto fail;
++            }
+         }
+ 
+         fprintf(stderr, "Successfully tested derivation %s -> %s.\n",

--- a/debian/patches/0011-fix-for-frame-mapping-in-hwcontext_opencl.patch
+++ b/debian/patches/0011-fix-for-frame-mapping-in-hwcontext_opencl.patch
@@ -1,0 +1,32 @@
+Index: jellyfin-ffmpeg/libavutil/hwcontext_opencl.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_opencl.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_opencl.c
+@@ -2004,7 +2004,8 @@ static int opencl_map_frame(AVHWFramesCo
+             goto fail;
+         }
+ 
+-        dst->data[p] = map->address[p];
++        dst->data[p]     = map->address[p];
++        dst->linesize[p] = row_pitch;
+ 
+         av_log(hwfc, AV_LOG_DEBUG, "Map plane %d (%p -> %p).\n",
+                p, src->data[p], dst->data[p]);
+@@ -2329,7 +2330,7 @@ static void opencl_unmap_from_dxva2(AVHW
+ {
+     AVOpenCLFrameDescriptor    *desc = hwmap->priv;
+     OpenCLDeviceContext *device_priv = dst_fc->device_ctx->internal->priv;
+-    OpenCLFramesContext *frames_priv = dst_fc->device_ctx->internal->priv;
++    OpenCLFramesContext *frames_priv = dst_fc->internal->priv;
+     cl_event event;
+     cl_int cle;
+ 
+@@ -2493,7 +2494,7 @@ static void opencl_unmap_from_d3d11(AVHW
+ {
+     AVOpenCLFrameDescriptor    *desc = hwmap->priv;
+     OpenCLDeviceContext *device_priv = dst_fc->device_ctx->internal->priv;
+-    OpenCLFramesContext *frames_priv = dst_fc->device_ctx->internal->priv;
++    OpenCLFramesContext *frames_priv = dst_fc->internal->priv;
+     cl_event event;
+     cl_int cle;
+ 

--- a/debian/patches/0012-add-fixes-for-webvttenc-when-using-segement-muxer.patch
+++ b/debian/patches/0012-add-fixes-for-webvttenc-when-using-segement-muxer.patch
@@ -1,0 +1,36 @@
+# libavformat/webvttenc: Allow (but discard) additional streams
+
+# This allows having a video stream as reference stream  when using the segment muxer:
+
+# The video stream serves as a kind of 'heartbeat' to ensure that VTT segments are generated regularly, even when there aren't any subtitle packets for a while.
+
+# Example:
+# ffmpeg -i INPUT -map 0:3 -c:0 webvtt -map 0:0 -c:v:0 copy -f segment -segment_format webvtt -segment_time 6 -write_empty_segments 1 -y "sub_segment3%d.vtt"
+
+# Co-authored-by: SoftWorkz <softworkz@hotmail.com>
+
+Index: jellyfin-ffmpeg/libavformat/webvttenc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/webvttenc.c
++++ jellyfin-ffmpeg/libavformat/webvttenc.c
+@@ -49,8 +49,8 @@ static int webvtt_write_header(AVFormatC
+     AVCodecParameters *par = ctx->streams[0]->codecpar;
+     AVIOContext *pb = ctx->pb;
+ 
+-    if (ctx->nb_streams != 1 || par->codec_id != AV_CODEC_ID_WEBVTT) {
+-        av_log(ctx, AV_LOG_ERROR, "Exactly one WebVTT stream is needed.\n");
++    if (par->codec_id != AV_CODEC_ID_WEBVTT) {
++        av_log(ctx, AV_LOG_ERROR, "First stream must be WebVTT.\n");
+         return AVERROR(EINVAL);
+     }
+ 
+@@ -67,6 +67,9 @@ static int webvtt_write_packet(AVFormatC
+     buffer_size_t id_size, settings_size;
+     uint8_t *id, *settings;
+ 
++    if (pkt->stream_index != 0)
++        return 0;
++
+     avio_printf(pb, "\n");
+ 
+     id = av_packet_get_side_data(pkt, AV_PKT_DATA_WEBVTT_IDENTIFIER,

--- a/debian/patches/0013-add-opencl-scaler-and-format-converter-impl.patch
+++ b/debian/patches/0013-add-opencl-scaler-and-format-converter-impl.patch
@@ -1,0 +1,983 @@
+Index: jellyfin-ffmpeg/configure
+===================================================================
+--- jellyfin-ffmpeg.orig/configure
++++ jellyfin-ffmpeg/configure
+@@ -3621,6 +3621,7 @@ rubberband_filter_deps="librubberband"
+ sab_filter_deps="gpl swscale"
+ scale2ref_filter_deps="swscale"
+ scale_filter_deps="swscale"
++scale_opencl_filter_deps="opencl"
+ scale_qsv_filter_deps="libmfx"
+ scdet_filter_select="scene_sad"
+ select_filter_select="scene_sad"
+Index: jellyfin-ffmpeg/libavfilter/Makefile
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/Makefile
++++ jellyfin-ffmpeg/libavfilter/Makefile
+@@ -395,6 +395,7 @@ OBJS-$(CONFIG_SAB_FILTER)
+ OBJS-$(CONFIG_SCALE_FILTER)                  += vf_scale.o scale_eval.o
+ OBJS-$(CONFIG_SCALE_CUDA_FILTER)             += vf_scale_cuda.o vf_scale_cuda.ptx.o scale_eval.o
+ OBJS-$(CONFIG_SCALE_NPP_FILTER)              += vf_scale_npp.o scale_eval.o
++OBJS-$(CONFIG_SCALE_OPENCL_FILTER)           += vf_scale_opencl.o opencl.o opencl/scale.o scale_eval.o
+ OBJS-$(CONFIG_SCALE_QSV_FILTER)              += vf_scale_qsv.o
+ OBJS-$(CONFIG_SCALE_VAAPI_FILTER)            += vf_scale_vaapi.o scale_eval.o vaapi_vpp.o
+ OBJS-$(CONFIG_SCALE_VULKAN_FILTER)           += vf_scale_vulkan.o vulkan.o
+Index: jellyfin-ffmpeg/libavfilter/allfilters.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/allfilters.c
++++ jellyfin-ffmpeg/libavfilter/allfilters.c
+@@ -377,6 +377,7 @@ extern AVFilter ff_vf_sab;
+ extern AVFilter ff_vf_scale;
+ extern AVFilter ff_vf_scale_cuda;
+ extern AVFilter ff_vf_scale_npp;
++extern AVFilter ff_vf_scale_opencl;
+ extern AVFilter ff_vf_scale_qsv;
+ extern AVFilter ff_vf_scale_vaapi;
+ extern AVFilter ff_vf_scale_vulkan;
+Index: jellyfin-ffmpeg/libavfilter/opencl/scale.cl
+===================================================================
+--- /dev/null
++++ jellyfin-ffmpeg/libavfilter/opencl/scale.cl
+@@ -0,0 +1,216 @@
++/*
++ * Copyright (c) 2018 Gabriel Machado
++ * Copyright (c) 2021 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++__constant sampler_t sampler = (CLK_NORMALIZED_COORDS_FALSE |
++                                CLK_ADDRESS_CLAMP_TO_EDGE   |
++                                CLK_FILTER_NEAREST);
++
++__constant sampler_t sampler2 = (CLK_NORMALIZED_COORDS_FALSE |
++                                 CLK_ADDRESS_NONE            |
++                                 CLK_FILTER_NEAREST);
++
++__kernel void conv_yuv(__write_only image2d_t dst1,
++                       __read_only  image2d_t src1,
++                       __write_only image2d_t dst2,
++                       __read_only  image2d_t src2
++#ifdef NON_SEMI_PLANAR_OUT
++                      ,__write_only image2d_t dst3
++#endif
++#ifdef NON_SEMI_PLANAR_IN
++                      ,__read_only  image2d_t src3
++#endif
++                       )
++{
++    int xi = get_global_id(0);
++    int yi = get_global_id(1);
++    // each work item process four pixels
++    int x = 2 * xi;
++    int y = 2 * yi;
++
++    if (xi < get_image_width(dst2) && yi < get_image_height(dst2)) {
++        float y0 = read_imagef(src1, sampler, (int2)(x,     y)).x;
++        float y1 = read_imagef(src1, sampler, (int2)(x + 1, y)).x;
++        float y2 = read_imagef(src1, sampler, (int2)(x,     y + 1)).x;
++        float y3 = read_imagef(src1, sampler, (int2)(x + 1, y + 1)).x;
++#ifdef NON_SEMI_PLANAR_IN
++        float u = read_imagef(src2, sampler, (int2)(xi, yi)).x;
++        float v = read_imagef(src3, sampler, (int2)(xi, yi)).x;
++#else
++        float2 uv = read_imagef(src2, sampler, (int2)(xi, yi)).xy;
++        float u = uv.x;
++        float v = uv.y;
++#endif
++
++        write_imagef(dst1, (int2)(x,     y), (float4)(y0, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst1, (int2)(x + 1, y), (float4)(y1, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst1, (int2)(x,     y + 1), (float4)(y2, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst1, (int2)(x + 1, y + 1), (float4)(y3, 0.0f, 0.0f, 1.0f));
++#ifdef NON_SEMI_PLANAR_OUT
++        write_imagef(dst2, (int2)(xi, yi), (float4)(u, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst3, (int2)(xi, yi), (float4)(v, 0.0f, 0.0f, 1.0f));
++#else
++        write_imagef(dst2, (int2)(xi, yi), (float4)(u, v, 0.0f, 1.0f));
++#endif
++    }
++}
++
++__kernel void neighbor(__write_only image2d_t dst1,
++                       __read_only  image2d_t src1,
++                                    int2      src_size)
++{
++    int2 dst_pos = { get_global_id(0), get_global_id(1) };
++    float2 dst_size = { get_global_size(0), get_global_size(1) };
++
++    float2 src_coord = (convert_float2(dst_pos) + 0.5f) * convert_float2(src_size) / dst_size;
++    int2 src_pos = convert_int2(floor(src_coord - 0.5f));
++
++    if (src_pos.x < src_size.x && src_pos.y < src_size.y) {
++        float4 c = read_imagef(src1, sampler2, clamp(src_pos, 0, src_size - 1));
++        float y = c.x;
++        write_imagef(dst1, dst_pos, (float4)(y, 0.0f, 0.0f, 1.0f));
++    }
++}
++
++__kernel void neighbor_uv(__write_only image2d_t dst2,
++                          __read_only  image2d_t src2,
++#ifdef NON_SEMI_PLANAR_OUT
++                          __write_only image2d_t dst3,
++#endif
++#ifdef NON_SEMI_PLANAR_IN
++                          __read_only  image2d_t src3,
++#endif
++                                       int2      src_size)
++{
++    int2 dst_pos = { get_global_id(0), get_global_id(1) };
++    float2 dst_size = { get_global_size(0), get_global_size(1) };
++
++    float2 src_coord = (convert_float2(dst_pos) + 0.5f) * convert_float2(src_size) / dst_size;
++    int2 src_pos = convert_int2(floor(src_coord - 0.5f));
++
++    if (src_pos.x < src_size.x && src_pos.y < src_size.y) {
++#ifdef NON_SEMI_PLANAR_IN
++        float u = read_imagef(src2, sampler2, clamp(src_pos, 0, src_size - 1)).x;
++        float v = read_imagef(src3, sampler2, clamp(src_pos, 0, src_size - 1)).x;
++#else
++        float2 uv = read_imagef(src2, sampler2, clamp(src_pos, 0, src_size - 1)).xy;
++        float u = uv.x;
++        float v = uv.y;
++#endif
++
++#ifdef NON_SEMI_PLANAR_OUT
++        write_imagef(dst2, dst_pos, (float4)(u, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst3, dst_pos, (float4)(v, 0.0f, 0.0f, 1.0f));
++#else
++        write_imagef(dst2, dst_pos, (float4)(u, v, 0.0f, 1.0f));
++#endif
++    }
++}
++
++__kernel void scale(__write_only image2d_t dst1,
++                    __read_only  image2d_t src1,
++                    __constant   float    *cx,
++                    __constant   float    *cy,
++                                 int2      flt_size,
++                                 int2      src_size)
++{
++    int2 dst_pos = { get_global_id(0), get_global_id(1) };
++    float2 dst_size = { get_global_size(0), get_global_size(1) };
++
++    float2 src_coord = (convert_float2(dst_pos) + 0.5f) * convert_float2(src_size) / dst_size;
++    int2 src_pos = convert_int2(floor(src_coord - 0.5f));
++
++    if (src_pos.x < src_size.x && src_pos.y < src_size.y) {
++        int i, j;
++        float4 col1 = 0.0f, s1 = 0.0f;
++        for (i = 0; i < flt_size.y; ++i) {
++            s1 = 0.0f;
++            for (j = 0; j < flt_size.x; ++j) {
++                float4 c1 = read_imagef(src1, sampler2, clamp(src_pos + (int2)(flt_size.x / 2 - j, flt_size.y / 2 - i), 0, src_size - 1));
++                s1 += c1 * cx[dst_pos.x * flt_size.x + j];
++            }
++            col1 += s1 * cy[dst_pos.y * flt_size.y + i];
++        }
++        float y = col1.x;
++        write_imagef(dst1, dst_pos, (float4)(y, 0.0f, 0.0f, 1.0f));
++    }
++}
++
++__kernel void scale_uv(__write_only image2d_t dst2,
++                       __read_only  image2d_t src2,
++#ifdef NON_SEMI_PLANAR_OUT
++                       __write_only image2d_t dst3,
++#endif
++#ifdef NON_SEMI_PLANAR_IN
++                       __read_only  image2d_t src3,
++#endif
++                       __constant   float    *cx,
++                       __constant   float    *cy,
++                                    int2      flt_size,
++                                    int2      src_size)
++{
++    int2 dst_pos = { get_global_id(0), get_global_id(1) };
++    float2 dst_size = { get_global_size(0), get_global_size(1) };
++
++    float2 src_coord = (convert_float2(dst_pos) + 0.5f) * convert_float2(src_size) / dst_size;
++    int2 src_pos = convert_int2(floor(src_coord - 0.5f));
++
++    if (src_pos.x < src_size.x && src_pos.y < src_size.y) {
++        int i, j;
++        float4 col2 = 0.0f, s2 = 0.0f;
++#ifdef NON_SEMI_PLANAR_IN
++        float4 col3 = 0.0f, s3 = 0.0f;
++#endif
++        for (i = 0; i < flt_size.y; ++i) {
++            s2 = 0.0f;
++#ifdef NON_SEMI_PLANAR_IN
++            s3 = 0.0f;
++#endif
++            for (j = 0; j < flt_size.x; ++j) {
++                float4 c2 = read_imagef(src2, sampler2, clamp(src_pos + (int2)(flt_size.x / 2 - j, flt_size.y / 2 - i), 0, src_size - 1));
++                s2 += c2 * cx[dst_pos.x * flt_size.x + j];
++#ifdef NON_SEMI_PLANAR_IN
++                float4 c3 = read_imagef(src3, sampler2, clamp(src_pos + (int2)(flt_size.x / 2 - j, flt_size.y / 2 - i), 0, src_size - 1));
++                s3 += c3 * cx[dst_pos.x * flt_size.x + j];
++#endif
++            }
++            col2 += s2 * cy[dst_pos.y * flt_size.y + i];
++#ifdef NON_SEMI_PLANAR_IN
++            col3 += s3 * cy[dst_pos.y * flt_size.y + i];
++#endif
++        }
++
++#ifdef NON_SEMI_PLANAR_IN
++        float u = col2.x;
++        float v = col3.x;
++#else
++        float2 uv = col2.xy;
++        float u = uv.x;
++        float v = uv.y;
++#endif
++
++#ifdef NON_SEMI_PLANAR_OUT
++        write_imagef(dst2, dst_pos, (float4)(u, 0.0f, 0.0f, 1.0f));
++        write_imagef(dst3, dst_pos, (float4)(v, 0.0f, 0.0f, 1.0f));
++#else
++        write_imagef(dst2, dst_pos, (float4)(u, v, 0.0f, 1.0f));
++#endif
++    }
++}
+Index: jellyfin-ffmpeg/libavfilter/opencl_source.h
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/opencl_source.h
++++ jellyfin-ffmpeg/libavfilter/opencl_source.h
+@@ -27,6 +27,7 @@ extern const char *ff_opencl_source_desh
+ extern const char *ff_opencl_source_neighbor;
+ extern const char *ff_opencl_source_nlmeans;
+ extern const char *ff_opencl_source_overlay;
++extern const char *ff_opencl_source_scale;
+ extern const char *ff_opencl_source_pad;
+ extern const char *ff_opencl_source_tonemap;
+ extern const char *ff_opencl_source_transpose;
+Index: jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
+===================================================================
+--- /dev/null
++++ jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
+@@ -0,0 +1,709 @@
++/*
++ * Copyright (c) 2018 Gabriel Machado
++ * Copyright (c) 2021 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "libavutil/common.h"
++#include "libavutil/imgutils.h"
++#include "libavutil/mem.h"
++#include "libavutil/opt.h"
++#include "libavutil/pixdesc.h"
++
++#include "avfilter.h"
++#include "internal.h"
++#include "opencl.h"
++#include "opencl_source.h"
++#include "scale_eval.h"
++#include "video.h"
++
++#define OPENCL_SOURCE_NB 2
++
++static const enum AVPixelFormat supported_formats[] = {
++    AV_PIX_FMT_YUV420P,
++    AV_PIX_FMT_YUV420P16,
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_P016,
++};
++
++enum filters {
++    F_AREA,
++    F_BICUBIC,
++    F_BILINEAR,
++    F_GAUSSIAN,
++    F_LANCZOS,
++    F_NEIGHBOR,
++    F_SINC,
++    F_SPLINE,
++    F_EXPERIMENTAL
++};
++
++static const int filter_radius[] = {
++    [F_AREA]         =  1,
++    [F_BICUBIC]      =  2,
++    [F_BILINEAR]     =  1,
++    [F_GAUSSIAN]     =  4,
++    [F_LANCZOS]      =  3,
++    [F_NEIGHBOR]     = -1,
++    [F_SINC]         =  10,
++    [F_SPLINE]       =  10,
++    [F_EXPERIMENTAL] =  4
++};
++
++typedef struct ScaleOpenCLContext {
++    OpenCLFilterContext ocf;
++
++    cl_command_queue command_queue;
++    cl_mem           cx, cy;
++    cl_kernel        kernel;
++    cl_kernel        kernel_uv;
++    const char      *kernel_name;
++    const char      *kernel_name_uv;
++
++    char *w_expr,  *h_expr;
++    int   dst_w,    dst_h;
++    int   src_w,    src_h;
++    int   passthrough;
++    int   algorithm;
++    int   force_original_aspect_ratio;
++    int   force_divisible_by;
++    enum AVPixelFormat format;
++
++    enum AVPixelFormat in_fmt, out_fmt;
++    const AVPixFmtDescriptor *in_desc, *out_desc;
++    int in_planes, out_planes;
++
++    cl_int2   flt_size;
++    int       initialised;
++} ScaleOpenCLContext;
++
++static float netravali(float t, float B, float C)
++{
++    if (t > 2) {
++        return 0;
++    } else {
++        float tt  = t * t;
++        float ttt = t * tt;
++        if (t < 1) {
++            return ((12 -  9 * B - 6 * C) * ttt +
++                   (-18 + 12 * B + 6 * C) * tt  +
++                     (6 -  2 * B)) / 6;
++        } else {
++            return     ((-B -  6 * C) * ttt +
++                     (6 * B + 30 * C) * tt +
++                   (-12 * B - 48 * C) * t +
++                     (8 * B + 24 * C)) / 6;
++        }
++    }
++}
++
++static float sinc(float t)
++{
++    return (t == 0) ? 1.0 : sin(t * M_PI) / (t * M_PI);
++}
++
++static float lanczos(float t, float a)
++{
++    return (t < a) ? sinc(t) * sinc(t / a) : 0;
++}
++
++static double spline(double a, double b, double c, double d, double dist)
++{
++    if (dist <= 1.0)
++        return ((d * dist + c) * dist + b) * dist + a;
++    else
++        return spline(0.0,
++                      b + 2.0 * c + 3.0 * d,
++                      c + 3.0 * d,
++                      -b - 3.0 * c - 6.0 * d,
++                      dist - 1.0);
++}
++
++static float calc_weight(int algorithm, float ratio, float t)
++{
++    t = fabs(t);
++
++    switch (algorithm) {
++        case F_AREA: {
++            float t2 = t - 0.5;
++            if (t2 * ratio < -0.5)
++                return 1;
++            else if (t2 * ratio < 0.5)
++                return -t2 * ratio + 0.5;
++            else
++                return 0;
++        }
++
++        case F_BICUBIC: {
++            const float B = 0, C = 0.6;
++            return netravali(t, B, C);
++        }
++
++        case F_BILINEAR:
++            return t < 1 ? (1 - t) : 0;
++
++        case F_EXPERIMENTAL: {
++            double A = 1.0;
++            double c;
++
++            if (t < 1.0)
++                c = cos(t * M_PI);
++            else
++                c = -1.0;
++            if (c < 0.0)
++                c = -pow(-c, A);
++            else
++                c = pow(c, A);
++            return c * 0.5 + 0.5;
++        }
++
++        case F_GAUSSIAN: {
++            const float p = 3.0;
++            return exp2(-p * t * t);
++        }
++
++        case F_LANCZOS: {
++            return lanczos(t, filter_radius[algorithm]);
++        }
++
++        case F_NEIGHBOR:
++            return 1;
++
++        case F_SINC:
++            return sinc(t);
++
++        case F_SPLINE: {
++            const double p = -2.196152422706632;
++            return spline(1.0, 0.0, p, -p - 1.0, t);
++        }
++    }
++
++    return 0;
++}
++
++static int scale_opencl_init(AVFilterContext *avctx)
++{
++    ScaleOpenCLContext *ctx = avctx->priv;
++    AVBPrint header;
++    const char *opencl_sources[OPENCL_SOURCE_NB];
++    cl_int cle;
++    int i, j, err, filterw, filterh;
++    float scalex, scaley;
++    float *cx = NULL, *cy = NULL;
++
++    if (ctx->src_w == ctx->dst_w && ctx->src_h == ctx->dst_h) {
++        if (ctx->passthrough && ctx->in_fmt == ctx->out_fmt) {
++            ctx->initialised = 1;
++            return 0;
++        } else {
++            ctx->kernel_name = "conv_yuv";
++        }
++    } else if (ctx->algorithm == F_NEIGHBOR) {
++        ctx->kernel_name = "neighbor";
++        ctx->kernel_name_uv = "neighbor_uv";
++    } else {
++        ctx->kernel_name = "scale";
++        ctx->kernel_name_uv = "scale_uv";
++
++        scalex = FFMAX((float)(ctx->src_w / ctx->dst_w), 1);
++        scaley = FFMAX((float)(ctx->src_h / ctx->dst_h), 1);
++        filterw = ceil(2 * filter_radius[ctx->algorithm] * scalex);
++        filterh = ceil(2 * filter_radius[ctx->algorithm] * scaley);
++
++        filterw = FFMIN(filterw, ctx->src_w - 2);
++        filterw = FFMAX(filterw, 1);
++        filterh = FFMIN(filterh, ctx->src_h - 2);
++        filterh = FFMAX(filterh, 1);
++
++        ctx->flt_size.s[0] = filterw;
++        ctx->flt_size.s[1] = filterh;
++
++        av_log(avctx, AV_LOG_DEBUG, "filter size: %d %d.\n", filterw, filterh);
++
++        cx = av_malloc_array(ctx->dst_w * filterw, sizeof(cl_float));
++        cy = av_malloc_array(ctx->dst_h * filterh, sizeof(cl_float));
++
++        if (!cx || !cy) {
++            err = AVERROR(ENOMEM);
++            goto fail;
++        }
++
++        for (i = 0; i < ctx->dst_w; ++i) {
++            float s_x = (i + 0.5) * ctx->src_w / ctx->dst_w - 0.5;
++            float t = s_x - floor(s_x);  // fract
++
++            float sum = 0;
++            for (j = 0; j < filterw; ++j) {
++                int x = filterw / 2 - j;
++                sum += cx[i * filterw + j] = calc_weight(ctx->algorithm,
++                                                         scalex,
++                                                         (x - t) / scalex);
++            }
++
++            for (j = 0; j < filterw; ++j)
++                cx[i * filterw + j] /= sum;
++        }
++
++        for (i = 0; i < ctx->dst_h; ++i) {
++            float s_y = (i + 0.5) * ctx->src_h / ctx->dst_h - 0.5;
++            float t = s_y - floor(s_y);  // fract
++
++            float sum = 0;
++            for (j = 0; j < filterh; ++j) {
++                int y = filterh / 2 - j;
++                sum += cy[i * filterh + j] = calc_weight(ctx->algorithm,
++                                                         scaley,
++                                                         (y - t) / scaley);
++            }
++
++            for (j = 0; j < filterh; ++j)
++                cy[i * filterh + j] /= sum;
++        }
++
++        ctx->cx = clCreateBuffer(ctx->ocf.hwctx->context,
++                                 CL_MEM_READ_ONLY     |
++                                 CL_MEM_COPY_HOST_PTR |
++                                 CL_MEM_HOST_NO_ACCESS,
++                                 ctx->dst_w * filterw * sizeof(cl_float),
++                                 cx,
++                                 &cle);
++
++        ctx->cy = clCreateBuffer(ctx->ocf.hwctx->context,
++                                 CL_MEM_READ_ONLY     |
++                                 CL_MEM_COPY_HOST_PTR |
++                                 CL_MEM_HOST_NO_ACCESS,
++                                 ctx->dst_h * filterh * sizeof(cl_float),
++                                 cy,
++                                 &cle);
++        av_free(cx);
++        av_free(cy);
++        if (!ctx->cx || !ctx->cy) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to create weights buffer: %d.\n", cle);
++            err = AVERROR(EIO);
++            goto fail;
++        }
++    }
++
++    av_bprint_init(&header, 512, AV_BPRINT_SIZE_UNLIMITED);
++
++    if (ctx->in_planes > 2)
++        av_bprintf(&header, "#define NON_SEMI_PLANAR_IN\n");
++
++    if (ctx->out_planes > 2)
++        av_bprintf(&header, "#define NON_SEMI_PLANAR_OUT\n");
++
++    av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
++    opencl_sources[0] = header.str;
++    opencl_sources[1] = ff_opencl_source_scale;
++    err = ff_opencl_filter_load_program(avctx, opencl_sources, OPENCL_SOURCE_NB);
++
++    av_bprint_finalize(&header, NULL);
++    if (err < 0)
++        goto fail;
++
++    ctx->command_queue = clCreateCommandQueue(ctx->ocf.hwctx->context,
++                                              ctx->ocf.hwctx->device_id,
++                                              0, &cle);
++    if (!ctx->command_queue) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to create OpenCL command queue: %d.\n", cle);
++        err = AVERROR(EIO);
++        goto fail;
++    }
++
++    ctx->kernel = clCreateKernel(ctx->ocf.program, ctx->kernel_name, &cle);
++    if (!ctx->kernel) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to create kernel: %d.\n", cle);
++        err = AVERROR(EIO);
++        goto fail;
++    }
++
++    if (ctx->kernel_name_uv) {
++        ctx->kernel_uv = clCreateKernel(ctx->ocf.program, ctx->kernel_name_uv, &cle);
++        if (!ctx->kernel_uv) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to create kernel_uv: %d.\n", cle);
++            err = AVERROR(EIO);
++            goto fail;
++        }
++    }
++
++    ctx->initialised = 1;
++    return 0;
++
++fail:
++    av_bprint_finalize(&header, NULL);
++    if (ctx->command_queue)
++        clReleaseCommandQueue(ctx->command_queue);
++    if (ctx->kernel)
++        clReleaseKernel(ctx->kernel);
++    if (ctx->kernel_uv)
++        clReleaseKernel(ctx->kernel_uv);
++    if (ctx->cx)
++        clReleaseMemObject(ctx->cx);
++    if (ctx->cy)
++        clReleaseMemObject(ctx->cy);
++    if (cx)
++        av_free(cx);
++    if (cy)
++        av_free(cy);
++    return err;
++}
++
++static int format_is_supported(enum AVPixelFormat fmt)
++{
++    for (int i = 0; i < FF_ARRAY_ELEMS(supported_formats); i++)
++        if (supported_formats[i] == fmt)
++            return 1;
++    return 0;
++}
++
++static int scale_opencl_config_output(AVFilterLink *outlink)
++{
++    AVFilterContext  *avctx = outlink->src;
++    AVFilterLink    *inlink = avctx->inputs[0];
++    ScaleOpenCLContext *ctx = avctx->priv;
++    AVHWFramesContext *in_frames_ctx;
++    enum AVPixelFormat in_format;
++    enum AVPixelFormat out_format;
++    const AVPixFmtDescriptor *in_desc;
++    const AVPixFmtDescriptor *out_desc;
++    int ret;
++
++    if (!inlink->hw_frames_ctx)
++        return AVERROR(EINVAL);
++    in_frames_ctx = (AVHWFramesContext*)inlink->hw_frames_ctx->data;
++    in_format     = in_frames_ctx->sw_format;
++    out_format    = (ctx->format == AV_PIX_FMT_NONE) ? in_format : ctx->format;
++    in_desc       = av_pix_fmt_desc_get(in_format);
++    out_desc      = av_pix_fmt_desc_get(out_format);
++
++    if (!format_is_supported(in_format)) {
++        av_log(ctx, AV_LOG_ERROR, "Unsupported input format: %s\n",
++               av_get_pix_fmt_name(in_format));
++        return AVERROR(ENOSYS);
++    }
++    if (!format_is_supported(out_format)) {
++        av_log(ctx, AV_LOG_ERROR, "Unsupported output format: %s\n",
++               av_get_pix_fmt_name(out_format));
++        return AVERROR(ENOSYS);
++    }
++
++    ctx->in_fmt     = in_format;
++    ctx->out_fmt    = out_format;
++    ctx->in_desc    = in_desc;
++    ctx->out_desc   = out_desc;
++    ctx->in_planes  = av_pix_fmt_count_planes(ctx->in_fmt);
++    ctx->out_planes = av_pix_fmt_count_planes(ctx->out_fmt);
++    ctx->ocf.output_format = out_format;
++
++    if ((ret = ff_scale_eval_dimensions(ctx,
++                                        ctx->w_expr, ctx->h_expr,
++                                        inlink, outlink,
++                                        &ctx->dst_w, &ctx->dst_h)) < 0)
++        return ret;
++
++    ff_scale_adjust_dimensions(inlink, &ctx->dst_w, &ctx->dst_h,
++                               ctx->force_original_aspect_ratio, ctx->force_divisible_by);
++
++    if (((int64_t)(ctx->dst_h * inlink->w)) > INT_MAX  ||
++        ((int64_t)(ctx->dst_w * inlink->h)) > INT_MAX)
++        av_log(ctx, AV_LOG_ERROR, "Rescaled value for width or height is too big.\n");
++
++    ctx->src_w = inlink->w;
++    ctx->src_h = inlink->h;
++    ctx->ocf.output_width  = ctx->dst_w;
++    ctx->ocf.output_height = ctx->dst_h;
++
++    if (ctx->passthrough && ctx->src_w == ctx->dst_w && ctx->src_h == ctx->dst_h && ctx->in_fmt == ctx->out_fmt) {
++        av_buffer_unref(&outlink->hw_frames_ctx);
++        outlink->hw_frames_ctx = av_buffer_ref(inlink->hw_frames_ctx);
++        if (!outlink->hw_frames_ctx)
++            return AVERROR(ENOMEM);
++        return 0;
++    } else {
++        ctx->passthrough = 0;
++    }
++
++    ret = ff_opencl_filter_config_output(outlink);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static AVFrame *scale_opencl_get_video_buffer(AVFilterLink *inlink, int w, int h)
++{
++    ScaleOpenCLContext *ctx = inlink->dst->priv;
++
++    return ctx->passthrough ? ff_null_get_video_buffer(inlink, w, h) :
++                              ff_default_get_video_buffer(inlink, w, h);
++}
++
++static int scale_opencl_filter_frame(AVFilterLink *inlink, AVFrame *input)
++{
++    AVFilterContext     *avctx = inlink->dst;
++    AVFilterLink      *outlink = avctx->outputs[0];
++    ScaleOpenCLContext    *ctx = avctx->priv;
++    int x_subsample = 1 << ctx->in_desc->log2_chroma_w;
++    int y_subsample = 1 << ctx->in_desc->log2_chroma_h;
++    AVFrame *output = NULL;
++    size_t global_work[2];
++    cl_int cle;
++    cl_int2 src_size, uv_size;
++    int err, idx_arg1, idx_arg2;
++
++    av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
++           av_get_pix_fmt_name(input->format),
++           input->width, input->height, input->pts);
++
++    if (!input->hw_frames_ctx)
++        return AVERROR(EINVAL);
++
++    if (!ctx->initialised) {
++        err = scale_opencl_init(avctx);
++        if (err < 0)
++            goto fail;
++    }
++
++    if (ctx->passthrough && ctx->src_w == ctx->dst_w && ctx->src_h == ctx->dst_h && ctx->in_fmt == ctx->out_fmt)
++        return ff_filter_frame(outlink, input);
++
++    output = ff_get_video_buffer(outlink, outlink->w, outlink->h);
++    if (!output) {
++        err = AVERROR(ENOMEM);
++        goto fail;
++    }
++
++    err = av_frame_copy_props(output, input);
++    if (err < 0)
++        goto fail;
++    output->width  = outlink->w;
++    output->height = outlink->h;
++
++    if (!output->data[0] || !input->data[0] || !output->data[1] || !input->data[1]) {
++        err = AVERROR(EIO);
++        goto fail;
++    }
++
++    if (ctx->out_planes > 2 && !output->data[2]) {
++        err = AVERROR(EIO);
++        goto fail;
++    }
++
++    if (ctx->in_planes > 2 && !input->data[2]) {
++        err = AVERROR(EIO);
++        goto fail;
++    }
++
++    CL_SET_KERNEL_ARG(ctx->kernel, 0, cl_mem, &output->data[0]);
++    CL_SET_KERNEL_ARG(ctx->kernel, 1, cl_mem, &input->data[0]);
++
++    if (ctx->src_w == ctx->dst_w && ctx->src_h == ctx->dst_h) {
++        CL_SET_KERNEL_ARG(ctx->kernel, 2, cl_mem, &output->data[1]);
++        CL_SET_KERNEL_ARG(ctx->kernel, 3, cl_mem, &input->data[1]);
++
++        idx_arg1 = 4;
++        if (ctx->out_planes > 2)
++            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg1++, cl_mem, &output->data[2]);
++        if (ctx->in_planes > 2)
++            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg1++, cl_mem, &input->data[2]);
++
++        // conv_yuv
++        global_work[0] = output->width / x_subsample;
++        global_work[1] = output->height / y_subsample;
++
++        av_log(avctx, AV_LOG_DEBUG, "Run kernel %s "
++               "(%"SIZE_SPECIFIER"x%"SIZE_SPECIFIER").\n",
++               ctx->kernel_name, global_work[0], global_work[1]);
++
++        cle = clEnqueueNDRangeKernel(ctx->command_queue, ctx->kernel, 2, NULL,
++                                     global_work, NULL, 0, NULL, NULL);
++        CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to enqueue kernel: %d.\n", cle);
++    } else {
++        CL_SET_KERNEL_ARG(ctx->kernel_uv, 0, cl_mem, &output->data[1]);
++        CL_SET_KERNEL_ARG(ctx->kernel_uv, 1, cl_mem, &input->data[1]);
++
++        idx_arg1 = 2;
++        if (ctx->out_planes > 2)
++            CL_SET_KERNEL_ARG(ctx->kernel_uv, idx_arg1++, cl_mem, &output->data[2]);
++        if (ctx->in_planes > 2)
++            CL_SET_KERNEL_ARG(ctx->kernel_uv, idx_arg1++, cl_mem, &input->data[2]);
++
++        idx_arg2 = 2;
++        if (ctx->algorithm != F_NEIGHBOR) {
++            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg2++, cl_mem, &ctx->cx);
++            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg2++, cl_mem, &ctx->cy);
++            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg2++, cl_int2, &ctx->flt_size);
++
++            CL_SET_KERNEL_ARG(ctx->kernel_uv, idx_arg1++, cl_mem, &ctx->cx);
++            CL_SET_KERNEL_ARG(ctx->kernel_uv, idx_arg1++, cl_mem, &ctx->cy);
++            CL_SET_KERNEL_ARG(ctx->kernel_uv, idx_arg1++, cl_int2, &ctx->flt_size);
++        }
++
++        src_size.s[0] = ctx->src_w;
++        src_size.s[1] = ctx->src_h;
++        uv_size.s[0] = src_size.s[0] / x_subsample;
++        uv_size.s[1] = src_size.s[1] / y_subsample;
++        CL_SET_KERNEL_ARG(ctx->kernel, idx_arg2++, cl_int2, &src_size);
++        CL_SET_KERNEL_ARG(ctx->kernel_uv, idx_arg1++, cl_int2, &uv_size);
++
++        // scale, neighbor
++        global_work[0] = output->width;
++        global_work[1] = output->height;
++
++        av_log(avctx, AV_LOG_DEBUG, "Run kernel %s "
++               "(%"SIZE_SPECIFIER"x%"SIZE_SPECIFIER").\n",
++               ctx->kernel_name, global_work[0], global_work[1]);
++
++        cle = clEnqueueNDRangeKernel(ctx->command_queue, ctx->kernel, 2, NULL,
++                                     global_work, NULL, 0, NULL, NULL);
++        CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to enqueue kernel: %d.\n", cle);
++
++        // scale_uv, neighbor_uv
++        global_work[0] = output->width / x_subsample;
++        global_work[1] = output->height / y_subsample;
++
++        av_log(avctx, AV_LOG_DEBUG, "Run kernel %s "
++               "(%"SIZE_SPECIFIER"x%"SIZE_SPECIFIER").\n",
++               ctx->kernel_name_uv, global_work[0], global_work[1]);
++
++        cle = clEnqueueNDRangeKernel(ctx->command_queue, ctx->kernel_uv, 2, NULL,
++                                     global_work, NULL, 0, NULL, NULL);
++        CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to enqueue kernel: %d.\n", cle);
++    }
++
++    cle = clFinish(ctx->command_queue);
++    CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to finish command queue: %d.\n", cle);
++
++    av_frame_free(&input);
++
++    av_log(ctx, AV_LOG_DEBUG, "Filter output: %s, %ux%u (%"PRId64").\n",
++           av_get_pix_fmt_name(output->format),
++           output->width, output->height, output->pts);
++
++    return ff_filter_frame(outlink, output);
++
++fail:
++    clFinish(ctx->command_queue);
++    av_frame_free(&input);
++    av_frame_free(&output);
++    return err;
++}
++
++static av_cold void scale_opencl_uninit(AVFilterContext *avctx)
++{
++    ScaleOpenCLContext *ctx = avctx->priv;
++    cl_int cle;
++
++    if (ctx->kernel) {
++        cle = clReleaseKernel(ctx->kernel);
++        if (cle != CL_SUCCESS)
++            av_log(avctx, AV_LOG_ERROR, "Failed to release "
++                   "kernel: %d.\n", cle);
++    }
++
++    if (ctx->kernel_uv) {
++        cle = clReleaseKernel(ctx->kernel_uv);
++        if (cle != CL_SUCCESS)
++            av_log(avctx, AV_LOG_ERROR, "Failed to release "
++                   "kernel_uv: %d.\n", cle);
++    }
++
++    if (ctx->command_queue) {
++        cle = clReleaseCommandQueue(ctx->command_queue);
++        if (cle != CL_SUCCESS)
++            av_log(avctx, AV_LOG_ERROR, "Failed to release "
++                   "command queue: %d.\n", cle);
++    }
++
++    if (ctx->cx) {
++        cle = clReleaseMemObject(ctx->cx);
++        if (cle != CL_SUCCESS)
++            av_log(avctx, AV_LOG_ERROR, "Failed to release "
++            "weights buffer: %d.\n", cle);
++    }
++
++    if (ctx->cy) {
++        cle = clReleaseMemObject(ctx->cy);
++        if (cle != CL_SUCCESS)
++            av_log(avctx, AV_LOG_ERROR, "Failed to release "
++            "weights buffer: %d.\n", cle);
++    }
++
++    ff_opencl_filter_uninit(avctx);
++}
++
++#define OFFSET(x) offsetof(ScaleOpenCLContext, x)
++#define FLAGS (AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_VIDEO_PARAM)
++static const AVOption scale_opencl_options[] = {
++    { "w",           "Output video width",                               OFFSET(w_expr),      AV_OPT_TYPE_STRING,    { .str = "iw"            }, .flags = FLAGS },
++    { "h",           "Output video height",                              OFFSET(h_expr),      AV_OPT_TYPE_STRING,    { .str = "ih"            }, .flags = FLAGS },
++    { "format",      "Output pixel format",                              OFFSET(format),      AV_OPT_TYPE_PIXEL_FMT, { .i64 = AV_PIX_FMT_NONE }, AV_PIX_FMT_NONE, INT_MAX, FLAGS, "fmt" },
++    { "passthrough", "Do not process frames at all if parameters match", OFFSET(passthrough), AV_OPT_TYPE_BOOL,      { .i64 = 1               }, 0, 1, FLAGS },
++    { "algo",        "Scaling algorithm",                                OFFSET(algorithm),   AV_OPT_TYPE_INT,       { .i64 = F_BILINEAR      }, INT_MIN, INT_MAX, FLAGS, "algo" },
++        { "area",         "Area averaging",   0, AV_OPT_TYPE_CONST, { .i64 = F_AREA         }, 0, 0, FLAGS, "algo" },
++        { "bicubic",      "Bicubic",          0, AV_OPT_TYPE_CONST, { .i64 = F_BICUBIC      }, 0, 0, FLAGS, "algo" },
++        { "bilinear",     "Bilinear",         0, AV_OPT_TYPE_CONST, { .i64 = F_BILINEAR     }, 0, 0, FLAGS, "algo" },
++        { "gauss",        "Gaussian",         0, AV_OPT_TYPE_CONST, { .i64 = F_GAUSSIAN     }, 0, 0, FLAGS, "algo" },
++        { "lanczos",      "Lanczos",          0, AV_OPT_TYPE_CONST, { .i64 = F_LANCZOS      }, 0, 0, FLAGS, "algo" },
++        { "neighbor",     "Nearest Neighbor", 0, AV_OPT_TYPE_CONST, { .i64 = F_NEIGHBOR     }, 0, 0, FLAGS, "algo" },
++        { "sinc",         "Sinc",             0, AV_OPT_TYPE_CONST, { .i64 = F_SINC         }, 0, 0, FLAGS, "algo" },
++        { "spline",       "Bicubic Spline",   0, AV_OPT_TYPE_CONST, { .i64 = F_SPLINE       }, 0, 0, FLAGS, "algo" },
++        { "experimental", "Experimental",     0, AV_OPT_TYPE_CONST, { .i64 = F_EXPERIMENTAL }, 0, 0, FLAGS, "algo" },
++    { "force_original_aspect_ratio", "Decrease or increase w/h if necessary to keep the original AR", OFFSET(force_original_aspect_ratio), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 2, FLAGS, "force_oar" },
++        { "disable",       NULL,              0, AV_OPT_TYPE_CONST, {.i64 = 0 }, 0, 0, FLAGS, "force_oar" },
++        { "decrease",      NULL,              0, AV_OPT_TYPE_CONST, {.i64 = 1 }, 0, 0, FLAGS, "force_oar" },
++        { "increase",      NULL,              0, AV_OPT_TYPE_CONST, {.i64 = 2 }, 0, 0, FLAGS, "force_oar" },
++    { "force_divisible_by", "Enforce that the output resolution is divisible by a defined integer when force_original_aspect_ratio is used", OFFSET(force_divisible_by), AV_OPT_TYPE_INT, { .i64 = 1 }, 1, 256, FLAGS },
++    { NULL }
++};
++
++AVFILTER_DEFINE_CLASS(scale_opencl);
++
++static const AVFilterPad scale_opencl_inputs[] = {
++    {
++        .name             = "default",
++        .type             = AVMEDIA_TYPE_VIDEO,
++        .filter_frame     = &scale_opencl_filter_frame,
++        .get_video_buffer = &scale_opencl_get_video_buffer,
++        .config_props     = &ff_opencl_filter_config_input,
++    },
++    { NULL }
++};
++
++static const AVFilterPad scale_opencl_outputs[] = {
++    {
++        .name         = "default",
++        .type         = AVMEDIA_TYPE_VIDEO,
++        .config_props = &scale_opencl_config_output,
++    },
++    { NULL }
++};
++
++AVFilter ff_vf_scale_opencl = {
++    .name           = "scale_opencl",
++    .description    = NULL_IF_CONFIG_SMALL("Scale the input video size through OpenCL."),
++    .priv_size      = sizeof(ScaleOpenCLContext),
++    .priv_class     = &scale_opencl_class,
++    .init           = &ff_opencl_filter_init,
++    .uninit         = &scale_opencl_uninit,
++    .query_formats  = &ff_opencl_filter_query_formats,
++    .inputs         = scale_opencl_inputs,
++    .outputs        = scale_opencl_outputs,
++    .flags_internal = FF_FILTER_FLAG_HWFRAME_AWARE,
++};

--- a/debian/patches/0014-add-transfer-lut-for-opencl-tonemap.patch
+++ b/debian/patches/0014-add-transfer-lut-for-opencl-tonemap.patch
@@ -1,0 +1,556 @@
+Index: jellyfin-ffmpeg/libavfilter/opencl/colorspace_common.cl
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/opencl/colorspace_common.cl
++++ jellyfin-ffmpeg/libavfilter/opencl/colorspace_common.cl
+@@ -62,58 +62,52 @@ float3 get_chroma_sample(float3 a, float
+ 
+ // linearizer for PQ/ST2084
+ float eotf_st2084(float x) {
+-    if (x > 0.0f) {
+-        float xpow = powr(x, 1.0f / ST2084_M2);
+-        float num = max(xpow - ST2084_C1, 0.0f);
+-        float den = max(ST2084_C2 - ST2084_C3 * xpow, FLOAT_EPS);
+-        x = powr(num / den, 1.0f / ST2084_M1);
+-        return x * ST2084_MAX_LUMINANCE / REFERENCE_WHITE;
+-    } else {
+-        return 0.0f;
+-    }
++    x = max(x, 0.0f);
++    float xpow = native_powr(x, 1.0f / ST2084_M2);
++    float num = max(xpow - ST2084_C1, 0.0f);
++    float den = max(ST2084_C2 - ST2084_C3 * xpow, FLOAT_EPS);
++    x = native_powr(num / den, 1.0f / ST2084_M1);
++    return x * ST2084_MAX_LUMINANCE / REFERENCE_WHITE;
+ }
+ 
+ // delinearizer for PQ/ST2084
+ float inverse_eotf_st2084(float x) {
+-    if (x > 0.0f) {
+-        x *= REFERENCE_WHITE / ST2084_MAX_LUMINANCE;
+-        float xpow = powr(x, ST2084_M1);
++    x = max(x, 0.0f);
++    x *= REFERENCE_WHITE / ST2084_MAX_LUMINANCE;
++    float xpow = native_powr(x, ST2084_M1);
+ #if 0
+-        // Original formulation from SMPTE ST 2084:2014 publication.
+-        float num = ST2084_C1 + ST2084_C2 * xpow;
+-        float den = 1.0f + ST2084_C3 * xpow;
+-        return powr(num / den, ST2084_M2);
++    // Original formulation from SMPTE ST 2084:2014 publication.
++    float num = ST2084_C1 + ST2084_C2 * xpow;
++    float den = 1.0f + ST2084_C3 * xpow;
++    return native_powr(num / den, ST2084_M2);
+ #else
+-        // More stable arrangement that avoids some cancellation error.
+-        float num = (ST2084_C1 - 1.0f) + (ST2084_C2 - ST2084_C3) * xpow;
+-        float den = 1.0f + ST2084_C3 * xpow;
+-        return powr(1.0f + num / den, ST2084_M2);
++    // More stable arrangement that avoids some cancellation error.
++    float num = (ST2084_C1 - 1.0f) + (ST2084_C2 - ST2084_C3) * xpow;
++    float den = 1.0f + ST2084_C3 * xpow;
++    return native_powr(1.0f + num / den, ST2084_M2);
+ #endif
+-    } else {
+-        return 0.0f;
+-    }
+ }
+ 
+ float ootf_1_2(float x) {
+-    return x < 0.0f ? x : powr(x, 1.2f);
++    return x < 0.0f ? x : native_powr(x, 1.2f);
+ }
+ 
+ float inverse_ootf_1_2(float x) {
+-    return x < 0.0f ? x : powr(x, 1.0f / 1.2f);
++    return x < 0.0f ? x : native_powr(x, 1.0f / 1.2f);
+ }
+ 
+ float oetf_arib_b67(float x) {
+     x = max(x, 0.0f);
+     return x <= (1.0f / 12.0f)
+-           ? sqrt(3.0f * x)
+-           : (ARIB_B67_A * log(12.0f * x - ARIB_B67_B) + ARIB_B67_C);
++           ? native_sqrt(3.0f * x)
++           : (ARIB_B67_A * native_log(12.0f * x - ARIB_B67_B) + ARIB_B67_C);
+ }
+ 
+ float inverse_oetf_arib_b67(float x) {
+     x = max(x, 0.0f);
+     return x <= 0.5f
+            ? (x * x) * (1.0f / 3.0f)
+-           : (exp((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) * (1.0f / 12.0f);
++           : (native_exp((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) * (1.0f / 12.0f);
+ }
+ 
+ // linearizer for HLG/ARIB-B67
+@@ -126,21 +120,52 @@ float inverse_eotf_arib_b67(float x) {
+     return oetf_arib_b67(inverse_ootf_1_2(x));
+ }
+ 
++// delinearizer for BT709, BT2020-10
+ float inverse_eotf_bt1886(float x) {
+-    return x < 0.0f ? 0.0f : powr(x, 1.0f / 2.4f);
++    return x < 0.0f ? 0.0f : native_powr(x, 1.0f / 2.4f);
+ }
+ 
+ float oetf_bt709(float x) {
+-    x = max(0.0f, x);
++    x = max(x, 0.0f);
+     return x < BT709_BETA
+            ? (x * 4.5f)
+-           : (BT709_ALPHA * powr(x, 0.45f) - (BT709_ALPHA - 1.0f));
++           : (BT709_ALPHA * native_powr(x, 0.45f) - (BT709_ALPHA - 1.0f));
+ }
+ 
+ float inverse_oetf_bt709(float x) {
+     return x < (4.5f * BT709_BETA)
+            ? (x / 4.5f)
+-           : (powr((x + (BT709_ALPHA - 1.0f)) / BT709_ALPHA, 1.0f / 0.45f));
++           : (native_powr((x + (BT709_ALPHA - 1.0f)) / BT709_ALPHA, 1.0f / 0.45f));
++}
++
++#ifdef TRC_LUT
++float linearize_lut(float x) {
++    return lin_lut[clamp(convert_int(x * 1023.0f), 0, 1024)];
++}
++
++float delinearize_lut(float x) {
++    return delin_lut[clamp(convert_int(x * 1023.0f), 0, 1024)];
++}
++#endif
++
++float linearize_pq(float x) {
++#ifdef TRC_LUT_PQ
++    return pqlin_lut[clamp(convert_int(x * 1023.0f), 0, 1024)];
++#elif defined(TRC_LUT)
++    return linearize_lut(x);
++#else
++    return eotf_st2084(x);
++#endif
++}
++
++float delinearize_pq(float x) {
++#ifdef TRC_LUT_PQ
++    return pqdelin_lut[clamp(convert_int(x * 1023.0f), 0, 1024)];
++#elif defined(TRC_LUT)
++    return delinearize_lut(x);
++#else
++    return inverse_eotf_st2084(x);
++#endif
+ }
+ 
+ float3 yuv2rgb(float y, float u, float v) {
+Index: jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/opencl/tonemap.cl
++++ jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
+@@ -22,12 +22,19 @@ extern float3 lrgb2yuv(float3);
+ extern float  lrgb2y(float3);
+ extern float3 yuv2lrgb(float3);
+ extern float3 lrgb2lrgb(float3);
++extern float  linearize_pq(float);
++extern float  delinearize_pq(float);
++extern float  inverse_eotf_st2084(float);
+ extern float  get_luma_src(float3);
+ extern float  get_luma_dst(float3);
+-extern float  eotf_st2084(float);
+-extern float  inverse_eotf_st2084(float);
+ extern float3 get_chroma_sample(float3, float3, float3, float3);
+ 
++#ifdef TONEMAP_LUT
++float tonemapping_lut(float x) {
++    return tonemap_lut[clamp(convert_int(x * 1023.0f), 0, 1024)];
++}
++#endif
++
+ float hable_f(float in) {
+     float a = 0.15f, b = 0.50f, c = 0.10f, d = 0.20f, e = 0.02f, f = 0.30f;
+     return (in * (in * a + b * c) + d * e) / (in * (in * a + b) + d * f) - e / f;
+@@ -43,7 +50,7 @@ float linear(float s, float peak, float
+ 
+ float gamma(float s, float peak, float target_peak) {
+     float p = s > 0.05f ? s / peak : 0.05f / peak;
+-    float v = powr(p, 1.0f / tone_param);
++    float v = native_powr(p, 1.0f / tone_param);
+     return s > 0.05f ? v : (s * v / 0.05f);
+ }
+ 
+@@ -74,21 +81,23 @@ float mobius(float s, float peak, float
+ 
+ float bt2390(float s, float peak, float target_peak) {
+     float peak_pq = inverse_eotf_st2084(peak);
+-    float scale = 1.0f / peak_pq;
+-
+-    float s_pq = inverse_eotf_st2084(s) * scale;
+-    float maxLum = inverse_eotf_st2084(target_peak) * scale;
++    float s_pq = peak_pq > 0.0f
++                 ? (inverse_eotf_st2084(s) / peak_pq)
++                 : inverse_eotf_st2084(s);
++    float max_lum = peak_pq > 0.0f
++                    ? (inverse_eotf_st2084(target_peak) / peak_pq)
++                    : inverse_eotf_st2084(target_peak);
+ 
+-    float ks = 1.5f * maxLum - 0.5f;
++    float ks = 1.5f * max_lum - 0.5f;
+     float tb = (s_pq - ks) / (1.0f - ks);
+     float tb2 = tb * tb;
+     float tb3 = tb2 * tb;
+     float pb = (2.0f * tb3 - 3.0f * tb2 + 1.0f) * ks +
+                (tb3 - 2.0f * tb2 + tb) * (1.0f - ks) +
+-               (-2.0f * tb3 + 3.0f * tb2) * maxLum;
+-    float sig = (s_pq < ks) ? s_pq : pb;
++               (-2.0f * tb3 + 3.0f * tb2) * max_lum;
++    float sig = mix(pb, s_pq, s_pq < ks);
+ 
+-    return eotf_st2084(sig * peak_pq);
++    return linearize_pq(sig * peak_pq);
+ }
+ 
+ float3 map_one_pixel_rgb(float3 rgb, float peak) {
+@@ -108,19 +117,19 @@ float3 map_one_pixel_rgb(float3 rgb, flo
+     if (desat_param > 0.0f) {
+         float luma = get_luma_dst(rgb);
+         float coeff = max(sig - 0.18f, FLOAT_EPS) / max(sig, FLOAT_EPS);
+-        coeff = powr(coeff, 10.0f / desat_param);
++        coeff = native_powr(coeff, 10.0f / desat_param);
+         rgb = mix(rgb, (float3)luma, (float3)coeff);
+     }
+ 
+     sig = TONE_FUNC(sig, peak, target_peak);
+-
+     sig = min(sig, 1.0f);
+     rgb *= (sig / sig_old);
++
+     return rgb;
+ }
+ 
+ // Map from source space YUV to destination space RGB
+-float3 map_to_dst_space_from_yuv(float3 yuv, float peak) {
++float3 map_to_dst_space_from_yuv(float3 yuv) {
+     float3 c = yuv2lrgb(yuv);
+     c = lrgb2lrgb(c);
+     return c;
+@@ -162,16 +171,10 @@ __kernel void tonemap(__write_only image
+         float2 uv = read_imagef(src2, sampler, (int2)(xi, yi)).xy;
+ #endif
+ 
+-        float3 c0 = map_to_dst_space_from_yuv((float3)(y0, uv.x, uv.y), peak);
+-        float3 c1 = map_to_dst_space_from_yuv((float3)(y1, uv.x, uv.y), peak);
+-        float3 c2 = map_to_dst_space_from_yuv((float3)(y2, uv.x, uv.y), peak);
+-        float3 c3 = map_to_dst_space_from_yuv((float3)(y3, uv.x, uv.y), peak);
+-
+-        float sig0 = max(c0.x, max(c0.y, c0.z));
+-        float sig1 = max(c1.x, max(c1.y, c1.z));
+-        float sig2 = max(c2.x, max(c2.y, c2.z));
+-        float sig3 = max(c3.x, max(c3.y, c3.z));
+-        float sig = max(sig0, max(sig1, max(sig2, sig3)));
++        float3 c0 = map_to_dst_space_from_yuv((float3)(y0, uv.x, uv.y));
++        float3 c1 = map_to_dst_space_from_yuv((float3)(y1, uv.x, uv.y));
++        float3 c2 = map_to_dst_space_from_yuv((float3)(y2, uv.x, uv.y));
++        float3 c3 = map_to_dst_space_from_yuv((float3)(y3, uv.x, uv.y));
+ 
+         c0 = map_one_pixel_rgb(c0, peak);
+         c1 = map_one_pixel_rgb(c1, peak);
+Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/vf_tonemap_opencl.c
++++ jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
+@@ -34,6 +34,22 @@
+ 
+ #define OPENCL_SOURCE_NB 3
+ 
++#define FLOAT_EPS 1.175494351e-38f
++
++#undef REFERENCE_WHITE
++#define REFERENCE_WHITE 203.0f
++#define ST2084_MAX_LUMINANCE 10000.0f
++
++#define ST2084_M1 0.1593017578125f
++#define ST2084_M2 78.84375f
++#define ST2084_C1 0.8359375f
++#define ST2084_C2 18.8515625f
++#define ST2084_C3 18.6875f
++
++#define ARIB_B67_A 0.17883277f
++#define ARIB_B67_B 0.28466892f
++#define ARIB_B67_C 0.55991073f
++
+ static const enum AVPixelFormat supported_formats[] = {
+     AV_PIX_FMT_YUV420P,
+     AV_PIX_FMT_YUV420P16,
+@@ -66,6 +82,9 @@ typedef struct TonemapOpenCLContext {
+     const AVPixFmtDescriptor *in_desc, *out_desc;
+     int in_planes, out_planes;
+ 
++    float *lin_lut, *delin_lut;
++    float *pqlin_lut, *pqdelin_lut;
++
+     enum TonemapAlgorithm tonemap;
+     enum AVPixelFormat    format;
+     double                peak;
+@@ -73,6 +92,7 @@ typedef struct TonemapOpenCLContext {
+     double                desat_param;
+     double                target_peak;
+     double                scene_threshold;
++    int                   lut_trc;
+     int                   initialised;
+     cl_kernel             kernel;
+     cl_command_queue      command_queue;
+@@ -109,6 +129,158 @@ static const char *const tonemap_func[TO
+     [TONEMAP_BT2390]   = "bt2390",
+ };
+ 
++// linearizer for PQ/ST2084
++static float eotf_st2084(float x)
++{
++    x = FFMAX(x, 0.0f);
++    float xpow = powf(x, 1.0f / ST2084_M2);
++    float num = FFMAX(xpow - ST2084_C1, 0.0f);
++    float den = FFMAX(ST2084_C2 - ST2084_C3 * xpow, FLOAT_EPS);
++    x = powf(num / den, 1.0f / ST2084_M1);
++    return x * ST2084_MAX_LUMINANCE / REFERENCE_WHITE;
++}
++
++// delinearizer for PQ/ST2084
++static float inverse_eotf_st2084(float x)
++{
++    x = FFMAX(x, 0.0f);
++    x *= REFERENCE_WHITE / ST2084_MAX_LUMINANCE;
++    float xpow = powf(x, ST2084_M1);
++#if 0
++    // Original formulation from SMPTE ST 2084:2014 publication.
++    float num = ST2084_C1 + ST2084_C2 * xpow;
++    float den = 1.0f + ST2084_C3 * xpow;
++    return powf(num / den, ST2084_M2);
++#else
++    // More stable arrangement that avoids some cancellation error.
++    float num = (ST2084_C1 - 1.0f) + (ST2084_C2 - ST2084_C3) * xpow;
++    float den = 1.0f + ST2084_C3 * xpow;
++    return powf(1.0f + num / den, ST2084_M2);
++#endif
++}
++
++static float ootf_1_2(float x) {
++    return x > 0.0f ? powf(x, 1.2f) : x;
++}
++
++static float inverse_ootf_1_2(float x) {
++    return x > 0.0f ? powf(x, 1.0f / 1.2f) : x;
++}
++
++static float oetf_arib_b67(float x) {
++    x = FFMAX(x, 0.0f);
++    return x <= (1.0f / 12.0f)
++           ? sqrtf(3.0f * x)
++           : (ARIB_B67_A * logf(12.0f * x - ARIB_B67_B) + ARIB_B67_C);
++}
++
++static float inverse_oetf_arib_b67(float x) {
++    x = FFMAX(x, 0.0f);
++    return x <= 0.5f
++           ? (x * x) * (1.0f / 3.0f)
++           : (expf((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) * (1.0f / 12.0f);
++}
++
++// linearizer for HLG/ARIB-B67
++static float eotf_arib_b67(float x) {
++    return ootf_1_2(inverse_oetf_arib_b67(x));
++}
++
++// delinearizer for HLG/ARIB-B67
++static float inverse_eotf_arib_b67(float x) {
++    return oetf_arib_b67(inverse_ootf_1_2(x));
++}
++
++// delinearizer for BT709, BT2020-10
++static float inverse_eotf_bt1886(float x) {
++    return x < 0.0f ? 0.0f : powf(x, 1.0f / 2.4f);
++}
++
++static float linearize(float x, enum AVColorTransferCharacteristic trc_in)
++{
++    if (trc_in == AVCOL_TRC_SMPTE2084)
++        return eotf_st2084(x);
++    else if (trc_in == AVCOL_TRC_ARIB_STD_B67)
++        return eotf_arib_b67(x);
++    else
++        return x;
++}
++
++static float delinearize(float x, enum AVColorTransferCharacteristic trc_out)
++{
++    if (trc_out == AVCOL_TRC_BT709 || trc_out == AVCOL_TRC_BT2020_10)
++        return inverse_eotf_bt1886(x);
++    if (trc_out == AVCOL_TRC_SMPTE2084)
++        return inverse_eotf_st2084(x);
++    else
++        return x;
++}
++
++static int compute_trc_luts(AVFilterContext *avctx)
++{
++    TonemapOpenCLContext *ctx = avctx->priv;
++    int lut_pq = ctx->tonemap == TONEMAP_BT2390 && ctx->trc_in != AVCOL_TRC_SMPTE2084;
++    int i;
++
++    if (!ctx->lin_lut && !(ctx->lin_lut = av_calloc(1024, sizeof(float))))
++        return AVERROR(ENOMEM);
++    if (!ctx->delin_lut && !(ctx->delin_lut = av_calloc(1024, sizeof(float))))
++        return AVERROR(ENOMEM);
++    if (lut_pq) {
++        if (!ctx->pqlin_lut && !(ctx->pqlin_lut = av_calloc(1024, sizeof(float))))
++            return AVERROR(ENOMEM);
++        if (!ctx->pqdelin_lut && !(ctx->pqdelin_lut = av_calloc(1024, sizeof(float))))
++            return AVERROR(ENOMEM);
++    }
++
++    for (i = 0; i < 1024; i++) {
++        float x = i / 1023.0f;
++        ctx->lin_lut[i] = FFMAX(linearize(x, ctx->trc_in), 0.0f);
++        ctx->delin_lut[i] = FFMAX(delinearize(x, ctx->trc_out), 0.0f);
++        if (lut_pq) {
++            ctx->pqlin_lut[i] = FFMAX(linearize(x, AVCOL_TRC_SMPTE2084), 0.0f);
++            ctx->pqdelin_lut[i] = FFMAX(delinearize(x, AVCOL_TRC_SMPTE2084), 0.0f);
++        }
++    }
++
++    return 0;
++}
++
++static void print_opencl_const_trc_luts(AVFilterContext *avctx, AVBPrint *buf)
++{
++    TonemapOpenCLContext *ctx = avctx->priv;
++    int i;
++
++    if (ctx->lin_lut) {
++        av_bprintf(buf, "__constant float lin_lut[1024] = {\n");
++        for (i = 0; i < 1024; i++) {
++            av_bprintf(buf, " %.5ff,", ctx->lin_lut[i]);
++        }
++        av_bprintf(buf, "};\n");
++    }
++    if (ctx->delin_lut) {
++        av_bprintf(buf, "__constant float delin_lut[1024] = {\n");
++        for (i = 0; i < 1024; i++) {
++            av_bprintf(buf, " %.5ff,", ctx->delin_lut[i]);
++        }
++        av_bprintf(buf, "};\n");
++    }
++    if (ctx->pqlin_lut) {
++        av_bprintf(buf, "__constant float pqlin_lut[1024] = {\n");
++        for (i = 0; i < 1024; i++) {
++            av_bprintf(buf, " %.5ff,", ctx->pqlin_lut[i]);
++        }
++        av_bprintf(buf, "};\n");
++    }
++    if (ctx->pqdelin_lut) {
++        av_bprintf(buf, "__constant float pqdelin_lut[1024] = {\n");
++        for (i = 0; i < 1024; i++) {
++            av_bprintf(buf, " %.5ff,", ctx->pqdelin_lut[i]);
++        }
++        av_bprintf(buf, "};\n");
++    }
++}
++
+ static void get_rgb2rgb_matrix(enum AVColorPrimaries in, enum AVColorPrimaries out,
+                                double rgb2rgb[3][3]) {
+     double rgb2xyz[3][3], xyz2rgb[3][3];
+@@ -128,6 +300,7 @@ static int tonemap_opencl_init(AVFilterC
+     double rgb2rgb[3][3], rgb2yuv[3][3], yuv2rgb[3][3];
+     const struct LumaCoefficients *luma_src, *luma_dst;
+     cl_int cle;
++    int lut_pq = ctx->tonemap == TONEMAP_BT2390 && ctx->trc_in != AVCOL_TRC_SMPTE2084;
+     int err;
+ 
+     switch(ctx->tonemap) {
+@@ -192,12 +365,6 @@ static int tonemap_opencl_init(AVFilterC
+     if (ctx->out_planes > 2)
+         av_bprintf(&header, "#define NON_SEMI_PLANAR_OUT\n");
+ 
+-    av_bprintf(&header, "#define powr native_powr\n");
+-    av_bprintf(&header, "#define exp native_exp\n");
+-    av_bprintf(&header, "#define log native_log\n");
+-    av_bprintf(&header, "#define log10 native_log10\n");
+-    av_bprintf(&header, "#define sqrt native_sqrt\n");
+-
+     if (ctx->primaries_out != ctx->primaries_in) {
+         get_rgb2rgb_matrix(ctx->primaries_in, ctx->primaries_out, rgb2rgb);
+         rgb2rgb_passthrough = 0;
+@@ -244,10 +411,22 @@ static int tonemap_opencl_init(AVFilterC
+     av_bprintf(&header, "__constant float3 luma_dst = {%.4ff, %.4ff, %.4ff};\n",
+                luma_dst->cr, luma_dst->cg, luma_dst->cb);
+ 
+-    av_bprintf(&header, "#define linearize %s\n",
+-               linearize_funcs[ctx->trc_in]);
+-    av_bprintf(&header, "#define delinearize %s\n",
+-               delinearize_funcs[ctx->trc_out]);
++    if (ctx->lut_trc) {
++        if (!ctx->lin_lut || !ctx->delin_lut) {
++            err = compute_trc_luts(avctx);
++            if (err < 0)
++                goto fail;
++        }
++        print_opencl_const_trc_luts(avctx, &header);
++        if (lut_pq)
++            av_bprintf(&header, "#define TRC_LUT_PQ\n");
++        av_bprintf(&header, "#define TRC_LUT\n");
++        av_bprintf(&header, "#define linearize %s\n", "linearize_lut");
++        av_bprintf(&header, "#define delinearize %s\n", "delinearize_lut");
++    } else {
++        av_bprintf(&header, "#define linearize %s\n", linearize_funcs[ctx->trc_in]);
++        av_bprintf(&header, "#define delinearize %s\n", delinearize_funcs[ctx->trc_out]);
++    }
+ 
+     av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
+     opencl_sources[0] = header.str;
+@@ -277,6 +456,14 @@ fail:
+         clReleaseCommandQueue(ctx->command_queue);
+     if (ctx->kernel)
+         clReleaseKernel(ctx->kernel);
++    if (ctx->lin_lut)
++        av_freep(&ctx->lin_lut);
++    if (ctx->delin_lut)
++        av_freep(&ctx->delin_lut);
++    if (ctx->pqlin_lut)
++        av_freep(&ctx->pqlin_lut);
++    if (ctx->pqdelin_lut)
++        av_freep(&ctx->pqdelin_lut);
+     return err;
+ }
+ 
+@@ -420,8 +607,10 @@ static int tonemap_opencl_filter_frame(A
+     if (err < 0)
+         goto fail;
+ 
+-    if (!ctx->peak)
++    if (!ctx->peak) {
+         ctx->peak = ff_determine_signal_peak(input);
++        av_log(ctx, AV_LOG_DEBUG, "Computed signal peak: %f\n", ctx->peak);
++    }
+ 
+     if (ctx->trc != -1)
+         output->color_trc = ctx->trc;
+@@ -499,6 +688,15 @@ static av_cold void tonemap_opencl_unini
+                    "command queue: %d.\n", cle);
+     }
+ 
++    if (ctx->lin_lut)
++        av_freep(&ctx->lin_lut);
++    if (ctx->delin_lut)
++        av_freep(&ctx->delin_lut);
++    if (ctx->pqlin_lut)
++        av_freep(&ctx->pqlin_lut);
++    if (ctx->pqdelin_lut)
++        av_freep(&ctx->pqdelin_lut);
++
+     ff_opencl_filter_uninit(avctx);
+ }
+ 
+@@ -537,6 +735,7 @@ static const AVOption tonemap_opencl_opt
+     { "param",     "Tonemap parameter",   OFFSET(param), AV_OPT_TYPE_DOUBLE, { .dbl = NAN }, DBL_MIN, DBL_MAX, FLAGS },
+     { "desat",     "Desaturation parameter",   OFFSET(desat_param), AV_OPT_TYPE_DOUBLE, { .dbl = 0.5}, 0, DBL_MAX, FLAGS },
+     { "threshold", "Scene detection threshold",   OFFSET(scene_threshold), AV_OPT_TYPE_DOUBLE, { .dbl = 0.2 }, 0, DBL_MAX, FLAGS },
++    { "luttrc",    "Enable LUT for de/linearize",   OFFSET(lut_trc), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, FLAGS },
+     { NULL }
+ };
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@
 0007-fix-for-fmp4-in-hlsenc.patch
 0008-fix-nvdec-exceeded-32-surfaces-error.patch
 0009-fix-for-nvenc-from-upstream.patch
+0010-fix-for-qsv-opencl-derivation-mapping.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,3 +9,4 @@
 0009-fix-for-nvenc-from-upstream.patch
 0010-fix-for-qsv-opencl-derivation-mapping.patch
 0011-fix-for-frame-mapping-in-hwcontext_opencl.patch
+0012-add-fixes-for-webvttenc-when-using-segement-muxer.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -11,3 +11,4 @@
 0011-fix-for-frame-mapping-in-hwcontext_opencl.patch
 0012-add-fixes-for-webvttenc-when-using-segement-muxer.patch
 0013-add-opencl-scaler-and-format-converter-impl.patch
+0014-add-transfer-lut-for-opencl-tonemap.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -10,3 +10,4 @@
 0010-fix-for-qsv-opencl-derivation-mapping.patch
 0011-fix-for-frame-mapping-in-hwcontext_opencl.patch
 0012-add-fixes-for-webvttenc-when-using-segement-muxer.patch
+0013-add-opencl-scaler-and-format-converter-impl.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@
 0008-fix-nvdec-exceeded-32-surfaces-error.patch
 0009-fix-for-nvenc-from-upstream.patch
 0010-fix-for-qsv-opencl-derivation-mapping.patch
+0011-fix-for-frame-mapping-in-hwcontext_opencl.patch

--- a/debian/rules
+++ b/debian/rules
@@ -35,6 +35,7 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-libopus \
 	--enable-libtheora \
 	--enable-libvorbis \
+	--enable-libdav1d \
 	--enable-libwebp \
 	--enable-libvpx \
 	--enable-libx264 \
@@ -44,7 +45,6 @@ CONFIG := --prefix=${TARGET_DIR} \
 
 CONFIG_ARM_COMMON := --toolchain=hardened \
 	--enable-cross-compile \
-	--enable-libdav1d \
 	--enable-omx \
 	--enable-omx-rpi \
 
@@ -70,14 +70,8 @@ CONFIG_x86 := --arch=amd64 \
 	--enable-nvdec \
 	--enable-ffnvcodec \
 
-CONFIG_DAV1D := --enable-libdav1d \
-
 HOST_ARCH := $(shell arch)
 BUILD_ARCH := ${DEB_HOST_MULTIARCH}
-
-ifeq ($(ENABLE_X86_DAV1D),true)
-	CONFIG_x86 += $(CONFIG_DAV1D)
-endif
 ifeq ($(BUILD_ARCH),x86_64-linux-gnu)
 	# Native amd64 build
 	CONFIG += $(CONFIG_x86)

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -42,17 +42,18 @@ prepare_extra_common() {
     nasmminver="2.13.02"
     nasmavx512ver="2.14.0"
     if [ "$(printf '%s\n' "$nasmminver" "$nasmver" | sort -V | head -n1)" = "$nasmminver" ]; then
-        export ENABLE_X86_DAV1D=true
+        x86asm=true
         if [ "$(printf '%s\n' "$nasmavx512ver" "$nasmver" | sort -V | head -n1)" = "$nasmavx512ver" ]; then
             avx512=true
         else
             avx512=false
         fi
     else
-        export ENABLE_X86_DAV1D=false
+        x86asm=false
+        avx512=false
     fi
-    if [ "${ENABLE_X86_DAV1D}" = "true" ] && [ "${ARCH}" = "amd64" ]; then
-        meson -Denable_asm=true \
+    if [ "${ARCH}" = "amd64" ]; then
+        meson -Denable_asm=$x86asm \
               -Denable_avx512=$avx512 \
               -Denable_tests=false \
               -Ddefault_library=shared \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -130,7 +130,7 @@ prepare_extra_amd64() {
 
     # Download and install gmmlib
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-21.2.1 --depth=1 https://github.com/intel/gmmlib
+    git clone -b intel-gmmlib-21.3.1 --depth=1 https://github.com/intel/gmmlib
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -143,7 +143,7 @@ prepare_extra_amd64() {
 
     # Download and install MediaSDK
     pushd ${SOURCE_DIR}
-    git clone -b intel-mediasdk-21.2.3 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
+    git clone -b intel-mediasdk-21.3.3 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
     pushd MediaSDK
     sed -i 's|MFX_PLUGINS_CONF_DIR "/plugins.cfg"|"/usr/lib/jellyfin-ffmpeg/lib/mfx/plugins.cfg"|g' api/mfx_dispatch/linux/mfxloader.cpp
     mkdir build && pushd build
@@ -161,7 +161,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     #pushd ${SOURCE_DIR}
-    #git clone -b intel-media-21.2.3 --depth=1 https://github.com/intel/media-driver
+    #git clone -b intel-media-21.3.3 --depth=1 https://github.com/intel/media-driver
     #pushd media-driver
     #mkdir build && pushd build
     #cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \


### PR DESCRIPTION
**Changes**
- Only disable x86 ASM accel in dav1d if nasm is outdated
- Add fixes for QuickSync-OpenCL derivation/mapping on Linux (faster OCL tonemap on QSV)
- Add more SW format support in OpenCL tonemap (reduce CPU overhead)
- Add fixes for frame mapping in hwcontext_opencl
- Add options to set input metadata in tonemap_vaapi (instead of throwing error if the embedded one does not exist)
metadata syntax: `G(%hu|%hu)B(%hu|%hu)R(%hu|%hu)WP(%hu|%hu)L(%u|%u)` and `CLL(%hu)FALL(%hu)`
- Add fixes for webvttenc when using segment muxer and regular -map
- Add opencl scaler and format converter impl
- Add AMF HEVC 10-bit encoding support (Windows only, APU>=Renoir or GPU>=Navi)
- Add d3d11-opencl interop for AMD (Windows only)
- Add transfer LUT for opencl tonemap (Reduce overhead on iGPU)

**Win64 build** (Windows build script coming soon™)
[jellyfin-ffmpeg_4.4-1-windows_amd64.zip](https://github.com/jellyfin/jellyfin-ffmpeg/files/7246536/jellyfin-ffmpeg_4.4-1-windows_amd64.zip)
