### PR TITLE
Remove OMX and MMAL from ARM builds

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -19,10 +19,12 @@ ENV CFLAGS="-I${TARGET_DIR}/include $CFLAGS"
 
 # Prepare Debian build environment
 RUN apt-get update \
- && yes | apt-get install -y apt-transport-https ninja-build debhelper gnupg wget devscripts mmv equivs git nasm cmake pkg-config subversion dh-autoreconf libdrm-dev libpciaccess-dev python3-pip
+ && yes | apt-get install -y apt-transport-https curl ninja-build debhelper gnupg wget devscripts mmv equivs git nasm cmake pkg-config subversion dh-autoreconf libdrm-dev libpciaccess-dev python3-pip
 
 #Install meson
 RUN pip3 install meson
+# Avoids timeouts when using git
+RUN git config --global http.postbuffer 524288000
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/docker-build.sh /docker-build.sh
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
-jellyfin-ffmpeg (4.4.1-2) unstable; urgency=medium
+jellyfin-ffmpeg (4.4.1-3) unstable; urgency=medium
 
   * Remove OMX and MMAL from ARM builds
 
  -- ferferga <ferferga@hotmail.com>  Sun, 26 Dec 2021 19:58:10 +0100
+
+jellyfin-ffmpeg (4.4.1-2) unstable; urgency=medium
+
+  * Enable Link Time Optimization (LTO)
+
+ -- Bond-009 <bond.009@outlook.com>  Thu Apr 8 13:57:13 2021 +0200
  
 jellyfin-ffmpeg (4.4.1-1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (4.4.1-2) unstable; urgency=medium
+
+  * Remove OMX and MMAL from ARM builds
+
+ -- ferferga <ferferga@hotmail.com>  Sun, 26 Dec 2021 19:58:10 +0100
+ 
 jellyfin-ffmpeg (4.4.1-1) unstable; urgency=medium
 
   * New upstream version 4.4.1

--- a/debian/rules
+++ b/debian/rules
@@ -45,11 +45,8 @@ CONFIG := --prefix=${TARGET_DIR} \
 
 CONFIG_ARM_COMMON := --toolchain=hardened \
 	--enable-cross-compile \
-	--enable-omx \
-	--enable-omx-rpi \
 
 CONFIG_ARM := ${CONFIG_ARM_COMMON} \
-	--enable-mmal \
 	--arch=armhf \
 	--cross-prefix=/usr/bin/arm-linux-gnueabihf- \
 

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -431,8 +431,8 @@ popd
 popd
 
 # OpenCL headers
-svn checkout https://github.com/KhronosGroup/OpenCL-Headers/trunk/CL
-pushd CL
+git clone --depth=1 https://github.com/KhronosGroup/OpenCL-Headers
+pushd OpenCL-Headers/CL
 mkdir -p ${FF_DEPS_PREFIX}/include/CL
 mv * ${FF_DEPS_PREFIX}/include/CL
 popd
@@ -477,8 +477,8 @@ make PREFIX=${FF_DEPS_PREFIX} install
 popd
 
 # AMF
-svn checkout https://github.com/GPUOpen-LibrariesAndSDKs/AMF/trunk/amf/public/include
-pushd include
+git clone --depth=1 https://github.com/GPUOpen-LibrariesAndSDKs/AMF
+pushd AMF/amf/public/include
 mkdir -p ${FF_DEPS_PREFIX}/include/AMF
 mv * ${FF_DEPS_PREFIX}/include/AMF
 popd

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -95,8 +95,8 @@ prepare_extra_amd64() {
 
     # Download and setup AMD AMF headers
     # https://www.ffmpeg.org/general.html#AMD-AMF_002fVCE
-    svn checkout https://github.com/GPUOpen-LibrariesAndSDKs/AMF/trunk/amf/public/include
-    pushd include
+    git clone --depth=1 https://github.com/GPUOpen-LibrariesAndSDKs/AMF
+    pushd AMF/amf/public/include
     mkdir -p /usr/include/AMF
     mv * /usr/include/AMF
     popd

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -213,15 +213,6 @@ EOF
     ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime
     yes | apt-get install -y -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-arm-linux-gnueabihf g++-${GCC_VER}-arm-linux-gnueabihf libstdc++6-armhf-cross binutils-arm-linux-gnueabihf bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf liblttng-ust0:armhf libstdc++6:armhf
     popd
-
-    # Fetch RasPi headers to build MMAL and OMX-RPI support
-    pushd ${SOURCE_DIR}
-    svn checkout https://github.com/raspberrypi/firmware/trunk/opt/vc/include rpi/include
-    svn checkout https://github.com/raspberrypi/firmware/trunk/opt/vc/lib rpi/lib
-    cp -a rpi/include/* /usr/include
-    cp -a rpi/include/IL/* /usr/include
-    cp -a rpi/lib/* /usr/lib
-    popd
 }
 prepare_crossbuild_env_arm64() {
     # Prepare the Ubuntu-specific cross-build requirements
@@ -254,15 +245,6 @@ EOF
     pushd cross-gcc-packages-amd64/cross-gcc-${GCC_VER}-arm64
     ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime
     yes | apt-get install -y -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-aarch64-linux-gnu g++-${GCC_VER}-aarch64-linux-gnu libstdc++6-arm64-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 libfreetype6-dev:arm64 liblttng-ust0:arm64 libstdc++6:arm64
-    popd
-
-    # Fetch RasPi headers to build MMAL and OMX-RPI support
-    pushd ${SOURCE_DIR}
-    svn checkout https://github.com/raspberrypi/firmware/trunk/opt/vc/include rpi/include
-    svn checkout https://github.com/raspberrypi/firmware/trunk/opt/vc/lib rpi/lib
-    cp -a rpi/include/* /usr/include
-    cp -a rpi/include/IL/* /usr/include
-    cp -a rpi/lib/* /usr/lib
     popd
 }
 


### PR DESCRIPTION
For 10.8, I think we should remove all of the Pi-specific hardware acceleration stuff: it never worked properly (besides a very specific configuration set) and it's better to integrate something that truly works fine instead of the patchwork that current MMAL and OMX is.

Raspberry Pi development is transitioning towards V4L2 for hardware decoding/encoding and MMAL/OMX are in a deprecation path. They also only worked properly in Raspbian Stretch and Pi3 devices, other configurations produced mixed results. Right now, in Bullseye, ffmpeg and ffprobe doesn't start at all. 

With this patch, Pis will do software encoding/decoding (which is what most people ended using up anyway) until there's a better hardware acceleration path in the future.

Fixes jellyfin/jellyfin#32 jellyfin/jellyfin#75 