### PR TITLE
Enable Intel media driver building

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -1039,6 +1039,45 @@ Comment:
   Intel® Media SDK provides a plain C API to access hardware-accelerated video decode, encode and filtering
   on Intel® Gen graphics hardware platforms. Implementation written in C++ 11 with parts in C-for-Media (CM).
 
+Files: media-driver/*
+Copyright: 2007-2008, Dave Airlie
+           2007-2019, Intel Corporation
+           2007-2008, Jakob Bornecrantz
+           2014, NVIDIA Corporation
+           2007-2008, Red Hat Inc
+           2010, The WebM project authors
+           2002-2008, Tungsten Graphics, Inc.
+           1999-2000, Precision Insight, Inc.
+           2000, VA Linux Systems, Inc.
+           2008, Google Inc.
+License: Expat
+
+Files: media_driver/media_driver/linux/ult/ult_app/googletest/*
+Copyright: 2003-2015, Google Inc
+License: BSD-3-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * The names of its contributors may not be used to endorse or promote
+    products derived from this software without specific prior written
+    permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 Files: debian/*
 Copyright:
   2014-2017, Andreas Cadhalpun <Andreas.Cadhalpun@googlemail.com>

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -130,7 +130,7 @@ prepare_extra_amd64() {
 
     # Download and install gmmlib
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-21.3.5 --depth=1 https://github.com/intel/gmmlib
+    git clone -b intel-gmmlib-22.0.2 --depth=1 https://github.com/intel/gmmlib
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -143,7 +143,7 @@ prepare_extra_amd64() {
 
     # Download and install MediaSDK
     pushd ${SOURCE_DIR}
-    git clone -b intel-mediasdk-21.4.3 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
+    git clone -b intel-mediasdk-22.1.0 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
     pushd MediaSDK
     sed -i 's|MFX_PLUGINS_CONF_DIR "/plugins.cfg"|"/usr/lib/jellyfin-ffmpeg/lib/mfx/plugins.cfg"|g' api/mfx_dispatch/linux/mfxloader.cpp
     mkdir build && pushd build
@@ -162,23 +162,23 @@ prepare_extra_amd64() {
     # Download and install media-driver
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
-    #pushd ${SOURCE_DIR}
-    #git clone -b intel-media-21.4.3 --depth=1 https://github.com/intel/media-driver
-    #pushd media-driver
-    #mkdir build && pushd build
-    #cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
-    #      -DENABLE_KERNELS=ON \
-    #      -DENABLE_NONFREE_KERNELS=ON \
-    #      LIBVA_DRIVERS_PATH=${TARGET_DIR}/lib/dri \
-    #      ..
-    #make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/intel
-    #echo "intel${TARGET_DIR}/lib/libigfxcmrt.so* usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
-    #mkdir -p ${SOURCE_DIR}/intel/dri
-    #cp ${TARGET_DIR}/lib/dri/iHD*.so ${SOURCE_DIR}/intel/dri
-    #echo "intel/dri/iHD*.so usr/lib/jellyfin-ffmpeg/lib/dri" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
-    #popd
-    #popd
-    #popd
+    pushd ${SOURCE_DIR}
+    git clone -b intel-media-22.1.1 --depth=1 https://github.com/intel/media-driver
+    pushd media-driver
+    mkdir build && pushd build
+    cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
+          -DENABLE_KERNELS=ON \
+          -DENABLE_NONFREE_KERNELS=ON \
+          LIBVA_DRIVERS_PATH=${TARGET_DIR}/lib/dri \
+          ..
+    make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/intel
+    echo "intel${TARGET_DIR}/lib/libigfxcmrt.so* usr/lib/jellyfin-ffmpeg/lib" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    mkdir -p ${SOURCE_DIR}/intel/dri
+    cp ${TARGET_DIR}/lib/dri/iHD*.so ${SOURCE_DIR}/intel/dri
+    echo "intel/dri/iHD*.so usr/lib/jellyfin-ffmpeg/lib/dri" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    popd
+    popd
+    popd
 }
 # Prepare the cross-toolchain
 prepare_crossbuild_env_armhf() {


### PR DESCRIPTION
Changes:
* bump dependency versions
* enable building of [Intel media driver](https://github.com/intel/media-driver)
* add required licenses to `debian/copyright` (sourced from [intel-media-driver-non-free Debian package](https://packages.debian.org/source/bullseye/intel-media-driver-non-free) and [upstream repos license file](https://github.com/intel/media-driver/blob/master/LICENSE.md))

References: https://github.com/jellyfin/jellyfin-build/issues/12