### PR TITLE
Add libva-utils (vainfo)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ jellyfin-ffmpeg (4.4.1-2) unstable; urgency=medium
 
   * Fix the OpenCL dynamic linking issue on Win64 (#82)
   * Enable Intel media driver building (#89)
+  * Add libva-utils (#93)
 
  -- nyanmisaka <nst799610810@gmail.com>  Mon, 21 Feb 2022 13:26:03 +0800
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1052,7 +1052,46 @@ Copyright: 2007-2008, Dave Airlie
            2008, Google Inc.
 License: Expat
 
+Files: libva-utils/*
+Copyright: 2007-2019, Intel Corporation
+           2009, Splitted-Desktop Systems
+License: Expat
+
+Files: libva-utils/decode/loadjpeg.c
+       libva-utils/decode/tinyjpeg-internal.h
+       libva-utils/decode/tinyjpeg.c
+       libva-utils/decode/tinyjpeg.h
+Copyright: 2012, Intel Corporation
+           2006, Luc Saillard <luc@saillard.org>
+License: BSD-3-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+ .
+ - Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+ .
+ - Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+ .
+ - Neither the name of the author nor the names of its contributors may be
+  used to endorse or promote products derived from this software without
+  specific prior written permission.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.
+
 Files: media_driver/media_driver/linux/ult/ult_app/googletest/*
+       libva-utils/test/gtest/*
 Copyright: 2003-2015, Google Inc
 License: BSD-3-clause
  Redistribution and use in source and binary forms, with or without

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -115,6 +115,17 @@ prepare_extra_amd64() {
     popd
     popd
 
+    # Download and install libva-utils
+    pushd ${SOURCE_DIR}
+    git clone --depth=1 https://github.com/intel/libva-utils
+    pushd libva-utils
+    ./autogen.sh
+    ./configure --prefix=${TARGET_DIR}
+    make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/intel
+    echo "intel${TARGET_DIR}/bin/vainfo usr/lib/jellyfin-ffmpeg" >> ${SOURCE_DIR}/debian/jellyfin-ffmpeg.install
+    popd
+    popd
+
     # Download and install intel-vaapi-driver
     pushd ${SOURCE_DIR}
     git clone --depth=1 https://github.com/intel/intel-vaapi-driver
@@ -158,7 +169,6 @@ prepare_extra_amd64() {
     popd
     popd
 
-    # Uncomment for non-free QSV driver
     # Download and install media-driver
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
@@ -180,6 +190,7 @@ prepare_extra_amd64() {
     popd
     popd
 }
+
 # Prepare the cross-toolchain
 prepare_crossbuild_env_armhf() {
     # Prepare the Ubuntu-specific cross-build requirements


### PR DESCRIPTION
Since the distros `vainfo` package might be incompatible with the libva version we use, we're including it into our debian package.

Changes:
* Add building of vainfo (via libva-utils) to the build script (amd64 only)
* Add required licenses to the package config