### PR TITLE
Allow configuration of used driver via ENV variable

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -106,7 +106,7 @@ prepare_extra_amd64() {
     git clone --depth=1 https://github.com/intel/libva
     pushd libva
     sed -i 's|getenv("LIBVA_DRIVERS_PATH")|"/usr/lib/jellyfin-ffmpeg/lib/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/dri:/usr/local/lib/dri"|g' va/va.c
-    sed -i 's|getenv("LIBVA_DRIVER_NAME")|NULL|g' va/va.c
+    sed -i 's|getenv("LIBVA_DRIVER_NAME")|getenv("LIBVA_DRIVER_NAME_JELLYFIN")|g' va/va.c
     ./autogen.sh
     ./configure --prefix=${TARGET_DIR}
     make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/intel


### PR DESCRIPTION
Currently our shipped `vainfo` or any other program using our ffmpeg can't explicitly set the used driver via the ENV var. I don't see a reason why we should explicitly prevent this, so I added it back.

To explicitly set this environment for Jellyfin only (e.g. multiple GPUs, one for transcoding one for something else) the variable was renamed from `LIBVA_DRIVER_NAME` to `LIBVA_DRIVER_NAME_JELLYFIN`.