### PR TITLE
Add oneVPL runtime for QSV on 12th Gen Intel processors

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -19,10 +19,10 @@ ENV CFLAGS="-I${TARGET_DIR}/include $CFLAGS"
 
 # Prepare Debian build environment
 RUN apt-get update \
- && yes | apt-get install -y apt-transport-https curl ninja-build debhelper gnupg wget devscripts mmv equivs git nasm cmake pkg-config subversion dh-autoreconf libdrm-dev libpciaccess-dev python3-pip
+ && yes | apt-get install -y apt-transport-https curl ninja-build debhelper gnupg wget devscripts mmv equivs git nasm pkg-config subversion dh-autoreconf libdrm-dev libpciaccess-dev python3-pip
 
-#Install meson
-RUN pip3 install meson
+# Install meson and cmake
+RUN pip3 install meson cmake
 # Avoids timeouts when using git
 RUN git config --global http.postbuffer 524288000
 # Link to docker-build script

--- a/debian/copyright
+++ b/debian/copyright
@@ -1039,6 +1039,13 @@ Comment:
   Intel® Media SDK provides a plain C API to access hardware-accelerated video decode, encode and filtering
   on Intel® Gen graphics hardware platforms. Implementation written in C++ 11 with parts in C-for-Media (CM).
 
+Files: oneVPL-intel-gpu/*
+Copyright: 2021, Intel Corporation
+License: Expat
+Comment:
+  Intel® oneVPL GPU Runtime is a Runtime implementation of oneVPL API for Intel Gen GPUs. Runtime provides
+  access to hardware-accelerated video decode, encode and filtering.
+
 Files: media-driver/*
 Copyright: 2007-2008, Dave Airlie
            2007-2019, Intel Corporation


### PR DESCRIPTION
QSV support for Alder Lake processors.
https://github.com/Intel-Media-SDK/MediaSDK#media-sdk-support-matrix

**Changes**
- Add oneVPL runtime for QSV on 12th Gen Intel processors