### PR TITLE
Add support for Ubuntu 22.04 LTS, clean up EOL distros

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
     uses: jellyfin/jellyfin-ffmpeg/.github/workflows/_meta.yaml@jellyfin
     with:
       distro: 'ubuntu'
-      codenames: '["focal", "bionic", "impish", "hirsute"]'
+      codenames: '["jammy", "focal", "bionic", "impish"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: jellyfin/jellyfin-ffmpeg/.github/workflows/_meta.yaml@jellyfin
     with:
       distro: 'ubuntu'
-      codenames: '["focal", "bionic", "impish", "hirsute"]'
+      codenames: '["jammy", "focal", "bionic", "impish"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: true
     secrets:
@@ -55,10 +55,10 @@ jobs:
         arrays: [
           {distro: 'debian', codename: 'buster'},
           {distro: 'debian', codename: 'bullseye'},
+          {distro: 'ubuntu', codename: 'jammy'},
           {distro: 'ubuntu', codename: 'focal'},
           {distro: 'ubuntu', codename: 'bionic'},
           {distro: 'ubuntu', codename: 'impish'},
-          {distro: 'ubuntu', codename: 'hirsute'},
           {distro: 'windows', codename: 'windows'},
         ]
     steps:

--- a/build
+++ b/build
@@ -6,11 +6,10 @@ usage() {
     echo -e "Releases:          Arches:"
     echo -e " * buster           * amd64"
     echo -e " * bullseye         * armhf"
-    echo -e " * xenial           * arm64"
-    echo -e " * bionic"
+    echo -e " * bionic           * arm64"
     echo -e " * focal"
-    echo -e " * hirsute"
     echo -e " * impish"
+    echo -e " * jammy"
 }
 
 if [[ -z ${1} ]]; then
@@ -28,40 +27,20 @@ case ${cli_release} in
         release="debian:bullseye"
         gcc_version="10"
     ;;
-    'xenial')
-        release="ubuntu:xenial"
-        gcc_version="5"
-    ;;
     'bionic')
         release="ubuntu:bionic"
-        gcc_version="7"
-    ;;
-    'cosmic')
-        release="ubuntu:cosmic"
-        gcc_version="7"
-    ;;
-    'disco')
-        release="ubuntu:disco"
-        gcc_version="7"
-    ;;
-    'eoan')
-        release="ubuntu:eoan"
         gcc_version="7"
     ;;
     'focal')
         release="ubuntu:focal"
         gcc_version="9"
     ;;
-    'groovy')
-        release="ubuntu:groovy"
-        gcc_version="10"
-    ;;
-    'hirsute')
-        release="ubuntu:hirsute"
-        gcc_version="10"
-    ;;
     'impish')
         release="ubuntu:impish"
+        gcc_version="11"
+    ;;
+    'jammy')
+        release="ubuntu:jammy"
         gcc_version="11"
     ;;
     *)

--- a/build.yaml
+++ b/build.yaml
@@ -9,16 +9,15 @@ packages:
   - bullseye-amd64
   - bullseye-armhf
   - bullseye-arm64
-  - xenial-amd64
   - bionic-amd64
   - bionic-armhf
   - bionic-arm64
   - focal-amd64
   - focal-armhf
   - focal-arm64
-  - hirsute-amd64
-  - hirsute-armhf
-  - hirsute-arm64
   - impish-amd64
   - impish-armhf
   - impish-arm64
+  - jammy-amd64
+  - jammy-armhf
+  - jammy-arm64

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -239,7 +239,7 @@ EOF
     # Install dependencies
     pushd cross-gcc-packages-amd64/cross-gcc-${GCC_VER}-armhf
     ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime
-    yes | apt-get install -y -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-arm-linux-gnueabihf g++-${GCC_VER}-arm-linux-gnueabihf libstdc++6-armhf-cross binutils-arm-linux-gnueabihf bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf liblttng-ust0:armhf libstdc++6:armhf
+    yes | apt-get install -y -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-arm-linux-gnueabihf g++-${GCC_VER}-arm-linux-gnueabihf libstdc++6-armhf-cross binutils-arm-linux-gnueabihf bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf libstdc++6:armhf
     popd
 }
 prepare_crossbuild_env_arm64() {
@@ -272,7 +272,7 @@ EOF
     # Install dependencies
     pushd cross-gcc-packages-amd64/cross-gcc-${GCC_VER}-arm64
     ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime
-    yes | apt-get install -y -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-aarch64-linux-gnu g++-${GCC_VER}-aarch64-linux-gnu libstdc++6-arm64-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 libfreetype6-dev:arm64 liblttng-ust0:arm64 libstdc++6:arm64
+    yes | apt-get install -y -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-aarch64-linux-gnu g++-${GCC_VER}-aarch64-linux-gnu libstdc++6-arm64-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 libfreetype6-dev:arm64 libstdc++6:arm64
     popd
 }
 


### PR DESCRIPTION
**Changes**
- Add support for the upcoming Ubuntu 22.04 LTS aka jammy
- Clean up EOL distros in build scripts