### PR TITLE
Fix the libass AR and blur issue made by a fallible guess

### DIFF
--- a/debian/patches/0024-add-sub2video-option-to-subtitles-filter.patch
+++ b/debian/patches/0024-add-sub2video-option-to-subtitles-filter.patch
@@ -26,7 +26,19 @@ Index: jellyfin-ffmpeg/libavfilter/vf_subtitles.c
  
  /* libass supports a log level ranging from 0 to 7 */
  static const int ass_libavfilter_log_level_map[] = {
-@@ -151,6 +155,8 @@ static int config_input(AVFilterLink *in
+@@ -145,12 +149,19 @@ static int config_input(AVFilterLink *in
+     ff_draw_init(&ass->draw, inlink->format, ass->alpha ? FF_DRAW_PROCESS_ALPHA : 0);
+ 
+     ass_set_frame_size  (ass->renderer, inlink->w, inlink->h);
+-    if (ass->original_w && ass->original_h)
++    if (ass->original_w && ass->original_h) {
+         ass_set_aspect_ratio(ass->renderer, (double)inlink->w / inlink->h,
+                              (double)ass->original_w / ass->original_h);
++        ass_set_storage_size(ass->renderer, ass->original_w, ass->original_h);
++    } else {
++        ass_set_storage_size(ass->renderer, inlink->w, inlink->h);
++    }
++
      if (ass->shaping != -1)
          ass_set_shaper(ass->renderer, ass->shaping);
  
@@ -35,7 +47,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_subtitles.c
      return 0;
  }
  
-@@ -181,18 +187,41 @@ static int filter_frame(AVFilterLink *in
+@@ -181,18 +192,41 @@ static int filter_frame(AVFilterLink *in
      AVFilterLink *outlink = ctx->outputs[0];
      AssContext *ass = ctx->priv;
      int detect_change = 0;
@@ -79,7 +91,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_subtitles.c
  static const AVFilterPad ass_inputs[] = {
      {
          .name             = "default",
-@@ -243,6 +272,9 @@ static av_cold int init_ass(AVFilterCont
+@@ -243,6 +277,9 @@ static av_cold int init_ass(AVFilterCont
                 ass->filename);
          return AVERROR(EINVAL);
      }
@@ -89,7 +101,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_subtitles.c
      return 0;
  }
  
-@@ -264,8 +296,8 @@ AVFilter ff_vf_ass = {
+@@ -264,8 +301,8 @@ AVFilter ff_vf_ass = {
  static const AVOption subtitles_options[] = {
      COMMON_OPTIONS
      {"charenc",      "set input character encoding", OFFSET(charenc),      AV_OPT_TYPE_STRING, {.str = NULL}, 0, 0, FLAGS},
@@ -100,7 +112,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_subtitles.c
      {"force_style",  "force subtitle style",         OFFSET(force_style),  AV_OPT_TYPE_STRING, {.str = NULL}, 0, 0, FLAGS},
      {NULL},
  };
-@@ -473,6 +505,8 @@ static av_cold int init_subtitles(AVFilt
+@@ -473,6 +510,8 @@ static av_cold int init_subtitles(AVFilt
          avsubtitle_free(&sub);
      }
  


### PR DESCRIPTION
**Changes**
- pass video resolution to libass by [`ass_set_storage_size`](https://github.com/libass/libass/blob/15a783f48cd3ec6f1184bceb2373ae52a5f7a2b0/libass/ass.h#L380-L383)

**Issues**
- Fixes https://code.videolan.org/videolan/vlc/-/issues/26634

![image](https://user-images.githubusercontent.com/14953024/159154057-41c31022-545e-4ab1-9a48-42550185c2e0.png)
