### PR TITLE
refactor(ci): use relative `uses` instead of absolute

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build_debian:
-    uses: jellyfin/jellyfin-ffmpeg/.github/workflows/_meta.yaml@jellyfin
+    uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'debian'
       codenames: '["buster", "bullseye"]'
@@ -27,7 +27,7 @@ jobs:
       release: false
 
   build_ubuntu:
-    uses: jellyfin/jellyfin-ffmpeg/.github/workflows/_meta.yaml@jellyfin
+    uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
       codenames: '["jammy", "focal", "bionic", "impish"]'
@@ -35,7 +35,7 @@ jobs:
       release: false
 
   build_windows:
-    uses: jellyfin/jellyfin-ffmpeg/.github/workflows/_meta.yaml@jellyfin
+    uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'windows'
       codenames: '["windows"]'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_publish_debian:
-    uses: jellyfin/jellyfin-ffmpeg/.github/workflows/_meta.yaml@jellyfin
+    uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'debian'
       codenames: '["buster", "bullseye"]'
@@ -19,7 +19,7 @@ jobs:
       deploy-key: ${{ secrets.DEPLOY_KEY }}
 
   build_publish_ubuntu:
-    uses: jellyfin/jellyfin-ffmpeg/.github/workflows/_meta.yaml@jellyfin
+    uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
       codenames: '["jammy", "focal", "bionic", "impish"]'
@@ -31,7 +31,7 @@ jobs:
       deploy-key: ${{ secrets.DEPLOY_KEY }}
 
   build_publish_windows:
-    uses: jellyfin/jellyfin-ffmpeg/.github/workflows/_meta.yaml@jellyfin
+    uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'windows'
       codenames: '["windows"]'


### PR DESCRIPTION
This PR aims to alter the CI workflow, so that it referes to the `meta` workflow in an relative manner instead of an absolute.
Basically, instead of referring to exactly the meta workflow present in the default branch of this repository it refers to the workflow version within the repository itself (be that a fork or the official one).

for reference https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
* alter `uses` calls to use reusable workflows in the same repository

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->
* n/a