### PR TITLE
Add patch allowing webp in id3v2 tags

### DIFF
--- a/debian/patches/0034-add-webp-support-for-id3v2.patch
+++ b/debian/patches/0034-add-webp-support-for-id3v2.patch
@@ -1,0 +1,12 @@
+Index: jellyfin-ffmpeg/libavformat/id3v2.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/id3v2.c
++++ jellyfin-ffmpeg/libavformat/id3v2.c
+@@ -135,6 +135,7 @@ const CodecMime ff_id3v2_mime_tags[] = {
+     { "image/png",  AV_CODEC_ID_PNG   },
+     { "image/tiff", AV_CODEC_ID_TIFF  },
+     { "image/bmp",  AV_CODEC_ID_BMP   },
++    { "image/webp", AV_CODEC_ID_WEBP  },
+     { "JPG",        AV_CODEC_ID_MJPEG }, /* ID3v2.2  */
+     { "PNG",        AV_CODEC_ID_PNG   }, /* ID3v2.2  */
+     { "",           AV_CODEC_ID_NONE  },

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -31,3 +31,4 @@
 0031-add-a-vaapi-overlay-filter.patch
 0032-add-async-support-for-qsv-vpp.patch
 0033-add-fixes-for-corrupted-hevc-vaapi-on-tgl.patch
+0034-add-webp-support-for-id3v2.patch


### PR DESCRIPTION
ID3v2 has no limit on what mime type the image can has, so add webp to the allowed mime types in ffmpeg too.