### PR TITLE
Add ac4 patch to enable ATSC 3.0

### DIFF
--- a/debian/patches/ac4.patch
+++ b/debian/patches/ac4.patch
@@ -1,0 +1,12515 @@
+Description: <short summary of the patch>
+ TODO: Put a short summary on the line above and replace this paragraph
+ with a longer explanation of this change. Complete the meta-information
+ with other relevant fields (see below for details). To make it easier, the
+ information below has been extracted from the changelog. Adjust it or drop
+ it.
+ .
+ jellyfin-ffmpeg (4.4.1-4) unstable; urgency=medium
+ .
+   * Update dependencies (#120)
+   * Update dav1d to 1.0.0 (#118)
+   * fix libass AR and blur issue (#119)
+Author: Joshua Boniface <joshua@boniface.me>
+
+---
+The information above should follow the Patch Tagging Guidelines, please
+checkout http://dep.debian.net/deps/dep3/ to learn about the format. Here
+are templates for supplementary fields that you might want to add:
+
+Origin: <vendor|upstream|other>, <url of original patch>
+Bug: <url in upstream bugtracker>
+Bug-Debian: https://bugs.debian.org/<bugnumber>
+Bug-Ubuntu: https://launchpad.net/bugs/<bugnumber>
+Forwarded: <no|not-needed|url proving that it has been forwarded>
+Reviewed-By: <name and email of someone who approved the patch>
+Last-Update: 2022-04-07
+
+--- jellyfin-ffmpeg-4.4.1.orig/libavcodec/Makefile
++++ jellyfin-ffmpeg-4.4.1/libavcodec/Makefile
+@@ -183,6 +183,7 @@ OBJS-$(CONFIG_AC3_ENCODER)             +
+                                           ac3.o kbdwin.o
+ OBJS-$(CONFIG_AC3_FIXED_ENCODER)       += ac3enc_fixed.o ac3enc.o ac3tab.o ac3.o kbdwin.o
+ OBJS-$(CONFIG_AC3_MF_ENCODER)          += mfenc.o mf_utils.o
++OBJS-$(CONFIG_AC4_DECODER)             += ac4dec.o kbdwin.o
+ OBJS-$(CONFIG_ACELP_KELVIN_DECODER)    += g729dec.o lsp.o celp_math.o celp_filters.o acelp_filters.o acelp_pitch_delay.o acelp_vectors.o g729postfilter.o
+ OBJS-$(CONFIG_AGM_DECODER)             += agm.o
+ OBJS-$(CONFIG_AIC_DECODER)             += aic.o
+--- /dev/null
++++ jellyfin-ffmpeg-4.4.1/libavcodec/Makefile.orig
+@@ -0,0 +1,1299 @@
++NAME = avcodec
++DESC = FFmpeg codec library
++
++HEADERS = ac3_parser.h                                                  \
++          adts_parser.h                                                 \
++          avcodec.h                                                     \
++          avdct.h                                                       \
++          avfft.h                                                       \
++          bsf.h                                                         \
++          codec.h                                                       \
++          codec_desc.h                                                  \
++          codec_id.h                                                    \
++          codec_par.h                                                   \
++          d3d11va.h                                                     \
++          dirac.h                                                       \
++          dv_profile.h                                                  \
++          dxva2.h                                                       \
++          jni.h                                                         \
++          mediacodec.h                                                  \
++          packet.h                                                      \
++          qsv.h                                                         \
++          vaapi.h                                                       \
++          vdpau.h                                                       \
++          version.h                                                     \
++          videotoolbox.h                                                \
++          vorbis_parser.h                                               \
++          xvmc.h                                                        \
++
++OBJS = ac3_parser.o                                                     \
++       adts_parser.o                                                    \
++       allcodecs.o                                                      \
++       avcodec.o                                                        \
++       avdct.o                                                          \
++       avpacket.o                                                       \
++       avpicture.o                                                      \
++       bitstream.o                                                      \
++       bitstream_filter.o                                               \
++       bitstream_filters.o                                              \
++       bsf.o                                                            \
++       codec_desc.o                                                     \
++       codec_par.o                                                      \
++       d3d11va.o                                                        \
++       decode.o                                                         \
++       dirac.o                                                          \
++       dv_profile.o                                                     \
++       encode.o                                                         \
++       imgconvert.o                                                     \
++       jni.o                                                            \
++       mathtables.o                                                     \
++       mediacodec.o                                                     \
++       mpeg12framerate.o                                                \
++       options.o                                                        \
++       parser.o                                                         \
++       parsers.o                                                        \
++       profiles.o                                                       \
++       qsv_api.o                                                        \
++       raw.o                                                            \
++       utils.o                                                          \
++       vorbis_parser.o                                                  \
++       xiph.o                                                           \
++
++# subsystems
++OBJS-$(CONFIG_AANDCTTABLES)            += aandcttab.o
++OBJS-$(CONFIG_AC3DSP)                  += ac3dsp.o ac3.o ac3tab.o
++OBJS-$(CONFIG_ADTS_HEADER)             += adts_header.o mpeg4audio.o
++OBJS-$(CONFIG_AMF)                     += amfenc.o
++OBJS-$(CONFIG_AUDIO_FRAME_QUEUE)       += audio_frame_queue.o
++OBJS-$(CONFIG_ATSC_A53)                += atsc_a53.o
++OBJS-$(CONFIG_AUDIODSP)                += audiodsp.o
++OBJS-$(CONFIG_BLOCKDSP)                += blockdsp.o
++OBJS-$(CONFIG_BSWAPDSP)                += bswapdsp.o
++OBJS-$(CONFIG_CABAC)                   += cabac.o
++OBJS-$(CONFIG_CBS)                     += cbs.o cbs_bsf.o
++OBJS-$(CONFIG_CBS_AV1)                 += cbs_av1.o
++OBJS-$(CONFIG_CBS_H264)                += cbs_h2645.o cbs_sei.o h2645_parse.o
++OBJS-$(CONFIG_CBS_H265)                += cbs_h2645.o cbs_sei.o h2645_parse.o
++OBJS-$(CONFIG_CBS_JPEG)                += cbs_jpeg.o
++OBJS-$(CONFIG_CBS_MPEG2)               += cbs_mpeg2.o
++OBJS-$(CONFIG_CBS_VP9)                 += cbs_vp9.o
++OBJS-$(CONFIG_CRYSTALHD)               += crystalhd.o
++OBJS-$(CONFIG_DCT)                     += dct.o dct32_fixed.o dct32_float.o
++OBJS-$(CONFIG_ERROR_RESILIENCE)        += error_resilience.o
++OBJS-$(CONFIG_EXIF)                    += exif.o tiff_common.o
++OBJS-$(CONFIG_FAANDCT)                 += faandct.o
++OBJS-$(CONFIG_FAANIDCT)                += faanidct.o
++OBJS-$(CONFIG_FDCTDSP)                 += fdctdsp.o jfdctfst.o jfdctint.o
++FFT-OBJS-$(CONFIG_HARDCODED_TABLES)    += cos_tables.o
++OBJS-$(CONFIG_FFT)                     += avfft.o fft_float.o fft_fixed_32.o \
++                                          fft_init_table.o $(FFT-OBJS-yes)
++OBJS-$(CONFIG_FLACDSP)                 += flacdsp.o
++OBJS-$(CONFIG_FMTCONVERT)              += fmtconvert.o
++OBJS-$(CONFIG_GOLOMB)                  += golomb.o
++OBJS-$(CONFIG_H263DSP)                 += h263dsp.o
++OBJS-$(CONFIG_H264CHROMA)              += h264chroma.o
++OBJS-$(CONFIG_H264DSP)                 += h264dsp.o h264idct.o
++OBJS-$(CONFIG_H264PARSE)               += h264_parse.o h2645_parse.o h264_ps.o
++OBJS-$(CONFIG_H264PRED)                += h264pred.o
++OBJS-$(CONFIG_H264QPEL)                += h264qpel.o
++OBJS-$(CONFIG_HEVCPARSE)               += hevc_parse.o h2645_parse.o hevc_ps.o hevc_sei.o hevc_data.o \
++                                          dynamic_hdr10_plus.o
++OBJS-$(CONFIG_HPELDSP)                 += hpeldsp.o
++OBJS-$(CONFIG_HUFFMAN)                 += huffman.o
++OBJS-$(CONFIG_HUFFYUVDSP)              += huffyuvdsp.o
++OBJS-$(CONFIG_HUFFYUVENCDSP)           += huffyuvencdsp.o
++OBJS-$(CONFIG_IDCTDSP)                 += idctdsp.o simple_idct.o jrevdct.o
++OBJS-$(CONFIG_IIRFILTER)               += iirfilter.o
++OBJS-$(CONFIG_MDCT15)                  += mdct15.o
++OBJS-$(CONFIG_INTRAX8)                 += intrax8.o intrax8dsp.o msmpeg4data.o
++OBJS-$(CONFIG_IVIDSP)                  += ivi_dsp.o
++OBJS-$(CONFIG_JNI)                     += ffjni.o jni.o
++OBJS-$(CONFIG_JPEGTABLES)              += jpegtables.o
++OBJS-$(CONFIG_LLAUDDSP)                += lossless_audiodsp.o
++OBJS-$(CONFIG_LLVIDDSP)                += lossless_videodsp.o
++OBJS-$(CONFIG_LLVIDENCDSP)             += lossless_videoencdsp.o
++OBJS-$(CONFIG_LPC)                     += lpc.o
++OBJS-$(CONFIG_LSP)                     += lsp.o
++OBJS-$(CONFIG_LZF)                     += lzf.o
++OBJS-$(CONFIG_MDCT)                    += mdct_float.o mdct_fixed_32.o
++OBJS-$(CONFIG_ME_CMP)                  += me_cmp.o
++OBJS-$(CONFIG_MEDIACODEC)              += mediacodecdec_common.o mediacodec_surface.o mediacodec_wrapper.o mediacodec_sw_buffer.o
++OBJS-$(CONFIG_MPEG_ER)                 += mpeg_er.o
++OBJS-$(CONFIG_MPEGAUDIO)               += mpegaudio.o mpegaudiodec_common.o
++OBJS-$(CONFIG_MPEGAUDIODSP)            += mpegaudiodsp.o                \
++                                          mpegaudiodsp_data.o           \
++                                          mpegaudiodsp_fixed.o          \
++                                          mpegaudiodsp_float.o
++OBJS-$(CONFIG_MPEGAUDIOHEADER)         += mpegaudiodecheader.o mpegaudiodata.o
++OBJS-$(CONFIG_MPEGVIDEO)               += mpegvideo.o mpegvideodsp.o rl.o \
++                                          mpegvideo_motion.o mpegutils.o \
++                                          mpegvideodata.o mpegpicture.o
++OBJS-$(CONFIG_MPEGVIDEOENC)            += mpegvideo_enc.o mpeg12data.o  \
++                                          motion_est.o ratecontrol.o    \
++                                          mpegvideoencdsp.o
++OBJS-$(CONFIG_MSS34DSP)                += mss34dsp.o
++OBJS-$(CONFIG_NVENC)                   += nvenc.o
++OBJS-$(CONFIG_PIXBLOCKDSP)             += pixblockdsp.o
++OBJS-$(CONFIG_QPELDSP)                 += qpeldsp.o
++OBJS-$(CONFIG_QSV)                     += qsv.o
++OBJS-$(CONFIG_QSVDEC)                  += qsvdec.o
++OBJS-$(CONFIG_QSVENC)                  += qsvenc.o
++OBJS-$(CONFIG_RANGECODER)              += rangecoder.o
++OBJS-$(CONFIG_RDFT)                    += rdft.o
++OBJS-$(CONFIG_RV34DSP)                 += rv34dsp.o
++OBJS-$(CONFIG_SHARED)                  += log2_tab.o reverse.o
++OBJS-$(CONFIG_SINEWIN)                 += sinewin.o
++OBJS-$(CONFIG_SNAPPY)                  += snappy.o
++OBJS-$(CONFIG_STARTCODE)               += startcode.o
++OBJS-$(CONFIG_TEXTUREDSP)              += texturedsp.o
++OBJS-$(CONFIG_TEXTUREDSPENC)           += texturedspenc.o
++OBJS-$(CONFIG_TPELDSP)                 += tpeldsp.o
++OBJS-$(CONFIG_VAAPI_ENCODE)            += vaapi_encode.o
++OBJS-$(CONFIG_VC1DSP)                  += vc1dsp.o
++OBJS-$(CONFIG_VIDEODSP)                += videodsp.o
++OBJS-$(CONFIG_VP3DSP)                  += vp3dsp.o
++OBJS-$(CONFIG_VP56DSP)                 += vp56dsp.o
++OBJS-$(CONFIG_VP8DSP)                  += vp8dsp.o
++OBJS-$(CONFIG_V4L2_M2M)                += v4l2_m2m.o v4l2_context.o v4l2_buffers.o v4l2_fmt.o
++OBJS-$(CONFIG_WMA_FREQS)               += wma_freqs.o
++OBJS-$(CONFIG_WMV2DSP)                 += wmv2dsp.o
++
++# decoders/encoders
++OBJS-$(CONFIG_ZERO12V_DECODER)         += 012v.o
++OBJS-$(CONFIG_A64MULTI_ENCODER)        += a64multienc.o elbg.o
++OBJS-$(CONFIG_A64MULTI5_ENCODER)       += a64multienc.o elbg.o
++OBJS-$(CONFIG_AAC_DECODER)             += aacdec.o aactab.o aacsbr.o aacps_common.o aacps_float.o \
++                                          mpeg4audio.o kbdwin.o \
++                                          sbrdsp.o aacpsdsp_float.o cbrt_data.o
++OBJS-$(CONFIG_AAC_FIXED_DECODER)       += aacdec_fixed.o aactab.o aacsbr_fixed.o aacps_common.o aacps_fixed.o \
++                                          mpeg4audio.o kbdwin.o \
++                                          sbrdsp_fixed.o aacpsdsp_fixed.o cbrt_data_fixed.o
++OBJS-$(CONFIG_AAC_ENCODER)             += aacenc.o aaccoder.o aacenctab.o    \
++                                          aacpsy.o aactab.o      \
++                                          aacenc_is.o \
++                                          aacenc_tns.o \
++                                          aacenc_ltp.o \
++                                          aacenc_pred.o \
++                                          psymodel.o mpeg4audio.o kbdwin.o
++OBJS-$(CONFIG_AAC_MF_ENCODER)          += mfenc.o mf_utils.o
++OBJS-$(CONFIG_AASC_DECODER)            += aasc.o msrledec.o
++OBJS-$(CONFIG_AC3_DECODER)             += ac3dec_float.o ac3dec_data.o ac3.o kbdwin.o ac3tab.o
++OBJS-$(CONFIG_AC3_FIXED_DECODER)       += ac3dec_fixed.o ac3dec_data.o ac3.o kbdwin.o ac3tab.o
++OBJS-$(CONFIG_AC3_ENCODER)             += ac3enc_float.o ac3enc.o ac3tab.o \
++                                          ac3.o kbdwin.o
++OBJS-$(CONFIG_AC3_FIXED_ENCODER)       += ac3enc_fixed.o ac3enc.o ac3tab.o ac3.o kbdwin.o
++OBJS-$(CONFIG_AC3_MF_ENCODER)          += mfenc.o mf_utils.o
++OBJS-$(CONFIG_ACELP_KELVIN_DECODER)    += g729dec.o lsp.o celp_math.o celp_filters.o acelp_filters.o acelp_pitch_delay.o acelp_vectors.o g729postfilter.o
++OBJS-$(CONFIG_AGM_DECODER)             += agm.o
++OBJS-$(CONFIG_AIC_DECODER)             += aic.o
++OBJS-$(CONFIG_ALAC_DECODER)            += alac.o alac_data.o alacdsp.o
++OBJS-$(CONFIG_ALAC_ENCODER)            += alacenc.o alac_data.o
++OBJS-$(CONFIG_ALIAS_PIX_DECODER)       += aliaspixdec.o
++OBJS-$(CONFIG_ALIAS_PIX_ENCODER)       += aliaspixenc.o
++OBJS-$(CONFIG_ALS_DECODER)             += alsdec.o bgmc.o mlz.o mpeg4audio.o
++OBJS-$(CONFIG_AMRNB_DECODER)           += amrnbdec.o celp_filters.o   \
++                                          celp_math.o acelp_filters.o \
++                                          acelp_vectors.o             \
++                                          acelp_pitch_delay.o
++OBJS-$(CONFIG_AMRWB_DECODER)           += amrwbdec.o celp_filters.o   \
++                                          celp_math.o acelp_filters.o \
++                                          acelp_vectors.o             \
++                                          acelp_pitch_delay.o
++OBJS-$(CONFIG_AMV_ENCODER)             += mjpegenc.o mjpegenc_common.o \
++                                          mjpegenc_huffman.o
++OBJS-$(CONFIG_ANM_DECODER)             += anm.o
++OBJS-$(CONFIG_ANSI_DECODER)            += ansi.o cga_data.o
++OBJS-$(CONFIG_APE_DECODER)             += apedec.o
++OBJS-$(CONFIG_APTX_DECODER)            += aptxdec.o aptx.o
++OBJS-$(CONFIG_APTX_ENCODER)            += aptxenc.o aptx.o
++OBJS-$(CONFIG_APTX_HD_DECODER)         += aptxdec.o aptx.o
++OBJS-$(CONFIG_APTX_HD_ENCODER)         += aptxenc.o aptx.o
++OBJS-$(CONFIG_APNG_DECODER)            += png.o pngdec.o pngdsp.o
++OBJS-$(CONFIG_APNG_ENCODER)            += png.o pngenc.o
++OBJS-$(CONFIG_ARBC_DECODER)            += arbc.o
++OBJS-$(CONFIG_ARGO_DECODER)            += argo.o
++OBJS-$(CONFIG_SSA_DECODER)             += assdec.o ass.o
++OBJS-$(CONFIG_SSA_ENCODER)             += assenc.o ass.o
++OBJS-$(CONFIG_ASS_DECODER)             += assdec.o ass.o
++OBJS-$(CONFIG_ASS_ENCODER)             += assenc.o ass.o
++OBJS-$(CONFIG_ASV1_DECODER)            += asvdec.o asv.o mpeg12data.o
++OBJS-$(CONFIG_ASV1_ENCODER)            += asvenc.o asv.o mpeg12data.o
++OBJS-$(CONFIG_ASV2_DECODER)            += asvdec.o asv.o mpeg12data.o
++OBJS-$(CONFIG_ASV2_ENCODER)            += asvenc.o asv.o mpeg12data.o
++OBJS-$(CONFIG_ATRAC1_DECODER)          += atrac1.o atrac.o
++OBJS-$(CONFIG_ATRAC3_DECODER)          += atrac3.o atrac.o
++OBJS-$(CONFIG_ATRAC3AL_DECODER)        += atrac3.o atrac.o
++OBJS-$(CONFIG_ATRAC3P_DECODER)         += atrac3plusdec.o atrac3plus.o \
++                                          atrac3plusdsp.o atrac.o
++OBJS-$(CONFIG_ATRAC3PAL_DECODER)       += atrac3plusdec.o atrac3plus.o \
++                                          atrac3plusdsp.o atrac.o
++OBJS-$(CONFIG_ATRAC9_DECODER)          += atrac9dec.o
++OBJS-$(CONFIG_AURA_DECODER)            += cyuv.o
++OBJS-$(CONFIG_AURA2_DECODER)           += aura.o
++OBJS-$(CONFIG_AV1_DECODER)             += av1dec.o
++OBJS-$(CONFIG_AV1_CUVID_DECODER)       += cuviddec.o
++OBJS-$(CONFIG_AVRN_DECODER)            += avrndec.o
++OBJS-$(CONFIG_AVRP_DECODER)            += r210dec.o
++OBJS-$(CONFIG_AVRP_ENCODER)            += r210enc.o
++OBJS-$(CONFIG_AVS_DECODER)             += avs.o
++OBJS-$(CONFIG_AVUI_DECODER)            += avuidec.o
++OBJS-$(CONFIG_AVUI_ENCODER)            += avuienc.o
++OBJS-$(CONFIG_AYUV_DECODER)            += v408dec.o
++OBJS-$(CONFIG_AYUV_ENCODER)            += v408enc.o
++OBJS-$(CONFIG_BETHSOFTVID_DECODER)     += bethsoftvideo.o
++OBJS-$(CONFIG_BFI_DECODER)             += bfi.o
++OBJS-$(CONFIG_BINK_DECODER)            += bink.o binkdsp.o
++OBJS-$(CONFIG_BINKAUDIO_DCT_DECODER)   += binkaudio.o
++OBJS-$(CONFIG_BINKAUDIO_RDFT_DECODER)  += binkaudio.o
++OBJS-$(CONFIG_BINTEXT_DECODER)         += bintext.o cga_data.o
++OBJS-$(CONFIG_BITPACKED_DECODER)       += bitpacked.o
++OBJS-$(CONFIG_BMP_DECODER)             += bmp.o msrledec.o
++OBJS-$(CONFIG_BMP_ENCODER)             += bmpenc.o
++OBJS-$(CONFIG_BMV_AUDIO_DECODER)       += bmvaudio.o
++OBJS-$(CONFIG_BMV_VIDEO_DECODER)       += bmvvideo.o
++OBJS-$(CONFIG_BRENDER_PIX_DECODER)     += brenderpix.o
++OBJS-$(CONFIG_C93_DECODER)             += c93.o
++OBJS-$(CONFIG_CAVS_DECODER)            += cavs.o cavsdec.o cavsdsp.o \
++                                          cavsdata.o
++OBJS-$(CONFIG_CCAPTION_DECODER)        += ccaption_dec.o ass.o
++OBJS-$(CONFIG_CDGRAPHICS_DECODER)      += cdgraphics.o
++OBJS-$(CONFIG_CDTOONS_DECODER)         += cdtoons.o
++OBJS-$(CONFIG_CDXL_DECODER)            += cdxl.o
++OBJS-$(CONFIG_CFHD_DECODER)            += cfhd.o cfhddata.o cfhddsp.o
++OBJS-$(CONFIG_CFHD_ENCODER)            += cfhdenc.o cfhddata.o cfhdencdsp.o
++OBJS-$(CONFIG_CINEPAK_DECODER)         += cinepak.o
++OBJS-$(CONFIG_CINEPAK_ENCODER)         += cinepakenc.o elbg.o
++OBJS-$(CONFIG_CLEARVIDEO_DECODER)      += clearvideo.o
++OBJS-$(CONFIG_CLJR_DECODER)            += cljrdec.o
++OBJS-$(CONFIG_CLJR_ENCODER)            += cljrenc.o
++OBJS-$(CONFIG_CLLC_DECODER)            += cllc.o canopus.o
++OBJS-$(CONFIG_COMFORTNOISE_DECODER)    += cngdec.o celp_filters.o
++OBJS-$(CONFIG_COMFORTNOISE_ENCODER)    += cngenc.o
++OBJS-$(CONFIG_COOK_DECODER)            += cook.o
++OBJS-$(CONFIG_CPIA_DECODER)            += cpia.o
++OBJS-$(CONFIG_CRI_DECODER)             += cri.o
++OBJS-$(CONFIG_CSCD_DECODER)            += cscd.o
++OBJS-$(CONFIG_CYUV_DECODER)            += cyuv.o
++OBJS-$(CONFIG_DCA_DECODER)             += dcadec.o dca.o dcadata.o dcahuff.o \
++                                          dca_core.o dca_exss.o dca_xll.o dca_lbr.o \
++                                          dcadsp.o dcadct.o synth_filter.o
++OBJS-$(CONFIG_DCA_ENCODER)             += dcaenc.o dcadata.o dcahuff.o \
++                                          dcaadpcm.o
++OBJS-$(CONFIG_DDS_DECODER)             += dds.o
++OBJS-$(CONFIG_DERF_DPCM_DECODER)       += dpcm.o
++OBJS-$(CONFIG_DIRAC_DECODER)           += diracdec.o dirac.o diracdsp.o diractab.o \
++                                          dirac_arith.o dirac_dwt.o dirac_vlc.o
++OBJS-$(CONFIG_DFA_DECODER)             += dfa.o
++OBJS-$(CONFIG_DNXHD_DECODER)           += dnxhddec.o dnxhddata.o
++OBJS-$(CONFIG_DNXHD_ENCODER)           += dnxhdenc.o dnxhddata.o
++OBJS-$(CONFIG_DOLBY_E_DECODER)         += dolby_e.o dolby_e_parse.o kbdwin.o
++OBJS-$(CONFIG_DPX_DECODER)             += dpx.o
++OBJS-$(CONFIG_DPX_ENCODER)             += dpxenc.o
++OBJS-$(CONFIG_DSD_LSBF_DECODER)        += dsddec.o dsd.o
++OBJS-$(CONFIG_DSD_MSBF_DECODER)        += dsddec.o dsd.o
++OBJS-$(CONFIG_DSD_LSBF_PLANAR_DECODER) += dsddec.o dsd.o
++OBJS-$(CONFIG_DSD_MSBF_PLANAR_DECODER) += dsddec.o dsd.o
++OBJS-$(CONFIG_DSICINAUDIO_DECODER)     += dsicinaudio.o
++OBJS-$(CONFIG_DSICINVIDEO_DECODER)     += dsicinvideo.o
++OBJS-$(CONFIG_DSS_SP_DECODER)          += dss_sp.o
++OBJS-$(CONFIG_DST_DECODER)             += dstdec.o dsd.o
++OBJS-$(CONFIG_DVBSUB_DECODER)          += dvbsubdec.o
++OBJS-$(CONFIG_DVBSUB_ENCODER)          += dvbsubenc.o
++OBJS-$(CONFIG_DVDSUB_DECODER)          += dvdsubdec.o dvdsub.o
++OBJS-$(CONFIG_DVDSUB_ENCODER)          += dvdsubenc.o dvdsub.o
++OBJS-$(CONFIG_DVAUDIO_DECODER)         += dvaudiodec.o
++OBJS-$(CONFIG_DVVIDEO_DECODER)         += dvdec.o dv.o dvdata.o
++OBJS-$(CONFIG_DVVIDEO_ENCODER)         += dvenc.o dv.o dvdata.o
++OBJS-$(CONFIG_DXA_DECODER)             += dxa.o
++OBJS-$(CONFIG_DXTORY_DECODER)          += dxtory.o
++OBJS-$(CONFIG_DXV_DECODER)             += dxv.o
++OBJS-$(CONFIG_EAC3_DECODER)            += eac3_data.o
++OBJS-$(CONFIG_EAC3_ENCODER)            += eac3enc.o eac3_data.o
++OBJS-$(CONFIG_EACMV_DECODER)           += eacmv.o
++OBJS-$(CONFIG_EAMAD_DECODER)           += eamad.o eaidct.o mpeg12.o \
++                                          mpeg12data.o
++OBJS-$(CONFIG_EATGQ_DECODER)           += eatgq.o eaidct.o
++OBJS-$(CONFIG_EATGV_DECODER)           += eatgv.o
++OBJS-$(CONFIG_EATQI_DECODER)           += eatqi.o eaidct.o mpeg12.o mpeg12data.o mpegvideodata.o rl.o
++OBJS-$(CONFIG_EIGHTBPS_DECODER)        += 8bps.o
++OBJS-$(CONFIG_EIGHTSVX_EXP_DECODER)    += 8svx.o
++OBJS-$(CONFIG_EIGHTSVX_FIB_DECODER)    += 8svx.o
++OBJS-$(CONFIG_ESCAPE124_DECODER)       += escape124.o
++OBJS-$(CONFIG_ESCAPE130_DECODER)       += escape130.o
++OBJS-$(CONFIG_EVRC_DECODER)            += evrcdec.o acelp_vectors.o lsp.o
++OBJS-$(CONFIG_EXR_DECODER)             += exr.o exrdsp.o
++OBJS-$(CONFIG_EXR_ENCODER)             += exrenc.o
++OBJS-$(CONFIG_FASTAUDIO_DECODER)       += fastaudio.o
++OBJS-$(CONFIG_FFV1_DECODER)            += ffv1dec.o ffv1.o
++OBJS-$(CONFIG_FFV1_ENCODER)            += ffv1enc.o ffv1.o
++OBJS-$(CONFIG_FFWAVESYNTH_DECODER)     += ffwavesynth.o
++OBJS-$(CONFIG_FIC_DECODER)             += fic.o
++OBJS-$(CONFIG_FITS_DECODER)            += fitsdec.o fits.o
++OBJS-$(CONFIG_FITS_ENCODER)            += fitsenc.o
++OBJS-$(CONFIG_FLAC_DECODER)            += flacdec.o flacdata.o flac.o
++OBJS-$(CONFIG_FLAC_ENCODER)            += flacenc.o flacdata.o flac.o
++OBJS-$(CONFIG_FLASHSV_DECODER)         += flashsv.o
++OBJS-$(CONFIG_FLASHSV_ENCODER)         += flashsvenc.o
++OBJS-$(CONFIG_FLASHSV2_ENCODER)        += flashsv2enc.o
++OBJS-$(CONFIG_FLASHSV2_DECODER)        += flashsv.o
++OBJS-$(CONFIG_FLIC_DECODER)            += flicvideo.o
++OBJS-$(CONFIG_FLV_DECODER)             += flvdec.o
++OBJS-$(CONFIG_FLV_ENCODER)             += flvenc.o
++OBJS-$(CONFIG_FMVC_DECODER)            += fmvc.o
++OBJS-$(CONFIG_FOURXM_DECODER)          += 4xm.o
++OBJS-$(CONFIG_FRAPS_DECODER)           += fraps.o
++OBJS-$(CONFIG_FRWU_DECODER)            += frwu.o
++OBJS-$(CONFIG_G2M_DECODER)             += g2meet.o elsdec.o mjpegdec_common.o
++OBJS-$(CONFIG_G723_1_DECODER)          += g723_1dec.o g723_1.o \
++                                          acelp_vectors.o celp_filters.o celp_math.o
++OBJS-$(CONFIG_G723_1_ENCODER)          += g723_1enc.o g723_1.o \
++                                          acelp_vectors.o celp_filters.o celp_math.o
++OBJS-$(CONFIG_G729_DECODER)            += g729dec.o lsp.o celp_math.o celp_filters.o acelp_filters.o acelp_pitch_delay.o acelp_vectors.o g729postfilter.o
++OBJS-$(CONFIG_GDV_DECODER)             += gdv.o
++OBJS-$(CONFIG_GIF_DECODER)             += gifdec.o lzw.o
++OBJS-$(CONFIG_GIF_ENCODER)             += gif.o lzwenc.o
++OBJS-$(CONFIG_GREMLIN_DPCM_DECODER)    += dpcm.o
++OBJS-$(CONFIG_GSM_DECODER)             += gsmdec.o gsmdec_data.o msgsmdec.o
++OBJS-$(CONFIG_GSM_MS_DECODER)          += gsmdec.o gsmdec_data.o msgsmdec.o
++OBJS-$(CONFIG_H261_DECODER)            += h261dec.o h261data.o h261.o
++OBJS-$(CONFIG_H261_ENCODER)            += h261enc.o h261data.o h261.o
++OBJS-$(CONFIG_H263_DECODER)            += h263dec.o h263.o ituh263dec.o        \
++                                          mpeg4video.o mpeg4videodec.o \
++                                          h263data.o
++OBJS-$(CONFIG_H263I_DECODER)           += intelh263dec.o
++OBJS-$(CONFIG_H263_ENCODER)            += mpeg4video.o  \
++                                          h263.o ituh263enc.o h263data.o
++OBJS-$(CONFIG_H263_V4L2M2M_DECODER)    += v4l2_m2m_dec.o
++OBJS-$(CONFIG_H263_V4L2M2M_ENCODER)    += v4l2_m2m_enc.o
++OBJS-$(CONFIG_H264_DECODER)            += h264dec.o h264_cabac.o h264_cavlc.o \
++                                          h264_direct.o h264_loopfilter.o  \
++                                          h264_mb.o h264_picture.o \
++                                          h264_refs.o h264_sei.o \
++                                          h264_slice.o h264data.o
++OBJS-$(CONFIG_H264_AMF_ENCODER)        += amfenc_h264.o
++OBJS-$(CONFIG_H264_CUVID_DECODER)      += cuviddec.o
++OBJS-$(CONFIG_H264_MEDIACODEC_DECODER) += mediacodecdec.o
++OBJS-$(CONFIG_H264_MF_ENCODER)         += mfenc.o mf_utils.o
++OBJS-$(CONFIG_H264_MMAL_DECODER)       += mmaldec.o
++OBJS-$(CONFIG_H264_NVENC_ENCODER)      += nvenc_h264.o
++OBJS-$(CONFIG_NVENC_ENCODER)           += nvenc_h264.o
++OBJS-$(CONFIG_NVENC_H264_ENCODER)      += nvenc_h264.o
++OBJS-$(CONFIG_H264_OMX_ENCODER)        += omx.o
++OBJS-$(CONFIG_H264_QSV_DECODER)        += qsvdec.o
++OBJS-$(CONFIG_H264_QSV_ENCODER)        += qsvenc_h264.o
++OBJS-$(CONFIG_H264_RKMPP_DECODER)      += rkmppdec.o
++OBJS-$(CONFIG_H264_VAAPI_ENCODER)      += vaapi_encode_h264.o h264_levels.o
++OBJS-$(CONFIG_H264_VIDEOTOOLBOX_ENCODER) += videotoolboxenc.o
++OBJS-$(CONFIG_H264_V4L2M2M_DECODER)    += v4l2_m2m_dec.o
++OBJS-$(CONFIG_H264_V4L2M2M_ENCODER)    += v4l2_m2m_enc.o
++OBJS-$(CONFIG_HAP_DECODER)             += hapdec.o hap.o
++OBJS-$(CONFIG_HAP_ENCODER)             += hapenc.o hap.o
++OBJS-$(CONFIG_HCA_DECODER)             += hcadec.o
++OBJS-$(CONFIG_HCOM_DECODER)            += hcom.o
++OBJS-$(CONFIG_HEVC_DECODER)            += hevcdec.o hevc_mvs.o \
++                                          hevc_cabac.o hevc_refs.o hevcpred.o    \
++                                          hevcdsp.o hevc_filter.o hevc_data.o
++OBJS-$(CONFIG_HEVC_AMF_ENCODER)        += amfenc_hevc.o
++OBJS-$(CONFIG_HEVC_CUVID_DECODER)      += cuviddec.o
++OBJS-$(CONFIG_HEVC_MEDIACODEC_DECODER) += mediacodecdec.o
++OBJS-$(CONFIG_HEVC_MF_ENCODER)         += mfenc.o mf_utils.o
++OBJS-$(CONFIG_HEVC_NVENC_ENCODER)      += nvenc_hevc.o
++OBJS-$(CONFIG_NVENC_HEVC_ENCODER)      += nvenc_hevc.o
++OBJS-$(CONFIG_HEVC_QSV_DECODER)        += qsvdec.o
++OBJS-$(CONFIG_HEVC_QSV_ENCODER)        += qsvenc_hevc.o hevc_ps_enc.o       \
++                                          hevc_data.o
++OBJS-$(CONFIG_HEVC_RKMPP_DECODER)      += rkmppdec.o
++OBJS-$(CONFIG_HEVC_VAAPI_ENCODER)      += vaapi_encode_h265.o h265_profile_level.o
++OBJS-$(CONFIG_HEVC_V4L2M2M_DECODER)    += v4l2_m2m_dec.o
++OBJS-$(CONFIG_HEVC_V4L2M2M_ENCODER)    += v4l2_m2m_enc.o
++OBJS-$(CONFIG_HNM4_VIDEO_DECODER)      += hnm4video.o
++OBJS-$(CONFIG_HQ_HQA_DECODER)          += hq_hqa.o hq_hqadata.o hq_hqadsp.o \
++                                          canopus.o
++OBJS-$(CONFIG_HQX_DECODER)             += hqx.o hqxvlc.o hqxdsp.o canopus.o
++OBJS-$(CONFIG_HUFFYUV_DECODER)         += huffyuv.o huffyuvdec.o
++OBJS-$(CONFIG_HUFFYUV_ENCODER)         += huffyuv.o huffyuvenc.o
++OBJS-$(CONFIG_HYMT_DECODER)            += huffyuv.o huffyuvdec.o
++OBJS-$(CONFIG_IDCIN_DECODER)           += idcinvideo.o
++OBJS-$(CONFIG_IDF_DECODER)             += bintext.o cga_data.o
++OBJS-$(CONFIG_IFF_ILBM_DECODER)        += iff.o
++OBJS-$(CONFIG_ILBC_DECODER)            += ilbcdec.o
++OBJS-$(CONFIG_IMC_DECODER)             += imc.o
++OBJS-$(CONFIG_IMM4_DECODER)            += imm4.o
++OBJS-$(CONFIG_IMM5_DECODER)            += imm5.o
++OBJS-$(CONFIG_INDEO2_DECODER)          += indeo2.o
++OBJS-$(CONFIG_INDEO3_DECODER)          += indeo3.o
++OBJS-$(CONFIG_INDEO4_DECODER)          += indeo4.o ivi.o
++OBJS-$(CONFIG_INDEO5_DECODER)          += indeo5.o ivi.o
++OBJS-$(CONFIG_INTERPLAY_ACM_DECODER)   += interplayacm.o
++OBJS-$(CONFIG_INTERPLAY_DPCM_DECODER)  += dpcm.o
++OBJS-$(CONFIG_INTERPLAY_VIDEO_DECODER) += interplayvideo.o
++OBJS-$(CONFIG_IPU_DECODER)             += mpeg12dec.o mpeg12.o mpeg12data.o
++OBJS-$(CONFIG_JACOSUB_DECODER)         += jacosubdec.o ass.o
++OBJS-$(CONFIG_JPEG2000_ENCODER)        += j2kenc.o mqcenc.o mqc.o jpeg2000.o \
++                                          jpeg2000dwt.o
++OBJS-$(CONFIG_JPEG2000_DECODER)        += jpeg2000dec.o jpeg2000.o jpeg2000dsp.o \
++                                          jpeg2000dwt.o mqcdec.o mqc.o
++OBJS-$(CONFIG_JPEGLS_DECODER)          += jpeglsdec.o jpegls.o
++OBJS-$(CONFIG_JPEGLS_ENCODER)          += jpeglsenc.o jpegls.o
++OBJS-$(CONFIG_JV_DECODER)              += jvdec.o
++OBJS-$(CONFIG_KGV1_DECODER)            += kgv1dec.o
++OBJS-$(CONFIG_KMVC_DECODER)            += kmvc.o
++OBJS-$(CONFIG_LAGARITH_DECODER)        += lagarith.o lagarithrac.o
++OBJS-$(CONFIG_LJPEG_ENCODER)           += ljpegenc.o mjpegenc_common.o
++OBJS-$(CONFIG_LOCO_DECODER)            += loco.o
++OBJS-$(CONFIG_LSCR_DECODER)            += lscrdec.o png.o pngdec.o pngdsp.o
++OBJS-$(CONFIG_M101_DECODER)            += m101.o
++OBJS-$(CONFIG_MACE3_DECODER)           += mace.o
++OBJS-$(CONFIG_MACE6_DECODER)           += mace.o
++OBJS-$(CONFIG_MAGICYUV_DECODER)        += magicyuv.o
++OBJS-$(CONFIG_MAGICYUV_ENCODER)        += magicyuvenc.o
++OBJS-$(CONFIG_MDEC_DECODER)            += mdec.o mpeg12.o mpeg12data.o
++OBJS-$(CONFIG_METASOUND_DECODER)       += metasound.o metasound_data.o \
++                                          twinvq.o
++OBJS-$(CONFIG_MICRODVD_DECODER)        += microdvddec.o ass.o
++OBJS-$(CONFIG_MIMIC_DECODER)           += mimic.o
++OBJS-$(CONFIG_MJPEG_DECODER)           += mjpegdec.o mjpegdec_common.o
++OBJS-$(CONFIG_MJPEG_QSV_DECODER)       += qsvdec.o
++OBJS-$(CONFIG_MJPEG_ENCODER)           += mjpegenc.o mjpegenc_common.o \
++                                          mjpegenc_huffman.o
++OBJS-$(CONFIG_MJPEGB_DECODER)          += mjpegbdec.o
++OBJS-$(CONFIG_MJPEG_CUVID_DECODER)     += cuviddec.o
++OBJS-$(CONFIG_MJPEG_QSV_ENCODER)       += qsvenc_jpeg.o
++OBJS-$(CONFIG_MJPEG_VAAPI_ENCODER)     += vaapi_encode_mjpeg.o
++OBJS-$(CONFIG_MLP_DECODER)             += mlpdec.o mlpdsp.o
++OBJS-$(CONFIG_MLP_ENCODER)             += mlpenc.o mlp.o
++OBJS-$(CONFIG_MMVIDEO_DECODER)         += mmvideo.o
++OBJS-$(CONFIG_MOBICLIP_DECODER)        += mobiclip.o
++OBJS-$(CONFIG_MOTIONPIXELS_DECODER)    += motionpixels.o
++OBJS-$(CONFIG_MOVTEXT_DECODER)         += movtextdec.o ass.o
++OBJS-$(CONFIG_MOVTEXT_ENCODER)         += movtextenc.o ass_split.o
++OBJS-$(CONFIG_MP1_DECODER)             += mpegaudiodec_fixed.o
++OBJS-$(CONFIG_MP1FLOAT_DECODER)        += mpegaudiodec_float.o
++OBJS-$(CONFIG_MP2_DECODER)             += mpegaudiodec_fixed.o
++OBJS-$(CONFIG_MP2_ENCODER)             += mpegaudioenc_float.o mpegaudio.o \
++                                          mpegaudiodata.o mpegaudiodsp_data.o
++OBJS-$(CONFIG_MP2FIXED_ENCODER)        += mpegaudioenc_fixed.o mpegaudio.o \
++                                          mpegaudiodata.o mpegaudiodsp_data.o
++OBJS-$(CONFIG_MP2FLOAT_DECODER)        += mpegaudiodec_float.o
++OBJS-$(CONFIG_MP3_DECODER)             += mpegaudiodec_fixed.o
++OBJS-$(CONFIG_MP3_MF_ENCODER)          += mfenc.o mf_utils.o
++OBJS-$(CONFIG_MP3ADU_DECODER)          += mpegaudiodec_fixed.o
++OBJS-$(CONFIG_MP3ADUFLOAT_DECODER)     += mpegaudiodec_float.o
++OBJS-$(CONFIG_MP3FLOAT_DECODER)        += mpegaudiodec_float.o
++OBJS-$(CONFIG_MP3ON4_DECODER)          += mpegaudiodec_fixed.o mpeg4audio.o
++OBJS-$(CONFIG_MP3ON4FLOAT_DECODER)     += mpegaudiodec_float.o mpeg4audio.o
++OBJS-$(CONFIG_MPC7_DECODER)            += mpc7.o mpc.o
++OBJS-$(CONFIG_MPC8_DECODER)            += mpc8.o mpc.o
++OBJS-$(CONFIG_MPEGVIDEO_DECODER)       += mpeg12dec.o mpeg12.o mpeg12data.o
++OBJS-$(CONFIG_MPEG1VIDEO_DECODER)      += mpeg12dec.o mpeg12.o mpeg12data.o
++OBJS-$(CONFIG_MPEG1VIDEO_ENCODER)      += mpeg12enc.o mpeg12.o
++OBJS-$(CONFIG_MPEG1_CUVID_DECODER)     += cuviddec.o
++OBJS-$(CONFIG_MPEG1_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
++OBJS-$(CONFIG_MPEG2_MMAL_DECODER)      += mmaldec.o
++OBJS-$(CONFIG_MPEG2_QSV_DECODER)       += qsvdec.o
++OBJS-$(CONFIG_MPEG2_QSV_ENCODER)       += qsvenc_mpeg2.o
++OBJS-$(CONFIG_MPEG2VIDEO_DECODER)      += mpeg12dec.o mpeg12.o mpeg12data.o
++OBJS-$(CONFIG_MPEG2VIDEO_ENCODER)      += mpeg12enc.o mpeg12.o
++OBJS-$(CONFIG_MPEG2_CUVID_DECODER)     += cuviddec.o
++OBJS-$(CONFIG_MPEG2_MEDIACODEC_DECODER) += mediacodecdec.o
++OBJS-$(CONFIG_MPEG2_VAAPI_ENCODER)     += vaapi_encode_mpeg2.o
++OBJS-$(CONFIG_MPEG2_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
++OBJS-$(CONFIG_MPEG4_DECODER)           += xvididct.o
++OBJS-$(CONFIG_MPEG4_ENCODER)           += mpeg4videoenc.o
++OBJS-$(CONFIG_MPEG4_CUVID_DECODER)     += cuviddec.o
++OBJS-$(CONFIG_MPEG4_MEDIACODEC_DECODER) += mediacodecdec.o
++OBJS-$(CONFIG_MPEG4_OMX_ENCODER)       += omx.o
++OBJS-$(CONFIG_MPEG4_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
++OBJS-$(CONFIG_MPEG4_V4L2M2M_ENCODER)   += v4l2_m2m_enc.o
++OBJS-$(CONFIG_MPL2_DECODER)            += mpl2dec.o ass.o
++OBJS-$(CONFIG_MSA1_DECODER)            += mss3.o
++OBJS-$(CONFIG_MSCC_DECODER)            += mscc.o
++OBJS-$(CONFIG_MSMPEG4V1_DECODER)       += msmpeg4dec.o msmpeg4.o msmpeg4data.o
++OBJS-$(CONFIG_MSMPEG4V2_DECODER)       += msmpeg4dec.o msmpeg4.o msmpeg4data.o
++OBJS-$(CONFIG_MSMPEG4V2_ENCODER)       += msmpeg4enc.o msmpeg4.o msmpeg4data.o
++OBJS-$(CONFIG_MSMPEG4V3_DECODER)       += msmpeg4dec.o msmpeg4.o msmpeg4data.o
++OBJS-$(CONFIG_MSMPEG4V3_ENCODER)       += msmpeg4enc.o msmpeg4.o msmpeg4data.o
++OBJS-$(CONFIG_MSP2_DECODER)            += msp2dec.o
++OBJS-$(CONFIG_MSRLE_DECODER)           += msrle.o msrledec.o
++OBJS-$(CONFIG_MSS1_DECODER)            += mss1.o mss12.o
++OBJS-$(CONFIG_MSS2_DECODER)            += mss2.o mss12.o mss2dsp.o wmv2data.o
++OBJS-$(CONFIG_MSVIDEO1_DECODER)        += msvideo1.o
++OBJS-$(CONFIG_MSVIDEO1_ENCODER)        += msvideo1enc.o elbg.o
++OBJS-$(CONFIG_MSZH_DECODER)            += lcldec.o
++OBJS-$(CONFIG_MTS2_DECODER)            += mss4.o
++OBJS-$(CONFIG_MV30_DECODER)            += mv30.o
++OBJS-$(CONFIG_MVC1_DECODER)            += mvcdec.o
++OBJS-$(CONFIG_MVC2_DECODER)            += mvcdec.o
++OBJS-$(CONFIG_MVDV_DECODER)            += midivid.o
++OBJS-$(CONFIG_MVHA_DECODER)            += mvha.o
++OBJS-$(CONFIG_MWSC_DECODER)            += mwsc.o
++OBJS-$(CONFIG_MXPEG_DECODER)           += mxpegdec.o
++OBJS-$(CONFIG_NELLYMOSER_DECODER)      += nellymoserdec.o nellymoser.o
++OBJS-$(CONFIG_NELLYMOSER_ENCODER)      += nellymoserenc.o nellymoser.o
++OBJS-$(CONFIG_NOTCHLC_DECODER)         += notchlc.o
++OBJS-$(CONFIG_NUV_DECODER)             += nuv.o rtjpeg.o
++OBJS-$(CONFIG_ON2AVC_DECODER)          += on2avc.o on2avcdata.o
++OBJS-$(CONFIG_OPUS_DECODER)            += opusdec.o opus.o opus_celt.o opus_rc.o \
++                                          opus_pvq.o opus_silk.o opustab.o vorbis_data.o \
++                                          opusdsp.o
++OBJS-$(CONFIG_OPUS_ENCODER)            += opusenc.o opus.o opus_rc.o opustab.o opus_pvq.o \
++                                          opusenc_psy.o vorbis_data.o
++OBJS-$(CONFIG_PAF_AUDIO_DECODER)       += pafaudio.o
++OBJS-$(CONFIG_PAF_VIDEO_DECODER)       += pafvideo.o
++OBJS-$(CONFIG_PAM_DECODER)             += pnmdec.o pnm.o
++OBJS-$(CONFIG_PAM_ENCODER)             += pamenc.o
++OBJS-$(CONFIG_PBM_DECODER)             += pnmdec.o pnm.o
++OBJS-$(CONFIG_PBM_ENCODER)             += pnmenc.o
++OBJS-$(CONFIG_PCX_DECODER)             += pcx.o
++OBJS-$(CONFIG_PCX_ENCODER)             += pcxenc.o
++OBJS-$(CONFIG_PFM_DECODER)             += pnmdec.o pnm.o
++OBJS-$(CONFIG_PFM_ENCODER)             += pnmenc.o
++OBJS-$(CONFIG_PGM_DECODER)             += pnmdec.o pnm.o
++OBJS-$(CONFIG_PGM_ENCODER)             += pnmenc.o
++OBJS-$(CONFIG_PGMYUV_DECODER)          += pnmdec.o pnm.o
++OBJS-$(CONFIG_PGMYUV_ENCODER)          += pnmenc.o
++OBJS-$(CONFIG_PGSSUB_DECODER)          += pgssubdec.o
++OBJS-$(CONFIG_PGX_DECODER)             += pgxdec.o
++OBJS-$(CONFIG_PHOTOCD_DECODER)         += photocd.o
++OBJS-$(CONFIG_PICTOR_DECODER)          += pictordec.o cga_data.o
++OBJS-$(CONFIG_PIXLET_DECODER)          += pixlet.o
++OBJS-$(CONFIG_PJS_DECODER)             += textdec.o ass.o
++OBJS-$(CONFIG_PNG_DECODER)             += png.o pngdec.o pngdsp.o
++OBJS-$(CONFIG_PNG_ENCODER)             += png.o pngenc.o
++OBJS-$(CONFIG_PPM_DECODER)             += pnmdec.o pnm.o
++OBJS-$(CONFIG_PPM_ENCODER)             += pnmenc.o
++OBJS-$(CONFIG_PRORES_DECODER)          += proresdec2.o proresdsp.o proresdata.o
++OBJS-$(CONFIG_PRORES_ENCODER)          += proresenc_anatoliy.o proresdata.o
++OBJS-$(CONFIG_PRORES_AW_ENCODER)       += proresenc_anatoliy.o proresdata.o
++OBJS-$(CONFIG_PRORES_KS_ENCODER)       += proresenc_kostya.o proresdata.o
++OBJS-$(CONFIG_PROSUMER_DECODER)        += prosumer.o
++OBJS-$(CONFIG_PSD_DECODER)             += psd.o
++OBJS-$(CONFIG_PTX_DECODER)             += ptx.o
++OBJS-$(CONFIG_QCELP_DECODER)           += qcelpdec.o                     \
++                                          celp_filters.o acelp_vectors.o \
++                                          acelp_filters.o
++OBJS-$(CONFIG_QDM2_DECODER)            += qdm2.o
++OBJS-$(CONFIG_QDMC_DECODER)            += qdmc.o
++OBJS-$(CONFIG_QDRAW_DECODER)           += qdrw.o
++OBJS-$(CONFIG_QPEG_DECODER)            += qpeg.o
++OBJS-$(CONFIG_QTRLE_DECODER)           += qtrle.o
++OBJS-$(CONFIG_QTRLE_ENCODER)           += qtrleenc.o
++OBJS-$(CONFIG_R10K_DECODER)            += r210dec.o
++OBJS-$(CONFIG_R10K_ENCODER)            += r210enc.o
++OBJS-$(CONFIG_R210_DECODER)            += r210dec.o
++OBJS-$(CONFIG_R210_ENCODER)            += r210enc.o
++OBJS-$(CONFIG_RA_144_DECODER)          += ra144dec.o ra144.o celp_filters.o
++OBJS-$(CONFIG_RA_144_ENCODER)          += ra144enc.o ra144.o celp_filters.o
++OBJS-$(CONFIG_RA_288_DECODER)          += ra288.o celp_filters.o
++OBJS-$(CONFIG_RALF_DECODER)            += ralf.o
++OBJS-$(CONFIG_RASC_DECODER)            += rasc.o
++OBJS-$(CONFIG_RAWVIDEO_DECODER)        += rawdec.o
++OBJS-$(CONFIG_RAWVIDEO_ENCODER)        += rawenc.o
++OBJS-$(CONFIG_REALTEXT_DECODER)        += realtextdec.o ass.o
++OBJS-$(CONFIG_RL2_DECODER)             += rl2.o
++OBJS-$(CONFIG_ROQ_DECODER)             += roqvideodec.o roqvideo.o
++OBJS-$(CONFIG_ROQ_ENCODER)             += roqvideoenc.o roqvideo.o elbg.o
++OBJS-$(CONFIG_ROQ_DPCM_DECODER)        += dpcm.o
++OBJS-$(CONFIG_ROQ_DPCM_ENCODER)        += roqaudioenc.o
++OBJS-$(CONFIG_RPZA_DECODER)            += rpza.o
++OBJS-$(CONFIG_RPZA_ENCODER)            += rpzaenc.o
++OBJS-$(CONFIG_RSCC_DECODER)            += rscc.o
++OBJS-$(CONFIG_RV10_DECODER)            += rv10.o
++OBJS-$(CONFIG_RV10_ENCODER)            += rv10enc.o
++OBJS-$(CONFIG_RV20_DECODER)            += rv10.o
++OBJS-$(CONFIG_RV20_ENCODER)            += rv20enc.o
++OBJS-$(CONFIG_RV30_DECODER)            += rv30.o rv34.o rv30dsp.o
++OBJS-$(CONFIG_RV40_DECODER)            += rv40.o rv34.o rv40dsp.o
++OBJS-$(CONFIG_SAMI_DECODER)            += samidec.o ass.o htmlsubtitles.o
++OBJS-$(CONFIG_S302M_DECODER)           += s302m.o
++OBJS-$(CONFIG_S302M_ENCODER)           += s302menc.o
++OBJS-$(CONFIG_SANM_DECODER)            += sanm.o
++OBJS-$(CONFIG_SCPR_DECODER)            += scpr.o
++OBJS-$(CONFIG_SCREENPRESSO_DECODER)    += screenpresso.o
++OBJS-$(CONFIG_SDX2_DPCM_DECODER)       += dpcm.o
++OBJS-$(CONFIG_SGA_DECODER)             += sga.o
++OBJS-$(CONFIG_SGI_DECODER)             += sgidec.o
++OBJS-$(CONFIG_SGI_ENCODER)             += sgienc.o rle.o
++OBJS-$(CONFIG_SGIRLE_DECODER)          += sgirledec.o
++OBJS-$(CONFIG_SHEERVIDEO_DECODER)      += sheervideo.o
++OBJS-$(CONFIG_SHORTEN_DECODER)         += shorten.o
++OBJS-$(CONFIG_SIPR_DECODER)            += sipr.o acelp_pitch_delay.o \
++                                          celp_math.o acelp_vectors.o \
++                                          acelp_filters.o celp_filters.o \
++                                          sipr16k.o
++OBJS-$(CONFIG_SIREN_DECODER)           += siren.o
++OBJS-$(CONFIG_SIMBIOSIS_IMX_DECODER)   += imx.o
++OBJS-$(CONFIG_SMACKAUD_DECODER)        += smacker.o
++OBJS-$(CONFIG_SMACKER_DECODER)         += smacker.o
++OBJS-$(CONFIG_SMC_DECODER)             += smc.o
++OBJS-$(CONFIG_SNOW_DECODER)            += snowdec.o snow.o snow_dwt.o
++OBJS-$(CONFIG_SNOW_ENCODER)            += snowenc.o snow.o snow_dwt.o             \
++                                          h263.o h263data.o ituh263enc.o
++OBJS-$(CONFIG_SOL_DPCM_DECODER)        += dpcm.o
++OBJS-$(CONFIG_SONIC_DECODER)           += sonic.o
++OBJS-$(CONFIG_SONIC_ENCODER)           += sonic.o
++OBJS-$(CONFIG_SONIC_LS_ENCODER)        += sonic.o
++OBJS-$(CONFIG_SPEEDHQ_DECODER)         += speedhq.o mpeg12.o mpeg12data.o simple_idct.o
++OBJS-$(CONFIG_SPEEDHQ_ENCODER)         += speedhq.o mpeg12data.o mpeg12enc.o speedhqenc.o
++OBJS-$(CONFIG_SP5X_DECODER)            += sp5xdec.o
++OBJS-$(CONFIG_SRGC_DECODER)            += mscc.o
++OBJS-$(CONFIG_SRT_DECODER)             += srtdec.o ass.o htmlsubtitles.o
++OBJS-$(CONFIG_SRT_ENCODER)             += srtenc.o ass_split.o
++OBJS-$(CONFIG_STL_DECODER)             += textdec.o ass.o
++OBJS-$(CONFIG_SUBRIP_DECODER)          += srtdec.o ass.o htmlsubtitles.o
++OBJS-$(CONFIG_SUBRIP_ENCODER)          += srtenc.o ass_split.o
++OBJS-$(CONFIG_SUBVIEWER1_DECODER)      += textdec.o ass.o
++OBJS-$(CONFIG_SUBVIEWER_DECODER)       += subviewerdec.o ass.o
++OBJS-$(CONFIG_SUNRAST_DECODER)         += sunrast.o
++OBJS-$(CONFIG_SUNRAST_ENCODER)         += sunrastenc.o
++OBJS-$(CONFIG_LIBRSVG_DECODER)         += librsvgdec.o
++OBJS-$(CONFIG_SBC_DECODER)             += sbcdec.o sbcdec_data.o sbc.o
++OBJS-$(CONFIG_SBC_ENCODER)             += sbcenc.o sbc.o sbcdsp.o sbcdsp_data.o
++OBJS-$(CONFIG_SVQ1_DECODER)            += svq1dec.o svq1.o h263data.o
++OBJS-$(CONFIG_SVQ1_ENCODER)            += svq1enc.o svq1.o  h263data.o  \
++                                          h263.o ituh263enc.o
++OBJS-$(CONFIG_SVQ3_DECODER)            += svq3.o mpegutils.o h264data.o
++OBJS-$(CONFIG_TEXT_DECODER)            += textdec.o ass.o
++OBJS-$(CONFIG_TEXT_ENCODER)            += srtenc.o ass_split.o
++OBJS-$(CONFIG_TAK_DECODER)             += takdec.o tak.o takdsp.o
++OBJS-$(CONFIG_TARGA_DECODER)           += targa.o
++OBJS-$(CONFIG_TARGA_ENCODER)           += targaenc.o rle.o
++OBJS-$(CONFIG_TARGA_Y216_DECODER)      += targa_y216dec.o
++OBJS-$(CONFIG_TDSC_DECODER)            += tdsc.o
++OBJS-$(CONFIG_TIERTEXSEQVIDEO_DECODER) += tiertexseqv.o
++OBJS-$(CONFIG_TIFF_DECODER)            += tiff.o lzw.o faxcompr.o tiff_common.o
++OBJS-$(CONFIG_TIFF_ENCODER)            += tiffenc.o rle.o lzwenc.o
++OBJS-$(CONFIG_TMV_DECODER)             += tmv.o cga_data.o
++OBJS-$(CONFIG_TRUEHD_DECODER)          += mlpdec.o mlpdsp.o
++OBJS-$(CONFIG_TRUEHD_ENCODER)          += mlpenc.o mlp.o
++OBJS-$(CONFIG_TRUEMOTION1_DECODER)     += truemotion1.o
++OBJS-$(CONFIG_TRUEMOTION2_DECODER)     += truemotion2.o
++OBJS-$(CONFIG_TRUEMOTION2RT_DECODER)   += truemotion2rt.o
++OBJS-$(CONFIG_TRUESPEECH_DECODER)      += truespeech.o
++OBJS-$(CONFIG_TSCC_DECODER)            += tscc.o msrledec.o
++OBJS-$(CONFIG_TSCC2_DECODER)           += tscc2.o
++OBJS-$(CONFIG_TTA_DECODER)             += tta.o ttadata.o ttadsp.o
++OBJS-$(CONFIG_TTA_ENCODER)             += ttaenc.o ttaencdsp.o ttadata.o
++OBJS-$(CONFIG_TTML_ENCODER)            += ttmlenc.o ass_split.o
++OBJS-$(CONFIG_TWINVQ_DECODER)          += twinvqdec.o twinvq.o metasound_data.o
++OBJS-$(CONFIG_TXD_DECODER)             += txd.o
++OBJS-$(CONFIG_ULTI_DECODER)            += ulti.o
++OBJS-$(CONFIG_UTVIDEO_DECODER)         += utvideodec.o utvideodsp.o
++OBJS-$(CONFIG_UTVIDEO_ENCODER)         += utvideoenc.o
++OBJS-$(CONFIG_V210_DECODER)            += v210dec.o
++OBJS-$(CONFIG_V210_ENCODER)            += v210enc.o
++OBJS-$(CONFIG_V210X_DECODER)           += v210x.o
++OBJS-$(CONFIG_V308_DECODER)            += v308dec.o
++OBJS-$(CONFIG_V308_ENCODER)            += v308enc.o
++OBJS-$(CONFIG_V408_DECODER)            += v408dec.o
++OBJS-$(CONFIG_V408_ENCODER)            += v408enc.o
++OBJS-$(CONFIG_V410_DECODER)            += v410dec.o
++OBJS-$(CONFIG_V410_ENCODER)            += v410enc.o
++OBJS-$(CONFIG_VB_DECODER)              += vb.o
++OBJS-$(CONFIG_VBLE_DECODER)            += vble.o
++OBJS-$(CONFIG_VC1_DECODER)             += vc1dec.o vc1_block.o vc1_loopfilter.o \
++                                          vc1_mc.o vc1_pred.o vc1.o vc1data.o \
++                                          msmpeg4dec.o msmpeg4.o msmpeg4data.o \
++                                          wmv2dsp.o wmv2data.o
++OBJS-$(CONFIG_VC1_CUVID_DECODER)       += cuviddec.o
++OBJS-$(CONFIG_VC1_MMAL_DECODER)        += mmaldec.o
++OBJS-$(CONFIG_VC1_QSV_DECODER)         += qsvdec.o
++OBJS-$(CONFIG_VC1_V4L2M2M_DECODER)     += v4l2_m2m_dec.o
++OBJS-$(CONFIG_VC2_ENCODER)             += vc2enc.o vc2enc_dwt.o diractab.o
++OBJS-$(CONFIG_VCR1_DECODER)            += vcr1.o
++OBJS-$(CONFIG_VMDAUDIO_DECODER)        += vmdaudio.o
++OBJS-$(CONFIG_VMDVIDEO_DECODER)        += vmdvideo.o
++OBJS-$(CONFIG_VMNC_DECODER)            += vmnc.o
++OBJS-$(CONFIG_VORBIS_DECODER)          += vorbisdec.o vorbisdsp.o vorbis.o \
++                                          vorbis_data.o
++OBJS-$(CONFIG_VORBIS_ENCODER)          += vorbisenc.o vorbis.o \
++                                          vorbis_data.o
++OBJS-$(CONFIG_VP3_DECODER)             += vp3.o
++OBJS-$(CONFIG_VP5_DECODER)             += vp5.o vp56.o vp56data.o vp56rac.o
++OBJS-$(CONFIG_VP6_DECODER)             += vp6.o vp56.o vp56data.o \
++                                          vp6dsp.o vp56rac.o
++OBJS-$(CONFIG_VP7_DECODER)             += vp8.o vp56rac.o
++OBJS-$(CONFIG_VP8_DECODER)             += vp8.o vp56rac.o
++OBJS-$(CONFIG_VP8_CUVID_DECODER)       += cuviddec.o
++OBJS-$(CONFIG_VP8_MEDIACODEC_DECODER)  += mediacodecdec.o
++OBJS-$(CONFIG_VP8_QSV_DECODER)         += qsvdec.o
++OBJS-$(CONFIG_VP8_RKMPP_DECODER)       += rkmppdec.o
++OBJS-$(CONFIG_VP8_VAAPI_ENCODER)       += vaapi_encode_vp8.o
++OBJS-$(CONFIG_VP8_V4L2M2M_DECODER)     += v4l2_m2m_dec.o
++OBJS-$(CONFIG_VP8_V4L2M2M_ENCODER)     += v4l2_m2m_enc.o
++OBJS-$(CONFIG_VP9_DECODER)             += vp9.o vp9data.o vp9dsp.o vp9lpf.o vp9recon.o \
++                                          vp9block.o vp9prob.o vp9mvs.o vp56rac.o \
++                                          vp9dsp_8bpp.o vp9dsp_10bpp.o vp9dsp_12bpp.o
++OBJS-$(CONFIG_VP9_CUVID_DECODER)       += cuviddec.o
++OBJS-$(CONFIG_VP9_MEDIACODEC_DECODER)  += mediacodecdec.o
++OBJS-$(CONFIG_VP9_RKMPP_DECODER)       += rkmppdec.o
++OBJS-$(CONFIG_VP9_VAAPI_ENCODER)       += vaapi_encode_vp9.o
++OBJS-$(CONFIG_VP9_QSV_ENCODER)         += qsvenc_vp9.o
++OBJS-$(CONFIG_VPLAYER_DECODER)         += textdec.o ass.o
++OBJS-$(CONFIG_VP9_V4L2M2M_DECODER)     += v4l2_m2m_dec.o
++OBJS-$(CONFIG_VQA_DECODER)             += vqavideo.o
++OBJS-$(CONFIG_WAVPACK_DECODER)         += wavpack.o wavpackdata.o dsd.o
++OBJS-$(CONFIG_WAVPACK_ENCODER)         += wavpackdata.o wavpackenc.o
++OBJS-$(CONFIG_WCMV_DECODER)            += wcmv.o
++OBJS-$(CONFIG_WEBP_DECODER)            += webp.o
++OBJS-$(CONFIG_WEBVTT_DECODER)          += webvttdec.o ass.o
++OBJS-$(CONFIG_WEBVTT_ENCODER)          += webvttenc.o ass_split.o
++OBJS-$(CONFIG_WMALOSSLESS_DECODER)     += wmalosslessdec.o wma_common.o
++OBJS-$(CONFIG_WMAPRO_DECODER)          += wmaprodec.o wma.o wma_common.o
++OBJS-$(CONFIG_WMAV1_DECODER)           += wmadec.o wma.o wma_common.o aactab.o
++OBJS-$(CONFIG_WMAV1_ENCODER)           += wmaenc.o wma.o wma_common.o aactab.o
++OBJS-$(CONFIG_WMAV2_DECODER)           += wmadec.o wma.o wma_common.o aactab.o
++OBJS-$(CONFIG_WMAV2_ENCODER)           += wmaenc.o wma.o wma_common.o aactab.o
++OBJS-$(CONFIG_WMAVOICE_DECODER)        += wmavoice.o \
++                                          celp_filters.o \
++                                          acelp_vectors.o acelp_filters.o
++OBJS-$(CONFIG_WMV1_DECODER)            += msmpeg4dec.o msmpeg4.o msmpeg4data.o
++OBJS-$(CONFIG_WMV1_ENCODER)            += msmpeg4enc.o msmpeg4.o msmpeg4data.o
++OBJS-$(CONFIG_WMV2_DECODER)            += wmv2dec.o wmv2.o wmv2data.o \
++                                          msmpeg4dec.o msmpeg4.o msmpeg4data.o
++OBJS-$(CONFIG_WMV2_ENCODER)            += wmv2enc.o wmv2.o wmv2data.o \
++                                          msmpeg4.o msmpeg4enc.o msmpeg4data.o
++OBJS-$(CONFIG_WNV1_DECODER)            += wnv1.o
++OBJS-$(CONFIG_WRAPPED_AVFRAME_DECODER) += wrapped_avframe.o
++OBJS-$(CONFIG_WRAPPED_AVFRAME_ENCODER) += wrapped_avframe.o
++OBJS-$(CONFIG_WS_SND1_DECODER)         += ws-snd1.o
++OBJS-$(CONFIG_XAN_DPCM_DECODER)        += dpcm.o
++OBJS-$(CONFIG_XAN_WC3_DECODER)         += xan.o
++OBJS-$(CONFIG_XAN_WC4_DECODER)         += xxan.o
++OBJS-$(CONFIG_XBIN_DECODER)            += bintext.o cga_data.o
++OBJS-$(CONFIG_XBM_DECODER)             += xbmdec.o
++OBJS-$(CONFIG_XBM_ENCODER)             += xbmenc.o
++OBJS-$(CONFIG_XFACE_DECODER)           += xfacedec.o xface.o
++OBJS-$(CONFIG_XFACE_ENCODER)           += xfaceenc.o xface.o
++OBJS-$(CONFIG_XL_DECODER)              += xl.o
++OBJS-$(CONFIG_XMA1_DECODER)            += wmaprodec.o wma.o wma_common.o
++OBJS-$(CONFIG_XMA2_DECODER)            += wmaprodec.o wma.o wma_common.o
++OBJS-$(CONFIG_XPM_DECODER)             += xpmdec.o
++OBJS-$(CONFIG_XSUB_DECODER)            += xsubdec.o
++OBJS-$(CONFIG_XSUB_ENCODER)            += xsubenc.o
++OBJS-$(CONFIG_XWD_DECODER)             += xwddec.o
++OBJS-$(CONFIG_XWD_ENCODER)             += xwdenc.o
++OBJS-$(CONFIG_Y41P_DECODER)            += y41pdec.o
++OBJS-$(CONFIG_Y41P_ENCODER)            += y41penc.o
++OBJS-$(CONFIG_YLC_DECODER)             += ylc.o
++OBJS-$(CONFIG_YOP_DECODER)             += yop.o
++OBJS-$(CONFIG_YUV4_DECODER)            += yuv4dec.o
++OBJS-$(CONFIG_YUV4_ENCODER)            += yuv4enc.o
++OBJS-$(CONFIG_ZEROCODEC_DECODER)       += zerocodec.o
++OBJS-$(CONFIG_ZLIB_DECODER)            += lcldec.o
++OBJS-$(CONFIG_ZLIB_ENCODER)            += lclenc.o
++OBJS-$(CONFIG_ZMBV_DECODER)            += zmbv.o
++OBJS-$(CONFIG_ZMBV_ENCODER)            += zmbvenc.o
++
++# (AD)PCM decoders/encoders
++OBJS-$(CONFIG_PCM_ALAW_DECODER)           += pcm.o
++OBJS-$(CONFIG_PCM_ALAW_ENCODER)           += pcm.o
++OBJS-$(CONFIG_PCM_BLURAY_DECODER)         += pcm-bluray.o
++OBJS-$(CONFIG_PCM_DVD_DECODER)            += pcm-dvd.o
++OBJS-$(CONFIG_PCM_DVD_ENCODER)            += pcm-dvdenc.o
++OBJS-$(CONFIG_PCM_F16LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_F24LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_F32BE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_F32BE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_F32LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_F32LE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_F64BE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_F64BE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_F64LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_F64LE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_LXF_DECODER)            += pcm.o
++OBJS-$(CONFIG_PCM_MULAW_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_MULAW_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S8_DECODER)             += pcm.o
++OBJS-$(CONFIG_PCM_S8_ENCODER)             += pcm.o
++OBJS-$(CONFIG_PCM_S8_PLANAR_DECODER)      += pcm.o
++OBJS-$(CONFIG_PCM_S8_PLANAR_ENCODER)      += pcm.o
++OBJS-$(CONFIG_PCM_S16BE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S16BE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S16BE_PLANAR_DECODER)   += pcm.o
++OBJS-$(CONFIG_PCM_S16BE_PLANAR_ENCODER)   += pcm.o
++OBJS-$(CONFIG_PCM_S16LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S16LE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S16LE_PLANAR_DECODER)   += pcm.o
++OBJS-$(CONFIG_PCM_S16LE_PLANAR_ENCODER)   += pcm.o
++OBJS-$(CONFIG_PCM_S24BE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S24BE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S24DAUD_DECODER)        += pcm.o
++OBJS-$(CONFIG_PCM_S24DAUD_ENCODER)        += pcm.o
++OBJS-$(CONFIG_PCM_S24LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S24LE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S24LE_PLANAR_DECODER)   += pcm.o
++OBJS-$(CONFIG_PCM_S24LE_PLANAR_ENCODER)   += pcm.o
++OBJS-$(CONFIG_PCM_S32BE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S32BE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S32LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S32LE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S32LE_PLANAR_DECODER)   += pcm.o
++OBJS-$(CONFIG_PCM_S32LE_PLANAR_ENCODER)   += pcm.o
++OBJS-$(CONFIG_PCM_S64BE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S64BE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S64LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_S64LE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_SGA_DECODER)            += pcm.o
++OBJS-$(CONFIG_PCM_U8_DECODER)             += pcm.o
++OBJS-$(CONFIG_PCM_U8_ENCODER)             += pcm.o
++OBJS-$(CONFIG_PCM_U16BE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U16BE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U16LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U16LE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U24BE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U24BE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U24LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U24LE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U32BE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U32BE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U32LE_DECODER)          += pcm.o
++OBJS-$(CONFIG_PCM_U32LE_ENCODER)          += pcm.o
++OBJS-$(CONFIG_PCM_VIDC_DECODER)           += pcm.o
++OBJS-$(CONFIG_PCM_VIDC_ENCODER)           += pcm.o
++
++OBJS-$(CONFIG_ADPCM_4XM_DECODER)          += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_ADX_DECODER)          += adxdec.o adx.o
++OBJS-$(CONFIG_ADPCM_ADX_ENCODER)          += adxenc.o adx.o
++OBJS-$(CONFIG_ADPCM_AFC_DECODER)          += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_AGM_DECODER)          += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_AICA_DECODER)         += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_ARGO_DECODER)         += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_ARGO_ENCODER)         += adpcm.o adpcmenc.o
++OBJS-$(CONFIG_ADPCM_CT_DECODER)           += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_DTK_DECODER)          += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_EA_DECODER)           += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_EA_MAXIS_XA_DECODER)  += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_EA_R1_DECODER)        += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_EA_R2_DECODER)        += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_EA_R3_DECODER)        += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_EA_XAS_DECODER)       += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_G722_DECODER)         += g722.o g722dsp.o g722dec.o
++OBJS-$(CONFIG_ADPCM_G722_ENCODER)         += g722.o g722dsp.o g722enc.o
++OBJS-$(CONFIG_ADPCM_G726_DECODER)         += g726.o
++OBJS-$(CONFIG_ADPCM_G726_ENCODER)         += g726.o
++OBJS-$(CONFIG_ADPCM_G726LE_DECODER)       += g726.o
++OBJS-$(CONFIG_ADPCM_G726LE_ENCODER)       += g726.o
++OBJS-$(CONFIG_ADPCM_IMA_AMV_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_ALP_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_ALP_ENCODER)      += adpcmenc.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_APC_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_APM_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_APM_ENCODER)      += adpcmenc.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_CUNNING_DECODER)  += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_DAT4_DECODER)     += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_DK3_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_DK4_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_EA_EACS_DECODER)  += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_EA_SEAD_DECODER)  += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_ISS_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_MOFLEX_DECODER)   += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_MTF_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_OKI_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_QT_DECODER)       += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_QT_ENCODER)       += adpcmenc.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_RAD_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_SSI_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_SSI_ENCODER)      += adpcmenc.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_SMJPEG_DECODER)   += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_WAV_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_WAV_ENCODER)      += adpcmenc.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_IMA_WS_DECODER)       += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_MS_DECODER)           += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_MS_ENCODER)           += adpcmenc.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_MTAF_DECODER)         += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_PSX_DECODER)          += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_SBPRO_2_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_SBPRO_3_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_SBPRO_4_DECODER)      += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_SWF_DECODER)          += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_SWF_ENCODER)          += adpcmenc.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_THP_DECODER)          += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_THP_LE_DECODER)       += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_VIMA_DECODER)         += vima.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_XA_DECODER)           += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_YAMAHA_DECODER)       += adpcm.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_YAMAHA_ENCODER)       += adpcmenc.o adpcm_data.o
++OBJS-$(CONFIG_ADPCM_ZORK_DECODER)         += adpcm.o adpcm_data.o
++
++# hardware accelerators
++OBJS-$(CONFIG_D3D11VA)                    += dxva2.o
++OBJS-$(CONFIG_DXVA2)                      += dxva2.o
++OBJS-$(CONFIG_NVDEC)                      += nvdec.o
++OBJS-$(CONFIG_VAAPI)                      += vaapi_decode.o
++OBJS-$(CONFIG_VIDEOTOOLBOX)               += videotoolbox.o
++OBJS-$(CONFIG_VDPAU)                      += vdpau.o
++
++OBJS-$(CONFIG_AV1_D3D11VA_HWACCEL)        += dxva2_av1.o
++OBJS-$(CONFIG_AV1_DXVA2_HWACCEL)          += dxva2_av1.o
++OBJS-$(CONFIG_AV1_NVDEC_HWACCEL)          += nvdec_av1.o
++OBJS-$(CONFIG_AV1_VAAPI_HWACCEL)          += vaapi_av1.o
++OBJS-$(CONFIG_H263_VAAPI_HWACCEL)         += vaapi_mpeg4.o
++OBJS-$(CONFIG_H263_VIDEOTOOLBOX_HWACCEL)  += videotoolbox.o
++OBJS-$(CONFIG_H264_D3D11VA_HWACCEL)       += dxva2_h264.o
++OBJS-$(CONFIG_H264_DXVA2_HWACCEL)         += dxva2_h264.o
++OBJS-$(CONFIG_H264_NVDEC_HWACCEL)         += nvdec_h264.o
++OBJS-$(CONFIG_H264_QSV_HWACCEL)           += qsvdec.o
++OBJS-$(CONFIG_H264_VAAPI_HWACCEL)         += vaapi_h264.o
++OBJS-$(CONFIG_H264_VDPAU_HWACCEL)         += vdpau_h264.o
++OBJS-$(CONFIG_H264_VIDEOTOOLBOX_HWACCEL)  += videotoolbox.o
++OBJS-$(CONFIG_HEVC_D3D11VA_HWACCEL)       += dxva2_hevc.o
++OBJS-$(CONFIG_HEVC_DXVA2_HWACCEL)         += dxva2_hevc.o
++OBJS-$(CONFIG_HEVC_NVDEC_HWACCEL)         += nvdec_hevc.o
++OBJS-$(CONFIG_HEVC_QSV_HWACCEL)           += qsvdec.o
++OBJS-$(CONFIG_HEVC_VAAPI_HWACCEL)         += vaapi_hevc.o h265_profile_level.o
++OBJS-$(CONFIG_HEVC_VDPAU_HWACCEL)         += vdpau_hevc.o h265_profile_level.o
++OBJS-$(CONFIG_MJPEG_NVDEC_HWACCEL)        += nvdec_mjpeg.o
++OBJS-$(CONFIG_MJPEG_VAAPI_HWACCEL)        += vaapi_mjpeg.o
++OBJS-$(CONFIG_MPEG1_NVDEC_HWACCEL)        += nvdec_mpeg12.o
++OBJS-$(CONFIG_MPEG1_VDPAU_HWACCEL)        += vdpau_mpeg12.o
++OBJS-$(CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL) += videotoolbox.o
++OBJS-$(CONFIG_MPEG1_XVMC_HWACCEL)         += mpegvideo_xvmc.o
++OBJS-$(CONFIG_MPEG2_D3D11VA_HWACCEL)      += dxva2_mpeg2.o
++OBJS-$(CONFIG_MPEG2_DXVA2_HWACCEL)        += dxva2_mpeg2.o
++OBJS-$(CONFIG_MPEG2_NVDEC_HWACCEL)        += nvdec_mpeg12.o
++OBJS-$(CONFIG_MPEG2_QSV_HWACCEL)          += qsvdec.o
++OBJS-$(CONFIG_MPEG2_VAAPI_HWACCEL)        += vaapi_mpeg2.o
++OBJS-$(CONFIG_MPEG2_VDPAU_HWACCEL)        += vdpau_mpeg12.o
++OBJS-$(CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL) += videotoolbox.o
++OBJS-$(CONFIG_MPEG2_XVMC_HWACCEL)         += mpegvideo_xvmc.o
++OBJS-$(CONFIG_MPEG4_NVDEC_HWACCEL)        += nvdec_mpeg4.o
++OBJS-$(CONFIG_MPEG4_VAAPI_HWACCEL)        += vaapi_mpeg4.o
++OBJS-$(CONFIG_MPEG4_VDPAU_HWACCEL)        += vdpau_mpeg4.o
++OBJS-$(CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL) += videotoolbox.o
++OBJS-$(CONFIG_VC1_D3D11VA_HWACCEL)        += dxva2_vc1.o
++OBJS-$(CONFIG_VC1_DXVA2_HWACCEL)          += dxva2_vc1.o
++OBJS-$(CONFIG_VC1_NVDEC_HWACCEL)          += nvdec_vc1.o
++OBJS-$(CONFIG_VC1_QSV_HWACCEL)            += qsvdec.o
++OBJS-$(CONFIG_VC1_VAAPI_HWACCEL)          += vaapi_vc1.o
++OBJS-$(CONFIG_VC1_VDPAU_HWACCEL)          += vdpau_vc1.o
++OBJS-$(CONFIG_VP8_NVDEC_HWACCEL)          += nvdec_vp8.o
++OBJS-$(CONFIG_VP8_VAAPI_HWACCEL)          += vaapi_vp8.o
++OBJS-$(CONFIG_VP9_D3D11VA_HWACCEL)        += dxva2_vp9.o
++OBJS-$(CONFIG_VP9_DXVA2_HWACCEL)          += dxva2_vp9.o
++OBJS-$(CONFIG_VP9_NVDEC_HWACCEL)          += nvdec_vp9.o
++OBJS-$(CONFIG_VP9_VAAPI_HWACCEL)          += vaapi_vp9.o
++OBJS-$(CONFIG_VP9_VDPAU_HWACCEL)          += vdpau_vp9.o
++OBJS-$(CONFIG_VP8_QSV_HWACCEL)            += qsvdec.o
++
++# libavformat dependencies
++OBJS-$(CONFIG_ISO_MEDIA)               += mpeg4audio.o mpegaudiodata.o
++
++OBJS-$(CONFIG_ADTS_MUXER)              += mpeg4audio.o
++OBJS-$(CONFIG_CODEC2_DEMUXER)          += codec2utils.o
++OBJS-$(CONFIG_CODEC2_MUXER)            += codec2utils.o
++OBJS-$(CONFIG_CODEC2RAW_DEMUXER)       += codec2utils.o
++OBJS-$(CONFIG_DNXHD_DEMUXER)           += dnxhddata.o
++OBJS-$(CONFIG_FITS_DEMUXER)            += fits.o
++OBJS-$(CONFIG_LATM_MUXER)              += mpeg4audio.o
++OBJS-$(CONFIG_MATROSKA_AUDIO_MUXER)    += mpeg4audio.o
++OBJS-$(CONFIG_MATROSKA_MUXER)          += mpeg4audio.o
++OBJS-$(CONFIG_MOV_DEMUXER)             += ac3tab.o
++OBJS-$(CONFIG_MATROSKA_DEMUXER)        += mpeg4audio.o
++OBJS-$(CONFIG_MXF_MUXER)               += dnxhddata.o
++OBJS-$(CONFIG_NUT_MUXER)               += mpegaudiodata.o
++OBJS-$(CONFIG_RTP_MUXER)               += mpeg4audio.o
++OBJS-$(CONFIG_SPDIF_MUXER)             += dca.o
++OBJS-$(CONFIG_TAK_DEMUXER)             += tak.o
++OBJS-$(CONFIG_WEBM_MUXER)              += mpeg4audio.o
++
++# libavfilter dependencies
++OBJS-$(CONFIG_ELBG_FILTER)             += elbg.o
++
++# external codec libraries
++OBJS-$(CONFIG_AAC_AT_DECODER)             += audiotoolboxdec.o
++OBJS-$(CONFIG_AC3_AT_DECODER)             += audiotoolboxdec.o
++OBJS-$(CONFIG_ADPCM_IMA_QT_AT_DECODER)    += audiotoolboxdec.o
++OBJS-$(CONFIG_ALAC_AT_DECODER)            += audiotoolboxdec.o
++OBJS-$(CONFIG_AMR_NB_AT_DECODER)          += audiotoolboxdec.o
++OBJS-$(CONFIG_EAC3_AT_DECODER)            += audiotoolboxdec.o
++OBJS-$(CONFIG_GSM_MS_AT_DECODER)          += audiotoolboxdec.o
++OBJS-$(CONFIG_ILBC_AT_DECODER)            += audiotoolboxdec.o
++OBJS-$(CONFIG_MP1_AT_DECODER)             += audiotoolboxdec.o
++OBJS-$(CONFIG_MP2_AT_DECODER)             += audiotoolboxdec.o
++OBJS-$(CONFIG_MP3_AT_DECODER)             += audiotoolboxdec.o
++OBJS-$(CONFIG_PCM_MULAW_AT_DECODER)       += audiotoolboxdec.o
++OBJS-$(CONFIG_PCM_ALAW_AT_DECODER)        += audiotoolboxdec.o
++OBJS-$(CONFIG_QDMC_AT_DECODER)            += audiotoolboxdec.o
++OBJS-$(CONFIG_QDM2_AT_DECODER)            += audiotoolboxdec.o
++OBJS-$(CONFIG_AAC_AT_ENCODER)             += audiotoolboxenc.o
++OBJS-$(CONFIG_ALAC_AT_ENCODER)            += audiotoolboxenc.o
++OBJS-$(CONFIG_ILBC_AT_ENCODER)            += audiotoolboxenc.o
++OBJS-$(CONFIG_PCM_ALAW_AT_ENCODER)        += audiotoolboxenc.o
++OBJS-$(CONFIG_PCM_MULAW_AT_ENCODER)       += audiotoolboxenc.o
++OBJS-$(CONFIG_LIBAOM_AV1_DECODER)         += libaomdec.o
++OBJS-$(CONFIG_LIBAOM_AV1_ENCODER)         += libaomenc.o
++OBJS-$(CONFIG_LIBARIBB24_DECODER)         += libaribb24.o ass.o
++OBJS-$(CONFIG_LIBCELT_DECODER)            += libcelt_dec.o
++OBJS-$(CONFIG_LIBCODEC2_DECODER)          += libcodec2.o codec2utils.o
++OBJS-$(CONFIG_LIBCODEC2_ENCODER)          += libcodec2.o codec2utils.o
++OBJS-$(CONFIG_LIBDAV1D_DECODER)           += libdav1d.o
++OBJS-$(CONFIG_LIBDAVS2_DECODER)           += libdavs2.o
++OBJS-$(CONFIG_LIBFDK_AAC_DECODER)         += libfdk-aacdec.o
++OBJS-$(CONFIG_LIBFDK_AAC_ENCODER)         += libfdk-aacenc.o
++OBJS-$(CONFIG_LIBGSM_DECODER)             += libgsmdec.o
++OBJS-$(CONFIG_LIBGSM_ENCODER)             += libgsmenc.o
++OBJS-$(CONFIG_LIBGSM_MS_DECODER)          += libgsmdec.o
++OBJS-$(CONFIG_LIBGSM_MS_ENCODER)          += libgsmenc.o
++OBJS-$(CONFIG_LIBILBC_DECODER)            += libilbc.o
++OBJS-$(CONFIG_LIBILBC_ENCODER)            += libilbc.o
++OBJS-$(CONFIG_LIBKVAZAAR_ENCODER)         += libkvazaar.o
++OBJS-$(CONFIG_LIBMP3LAME_ENCODER)         += libmp3lame.o
++OBJS-$(CONFIG_LIBOPENCORE_AMRNB_DECODER)  += libopencore-amr.o
++OBJS-$(CONFIG_LIBOPENCORE_AMRNB_ENCODER)  += libopencore-amr.o
++OBJS-$(CONFIG_LIBOPENCORE_AMRWB_DECODER)  += libopencore-amr.o
++OBJS-$(CONFIG_LIBOPENH264_DECODER)        += libopenh264dec.o libopenh264.o
++OBJS-$(CONFIG_LIBOPENH264_ENCODER)        += libopenh264enc.o libopenh264.o
++OBJS-$(CONFIG_LIBOPENJPEG_DECODER)        += libopenjpegdec.o
++OBJS-$(CONFIG_LIBOPENJPEG_ENCODER)        += libopenjpegenc.o
++OBJS-$(CONFIG_LIBOPUS_DECODER)            += libopusdec.o libopus.o     \
++                                             vorbis_data.o
++OBJS-$(CONFIG_LIBOPUS_ENCODER)            += libopusenc.o libopus.o     \
++                                             vorbis_data.o
++OBJS-$(CONFIG_LIBRAV1E_ENCODER)           += librav1e.o
++OBJS-$(CONFIG_LIBSHINE_ENCODER)           += libshine.o
++OBJS-$(CONFIG_LIBSPEEX_DECODER)           += libspeexdec.o
++OBJS-$(CONFIG_LIBSPEEX_ENCODER)           += libspeexenc.o
++OBJS-$(CONFIG_LIBSVTAV1_ENCODER)          += libsvtav1.o
++OBJS-$(CONFIG_LIBTHEORA_ENCODER)          += libtheoraenc.o
++OBJS-$(CONFIG_LIBTWOLAME_ENCODER)         += libtwolame.o
++OBJS-$(CONFIG_LIBUAVS3D_DECODER)          += libuavs3d.o
++OBJS-$(CONFIG_LIBVO_AMRWBENC_ENCODER)     += libvo-amrwbenc.o
++OBJS-$(CONFIG_LIBVORBIS_DECODER)          += libvorbisdec.o
++OBJS-$(CONFIG_LIBVORBIS_ENCODER)          += libvorbisenc.o \
++                                             vorbis_data.o
++OBJS-$(CONFIG_LIBVPX_VP8_DECODER)         += libvpxdec.o
++OBJS-$(CONFIG_LIBVPX_VP8_ENCODER)         += libvpxenc.o
++OBJS-$(CONFIG_LIBVPX_VP9_DECODER)         += libvpxdec.o libvpx.o
++OBJS-$(CONFIG_LIBVPX_VP9_ENCODER)         += libvpxenc.o libvpx.o
++OBJS-$(CONFIG_LIBWEBP_ENCODER)            += libwebpenc_common.o libwebpenc.o
++OBJS-$(CONFIG_LIBWEBP_ANIM_ENCODER)       += libwebpenc_common.o libwebpenc_animencoder.o
++OBJS-$(CONFIG_LIBX262_ENCODER)            += libx264.o
++OBJS-$(CONFIG_LIBX264_ENCODER)            += libx264.o
++OBJS-$(CONFIG_LIBX265_ENCODER)            += libx265.o
++OBJS-$(CONFIG_LIBXAVS_ENCODER)            += libxavs.o
++OBJS-$(CONFIG_LIBXAVS2_ENCODER)           += libxavs2.o
++OBJS-$(CONFIG_LIBXVID_ENCODER)            += libxvid.o
++OBJS-$(CONFIG_LIBZVBI_TELETEXT_DECODER)   += libzvbi-teletextdec.o ass.o
++
++# parsers
++OBJS-$(CONFIG_AAC_LATM_PARSER)         += latm_parser.o
++OBJS-$(CONFIG_AAC_PARSER)              += aac_parser.o aac_ac3_parser.o \
++                                          mpeg4audio.o
++OBJS-$(CONFIG_AC3_PARSER)              += ac3tab.o aac_ac3_parser.o
++OBJS-$(CONFIG_ADX_PARSER)              += adx_parser.o adx.o
++OBJS-$(CONFIG_AV1_PARSER)              += av1_parser.o av1_parse.o
++OBJS-$(CONFIG_AVS2_PARSER)             += avs2_parser.o
++OBJS-$(CONFIG_AVS3_PARSER)             += avs3_parser.o
++OBJS-$(CONFIG_BMP_PARSER)              += bmp_parser.o
++OBJS-$(CONFIG_CAVSVIDEO_PARSER)        += cavs_parser.o
++OBJS-$(CONFIG_COOK_PARSER)             += cook_parser.o
++OBJS-$(CONFIG_CRI_PARSER)              += cri_parser.o
++OBJS-$(CONFIG_DCA_PARSER)              += dca_parser.o dca_exss.o dca.o
++OBJS-$(CONFIG_DIRAC_PARSER)            += dirac_parser.o
++OBJS-$(CONFIG_DNXHD_PARSER)            += dnxhd_parser.o dnxhddata.o
++OBJS-$(CONFIG_DOLBY_E_PARSER)          += dolby_e_parser.o dolby_e_parse.o
++OBJS-$(CONFIG_DPX_PARSER)              += dpx_parser.o
++OBJS-$(CONFIG_DVAUDIO_PARSER)          += dvaudio_parser.o
++OBJS-$(CONFIG_DVBSUB_PARSER)           += dvbsub_parser.o
++OBJS-$(CONFIG_DVD_NAV_PARSER)          += dvd_nav_parser.o
++OBJS-$(CONFIG_DVDSUB_PARSER)           += dvdsub_parser.o
++OBJS-$(CONFIG_FLAC_PARSER)             += flac_parser.o flacdata.o flac.o
++OBJS-$(CONFIG_G723_1_PARSER)           += g723_1_parser.o
++OBJS-$(CONFIG_G729_PARSER)             += g729_parser.o
++OBJS-$(CONFIG_GIF_PARSER)              += gif_parser.o
++OBJS-$(CONFIG_GSM_PARSER)              += gsm_parser.o
++OBJS-$(CONFIG_H261_PARSER)             += h261_parser.o
++OBJS-$(CONFIG_H263_PARSER)             += h263_parser.o
++OBJS-$(CONFIG_H264_PARSER)             += h264_parser.o h264_sei.o h264data.o
++OBJS-$(CONFIG_HEVC_PARSER)             += hevc_parser.o hevc_data.o
++OBJS-$(CONFIG_IPU_PARSER)              += ipu_parser.o
++OBJS-$(CONFIG_JPEG2000_PARSER)         += jpeg2000_parser.o
++OBJS-$(CONFIG_MJPEG_PARSER)            += mjpeg_parser.o
++OBJS-$(CONFIG_MLP_PARSER)              += mlp_parse.o mlp_parser.o mlp.o
++OBJS-$(CONFIG_MPEG4VIDEO_PARSER)       += mpeg4video_parser.o h263.o \
++                                          mpeg4videodec.o mpeg4video.o \
++                                          ituh263dec.o h263dec.o h263data.o
++OBJS-$(CONFIG_MPEGAUDIO_PARSER)        += mpegaudio_parser.o
++OBJS-$(CONFIG_MPEGVIDEO_PARSER)        += mpegvideo_parser.o    \
++                                          mpeg12.o mpeg12data.o
++OBJS-$(CONFIG_OPUS_PARSER)             += opus_parser.o opus.o opustab.o \
++                                          opus_rc.o vorbis_data.o
++OBJS-$(CONFIG_PNG_PARSER)              += png_parser.o
++OBJS-$(CONFIG_PNM_PARSER)              += pnm_parser.o pnm.o
++OBJS-$(CONFIG_RV30_PARSER)             += rv34_parser.o
++OBJS-$(CONFIG_RV40_PARSER)             += rv34_parser.o
++OBJS-$(CONFIG_SBC_PARSER)              += sbc_parser.o
++OBJS-$(CONFIG_SIPR_PARSER)             += sipr_parser.o
++OBJS-$(CONFIG_TAK_PARSER)              += tak_parser.o tak.o
++OBJS-$(CONFIG_VC1_PARSER)              += vc1_parser.o vc1.o vc1data.o  \
++                                          simple_idct.o wmv2data.o
++OBJS-$(CONFIG_VP3_PARSER)              += vp3_parser.o
++OBJS-$(CONFIG_VP8_PARSER)              += vp8_parser.o
++OBJS-$(CONFIG_VP9_PARSER)              += vp9_parser.o
++OBJS-$(CONFIG_WEBP_PARSER)             += webp_parser.o
++OBJS-$(CONFIG_XBM_PARSER)              += xbm_parser.o
++OBJS-$(CONFIG_XMA_PARSER)              += xma_parser.o
++
++# bitstream filters
++OBJS-$(CONFIG_AAC_ADTSTOASC_BSF)          += aac_adtstoasc_bsf.o mpeg4audio.o
++OBJS-$(CONFIG_AV1_METADATA_BSF)           += av1_metadata_bsf.o
++OBJS-$(CONFIG_AV1_FRAME_MERGE_BSF)        += av1_frame_merge_bsf.o
++OBJS-$(CONFIG_AV1_FRAME_SPLIT_BSF)        += av1_frame_split_bsf.o
++OBJS-$(CONFIG_CHOMP_BSF)                  += chomp_bsf.o
++OBJS-$(CONFIG_DUMP_EXTRADATA_BSF)         += dump_extradata_bsf.o
++OBJS-$(CONFIG_DCA_CORE_BSF)               += dca_core_bsf.o
++OBJS-$(CONFIG_EAC3_CORE_BSF)              += eac3_core_bsf.o
++OBJS-$(CONFIG_EXTRACT_EXTRADATA_BSF)      += extract_extradata_bsf.o    \
++                                             av1_parse.o h2645_parse.o
++OBJS-$(CONFIG_FILTER_UNITS_BSF)           += filter_units_bsf.o
++OBJS-$(CONFIG_H264_METADATA_BSF)          += h264_metadata_bsf.o h264_levels.o
++OBJS-$(CONFIG_H264_MP4TOANNEXB_BSF)       += h264_mp4toannexb_bsf.o
++OBJS-$(CONFIG_H264_REDUNDANT_PPS_BSF)     += h264_redundant_pps_bsf.o
++OBJS-$(CONFIG_HAPQA_EXTRACT_BSF)          += hapqa_extract_bsf.o hap.o
++OBJS-$(CONFIG_HEVC_METADATA_BSF)          += h265_metadata_bsf.o h265_profile_level.o
++OBJS-$(CONFIG_HEVC_MP4TOANNEXB_BSF)       += hevc_mp4toannexb_bsf.o
++OBJS-$(CONFIG_IMX_DUMP_HEADER_BSF)        += imx_dump_header_bsf.o
++OBJS-$(CONFIG_MJPEG2JPEG_BSF)             += mjpeg2jpeg_bsf.o
++OBJS-$(CONFIG_MJPEGA_DUMP_HEADER_BSF)     += mjpega_dump_header_bsf.o
++OBJS-$(CONFIG_MPEG4_UNPACK_BFRAMES_BSF)   += mpeg4_unpack_bframes_bsf.o
++OBJS-$(CONFIG_MOV2TEXTSUB_BSF)            += movsub_bsf.o
++OBJS-$(CONFIG_MP3_HEADER_DECOMPRESS_BSF)  += mp3_header_decompress_bsf.o \
++                                             mpegaudiodata.o
++OBJS-$(CONFIG_MPEG2_METADATA_BSF)         += mpeg2_metadata_bsf.o
++OBJS-$(CONFIG_NOISE_BSF)                  += noise_bsf.o
++OBJS-$(CONFIG_NULL_BSF)                   += null_bsf.o
++OBJS-$(CONFIG_OPUS_METADATA_BSF)          += opus_metadata_bsf.o
++OBJS-$(CONFIG_PCM_RECHUNK_BSF)            += pcm_rechunk_bsf.o
++OBJS-$(CONFIG_PRORES_METADATA_BSF)        += prores_metadata_bsf.o
++OBJS-$(CONFIG_REMOVE_EXTRADATA_BSF)       += remove_extradata_bsf.o
++OBJS-$(CONFIG_SETTS_BSF)                  += setts_bsf.o
++OBJS-$(CONFIG_TEXT2MOVSUB_BSF)            += movsub_bsf.o
++OBJS-$(CONFIG_TRACE_HEADERS_BSF)          += trace_headers_bsf.o
++OBJS-$(CONFIG_TRUEHD_CORE_BSF)            += truehd_core_bsf.o mlp_parse.o mlp.o
++OBJS-$(CONFIG_VP9_METADATA_BSF)           += vp9_metadata_bsf.o
++OBJS-$(CONFIG_VP9_RAW_REORDER_BSF)        += vp9_raw_reorder_bsf.o
++OBJS-$(CONFIG_VP9_SUPERFRAME_BSF)         += vp9_superframe_bsf.o
++OBJS-$(CONFIG_VP9_SUPERFRAME_SPLIT_BSF)   += vp9_superframe_split_bsf.o
++
++# thread libraries
++OBJS-$(HAVE_LIBC_MSVCRT)               += file_open.o
++OBJS-$(HAVE_THREADS)                   += pthread.o pthread_slice.o pthread_frame.o
++
++OBJS-$(CONFIG_FRAME_THREAD_ENCODER)    += frame_thread_encoder.o
++
++# Windows resource file
++SLIBOBJS-$(HAVE_GNU_WINDRES)           += avcodecres.o
++
++SKIPHEADERS                            += %_tablegen.h                  \
++                                          %_tables.h                    \
++                                          fft-internal.h                \
++                                          tableprint.h                  \
++                                          tableprint_vlc.h              \
++                                          aaccoder_twoloop.h            \
++                                          aaccoder_trellis.h            \
++                                          aacenc_quantization.h         \
++                                          aacenc_quantization_misc.h    \
++                                          $(ARCH)/vp56_arith.h          \
++
++SKIPHEADERS-$(CONFIG_AMF)              += amfenc.h
++SKIPHEADERS-$(CONFIG_D3D11VA)          += d3d11va.h dxva2_internal.h
++SKIPHEADERS-$(CONFIG_DXVA2)            += dxva2.h dxva2_internal.h
++SKIPHEADERS-$(CONFIG_JNI)              += ffjni.h
++SKIPHEADERS-$(CONFIG_LIBVPX)           += libvpx.h
++SKIPHEADERS-$(CONFIG_LIBWEBP_ENCODER)  += libwebpenc_common.h
++SKIPHEADERS-$(CONFIG_MEDIACODEC)       += mediacodecdec_common.h mediacodec_surface.h mediacodec_wrapper.h mediacodec_sw_buffer.h
++SKIPHEADERS-$(CONFIG_MEDIAFOUNDATION)  += mf_utils.h
++SKIPHEADERS-$(CONFIG_NVDEC)            += nvdec.h
++SKIPHEADERS-$(CONFIG_NVENC)            += nvenc.h
++SKIPHEADERS-$(CONFIG_QSV)              += qsv.h qsv_internal.h
++SKIPHEADERS-$(CONFIG_QSVENC)           += qsvenc.h
++SKIPHEADERS-$(CONFIG_XVMC)             += xvmc.h
++SKIPHEADERS-$(CONFIG_VAAPI)            += vaapi_decode.h vaapi_hevc.h vaapi_encode.h
++SKIPHEADERS-$(CONFIG_VDPAU)            += vdpau.h vdpau_internal.h
++SKIPHEADERS-$(CONFIG_VIDEOTOOLBOX)     += videotoolbox.h vt_internal.h
++SKIPHEADERS-$(CONFIG_V4L2_M2M)         += v4l2_buffers.h v4l2_context.h v4l2_m2m.h
++
++TESTPROGS = avpacket                                                    \
++            celp_math                                                   \
++            codec_desc                                                  \
++            htmlsubtitles                                               \
++            imgconvert                                                  \
++            jpeg2000dwt                                                 \
++            mathops                                                    \
++            utils                                                       \
++
++TESTPROGS-$(CONFIG_CABAC)                 += cabac
++TESTPROGS-$(CONFIG_DCT)                   += avfft
++TESTPROGS-$(CONFIG_FFT)                   += fft fft-fixed32
++TESTPROGS-$(CONFIG_GOLOMB)                += golomb
++TESTPROGS-$(CONFIG_IDCTDSP)               += dct
++TESTPROGS-$(CONFIG_IIRFILTER)             += iirfilter
++TESTPROGS-$(CONFIG_MJPEG_ENCODER)         += mjpegenc_huffman
++TESTPROGS-$(HAVE_MMX)                     += motion
++TESTPROGS-$(CONFIG_MPEGVIDEO)             += mpeg12framerate
++TESTPROGS-$(CONFIG_H264_METADATA_BSF)     += h264_levels
++TESTPROGS-$(CONFIG_HEVC_METADATA_BSF)     += h265_levels
++TESTPROGS-$(CONFIG_RANGECODER)            += rangecoder
++TESTPROGS-$(CONFIG_SNOW_ENCODER)          += snowenc
++
++TESTOBJS = dctref.o
++
++TOOLS = fourcc2pixfmt
++
++HOSTPROGS = aacps_tablegen                                              \
++            aacps_fixed_tablegen                                        \
++            cbrt_tablegen                                               \
++            cbrt_fixed_tablegen                                         \
++            cos_tablegen                                                \
++            dv_tablegen                                                 \
++            motionpixels_tablegen                                       \
++            mpegaudio_tablegen                                          \
++            mpegaudiodec_common_tablegen                                \
++            pcm_tablegen                                                \
++            qdm2_tablegen                                               \
++            sinewin_tablegen                                            \
++            sinewin_fixed_tablegen                                      \
++
++CLEANFILES = *_tables.c *_tables.h *_tablegen$(HOSTEXESUF)
++
++$(SUBDIR)tests/dct$(EXESUF): $(SUBDIR)dctref.o $(SUBDIR)aandcttab.o
++$(SUBDIR)dv_tablegen$(HOSTEXESUF): $(SUBDIR)dvdata_host.o
++
++TRIG_TABLES  = cos cos_fixed sin
++TRIG_TABLES := $(TRIG_TABLES:%=$(SUBDIR)%_tables.c)
++
++$(TRIG_TABLES): $(SUBDIR)%_tables.c: $(SUBDIR)cos_tablegen$(HOSTEXESUF)
++	$(M)./$< $* > $@
++
++ifdef CONFIG_SMALL
++$(SUBDIR)%_tablegen$(HOSTEXESUF): HOSTCFLAGS += -DCONFIG_SMALL=1
++else
++$(SUBDIR)%_tablegen$(HOSTEXESUF): HOSTCFLAGS += -DCONFIG_SMALL=0
++endif
++
++GEN_HEADERS = cbrt_tables.h cbrt_fixed_tables.h aacps_tables.h aacps_fixed_tables.h \
++              dv_tables.h     \
++              sinewin_tables.h sinewin_fixed_tables.h mpegaudio_tables.h \
++              mpegaudiodec_common_tables.h motionpixels_tables.h \
++              pcm_tables.h qdm2_tables.h
++GEN_HEADERS := $(addprefix $(SUBDIR), $(GEN_HEADERS))
++
++$(GEN_HEADERS): $(SUBDIR)%_tables.h: $(SUBDIR)%_tablegen$(HOSTEXESUF)
++	$(M)./$< > $@
++
++ifdef CONFIG_HARDCODED_TABLES
++$(SUBDIR)cbrt_data.o: $(SUBDIR)cbrt_tables.h
++$(SUBDIR)cbrt_data_fixed.o: $(SUBDIR)cbrt_fixed_tables.h
++$(SUBDIR)aacdec_fixed.o: $(SUBDIR)sinewin_fixed_tables.h
++$(SUBDIR)aacps_float.o: $(SUBDIR)aacps_tables.h
++$(SUBDIR)aacps_fixed.o: $(SUBDIR)aacps_fixed_tables.h
++$(SUBDIR)dvenc.o: $(SUBDIR)dv_tables.h
++$(SUBDIR)motionpixels.o: $(SUBDIR)motionpixels_tables.h
++$(SUBDIR)mpegaudiodec_common.o: $(SUBDIR)mpegaudiodec_common_tables.h
++$(SUBDIR)mpegaudiodec_fixed.o: $(SUBDIR)mpegaudio_tables.h
++$(SUBDIR)mpegaudiodec_float.o: $(SUBDIR)mpegaudio_tables.h
++$(SUBDIR)pcm.o: $(SUBDIR)pcm_tables.h
++$(SUBDIR)qdm2.o: $(SUBDIR)qdm2_tables.h
++$(SUBDIR)sinewin.o: $(SUBDIR)sinewin_tables.h
++endif
+--- /dev/null
++++ jellyfin-ffmpeg-4.4.1/libavcodec/ac4dec.c
+@@ -0,0 +1,5888 @@
++/*
++ * AC-4 Audio Decoder
++ *
++ * Copyright (c) 2019 Paul B Mahol
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#define _GNU_SOURCE
++#include <fenv.h>
++
++#define ASSERT_LEVEL 5
++#include "libavutil/avassert.h"
++#include "libavutil/tx.h"
++#include "libavutil/channel_layout.h"
++#include "libavutil/float_dsp.h"
++#include "libavutil/mem_internal.h"
++#include "libavutil/thread.h"
++#include "libavutil/qsort.h"
++#include "libavutil/opt.h"
++
++#include "ac4dec_data.h"
++#include "avcodec.h"
++#include "get_bits.h"
++#include "internal.h"
++#include "kbdwin.h"
++#include "unary.h"
++
++/* Number of model bits */
++#define SSF_MODEL_BITS 15
++
++/* Model unit for the CDF specification */
++#define SSF_MODEL_UNIT (1U<<(SSF_MODEL_BITS))
++
++/* Number of range bits */
++#define SSF_RANGE_BITS    30
++
++/* Half of the range unit */
++#define SSF_THRESHOLD_LARGE (1U<<((SSF_RANGE_BITS)-1))
++
++/* Quarter of the range unit */
++#define SSF_THRESHOLD_SMALL    (1U<<((SSF_RANGE_BITS)-2))
++
++/* Offset bits */
++#define SSF_OFFSET_BITS 14
++
++typedef struct ACState {
++    uint32_t ui_low;
++    uint32_t ui_range;
++    uint32_t ui_offset;
++    uint32_t ui_offset2;
++
++    uint32_t ui_threshold_small;
++    uint32_t ui_threshold_large;
++    uint32_t ui_model_unit;
++
++    uint32_t ui_range_bits;
++    uint32_t ui_model_bits;
++} ACState;
++
++typedef struct EMDFInfo {
++    int     version;
++    int     key_id;
++    int     substream_index;
++} EMDFInfo;
++
++typedef struct SubstreamChannelParameters {
++    uint8_t long_frame;
++    uint8_t transf_length_idx[2];
++    int     transf_length[2];
++
++    uint8_t different_framing;
++    uint8_t max_sfb_side[2];
++    uint8_t max_sfb[2];
++    uint8_t scale_factor_grouping[15];
++
++    uint8_t num_windows;
++    uint8_t num_window_groups;
++    uint8_t window_to_group[16];
++    uint8_t num_win_in_group[16];
++
++    uint8_t dual_maxsfb;
++    uint8_t side_limited;
++    uint8_t side_channel;
++} SubstreamChannelParameters;
++
++typedef struct SubstreamChannel {
++    SubstreamChannelParameters scp;
++
++    int     master_reset;
++    int     num_sbg_master;
++    int     num_sb_aspx;
++    int     num_sbg_noise;
++    int     num_sbg_sig_highres;
++    int     num_sbg_sig_lowres;
++    int     sba;
++    int     sbx;
++    int     sbz;
++
++    int     sap_mode;
++
++    int     N_prev;
++
++    uint8_t ms_used[16][128];
++    uint8_t sap_coeff_used[16][128];
++    int     dpcm_alpha_q[16][128];
++
++    int     delta_code_time;
++
++    int     num_sec_lsf[16];
++    int     num_sec[16];
++    uint8_t sfb_cb[16][128];
++    uint8_t sect_cb[16][128];
++    int     sect_start[16][128];
++    int     sect_end[16][128];
++    int     sect_sfb_offset[16][128];
++
++    int16_t quant_spec[2048];
++    float   scaled_spec[2048];
++    float   spec_reord[2048];
++    int16_t offset2sfb[2048];
++    uint8_t offset2g[2048];
++    int     win_offset[16];
++    DECLARE_ALIGNED(32, float, overlap)[4096];
++
++    int     max_quant_idx[16][128];
++    int     dpcm_sf[16][128];
++    int     dpcm_snf[16][128];
++    int     snf_data_exists;
++
++    float   sf_gain[16][128];
++
++    int     aspx_int_class;
++    int     aspx_num_noise;
++    int     aspx_num_noise_prev;
++    int     aspx_num_rel_left;
++    int     aspx_num_rel_right;
++    int     aspx_num_env;
++    int     aspx_num_env_prev;
++    int     aspx_freq_res[5];
++    int     aspx_var_bord_left;
++    int     aspx_var_bord_right;
++    int     aspx_rel_bord_left[4];
++    int     aspx_rel_bord_right[4];
++    int     aspx_tsg_ptr;
++    int     aspx_tsg_ptr_prev;
++
++    int     aspx_qmode_env;
++    int     aspx_sig_delta_dir[8];
++    int     aspx_noise_delta_dir[2];
++    int     aspx_tna_mode[16];
++    int     aspx_tna_mode_prev[16];
++    int     aspx_add_harmonic[16];
++    int     aspx_fic_used_in_sfb[16];
++    int     aspx_tic_used_in_slot[16];
++    int     aspx_xover_subband_offset;
++    int     aspx_balance;
++
++    uint8_t atsg_freqres[5];
++    uint8_t atsg_freqres_prev[5];
++    int     atsg_sig[6];
++    int     atsg_noise[3];
++    int     previous_stop_pos;
++
++    int     sbg_noise[6];
++    int     sbg_sig_lowres[24];
++    int     sbg_sig_highres[24];
++    int     sbg_lim[32];
++    int     sbg_patches[6];
++    int     sbg_patch_num_sb[6];
++    int     sbg_patch_start_sb[6];
++    int     sbg_master[24];
++
++    int     num_sbg_sig[5];
++    int     sbg_sig[5][24];
++    int     num_sbg_patches;
++    int     num_sbg_lim;
++
++    int     aspx_data[2][5][64];
++
++    int     qscf_prev[5][64];
++    int     qscf_noise_prev[2][64];
++    int     qscf_sig_sbg[5][64];
++    int     qscf_sig_sbg_prev[5][64];
++    int     qscf_noise_sbg[2][64];
++    float   scf_noise_sbg[2][64];
++    float   scf_sig_sbg[5][64];
++    float   scf_sig_sb[5][64];
++    float   scf_noise_sb[5][64];
++
++    float   gain_vec[32];
++    float   chirp_arr[6];
++    float   chirp_arr_prev[6];
++    float   est_sig_sb[5][64];
++    float   sine_idx_sb[5][64];
++    float   sine_idx_sb_prev[5][64];
++    float   sine_area_sb[5][64];
++    float   sine_lev_sb[5][64];
++    float   noise_lev_sb[5][64];
++    float   sig_gain_sb[5][64];
++    float   max_sig_gain_sbg[5][64];
++    float   max_sig_gain_sb[5][64];
++    float   noise_lev_sb_lim[5][64];
++    float   sig_gain_sb_lim[5][64];
++    float   boost_fact_sbg[5][64];
++    float   boost_fact_sb[5][64];
++    float   sig_gain_sb_adj[5][64];
++    float   noise_lev_sb_adj[5][64];
++    float   sine_lev_sb_adj[5][64];
++
++    int8_t  sine_idx_prev[42][64];
++    int16_t noise_idx_prev[42][64];
++
++    int     acpl_interpolation_type;
++    int     acpl_num_param_sets_cod;
++    int     acpl_param_timeslot[2];
++    int     acpl_data[11][16];
++
++    int     start_block, end_block;
++    int     stride_flag;
++    int     num_bands;
++    int     predictor_presence[4];
++    int     predictor_lag_delta[4];
++    int     predictor_lag[4];
++    int     variance_preserving[4];
++    int     alloc_offset[4];
++    int     delta[4];
++    int     gain_bits[4];
++    int     env_idx[19];
++    ACState acs;
++
++    DECLARE_ALIGNED(32, float, pcm)[2048];
++
++    DECLARE_ALIGNED(32, float, qmf_filt)[640];
++    DECLARE_ALIGNED(32, float, qsyn_filt)[1280];
++    DECLARE_ALIGNED(32, float, Q)[2][42][64];
++    DECLARE_ALIGNED(32, float, Q_prev)[2][42][64];
++    DECLARE_ALIGNED(32, float, Q_low)[2][42][64];
++    DECLARE_ALIGNED(32, float, Q_low_prev)[2][42][64];
++    DECLARE_ALIGNED(32, float, Q_low_ext)[2][42][64];
++    DECLARE_ALIGNED(32, float, Q_high)[2][42][64];
++    DECLARE_ALIGNED(32, float, cov)[64][3][3][2];
++    DECLARE_ALIGNED(32, float, alpha0)[64][2];
++    DECLARE_ALIGNED(32, float, alpha1)[64][2];
++    DECLARE_ALIGNED(32, float, Y)[2][42][64];
++    DECLARE_ALIGNED(32, float, Y_prev)[2][42][64];
++    DECLARE_ALIGNED(32, float, qmf_sine)[2][42][64];
++    DECLARE_ALIGNED(32, float, qmf_noise)[2][42][64];
++} SubstreamChannel;
++
++typedef struct Substream {
++    int     codec_mode;
++
++    int     aspx_quant_mode_env;
++    int     aspx_start_freq;
++    int     prev_aspx_start_freq;
++    int     aspx_stop_freq;
++    int     prev_aspx_stop_freq;
++    int     aspx_master_freq_scale;
++    int     prev_aspx_master_freq_scale;
++    int     aspx_interpolation;
++    int     aspx_preflat;
++    int     aspx_limiter;
++    int     aspx_noise_sbg;
++    int     aspx_num_env_bits_fixfix;
++    int     aspx_freq_res_mode;
++
++    int     acpl_qmf_band;
++    int     acpl_param_band;
++    int     acpl_num_param_bands_id;
++    int     acpl_quant_mode[2];
++
++    uint8_t mode_2ch;
++    uint8_t chel_matsel;
++
++    uint8_t compand_on[5];
++    int     compand_avg;
++
++    int     max_sfb_master;
++
++    uint8_t coding_config;
++    uint8_t mdct_stereo_proc[2];
++    float   matrix_stereo[16][128][2][2];
++    float   alpha_q[16][128];
++
++    int     spec_frontend_l;
++    int     spec_frontend_r;
++    int     spec_frontend_m;
++    int     spec_frontend_s;
++
++    SubstreamChannel ssch[9];
++} Substream;
++
++typedef struct PresentationSubstreamInfo {
++    int     alternative;
++    int     pres_ndot;
++    int     substream_index;
++} PresentationSubstreamInfo;
++
++typedef struct Metadata {
++    int     dialnorm_bits;
++    int     pre_dmixtyp_2ch;
++    int     phase90_info_2ch;
++    int     loro_center_mixgain;
++    int     loro_surround_mixgain;
++    int     loro_dmx_loud_corr;
++    int     ltrt_center_mixgain;
++    int     ltrt_surround_mixgain;
++    int     ltrt_dmx_loud_corr;
++    int     lfe_mixgain;
++    int     preferred_dmx_method;
++    int     pre_dmixtyp_5ch;
++    int     pre_upmixtyp_5ch;
++    int     pre_upmixtyp_3_4;
++    int     pre_upmixtyp_3_2_2;
++    int     phase90_info_mc;
++    int     surround_attenuation_known;
++    int     lfe_attenuation_known;
++    int     dc_block_on;
++
++    int     loudness_version;
++    int     loud_prac_type;
++    int     dialgate_prac_type;
++    int     loudcorr_type;
++    int     loudrelgat;
++    int     loudspchgat;
++    int     loudstrm3s;
++    int     max_loudstrm3s;
++    int     truepk;
++    int     max_truepk;
++    int     prgmbndy;
++    int     end_or_start;
++    int     prgmbndy_offset;
++    int     lra;
++    int     lra_prac_type;
++    int     loudmntry;
++    int     max_loudmntry;
++
++    int     drc_decoder_nr_modes;
++    int     drc_eac3_profile;
++} Metadata;
++
++typedef struct SubstreamInfo {
++    int     sus_ver;
++    int     channel_mode;
++    int     substream_index;
++    int     hsf_ext_substream_index;
++    int     sf_multiplier;
++    int     bitrate_indicator;
++    int     add_ch_base;
++    int     iframe[4];
++    int     back_channels_present;
++    int     centre_present;
++    int     top_channels_present;
++    Metadata meta;
++} SubstreamInfo;
++
++typedef struct SubstreamGroupInfo {
++    int           channel_coded;
++    int           group_index;
++    SubstreamInfo ssinfo;
++} SubstreamGroupInfo;
++
++typedef struct PresentationInfo {
++    int     single_substream;
++    int     enable_presentation;
++    int     presentation_config;
++    int     presentation_version;
++    int     add_emdf_substreams;
++    int     n_add_emdf_substreams;
++    int     n_substream_groups;
++    int     mdcompat;
++    int     presentation_id;
++    int     multiplier;
++    int     multiplier_bit;
++    int     pre_virtualized;
++    int     frame_rate_factor;
++    int     frame_rate_fraction;
++    int     multi_pid;
++    int     hsf_ext;
++    EMDFInfo emdf[32];
++    PresentationSubstreamInfo psinfo;
++    SubstreamInfo ssinfo;
++} PresentationInfo;
++
++typedef struct AC4DecodeContext {
++    AVClass        *class;                  ///< class for AVOptions
++    AVCodecContext *avctx;                  ///< parent context
++    AVFloatDSPContext *fdsp;
++    GetBitContext   gbc;                    ///< bitstream reader
++
++    int             target_presentation;
++
++    int             version;
++    int             sequence_counter;
++    int             sequence_counter_prev;
++    int             wait_frames;
++    int             nb_wait_frames;
++    int             fs_index;
++    int             frame_rate_index;
++    int             frame_len_base;
++    int             frame_len_base_idx;
++    AVRational      resampling_ratio;
++    int             num_qmf_timeslots;
++    int             num_aspx_timeslots;
++    int             num_ts_in_ats;
++    int             ts_offset_hfgen;
++    int             transform_length;
++    int             iframe_global;
++    int             first_frame;
++    int             have_iframe;
++    int             nb_presentations;
++    int             payload_base;
++    int             short_program_id;
++    int             nb_substreams;
++    int             total_groups;
++    int             substream_size[32];
++    int             substream_type[32];
++
++    DECLARE_ALIGNED(32, float, winl)[2048];
++    DECLARE_ALIGNED(32, float, winr)[2048];
++
++    av_tx_fn           tx_fn[8][5];
++    AVTXContext       *tx_ctx[8][5];
++
++    DECLARE_ALIGNED(32, float, kbd_window)[8][5][2048];
++
++    float              quant_lut[8192];
++
++    DECLARE_ALIGNED(32, float, cos_atab)[64][128];
++    DECLARE_ALIGNED(32, float, sin_atab)[64][128];
++    DECLARE_ALIGNED(32, float, cos_stab)[128][64];
++    DECLARE_ALIGNED(32, float, sin_stab)[128][64];
++
++    PresentationInfo   pinfo[8];
++    SubstreamGroupInfo ssgroup[8];
++    Substream          substream;
++} AC4DecodeContext;
++
++enum StrideFlag {
++    LONG_STRIDE,
++    SHORT_STRIDE,
++};
++
++enum ACPLMode {
++    ACPL_FULL,
++    ACPL_PARTIAL,
++};
++
++enum SubstreamType {
++    ST_SUBSTREAM,
++    ST_PRESENTATION,
++};
++
++enum StereoMode {
++    SM_LEVEL,
++    SM_BALANCE,
++};
++
++enum DataType {
++    DT_SIGNAL,
++    DT_NOISE,
++};
++
++enum SpectralFrontend {
++    SF_ASF,
++    SF_SSF,
++};
++
++enum HCBType {
++    F0,
++    DF,
++    DT,
++};
++
++enum CodecMode {
++    CM_SIMPLE,
++    CM_ASPX,
++    CM_ASPX_ACPL_1,
++    CM_ASPX_ACPL_2,
++    CM_ASPX_ACPL_3,
++};
++
++enum IntervalClass {
++    FIXFIX,
++    FIXVAR,
++    VARFIX,
++    VARVAR,
++};
++
++enum ACPLDataType {
++    ALPHA1,
++    ALPHA2,
++    BETA1,
++    BETA2,
++    BETA3,
++    GAMMA1,
++    GAMMA2,
++    GAMMA3,
++    GAMMA4,
++    GAMMA5,
++    GAMMA6,
++};
++
++static const AVRational resampling_ratios[] = {
++    {25025, 24000},
++    {25, 24},
++    {15, 16},
++    {25025, 24000},
++    {25, 24},
++    {25025, 24000},
++    {25, 24},
++    {15, 16},
++    {25025, 24000},
++    {25, 24},
++    {15, 16},
++    {25025, 24000},
++    {25, 24},
++    {1, 1},
++    {1, 1},
++    {1, 1},
++};
++
++static const uint8_t channel_mode_nb_channels[] = {
++    1, 2, 3, 5, 6, 7, 8, 7, 8, 7, 8, 11, 12, 13, 14, 24, 0
++};
++
++static const uint64_t channel_mode_layouts[] = {
++    AV_CH_LAYOUT_MONO,
++    AV_CH_LAYOUT_STEREO,
++    AV_CH_LAYOUT_SURROUND,
++    AV_CH_LAYOUT_5POINT0,
++    AV_CH_LAYOUT_5POINT1,
++    AV_CH_LAYOUT_7POINT0,
++    AV_CH_LAYOUT_7POINT1,
++    AV_CH_LAYOUT_7POINT0_FRONT,
++    AV_CH_LAYOUT_7POINT0_FRONT|AV_CH_LOW_FREQUENCY,
++    0,
++    0,
++    0,
++    0,
++    0,
++    0,
++    0,
++    0,
++    0,
++};
++
++static VLC channel_mode_vlc;
++static VLC bitrate_indicator_vlc;
++static VLC scale_factors_vlc;
++static VLC snf_vlc;
++static VLC asf_codebook_vlc[11];
++static VLC acpl_codebook_vlc[4][2][3];
++static VLC aspx_int_class_vlc;
++static VLC aspx_codebook_signal_vlc[2][2][3];
++static VLC aspx_codebook_noise_vlc[2][3];
++
++static av_cold int ac4_decode_init(AVCodecContext *avctx)
++{
++    AC4DecodeContext *s = avctx->priv_data;
++    int ret;
++
++    //feenableexcept(FE_INVALID | FE_OVERFLOW);
++
++    s->avctx = avctx;
++    s->first_frame = 1;
++
++    avctx->sample_fmt = AV_SAMPLE_FMT_FLTP;
++
++    INIT_VLC_STATIC(&channel_mode_vlc, 9, sizeof(channel_mode_bits),
++                    channel_mode_bits, 1, 1, channel_mode_codes, 2, 2, 512);
++    INIT_VLC_STATIC(&bitrate_indicator_vlc, 5, sizeof(bitrate_indicator_bits),
++                    bitrate_indicator_bits, 1, 1, bitrate_indicator_codes, 1, 1, 32);
++    INIT_VLC_STATIC(&scale_factors_vlc, 9, sizeof(scale_factors_bits),
++                    scale_factors_bits, 1, 1, scale_factors_codes, 1, 1, 850);
++    INIT_VLC_STATIC(&snf_vlc, 6, sizeof(snf_bits),
++                    snf_bits, 1, 1, snf_codes, 1, 1, 70);
++
++    INIT_VLC_STATIC(&asf_codebook_vlc[0], 9, sizeof(asf_codebook_1_bits),
++                    asf_codebook_1_bits, 1, 1, asf_codebook_1_codes, 1, 1, 542);
++    INIT_VLC_STATIC(&asf_codebook_vlc[1], 9, sizeof(asf_codebook_2_bits),
++                    asf_codebook_2_bits, 1, 1, asf_codebook_2_codes, 1, 1, 512);
++    INIT_VLC_STATIC(&asf_codebook_vlc[2], 9, sizeof(asf_codebook_3_bits),
++                    asf_codebook_3_bits, 1, 1, asf_codebook_3_codes, 1, 1, 612);
++    INIT_VLC_STATIC(&asf_codebook_vlc[3], 9, sizeof(asf_codebook_4_bits),
++                    asf_codebook_4_bits, 1, 1, asf_codebook_4_codes, 1, 1, 544);
++    INIT_VLC_STATIC(&asf_codebook_vlc[4], 9, sizeof(asf_codebook_5_bits),
++                    asf_codebook_5_bits, 1, 1, asf_codebook_5_codes, 1, 1, 576);
++    INIT_VLC_STATIC(&asf_codebook_vlc[5], 9, sizeof(asf_codebook_6_bits),
++                    asf_codebook_6_bits, 1, 1, asf_codebook_6_codes, 1, 1, 546);
++    INIT_VLC_STATIC(&asf_codebook_vlc[6], 9, sizeof(asf_codebook_7_bits),
++                    asf_codebook_7_bits, 1, 1, asf_codebook_7_codes, 1, 1, 542);
++    INIT_VLC_STATIC(&asf_codebook_vlc[7], 9, sizeof(asf_codebook_8_bits),
++                    asf_codebook_8_bits, 1, 1, asf_codebook_8_codes, 1, 1, 522);
++    INIT_VLC_STATIC(&asf_codebook_vlc[8], 9, sizeof(asf_codebook_9_bits),
++                    asf_codebook_9_bits, 1, 1, asf_codebook_9_codes, 1, 1, 670);
++    INIT_VLC_STATIC(&asf_codebook_vlc[9], 9, sizeof(asf_codebook_10_bits),
++                    asf_codebook_10_bits, 1, 1, asf_codebook_10_codes, 1, 1, 604);
++    INIT_VLC_STATIC(&asf_codebook_vlc[10], 9, sizeof(asf_codebook_11_bits),
++                    asf_codebook_11_bits, 1, 1, asf_codebook_11_codes, 1, 1, 674);
++
++    INIT_VLC_STATIC(&aspx_int_class_vlc, 5, sizeof(aspx_int_class_bits),
++                    aspx_int_class_bits, 1, 1, aspx_int_class_codes, 1, 1, 32);
++
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[0][0][0], 9, sizeof(aspx_hcb_env_level_15_f0_bits),
++                    aspx_hcb_env_level_15_f0_bits, 1, 1, aspx_hcb_env_level_15_f0_codes, 4, 4, 1024);
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[0][0][1], 9, sizeof(aspx_hcb_env_level_15_df_bits),
++                    aspx_hcb_env_level_15_df_bits, 1, 1, aspx_hcb_env_level_15_df_codes, 4, 4, 1888);
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[0][0][2], 9, sizeof(aspx_hcb_env_level_15_dt_bits),
++                    aspx_hcb_env_level_15_dt_bits, 1, 1, aspx_hcb_env_level_15_dt_codes, 4, 4, 1368);
++
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[0][1][0], 9, sizeof(aspx_hcb_env_level_30_f0_bits),
++                    aspx_hcb_env_level_30_f0_bits, 1, 1, aspx_hcb_env_level_30_f0_codes, 4, 4, 772);
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[0][1][1], 9, sizeof(aspx_hcb_env_level_30_df_bits),
++                    aspx_hcb_env_level_30_df_bits, 1, 1, aspx_hcb_env_level_30_df_codes, 4, 4, 1624);
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[0][1][2], 9, sizeof(aspx_hcb_env_level_30_dt_bits),
++                    aspx_hcb_env_level_30_dt_bits, 1, 1, aspx_hcb_env_level_30_dt_codes, 4, 4, 1598);
++
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[1][0][0], 9, sizeof(aspx_hcb_env_balance_15_f0_bits),
++                    aspx_hcb_env_balance_15_f0_bits, 1, 1, aspx_hcb_env_balance_15_f0_codes, 4, 4, 644);
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[1][0][1], 9, sizeof(aspx_hcb_env_balance_15_df_bits),
++                    aspx_hcb_env_balance_15_df_bits, 1, 1, aspx_hcb_env_balance_15_df_codes, 4, 4, 1056);
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[1][0][2], 9, sizeof(aspx_hcb_env_balance_15_dt_bits),
++                    aspx_hcb_env_balance_15_dt_bits, 1, 1, aspx_hcb_env_balance_15_dt_codes, 4, 4, 616);
++
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[1][1][0], 9, sizeof(aspx_hcb_env_balance_30_f0_bits),
++                    aspx_hcb_env_balance_30_f0_bits, 1, 1, aspx_hcb_env_balance_30_f0_codes, 2, 2, 520);
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[1][1][1], 9, sizeof(aspx_hcb_env_balance_30_df_bits),
++                    aspx_hcb_env_balance_30_df_bits, 1, 1, aspx_hcb_env_balance_30_df_codes, 4, 4, 768);
++    INIT_VLC_STATIC(&aspx_codebook_signal_vlc[1][1][2], 9, sizeof(aspx_hcb_env_balance_30_dt_bits),
++                    aspx_hcb_env_balance_30_dt_bits, 1, 1, aspx_hcb_env_balance_30_dt_codes, 2, 2, 576);
++
++    INIT_VLC_STATIC(&aspx_codebook_noise_vlc[0][0], 9, sizeof(aspx_hcb_noise_level_f0_bits),
++                    aspx_hcb_noise_level_f0_bits, 1, 1, aspx_hcb_noise_level_f0_codes, 2, 2, 672);
++    INIT_VLC_STATIC(&aspx_codebook_noise_vlc[0][1], 9, sizeof(aspx_hcb_noise_level_df_bits),
++                    aspx_hcb_noise_level_df_bits, 1, 1, aspx_hcb_noise_level_df_codes, 4, 4, 1024);
++    INIT_VLC_STATIC(&aspx_codebook_noise_vlc[0][2], 9, sizeof(aspx_hcb_noise_level_dt_bits),
++                    aspx_hcb_noise_level_dt_bits, 1, 1, aspx_hcb_noise_level_dt_codes, 2, 2, 768);
++
++    INIT_VLC_STATIC(&aspx_codebook_noise_vlc[1][0], 9, sizeof(aspx_hcb_noise_balance_f0_bits),
++                    aspx_hcb_noise_balance_f0_bits, 1, 1, aspx_hcb_noise_balance_f0_codes, 2, 2, 516);
++    INIT_VLC_STATIC(&aspx_codebook_noise_vlc[1][1], 9, sizeof(aspx_hcb_noise_balance_df_bits),
++                    aspx_hcb_noise_balance_df_bits, 1, 1, aspx_hcb_noise_balance_df_codes, 2, 2, 536);
++    INIT_VLC_STATIC(&aspx_codebook_noise_vlc[1][2], 9, sizeof(aspx_hcb_noise_balance_dt_bits),
++                    aspx_hcb_noise_balance_dt_bits, 1, 1, aspx_hcb_noise_balance_dt_codes, 2, 2, 530);
++
++    INIT_VLC_STATIC(&acpl_codebook_vlc[0][1][0], 9, sizeof(acpl_hcb_alpha_coarse_f0_bits),
++                    acpl_hcb_alpha_coarse_f0_bits, 1, 1, acpl_hcb_alpha_coarse_f0_codes, 2, 2, 516);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[0][1][1], 9, sizeof(acpl_hcb_alpha_coarse_df_bits),
++                    acpl_hcb_alpha_coarse_df_bits, 1, 1, acpl_hcb_alpha_coarse_df_codes, 4, 4, 1032);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[0][1][2], 9, sizeof(acpl_hcb_alpha_coarse_dt_bits),
++                    acpl_hcb_alpha_coarse_dt_bits, 1, 1, acpl_hcb_alpha_coarse_dt_codes, 4, 4, 642);
++
++    INIT_VLC_STATIC(&acpl_codebook_vlc[0][0][0], 9, sizeof(acpl_hcb_alpha_fine_f0_bits),
++                    acpl_hcb_alpha_fine_f0_bits, 1, 1, acpl_hcb_alpha_fine_f0_codes, 2, 2, 530);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[0][0][1], 9, sizeof(acpl_hcb_alpha_fine_df_bits),
++                    acpl_hcb_alpha_fine_df_bits, 1, 1, acpl_hcb_alpha_fine_df_codes, 4, 4, 1176);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[0][0][2], 9, sizeof(acpl_hcb_alpha_fine_dt_bits),
++                    acpl_hcb_alpha_fine_dt_bits, 1, 1, acpl_hcb_alpha_fine_dt_codes, 4, 4, 1158);
++
++    INIT_VLC_STATIC(&acpl_codebook_vlc[1][1][0], 9, sizeof(acpl_hcb_beta_coarse_f0_bits),
++                    acpl_hcb_beta_coarse_f0_bits, 1, 1, acpl_hcb_beta_coarse_f0_codes, 1, 1, 512);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[1][1][1], 9, sizeof(acpl_hcb_beta_coarse_df_bits),
++                    acpl_hcb_beta_coarse_df_bits, 1, 1, acpl_hcb_beta_coarse_df_codes, 1, 1, 512);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[1][1][2], 9, sizeof(acpl_hcb_beta_coarse_dt_bits),
++                    acpl_hcb_beta_coarse_dt_bits, 1, 1, acpl_hcb_beta_coarse_dt_codes, 1, 1, 512);
++
++    INIT_VLC_STATIC(&acpl_codebook_vlc[1][0][0], 9, sizeof(acpl_hcb_beta_fine_f0_bits),
++                    acpl_hcb_beta_fine_f0_bits, 1, 1, acpl_hcb_beta_fine_f0_codes, 1, 1, 512);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[1][0][1], 9, sizeof(acpl_hcb_beta_fine_df_bits),
++                    acpl_hcb_beta_fine_df_bits, 1, 1, acpl_hcb_beta_fine_df_codes, 4, 4, 528);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[1][0][2], 9, sizeof(acpl_hcb_beta_fine_dt_bits),
++                    acpl_hcb_beta_fine_dt_bits, 1, 1, acpl_hcb_beta_fine_dt_codes, 4, 4, 576);
++
++    INIT_VLC_STATIC(&acpl_codebook_vlc[2][1][0], 9, sizeof(acpl_hcb_beta3_coarse_f0_bits),
++                    acpl_hcb_beta3_coarse_f0_bits, 1, 1, acpl_hcb_beta3_coarse_f0_codes, 1, 1, 512);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[2][1][1], 9, sizeof(acpl_hcb_beta3_coarse_df_bits),
++                    acpl_hcb_beta3_coarse_df_bits, 1, 1, acpl_hcb_beta3_coarse_df_codes, 4, 4, 528);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[2][1][2], 9, sizeof(acpl_hcb_beta3_coarse_dt_bits),
++                    acpl_hcb_beta3_coarse_dt_bits, 1, 1, acpl_hcb_beta3_coarse_dt_codes, 2, 2, 576);
++
++    INIT_VLC_STATIC(&acpl_codebook_vlc[2][0][0], 9, sizeof(acpl_hcb_beta3_fine_f0_bits),
++                    acpl_hcb_beta3_fine_f0_bits, 1, 1, acpl_hcb_beta3_fine_f0_codes, 1, 1, 512);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[2][0][1], 9, sizeof(acpl_hcb_beta3_fine_df_bits),
++                    acpl_hcb_beta3_fine_df_bits, 1, 1, acpl_hcb_beta3_fine_df_codes, 4, 4, 580);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[2][0][2], 9, sizeof(acpl_hcb_beta3_fine_dt_bits),
++                    acpl_hcb_beta3_fine_dt_bits, 1, 1, acpl_hcb_beta3_fine_dt_codes, 4, 4, 768);
++
++    INIT_VLC_STATIC(&acpl_codebook_vlc[3][1][0], 9, sizeof(acpl_hcb_gamma_coarse_f0_bits),
++                    acpl_hcb_gamma_coarse_f0_bits, 1, 1, acpl_hcb_gamma_coarse_f0_codes, 2, 2, 528);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[3][1][1], 9, sizeof(acpl_hcb_gamma_coarse_df_bits),
++                    acpl_hcb_gamma_coarse_df_bits, 1, 1, acpl_hcb_gamma_coarse_df_codes, 4, 4, 644);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[3][1][2], 9, sizeof(acpl_hcb_gamma_coarse_dt_bits),
++                    acpl_hcb_gamma_coarse_dt_bits, 1, 1, acpl_hcb_gamma_coarse_dt_codes, 4, 4, 896);
++
++    INIT_VLC_STATIC(&acpl_codebook_vlc[3][0][0], 9, sizeof(acpl_hcb_gamma_fine_f0_bits),
++                    acpl_hcb_gamma_fine_f0_bits, 1, 1, acpl_hcb_gamma_fine_f0_codes, 4, 4, 544);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[3][0][1], 9, sizeof(acpl_hcb_gamma_fine_df_bits),
++                    acpl_hcb_gamma_fine_df_bits, 1, 1, acpl_hcb_gamma_fine_df_codes, 4, 4, 1026);
++    INIT_VLC_STATIC(&acpl_codebook_vlc[3][0][2], 9, sizeof(acpl_hcb_gamma_fine_dt_bits),
++                    acpl_hcb_gamma_fine_dt_bits, 1, 1, acpl_hcb_gamma_fine_dt_codes, 4, 4, 1792);
++
++    for (int j = 0; j < 8; j++) {
++        const uint16_t *transf_lengths = transf_length_48khz[j];
++
++        for (int i = 0; i < 5; i++) {
++            int N_w = transf_lengths[i];
++            float alpha = kbd_window_alpha[j][i];
++            float scale = 1.f / (float)N_w;
++
++            if ((ret = av_tx_init(&s->tx_ctx[j][i], &s->tx_fn[j][i], AV_TX_FLOAT_MDCT, 1, N_w, &scale, 0)))
++                return ret;
++
++            ff_kbd_window_init(s->kbd_window[j][i], alpha, N_w);
++        }
++    }
++
++    for (int i = 0; i < 8192; i++)
++        s->quant_lut[i] = powf(i, 4.f / 3.f);
++
++    for (int i = 0; i < 64; i++) {
++        for (int n = 0; n < 128; n++) {
++            s->cos_atab[i][n] = cosf(M_PI/128*(i+0.5)*(2*n-1));
++            s->sin_atab[i][n] = sinf(M_PI/128*(i+0.5)*(2*n-1));
++            s->cos_stab[n][i] = cosf(M_PI/128*(i+0.5)*(2*n-255)) / 64.f;
++            s->sin_stab[n][i] = sinf(M_PI/128*(i+0.5)*(2*n-255)) / 64.f;
++        }
++    }
++
++    s->fdsp = avpriv_float_dsp_alloc(avctx->flags & AV_CODEC_FLAG_BITEXACT);
++    if (!s->fdsp)
++        return AVERROR(ENOMEM);
++
++    return 0;
++}
++
++static int variable_bits(GetBitContext *gb, int bits)
++{
++    int value = 0;
++    int read_more;
++
++    do {
++        value += get_bits(gb, bits);
++        read_more = get_bits1(gb);
++        if (read_more) {
++            value <<= bits;
++            value += 1 << bits;
++        }
++    } while (read_more);
++
++    return value;
++}
++
++static int check_sequence(AC4DecodeContext *s)
++{
++    if (s->sequence_counter > 1020) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid sequence counter: %d\n", s->sequence_counter);
++        return AVERROR_INVALIDDATA;
++    }
++
++    if (s->sequence_counter == s->sequence_counter_prev + 1)
++        return 0;
++
++    if (s->sequence_counter != 0 && s->sequence_counter_prev == 0)
++        return 0;
++
++    if (s->sequence_counter == 1 && s->sequence_counter_prev == 1020)
++        return 0;
++
++    if (s->sequence_counter == 0 && s->sequence_counter_prev == 0)
++        return 0;
++
++    av_log(s->avctx, AV_LOG_ERROR, "unexpected sequence counter: %d vs %d\n", s->sequence_counter, s->sequence_counter_prev);
++    return AVERROR_INVALIDDATA;
++}
++
++static int frame_rate_multiply_info(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++
++    p->multiplier_bit = 0;
++
++    switch (s->frame_rate_index) {
++    case 2:
++    case 3:
++    case 4:
++        p->multiplier = get_bits1(gb);
++        if (p->multiplier)
++            p->multiplier_bit = get_bits1(gb);
++        p->frame_rate_factor = p->multiplier ? (p->multiplier_bit ? 4 : 2) : 1;
++        break;
++    case 0:
++    case 1:
++    case 7:
++    case 8:
++    case 9:
++        p->multiplier = get_bits1(gb);
++        p->frame_rate_factor = p->multiplier ? 2 : 1;
++        break;
++    default:
++        p->frame_rate_factor = 1;
++        break;
++    }
++
++    return 0;
++}
++
++static int emdf_payloads_substream_info(AC4DecodeContext *s, EMDFInfo *e)
++{
++    GetBitContext *gb = &s->gbc;
++
++    e->substream_index = get_bits(gb, 2);
++    if (e->substream_index == 3)
++        e->substream_index += variable_bits(gb, 2);
++
++    return 0;
++}
++
++static int emdf_protection(AC4DecodeContext *s, EMDFInfo *e)
++{
++    GetBitContext *gb = &s->gbc;
++    int first, second;
++
++    first = get_bits(gb, 2);
++    second = get_bits(gb, 2);
++
++    switch (first) {
++    case 0:
++        break;
++    case 1:
++        skip_bits(gb, 8);
++        break;
++    case 2:
++        skip_bits_long(gb, 32);
++        break;
++    case 3:
++        skip_bits_long(gb, 128);
++        break;
++    }
++
++    switch (second) {
++    case 0:
++        break;
++    case 1:
++        skip_bits(gb, 8);
++        break;
++    case 2:
++        skip_bits_long(gb, 32);
++        break;
++    case 3:
++        skip_bits_long(gb, 128);
++        break;
++    }
++
++    return 0;
++}
++
++static int emdf_info(AC4DecodeContext *s, EMDFInfo *e)
++{
++    GetBitContext *gb = &s->gbc;
++
++    e->version = get_bits(gb, 2);
++    if (e->version == 3)
++        e->version += variable_bits(gb, 2);
++    e->key_id = get_bits(gb, 3);
++    if (e->key_id == 7)
++        e->key_id += variable_bits(gb, 3);
++
++    if (get_bits1(gb))
++        emdf_payloads_substream_info(s, e);
++
++    emdf_protection(s, e);
++
++    return 0;
++}
++
++static int content_type(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++
++    skip_bits(gb, 3);
++    if (get_bits1(gb)) {
++        if (get_bits1(gb)) {
++            skip_bits(gb, 1);
++            skip_bits(gb, 16);
++        } else {
++            int language_tag_bytes = get_bits(gb, 6);
++
++            skip_bits_long(gb, 8 * language_tag_bytes);
++        }
++    }
++
++    return 0;
++}
++
++static int ac4_hsf_ext_substream_info(AC4DecodeContext *s, SubstreamInfo *ssi,
++                                      int substream_present)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (substream_present) {
++        ssi->hsf_ext_substream_index = get_bits(gb, 2);
++        if (ssi->hsf_ext_substream_index == 3)
++            ssi->hsf_ext_substream_index += variable_bits(gb, 2);
++    }
++
++    return 0;
++}
++
++static int ac4_substream_info(AC4DecodeContext *s, PresentationInfo *p,
++                              SubstreamInfo *ssi)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ssi->sus_ver = 0;
++    ssi->channel_mode = get_vlc2(gb, channel_mode_vlc.table, channel_mode_vlc.bits, 1);
++    if (ssi->channel_mode < 0) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid channel mode: %d\n", ssi->channel_mode);
++        return AVERROR_INVALIDDATA;
++    }
++
++    if (ssi->channel_mode == 16)
++        ssi->channel_mode += variable_bits(gb, 2);
++
++    if (s->fs_index == 1 && get_bits1(gb))
++        ssi->sf_multiplier = 1 + get_bits1(gb);
++    av_log(s->avctx, AV_LOG_DEBUG, "sf_multiplier: %d\n", ssi->sf_multiplier);
++
++    if (get_bits1(gb))
++        ssi->bitrate_indicator = get_vlc2(gb, bitrate_indicator_vlc.table, bitrate_indicator_vlc.bits, 1);
++
++    if (ssi->channel_mode == 7 ||
++        ssi->channel_mode == 8 ||
++        ssi->channel_mode == 9 ||
++        ssi->channel_mode == 10) {
++        ssi->add_ch_base = get_bits1(gb);
++    }
++
++    if (get_bits1(gb))
++        content_type(s, p);
++
++    for (int i = 0; i < p->frame_rate_factor; i++)
++        ssi->iframe[i] = get_bits1(gb);
++
++    ssi->substream_index = get_bits(gb, 2);
++    if (ssi->substream_index == 3)
++        ssi->substream_index += variable_bits(gb, 2);
++    s->substream_type[ssi->substream_index] = ST_SUBSTREAM;
++    av_log(s->avctx, AV_LOG_DEBUG, "substream index: %d\n", ssi->substream_index);
++
++    return 0;
++}
++
++static int presentation_config_ext_info(AC4DecodeContext *s)
++{
++    GetBitContext *gb = &s->gbc;
++    int n_skip_bytes;
++
++    n_skip_bytes = get_bits(gb, 5);
++    if (get_bits1(gb))
++        n_skip_bytes += variable_bits(gb, 2) << 5;
++
++    skip_bits_long(gb, 8 * n_skip_bytes);
++
++    return 0;
++}
++
++static int ac4_presentation_info(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    p->single_substream = get_bits1(gb);
++    if (p->single_substream != 1) {
++        p->presentation_config = get_bits(gb, 3);
++        if (p->presentation_config == 0x7) {
++            p->presentation_config += variable_bits(gb, 2);
++        }
++    }
++
++    p->presentation_version = get_unary(gb, 0, 31);
++
++    p->add_emdf_substreams = 0;
++    if (p->single_substream != 1 && p->presentation_config == 6) {
++        p->add_emdf_substreams = 1;
++    } else {
++        p->mdcompat = get_bits(gb, 3);
++
++        if (get_bits1(gb))
++            p->presentation_id = variable_bits(gb, 2);
++
++        frame_rate_multiply_info(s, p);
++        emdf_info(s, &p->emdf[0]);
++
++        if (p->single_substream == 1) {
++            ret = ac4_substream_info(s, p, &p->ssinfo);
++            if (ret < 0)
++                return ret;
++        } else {
++            p->hsf_ext = get_bits1(gb);
++            switch (p->presentation_config) {
++            case 0:
++                ret = ac4_substream_info(s, p, &p->ssinfo);
++                if (ret < 0)
++                    return ret;
++                ret = ac4_hsf_ext_substream_info(s, &p->ssinfo, 1);
++                if (ret < 0)
++                    return ret;
++                ret = ac4_substream_info(s, p, &p->ssinfo);
++                if (ret < 0)
++                    return ret;
++                break;
++            default:
++                presentation_config_ext_info(s);
++            }
++        }
++
++        p->pre_virtualized = get_bits1(gb);
++        p->add_emdf_substreams = get_bits1(gb);
++    }
++
++    if (p->add_emdf_substreams) {
++        p->n_add_emdf_substreams = get_bits(gb, 2);
++        if (p->n_add_emdf_substreams == 0)
++            p->n_add_emdf_substreams = variable_bits(gb, 2) + 4;
++
++        for (int i = 0; i < p->n_add_emdf_substreams; i++)
++            emdf_info(s, &p->emdf[i]);
++    }
++
++    return 0;
++}
++
++static int substream_index_table(AC4DecodeContext *s)
++{
++    GetBitContext *gb = &s->gbc;
++    int size_present;
++
++    s->nb_substreams = get_bits(gb, 2);
++    if (s->nb_substreams == 0)
++        s->nb_substreams = variable_bits(gb, 2) + 4;
++
++    av_log(s->avctx, AV_LOG_DEBUG, "nb_substreams: %d\n", s->nb_substreams);
++
++    if (s->nb_substreams == 1) {
++        size_present = get_bits1(gb);
++    } else {
++        size_present = 1;
++    }
++
++    if (size_present) {
++        for (int i = 0; i < s->nb_substreams; i++) {
++            int more_bits = get_bits1(gb);
++
++            s->substream_size[i] = get_bits(gb, 10);
++            if (more_bits)
++                s->substream_size[i] += variable_bits(gb, 2) << 10;
++            av_log(s->avctx, AV_LOG_DEBUG, "substream[%d] size: %d\n", i, s->substream_size[i]);
++        }
++    }
++
++    return 0;
++}
++
++static int presentation_substream_info(AC4DecodeContext *s, PresentationSubstreamInfo *psi)
++{
++    GetBitContext *gb = &s->gbc;
++
++    psi->alternative = get_bits1(gb);
++    psi->pres_ndot = get_bits1(gb);
++    psi->substream_index = get_bits(gb, 2);
++    if (psi->substream_index == 3)
++        psi->substream_index += variable_bits(gb, 2);
++    s->substream_type[psi->substream_index] = ST_PRESENTATION;
++    av_log(s->avctx, AV_LOG_DEBUG, "presentation substream index: %d\n", psi->substream_index);
++
++    return 0;
++}
++
++static int frame_rate_fractions_info(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++
++    p->frame_rate_fraction = 1;
++    if (s->frame_rate_index >= 5 && s->frame_rate_index <= 9) {
++        if (p->frame_rate_factor == 1) {
++            if (get_bits1(gb))
++                p->frame_rate_fraction = 2;
++        }
++    }
++
++    if (s->frame_rate_index >= 10 && s->frame_rate_index <= 12) {
++        if (get_bits1(gb)) {
++            if (get_bits1(gb))
++                p->frame_rate_fraction = 4;
++            else
++                p->frame_rate_fraction = 2;
++        }
++    }
++
++    return 0;
++}
++
++static int oamd_substream_info(AC4DecodeContext *s, SubstreamGroupInfo *ssi,
++                               int substreams_present)
++{
++    GetBitContext *gb = &s->gbc;
++
++    skip_bits1(gb);
++    if (substreams_present) {
++        int substream_index = get_bits(gb, 2);
++        if (substream_index == 3)
++            substream_index += variable_bits(gb, 2);
++    }
++
++    return 0;
++}
++
++static int ac4_substream_info_chan(AC4DecodeContext *s, SubstreamGroupInfo *g,
++                                   int substreams_present,
++                                   int sus_ver)
++{
++    GetBitContext *gb = &s->gbc;
++    SubstreamInfo *ssi = &g->ssinfo;
++
++    ssi->sus_ver = sus_ver;
++    ssi->channel_mode = get_vlc2(gb, channel_mode_vlc.table, channel_mode_vlc.bits, 3);
++    if (ssi->channel_mode < 0) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid chan channel mode: %d\n", ssi->channel_mode);
++        return AVERROR_INVALIDDATA;
++    }
++
++    if (ssi->channel_mode == 16)
++        ssi->channel_mode += variable_bits(gb, 2);
++
++    if (ssi->channel_mode == 11 ||
++        ssi->channel_mode == 12 ||
++        ssi->channel_mode == 13 ||
++        ssi->channel_mode == 14) {
++        ssi->back_channels_present = get_bits1(gb);
++        ssi->centre_present        = get_bits1(gb);
++        ssi->top_channels_present  = get_bits(gb, 2);
++    }
++
++    if (s->fs_index && get_bits1(gb))
++        ssi->sf_multiplier = 1 + get_bits1(gb);
++    av_log(s->avctx, AV_LOG_DEBUG, "sf_multiplier: %d\n", ssi->sf_multiplier);
++
++    if (get_bits1(gb))
++        ssi->bitrate_indicator = get_vlc2(gb, bitrate_indicator_vlc.table, bitrate_indicator_vlc.bits, 1);
++
++    if (ssi->channel_mode == 7 ||
++        ssi->channel_mode == 8 ||
++        ssi->channel_mode == 9 ||
++        ssi->channel_mode == 10)
++        ssi->add_ch_base = get_bits1(gb);
++
++    for (int i = 0; i < s->pinfo[0].frame_rate_factor; i++)
++        ssi->iframe[i] = get_bits1(gb);
++
++    if (substreams_present) {
++        ssi->substream_index = get_bits(gb, 2);
++        if (ssi->substream_index == 3)
++            ssi->substream_index += variable_bits(gb, 2);
++        av_log(s->avctx, AV_LOG_DEBUG, "substream index: %d\n", ssi->substream_index);
++    }
++
++    return 0;
++}
++
++static int ac4_substream_group_info(AC4DecodeContext *s,
++                                    SubstreamGroupInfo *g)
++{
++    GetBitContext *gb = &s->gbc;
++    int substreams_present;
++    int n_lf_substreams;
++    int hsf_ext;
++    int sus_ver;
++    int ret;
++
++    substreams_present = get_bits1(gb);
++    hsf_ext = get_bits1(gb);
++    if (get_bits1(gb)) {
++        n_lf_substreams = 1;
++    } else {
++        n_lf_substreams = get_bits(gb, 2) + 2;
++        if (n_lf_substreams == 5)
++            n_lf_substreams += variable_bits(gb, 2);
++    }
++    g->channel_coded = get_bits1(gb);
++    if (g->channel_coded) {
++        for (int sus = 0; sus < n_lf_substreams; sus++) {
++            if (s->version == 1) {
++                sus_ver = get_bits1(gb);
++            } else {
++                sus_ver = 1;
++            }
++
++            ret = ac4_substream_info_chan(s, g, substreams_present, sus_ver);
++            if (ret < 0)
++                return ret;
++            if (hsf_ext)
++                ac4_hsf_ext_substream_info(s, &g->ssinfo, substreams_present);
++        }
++    } else {
++        if (get_bits1(gb))
++            oamd_substream_info(s, g, substreams_present);
++        av_assert0(0);
++      /*for (int sus = 0; sus < n_lf_substreams; sus++) {
++            if (get_bits1(gb)) {
++                ac4_substream_info_ajoc(substreams_present);
++                if (hsf_ext)
++                    ac4_hsf_ext_substream_info(substreams_present);
++            } else {
++                ac4_substream_info_obj(substreams_present);
++                if (hsf_ext)
++                    ac4_hsf_ext_substream_info(substreams_present);
++            }
++        }*/
++    }
++
++    if (get_bits1(gb))
++        content_type(s, NULL);
++
++    return 0;
++}
++
++static int ac4_sgi_specifier(AC4DecodeContext *s, SubstreamGroupInfo *g)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (s->version == 1) {
++        av_assert0(0);
++        //ac4_substream_group_info(s);
++    } else {
++        g->group_index = get_bits(gb, 3);
++        if (g->group_index == 7)
++            g->group_index += variable_bits(gb, 2);
++    }
++
++    s->total_groups = FFMAX(s->total_groups, g->group_index);
++
++    return 0;
++}
++
++static int ac4_presentation_v1_info(AC4DecodeContext *s, PresentationInfo *p)
++{
++    GetBitContext *gb = &s->gbc;
++    int single_substream_group;
++
++    single_substream_group = get_bits1(gb);
++    if (single_substream_group != 1) {
++        p->presentation_config = get_bits(gb, 3);
++        if (p->presentation_config == 7)
++            p->presentation_config += variable_bits(gb, 2);
++    }
++    if (s->version != 1)
++        p->presentation_version = get_unary(gb, 0, 31);
++
++    if (single_substream_group != 1 && p->presentation_config == 6) {
++        p->add_emdf_substreams = 1;
++    } else {
++        if (s->version != 1)
++            p->mdcompat = get_bits(gb, 3);
++
++        if (get_bits1(gb))
++            p->presentation_id = variable_bits(gb, 2);
++
++        frame_rate_multiply_info(s, p);
++        frame_rate_fractions_info(s, p);
++        emdf_info(s, &p->emdf[0]);
++
++        if (get_bits1(gb))
++            p->enable_presentation = get_bits1(gb);
++
++        if (single_substream_group == 1) {
++            ac4_sgi_specifier(s, &s->ssgroup[0]);
++            p->n_substream_groups = 1;
++        } else {
++            p->multi_pid = get_bits1(gb);
++            switch (p->presentation_config) {
++            case 0:
++                /* Music and Effects + Dialogue */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                p->n_substream_groups = 2;
++                break;
++            case 1:
++                /* Main + DE */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                p->n_substream_groups = 1;
++                break;
++            case 2:
++                /* Main + Associated Audio */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                p->n_substream_groups = 2;
++                break;
++            case 3:
++                /* Music and Effects + Dialogue + Associated Audio */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                ac4_sgi_specifier(s, &s->ssgroup[2]);
++                p->n_substream_groups = 3;
++                break;
++            case 4:
++                /* Main + DE + Associated Audio */
++                ac4_sgi_specifier(s, &s->ssgroup[0]);
++                ac4_sgi_specifier(s, &s->ssgroup[1]);
++                ac4_sgi_specifier(s, &s->ssgroup[2]);
++                p->n_substream_groups = 2;
++                break;
++            case 5:
++                /* Arbitrary number of roles and substream groups */
++                p->n_substream_groups = get_bits(gb, 2) + 2;
++                if (p->n_substream_groups == 5)
++                    p->n_substream_groups += variable_bits(gb, 2);
++
++                for (int sg = 0; sg < p->n_substream_groups; sg++)
++                    ac4_sgi_specifier(s, &s->ssgroup[sg]);
++                break;
++            default:
++                /* EMDF and other data */
++                presentation_config_ext_info(s);
++                break;
++            }
++        }
++        p->pre_virtualized = get_bits1(gb);
++        p->add_emdf_substreams = get_bits1(gb);
++        presentation_substream_info(s, &p->psinfo);
++    }
++
++    if (p->add_emdf_substreams) {
++        p->n_add_emdf_substreams = get_bits(gb, 2);
++        if (p->n_add_emdf_substreams == 0)
++            p->n_add_emdf_substreams = variable_bits(gb, 2) + 4;
++        for (int i = 0; i < p->n_add_emdf_substreams; i++)
++            emdf_info(s, &p->emdf[i]);
++    }
++
++    return 0;
++}
++
++static int get_num_ts_in_ats(int frame_length)
++{
++    if (frame_length <= 2048 && frame_length >= 1536)
++        return 2;
++
++    return 1;
++}
++
++static int ac4_toc(AC4DecodeContext *s)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    s->version = get_bits(gb, 2);
++    if (s->version == 3)
++        s->version += variable_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "bitstream version: %d\n", s->version);
++    s->sequence_counter_prev = s->sequence_counter;
++    s->sequence_counter = get_bits(gb, 10);
++    av_log(s->avctx, AV_LOG_DEBUG, "sequence counter: %d\n", s->sequence_counter);
++
++    s->wait_frames = get_bits1(gb);
++    if (s->wait_frames) {
++        s->nb_wait_frames = get_bits(gb, 3);
++        if (s->nb_wait_frames > 0)
++            skip_bits(gb, 2);
++    }
++
++    s->fs_index = get_bits1(gb);
++    s->frame_rate_index = get_bits(gb, 4);
++    av_log(s->avctx, AV_LOG_DEBUG, "frame_rate_index: %d\n", s->frame_rate_index);
++    s->frame_len_base = frame_len_base_48khz[s->frame_rate_index];
++    s->num_ts_in_ats = get_num_ts_in_ats(s->frame_len_base);
++    s->frame_len_base_idx = frame_len_base_idx_48khz[s->frame_rate_index];
++    av_log(s->avctx, AV_LOG_DEBUG, "frame_len_base: %d\n", s->frame_len_base);
++    s->resampling_ratio = resampling_ratios[s->frame_rate_index];
++    s->num_qmf_timeslots = s->frame_len_base / 64;
++    s->num_aspx_timeslots = s->num_qmf_timeslots / s->num_ts_in_ats;
++    s->ts_offset_hfgen = 3 * s->num_ts_in_ats;
++    s->iframe_global = get_bits1(gb);
++    if (s->iframe_global) {
++        s->have_iframe = 1;
++    } else {
++        ret = check_sequence(s);
++        if (ret < 0)
++            return ret;
++    }
++    if (get_bits1(gb)) {
++        s->nb_presentations = 1;
++    } else {
++        if (get_bits1(gb)) {
++            s->nb_presentations = 2 + variable_bits(gb, 2);
++        } else {
++            s->nb_presentations = 0;
++        }
++    }
++
++    s->payload_base = 0;
++    if (get_bits1(gb)) {
++        s->payload_base = get_bits(gb, 5) + 1;
++        if (s->payload_base == 0x20) {
++            s->payload_base += variable_bits(gb, 3);
++        }
++    }
++
++    av_log(s->avctx, AV_LOG_DEBUG, "presentations: %d\n", s->nb_presentations);
++
++    if (s->version <= 1) {
++        for (int i = 0; i < s->nb_presentations; i++) {
++            ret = ac4_presentation_info(s, &s->pinfo[i]);
++            if (ret < 0)
++                return ret;
++        }
++    } else {
++        if (get_bits1(gb)) {
++            s->short_program_id = get_bits(gb, 16);
++            if (get_bits1(gb)) {
++                skip_bits_long(gb, 16 * 8);
++            }
++        }
++
++        for (int i = 0; i < s->nb_presentations; i++) {
++            ret = ac4_presentation_v1_info(s, &s->pinfo[i]);
++            if (ret < 0)
++                return ret;
++        }
++
++        av_log(s->avctx, AV_LOG_DEBUG, "total_groups: %d\n", s->total_groups + 1);
++        for (int i = 0; i <= s->total_groups; i++) {
++            ret = ac4_substream_group_info(s, &s->ssgroup[i]);
++            if (ret < 0)
++                return ret;
++        }
++    }
++
++    substream_index_table(s);
++
++    align_get_bits(gb);
++
++    av_log(s->avctx, AV_LOG_DEBUG, "TOC size: %d\n", get_bits_count(gb) >> 3);
++
++    return 0;
++}
++
++static int sb_to_pb(int acpl_num_param_bands_id, int acpl_qmf_band)
++{
++    if (acpl_qmf_band >= 0 &&
++        acpl_qmf_band <= 8)
++        return qmf_subbands[acpl_qmf_band][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 9 &&
++        acpl_qmf_band <= 10)
++        return qmf_subbands[9][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 11 &&
++        acpl_qmf_band <= 13)
++        return qmf_subbands[10][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 14 &&
++        acpl_qmf_band <= 17)
++        return qmf_subbands[11][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 18 &&
++        acpl_qmf_band <= 22)
++        return qmf_subbands[12][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 23 &&
++        acpl_qmf_band <= 34)
++        return qmf_subbands[13][acpl_num_param_bands_id];
++    if (acpl_qmf_band >= 35 &&
++        acpl_qmf_band <= 63)
++        return qmf_subbands[14][acpl_num_param_bands_id];
++    return 0;
++}
++
++static int acpl_config_1ch(AC4DecodeContext *s, Substream *ss, int mode)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ss->acpl_qmf_band = 0;
++    ss->acpl_param_band = 0;
++    ss->acpl_num_param_bands_id = get_bits(gb, 2);
++    ss->acpl_quant_mode[0] = get_bits1(gb);
++    if (mode == ACPL_PARTIAL) {
++        ss->acpl_qmf_band = get_bits(gb, 3) + 1;
++        ss->acpl_param_band = sb_to_pb(ss->acpl_num_param_bands_id, ss->acpl_qmf_band);
++    }
++
++    return 0;
++}
++
++static int acpl_config_2ch(AC4DecodeContext *s, Substream *ss)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ss->acpl_qmf_band = 0;
++    ss->acpl_param_band = 0;
++    ss->acpl_num_param_bands_id = get_bits(gb, 2);
++    ss->acpl_quant_mode[0] = get_bits1(gb);
++    ss->acpl_quant_mode[1] = get_bits1(gb);
++
++    return 0;
++}
++
++static void aspx_config(AC4DecodeContext *s, Substream *ss)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ss->aspx_quant_mode_env = get_bits1(gb);
++    ss->prev_aspx_start_freq = ss->aspx_start_freq;
++    ss->aspx_start_freq = get_bits(gb, 3);
++    ss->prev_aspx_stop_freq = ss->aspx_stop_freq;
++    ss->aspx_stop_freq = get_bits(gb, 2);
++    ss->prev_aspx_master_freq_scale = ss->aspx_master_freq_scale;
++    ss->aspx_master_freq_scale = get_bits1(gb);
++    ss->aspx_interpolation = get_bits1(gb);
++    ss->aspx_preflat = get_bits1(gb);
++    ss->aspx_limiter = get_bits1(gb);
++    ss->aspx_noise_sbg = get_bits(gb, 2);
++    ss->aspx_num_env_bits_fixfix = get_bits1(gb);
++    ss->aspx_freq_res_mode = get_bits(gb, 2);
++}
++
++static int get_transfer_length_from_idx(AC4DecodeContext *s, int idx)
++{
++    const uint16_t *transf_length_tab;
++
++    switch (s->frame_len_base) {
++    case 2048:
++        transf_length_tab = transf_length_48khz_2048;
++        break;
++    case 1920:
++        transf_length_tab = transf_length_48khz_1920;
++        break;
++    case 1536:
++        transf_length_tab = transf_length_48khz_1536;
++        break;
++    case 1024:
++        transf_length_tab = transf_length_48khz_1024;
++        break;
++    case 960:
++        transf_length_tab = transf_length_48khz_960;
++        break;
++    case 768:
++        transf_length_tab = transf_length_48khz_768;
++        break;
++    case 512:
++        transf_length_tab = transf_length_48khz_512;
++        break;
++    case 384:
++        transf_length_tab = transf_length_48khz_384;
++        break;
++    default:
++        av_assert0(0);
++    }
++
++    return transf_length_tab[idx];
++}
++
++static int asf_transform_info(AC4DecodeContext *s, Substream *ss,
++                              SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (s->frame_len_base >= 1536) {
++        ssch->scp.long_frame = get_bits1(gb);
++        if (ssch->scp.long_frame == 0) {
++            ssch->scp.transf_length_idx[0] = get_bits(gb, 2);
++            ssch->scp.transf_length_idx[1] = get_bits(gb, 2);
++            ssch->scp.transf_length[0] = get_transfer_length_from_idx(s, ssch->scp.transf_length_idx[0]);
++            ssch->scp.transf_length[1] = get_transfer_length_from_idx(s, ssch->scp.transf_length_idx[1]);
++        } else {
++            ssch->scp.transf_length[0] = s->frame_len_base;
++            ssch->scp.transf_length[1] = 0;
++        }
++    } else {
++        ssch->scp.long_frame = 0;
++        ssch->scp.transf_length_idx[0] = get_bits(gb, 2);
++        ssch->scp.transf_length[0] = get_transfer_length_from_idx(s, ssch->scp.transf_length_idx[0]);
++    }
++
++    return 0;
++}
++
++static int get_msfbl_bits(int transf_length)
++{
++    if (transf_length <= 2048 && transf_length >= 1536)
++        return 3;
++
++    return 2;
++}
++
++static int get_grp_bits(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    if (s->frame_len_base >= 1536 && ssch->scp.long_frame == 1)
++        return 0;
++
++    if (s->frame_len_base >= 1536 && ssch->scp.long_frame == 0)
++        return n_grp_bits_a[ssch->scp.transf_length_idx[0]][ssch->scp.transf_length_idx[1]];
++
++    if (s->frame_len_base < 1536 && s->frame_len_base > 512)
++        return n_grp_bits_b[ssch->scp.transf_length_idx[0]];
++
++    if (s->frame_len_base <= 512)
++        return n_grp_bits_c[ssch->scp.transf_length_idx[0]];
++
++    return 0;
++}
++
++static int get_msfb_bits(int transf_length)
++{
++    if (transf_length <= 2048 && transf_length >= 384)
++        return 6;
++
++    if (transf_length <= 256 && transf_length >= 192)
++        return 5;
++
++    return 4;
++}
++
++static int get_side_bits(int transf_length)
++{
++    if (transf_length <= 2048 && transf_length >= 480)
++        return 5;
++
++    if (transf_length <= 384 && transf_length >= 240)
++        return 4;
++
++    return 3;
++}
++
++static int get_max_sfb(AC4DecodeContext *s, SubstreamChannel *ssch,
++                       int g)
++{
++    int idx = 0;
++
++    if (s->frame_len_base >= 1536 && (ssch->scp.long_frame == 0) &&
++        (ssch->scp.transf_length_idx[0] != ssch->scp.transf_length_idx[1])) {
++        int num_windows_0 = 1 << (3 - ssch->scp.transf_length_idx[0]);
++
++        if (g >= ssch->scp.window_to_group[num_windows_0])
++            idx = 1;
++    }
++
++    if ((ssch->scp.side_limited == 1) ||
++        (ssch->scp.dual_maxsfb == 1 && ssch->scp.side_channel == 1))  {
++        return ssch->scp.max_sfb_side[idx];
++    } else {
++        return ssch->scp.max_sfb[idx];
++    }
++}
++
++static int get_transf_length(AC4DecodeContext *s, SubstreamChannel *ssch, int g, int *idx)
++{
++    const uint16_t *transf_length_tab;
++
++    switch (s->frame_len_base) {
++    case 2048:
++        transf_length_tab = transf_length_48khz_2048;
++        break;
++    case 1920:
++        transf_length_tab = transf_length_48khz_1920;
++        break;
++    case 1536:
++        transf_length_tab = transf_length_48khz_1536;
++        break;
++    case 1024:
++        transf_length_tab = transf_length_48khz_1024;
++        break;
++    case 960:
++        transf_length_tab = transf_length_48khz_960;
++        break;
++    case 768:
++        transf_length_tab = transf_length_48khz_768;
++        break;
++    case 512:
++        transf_length_tab = transf_length_48khz_512;
++        break;
++    case 384:
++        transf_length_tab = transf_length_48khz_384;
++        break;
++    default:
++        av_assert0(0);
++    }
++
++    if (s->frame_len_base >= 1536) {
++        if (ssch->scp.long_frame == 0) {
++            int num_windows_0 = 1 << (3 - ssch->scp.transf_length_idx[0]);
++
++            if (g < ssch->scp.window_to_group[num_windows_0]) {
++                if (idx)
++                    *idx = ssch->scp.transf_length_idx[0];
++                return transf_length_tab[ssch->scp.transf_length_idx[0]];
++            } else {
++                if (idx)
++                    *idx = ssch->scp.transf_length_idx[1];
++                return transf_length_tab[ssch->scp.transf_length_idx[1]];
++            }
++        } else {
++            if (idx)
++                *idx = 4;
++            return s->frame_len_base; // long frame, the transform length equals to frame_length
++        }
++    } else {
++        if (idx)
++            *idx = ssch->scp.transf_length_idx[0];
++        return transf_length_tab[ssch->scp.transf_length_idx[0]];
++    }
++}
++
++static const int get_sfb_size(int transf_length)
++{
++    switch (transf_length) {
++    case 2048:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_2048);
++        break;
++    case 1920:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_1920);
++        break;
++    case 1536:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_1536);
++        break;
++    case 1024:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_1024);
++        break;
++    case 960:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_960);
++        break;
++    case 768:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_768);
++        break;
++    case 512:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_512);
++        break;
++    case 480:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_480);
++        break;
++    case 384:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_384);
++        break;
++    case 256:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_256);
++        break;
++    case 240:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_240);
++        break;
++    case 192:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_192);
++        break;
++    case 128:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_128);
++        break;
++    case 120:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_120);
++        break;
++    case 96:
++        return FF_ARRAY_ELEMS(sfb_offset_48khz_96);
++        break;
++    default:
++        av_assert0(0);
++    }
++    return 0;
++}
++
++static const uint16_t *get_sfb_offset(int transf_length)
++{
++    switch (transf_length) {
++    case 2048:
++        return sfb_offset_48khz_2048;
++        break;
++    case 1920:
++        return sfb_offset_48khz_1920;
++        break;
++    case 1536:
++        return sfb_offset_48khz_1536;
++        break;
++    case 1024:
++        return sfb_offset_48khz_1024;
++        break;
++    case 960:
++        return sfb_offset_48khz_960;
++        break;
++    case 768:
++        return sfb_offset_48khz_768;
++        break;
++    case 512:
++        return sfb_offset_48khz_512;
++        break;
++    case 480:
++        return sfb_offset_48khz_480;
++        break;
++    case 384:
++        return sfb_offset_48khz_384;
++        break;
++    case 256:
++        return sfb_offset_48khz_256;
++        break;
++    case 240:
++        return sfb_offset_48khz_240;
++        break;
++    case 192:
++        return sfb_offset_48khz_192;
++        break;
++    case 128:
++        return sfb_offset_48khz_128;
++        break;
++    case 120:
++        return sfb_offset_48khz_120;
++        break;
++    case 96:
++        return sfb_offset_48khz_96;
++        break;
++    default:
++        av_assert0(0);
++    }
++
++    return 0;
++}
++
++static int num_sfb_96(int transf_length)
++{
++    if (transf_length >= 4096)
++        return 79;
++    else if (transf_length >= 3840)
++        return 76;
++    else if (transf_length >= 3072)
++        return 67;
++    else if (transf_length >= 2048)
++        return 57;
++    else if (transf_length >= 1920)
++        return 57;
++    else if (transf_length >= 1536)
++        return 49;
++    else if (transf_length >= 1024)
++        return 44;
++    else if (transf_length >= 920)
++        return 44;
++    else if (transf_length >= 768)
++        return 39;
++    else if (transf_length >= 512)
++        return 28;
++    else if (transf_length >= 480)
++        return 28;
++    else if (transf_length >= 384)
++        return 24;
++    else if (transf_length >= 256)
++        return 22;
++    else if (transf_length >= 240)
++        return 22;
++    else
++        return 18;
++}
++
++static int num_sfb_48(int transf_length)
++{
++    switch (transf_length) {
++    case 2048:
++        return 63; break;
++    case 1920:
++        return 61; break;
++    case 1536:
++        return 55; break;
++    case 1024:
++    case 960:
++        return 49; break;
++    case 768:
++        return 43; break;
++    case 512:
++    case 480:
++        return 36; break;
++    case 384:
++        return 33; break;
++    case 256:
++    case 240:
++        return 20; break;
++    case 192:
++        return 18; break;
++    case 128:
++    case 120:
++        return 14; break;
++    case 96:
++        return 12; break;
++    default:
++        av_assert0(0);
++    }
++
++    return 0;
++}
++
++static int asf_psy_elements(AC4DecodeContext *s, Substream *ss,
++                            SubstreamChannel *ssch, int n_grp_bits)
++{
++    int group_offset, win_offset, win;
++
++    ssch->scp.num_windows = 1;
++    ssch->scp.num_window_groups = 1;
++    ssch->scp.window_to_group[0] = 0;
++
++    if (ssch->scp.long_frame == 0) {
++        ssch->scp.num_windows = n_grp_bits + 1;
++        if (ssch->scp.different_framing) {
++            int num_windows_0 = 1 << (3 - ssch->scp.transf_length_idx[0]);
++
++            for (int i = n_grp_bits; i >= num_windows_0; i--) {
++                ssch->scp.scale_factor_grouping[i] = ssch->scp.scale_factor_grouping[i - 1];
++            }
++
++            ssch->scp.scale_factor_grouping[num_windows_0 - 1] = 0;
++            ssch->scp.num_windows++;
++        }
++
++        for (int i = 0; i < ssch->scp.num_windows - 1; i++) {
++            if (ssch->scp.scale_factor_grouping[i] == 0) {
++                ssch->scp.num_window_groups++;
++            }
++
++            ssch->scp.window_to_group[i + 1] = ssch->scp.num_window_groups - 1;
++        }
++    }
++
++    group_offset = 0;
++    win_offset = 0;
++    win = 0;
++    memset(ssch->offset2sfb, 0, sizeof(ssch->offset2sfb));
++    memset(ssch->offset2g, 0, sizeof(ssch->offset2g));
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int transf_length_g = get_transf_length(s, ssch, g, NULL);
++        const uint16_t *sfb_offset = get_sfb_offset(transf_length_g);
++        const int sfb_max_size = get_sfb_size(transf_length_g);
++        int max_sfb;
++
++        ssch->scp.num_win_in_group[g] = 0;
++        for (int w = 0; w < ssch->scp.num_windows; w++) {
++            if (ssch->scp.window_to_group[w] == g)
++                ssch->scp.num_win_in_group[g]++;
++        }
++
++        max_sfb = get_max_sfb(s, ssch, g);
++        if (max_sfb > sfb_max_size) {
++            av_log(s->avctx, AV_LOG_ERROR, "max_sfb=%d > sfb_max_size=%d\n", max_sfb, sfb_max_size);
++            return AVERROR_INVALIDDATA;
++        }
++        for (int sfb = 0; sfb < max_sfb; sfb++)
++            ssch->sect_sfb_offset[g][sfb] = group_offset + sfb_offset[sfb] * ssch->scp.num_win_in_group[g];
++        group_offset += sfb_offset[max_sfb] * ssch->scp.num_win_in_group[g];
++        ssch->sect_sfb_offset[g][max_sfb] = group_offset;
++        for (int sfb = 0; sfb < max_sfb; sfb++) {
++            for (int j = ssch->sect_sfb_offset[g][sfb]; j < ssch->sect_sfb_offset[g][sfb+1]; j++) {
++                ssch->offset2sfb[j] = sfb;
++                ssch->offset2g[j] = g;
++            }
++        }
++
++        for (int w = 0; w < ssch->scp.num_win_in_group[g]; w++) {
++            ssch->win_offset[win + w] = win_offset;
++            win_offset += transf_length_g;
++        }
++        win += ssch->scp.num_win_in_group[g];
++    }
++
++    av_log(s->avctx, AV_LOG_DEBUG, "long_frame: %d\n", ssch->scp.long_frame);
++    av_log(s->avctx, AV_LOG_DEBUG, "different_framing: %d\n", ssch->scp.different_framing);
++    av_log(s->avctx, AV_LOG_DEBUG, "num_windows: %d\n", ssch->scp.num_windows);
++    av_log(s->avctx, AV_LOG_DEBUG, "num_window_groups: %d\n", ssch->scp.num_window_groups);
++    av_log(s->avctx, AV_LOG_DEBUG, "transf_lengths:");
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        av_log(s->avctx, AV_LOG_DEBUG, " %d", get_transf_length(s, ssch, g, NULL));
++    }
++    av_log(s->avctx, AV_LOG_DEBUG, "\n");
++    av_log(s->avctx, AV_LOG_DEBUG, "num_win_in_group:");
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        av_log(s->avctx, AV_LOG_DEBUG, " %d", ssch->scp.num_win_in_group[g]);
++    }
++    av_log(s->avctx, AV_LOG_DEBUG, "\n");
++
++    return 0;
++}
++
++static int asf_psy_info(AC4DecodeContext *s, Substream *ss,
++                        SubstreamChannel *ssch,
++                        int dual_maxsfb, int side_limited)
++{
++    GetBitContext *gb = &s->gbc;
++    int n_side_bits = get_side_bits(ssch->scp.transf_length[0]);
++    int n_msfb_bits = get_msfb_bits(ssch->scp.transf_length[0]);
++    int n_grp_bits = get_grp_bits(s, ssch);
++
++    ssch->scp.different_framing = 0;
++    if ((s->frame_len_base >= 1536) && (ssch->scp.long_frame == 0) &&
++        (ssch->scp.transf_length_idx[0] != ssch->scp.transf_length_idx[1])) {
++        ssch->scp.different_framing = 1;
++    }
++
++    if (side_limited) {
++        ssch->scp.max_sfb_side[0] = get_bits(gb, n_side_bits);
++    } else {
++        ssch->scp.max_sfb[0] = get_bits(gb, n_msfb_bits);
++        if (dual_maxsfb)
++            ssch->scp.max_sfb_side[0] = get_bits(gb, n_msfb_bits);
++    }
++
++    if (ssch->scp.different_framing) {
++        n_side_bits = get_side_bits(ssch->scp.transf_length[1]);
++        n_msfb_bits = get_msfb_bits(ssch->scp.transf_length[1]);
++
++        if (side_limited) {
++            ssch->scp.max_sfb_side[1] = get_bits(gb, n_side_bits);
++        } else {
++            ssch->scp.max_sfb[1] = get_bits(gb, n_msfb_bits);
++            if (dual_maxsfb)
++                ssch->scp.max_sfb_side[1] = get_bits(gb, n_msfb_bits);
++        }
++    }
++
++    memset(ssch->scp.scale_factor_grouping, 0, sizeof(ssch->scp.scale_factor_grouping));
++    for (int i = 0; i < n_grp_bits; i++)
++        ssch->scp.scale_factor_grouping[i] = get_bits1(gb);
++
++    return asf_psy_elements(s, ss, ssch, n_grp_bits);
++}
++
++static int sf_info(AC4DecodeContext *s, Substream *ss,
++                   SubstreamChannel *ssch,
++                   int spec_frontend, int dual_maxsfb,
++                   int side_limited)
++{
++    int ret = 0;
++
++    ssch->scp.dual_maxsfb = dual_maxsfb;
++    ssch->scp.side_limited = side_limited;
++
++    if (spec_frontend == SF_ASF) {
++        asf_transform_info(s, ss, ssch);
++        ret = asf_psy_info(s, ss, ssch, dual_maxsfb, side_limited);
++    }
++
++    return ret;
++}
++
++static int sap_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (!get_bits1(gb)) {
++        for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++            int max_sfb_g = get_max_sfb(s, ssch, g);
++
++            for (int sfb = 0; sfb < max_sfb_g; sfb += 2) {
++                ssch->sap_coeff_used[g][sfb] = get_bits1(gb);
++                if (sfb + 1 < max_sfb_g)
++                    ssch->sap_coeff_used[g][sfb + 1] = ssch->sap_coeff_used[g][sfb];
++            }
++        }
++    } else {
++        for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++            int max_sfb_g = get_max_sfb(s, ssch, g);
++
++            for (int sfb = 0; sfb < max_sfb_g; sfb++)
++                ssch->sap_coeff_used[g][sfb] = 1;
++        }
++    }
++
++    ssch->delta_code_time = 0;
++    if (ssch->scp.num_window_groups != 1)
++        ssch->delta_code_time = get_bits1(gb);
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int max_sfb_g = get_max_sfb(s, ssch, g);
++
++        for (int sfb = 0; sfb < max_sfb_g; sfb += 2) {
++            if (ssch->sap_coeff_used[g][sfb]) {
++                ssch->dpcm_alpha_q[g][sfb] = get_vlc2(gb, scale_factors_vlc.table, scale_factors_vlc.bits, 3);
++                if (ssch->dpcm_alpha_q[g][sfb] < 0) {
++                    av_log(s->avctx, AV_LOG_ERROR, "sap data\n");
++                    return AVERROR_INVALIDDATA;
++                }
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int ssf_st_data(AC4DecodeContext *s, Substream *ss,
++                       SubstreamChannel *ssch, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int num_blocks;
++
++    ssch->env_idx[0] = get_bits(gb, 5);
++    if (iframe == 1 && ssch->stride_flag == SHORT_STRIDE)
++        get_bits(gb, 5);
++
++    if (ssch->stride_flag == SHORT_STRIDE) {
++        for (int block = 0; block < 4; block++)
++            ssch->gain_bits[block] = get_bits(gb, 4);
++    }
++
++    num_blocks = (ssch->stride_flag == SHORT_STRIDE) ? 4 : 1;
++
++    for (int block = 0; block < num_blocks; block++) {
++        if (block >= ssch->start_block && block < ssch->end_block) {
++            if (ssch->predictor_presence[block]) {
++                if (ssch->delta[block])
++                    ssch->predictor_lag_delta[block] = get_bits(gb, 4);
++                else
++                    ssch->predictor_lag[block] = get_bits(gb, 9);
++            }
++        }
++        ssch->variance_preserving[block] = get_bits1(gb);
++        ssch->alloc_offset[block] = get_bits(gb, 5);
++    }
++
++    return 0;
++}
++
++static int ac_init(AC4DecodeContext *s, ACState *acs)
++{
++    GetBitContext *gb = &s->gbc;
++
++    acs->ui_model_bits = SSF_MODEL_BITS;
++    acs->ui_model_unit = SSF_MODEL_UNIT;
++    acs->ui_range_bits = SSF_RANGE_BITS;
++    acs->ui_threshold_large = SSF_THRESHOLD_LARGE;
++    acs->ui_threshold_small = SSF_THRESHOLD_SMALL;
++
++    acs->ui_low = 0;
++    acs->ui_range = SSF_THRESHOLD_LARGE;
++
++    acs->ui_offset = get_bits1(gb);
++    for (int index = 1; index < acs->ui_range_bits; index++) {
++        uint32_t ui_tmp = get_bits1(gb);
++
++        acs->ui_offset <<= 1;
++        acs->ui_offset += ui_tmp;
++    }
++
++    acs->ui_offset2 = acs->ui_offset;
++
++    return 0;
++}
++
++static int32_t ac_decode(AC4DecodeContext *s, uint32_t cdf_low,
++                         uint32_t cdf_high,
++                         ACState *acs)
++{
++    GetBitContext *gb = &s->gbc;
++    uint32_t ui_tmp1, ui_tmp2;
++    uint32_t ui_range;
++
++    ui_range = acs->ui_range >> acs->ui_model_bits;
++    ui_tmp1 = ui_range * cdf_low;
++    acs->ui_offset = acs->ui_offset - ui_tmp1;
++
++    if (cdf_high < acs->ui_model_unit) {
++        ui_tmp2 = cdf_high - cdf_low;
++        acs->ui_range = ui_range * ui_tmp2;
++    } else {
++        acs->ui_range = acs->ui_range - ui_tmp1;
++    }
++
++    // denormalize
++    while (acs->ui_range <= acs->ui_threshold_small) {
++        /* Read a single bit from the bitstream */
++        uint32_t ui_tmp1 = get_bits1(gb);
++
++        acs->ui_range <<= 1;
++        acs->ui_offset <<= 1;
++        acs->ui_offset += ui_tmp1;
++        acs->ui_offset2 <<= 1;
++        if (acs->ui_offset & 1)
++            acs->ui_offset2++;
++    }
++
++    return 0;
++}
++
++static int32_t ac_decode_finish(ACState *acs)
++
++{
++    uint32_t fact, ui_bits, ui_val;
++    uint32_t ui_tmp1, ui_tmp2, ui_rev_idx;
++
++    acs->ui_low = acs->ui_offset & (acs->ui_threshold_large-1);
++
++    ui_tmp1 = acs->ui_threshold_large - acs->ui_offset;
++
++    acs->ui_low +=ui_tmp1;
++
++    for (int bit_idx = 1; bit_idx <= acs->ui_range_bits; bit_idx++) {
++        ui_rev_idx = acs->ui_range_bits - bit_idx;
++        fact = 1U << ui_rev_idx;
++        fact = fact - 1U;
++        ui_tmp1 = acs->ui_low + fact;
++        ui_bits = ui_tmp1 >> ui_rev_idx;
++        ui_val = ui_bits << ui_rev_idx;
++        ui_tmp1 = ui_val + fact;
++        ui_tmp2 = acs->ui_range - 1U;
++        ui_tmp2 += acs->ui_low;
++
++        if ((acs->ui_low <= ui_val) && (ui_tmp1 <= ui_tmp2))
++            break;
++    }
++
++    return 0;
++}
++
++static int ssf_ac_data(AC4DecodeContext *s, Substream *ss,
++                       SubstreamChannel *ssch)
++{
++    ac_init(s, &ssch->acs);
++    ac_decode_finish(&ssch->acs);
++
++    return 0;
++}
++
++static int ssf_granule(AC4DecodeContext *s, Substream *ss,
++                       SubstreamChannel *ssch, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ssch->stride_flag = get_bits1(gb);
++    if (iframe)
++        ssch->num_bands = get_bits(gb, 3) + 12;
++
++    ssch->start_block = 0;
++    ssch->end_block = 0;
++    if (ssch->stride_flag == LONG_STRIDE && !iframe)
++        ssch->end_block = 1;
++
++    if (ssch->stride_flag == SHORT_STRIDE) {
++        ssch->end_block = 4;
++        if (iframe)
++            ssch->start_block = 1;
++    }
++
++    for (int block = ssch->start_block; block < ssch->end_block; block++) {
++        ssch->predictor_presence[block] = get_bits1(gb);
++        if (ssch->predictor_presence[block]) {
++            if (ssch->start_block == 1 && block == 1) {
++                ssch->delta[block] = 0;
++            } else {
++                ssch->delta[block] = get_bits1(gb);
++            }
++        }
++    }
++
++    ret = ssf_st_data(s, ss, ssch, iframe);
++    if (ret < 0)
++        return ret;
++
++    return ssf_ac_data(s, ss, ssch);
++}
++
++static int ssf_data(AC4DecodeContext *s, Substream *ss,
++                    SubstreamChannel *ssch, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int ssf_iframe, ret;
++
++    if (iframe)
++        ssf_iframe = 1;
++    else
++        ssf_iframe = get_bits1(gb);
++
++    ret = ssf_granule(s, ss, ssch, ssf_iframe);
++    if (ret < 0)
++        return ret;
++    if (s->frame_len_base >= 1536)
++        ret = ssf_granule(s, ss, ssch, 0);
++
++    return ret;
++}
++
++static int asf_section_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    memset(&ssch->sect_cb, 0, sizeof(ssch->sect_cb));
++    memset(&ssch->sfb_cb, 0, sizeof(ssch->sfb_cb));
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int gidx;
++        int transf_length_g = get_transf_length(s, ssch, g, &gidx);
++        int sect_esc_val;
++        int n_sect_bits;
++        int k, i, max_sfb;
++
++        if (gidx <= 2) {
++            sect_esc_val = (1 << 3) - 1;
++            n_sect_bits = 3;
++        } else {
++            sect_esc_val = (1 << 5) - 1;
++            n_sect_bits = 5;
++        }
++        k = 0;
++        i = 0;
++        ssch->num_sec_lsf[g] = 0;
++        max_sfb = get_max_sfb(s, ssch, g);
++        while (k < max_sfb) {
++            int sect_len_incr;
++            int sect_len;
++
++            ssch->sect_cb[g][i] = get_bits(gb, 4);
++            if (ssch->sect_cb[g][i] > 11) {
++                av_log(s->avctx, AV_LOG_ERROR, "sect_cb[%d][%d] > 11\n", g, i);
++                return AVERROR_INVALIDDATA;
++            }
++            sect_len = 1;
++            sect_len_incr = get_bits(gb, n_sect_bits);
++            while (sect_len_incr == sect_esc_val) {
++                sect_len += sect_esc_val;
++                sect_len_incr = get_bits(gb, n_sect_bits);
++            }
++
++            sect_len += sect_len_incr;
++            ssch->sect_start[g][i] = k;
++            ssch->sect_end[g][i] = k + sect_len;
++
++            if (ssch->sect_start[g][i] < num_sfb_48(transf_length_g) &&
++                ssch->sect_end[g][i] >= num_sfb_48(transf_length_g)) {
++                ssch->num_sec_lsf[g] = i + 1;
++                if (ssch->sect_end[g][i] > num_sfb_48(transf_length_g)) {
++                    ssch->sect_end[g][i] = num_sfb_48(transf_length_g);
++                    i++;
++                    ssch->sect_start[g][i] = num_sfb_48(transf_length_g);
++                    ssch->sect_end[g][i] = k + sect_len;
++                    ssch->sect_cb[g][i] = ssch->sect_cb[g][i-1];
++                }
++            }
++
++            for (int sfb = k; sfb < k + sect_len; sfb++)
++                ssch->sfb_cb[g][sfb] = ssch->sect_cb[g][i];
++            k += sect_len;
++            i++;
++        }
++
++        ssch->num_sec[g] = i;
++        if (ssch->num_sec_lsf[g] == 0)
++            ssch->num_sec_lsf[g] = ssch->num_sec[g];
++    }
++
++    return 0;
++}
++
++static int ext_decode(AC4DecodeContext *s)
++{
++    GetBitContext *gb = &s->gbc;
++    int b, ext_val, N_ext = 0;
++
++    b = get_bits1(gb);
++    while (b) {
++        N_ext++;
++        b = get_bits1(gb);
++    }
++
++    ext_val = get_bits(gb, N_ext + 4);
++
++    return (1 << (N_ext + 4)) + ext_val;
++}
++
++static int asf_spectral_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    memset(&ssch->max_quant_idx, 0, sizeof(ssch->max_quant_idx));
++    memset(&ssch->quant_spec, 0, sizeof(ssch->quant_spec));
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        for (int i = 0; i < ssch->num_sec_lsf[g]; i++) {
++            int sect_start_line, sect_end_line, cb;
++
++            if (ssch->sect_cb[g][i] == 0 || ssch->sect_cb[g][i] > 11)
++                continue;
++
++            sect_start_line = ssch->sect_sfb_offset[g][ssch->sect_start[g][i]];
++            sect_end_line = ssch->sect_sfb_offset[g][ssch->sect_end[g][i]];
++            cb = ssch->sect_cb[g][i] - 1;
++
++            for (int k = sect_start_line; k < sect_end_line;) {
++                int cb_off = asf_codebook_off[cb];
++                int cb_mod = asf_codebook_mod[cb];
++                int x;
++
++                if (asf_codebook_dim[cb] == 4) {
++                    int cb_idx = get_vlc2(gb, asf_codebook_vlc[cb].table, asf_codebook_vlc[cb].bits, 3);
++                    int cb_mod2 = 9;
++                    int cb_mod3 = 27;
++
++                    if (cb_idx < 0) {
++                        av_log(s->avctx, AV_LOG_ERROR, "codebook_dim 4\n");
++                        return AVERROR_INVALIDDATA;
++                    }
++
++                    ssch->quant_spec[k]   = (cb_idx / cb_mod3) - cb_off;
++                    cb_idx -= (ssch->quant_spec[k]   + cb_off) * cb_mod3;
++                    ssch->quant_spec[k+1] = (cb_idx / cb_mod2) - cb_off;
++                    cb_idx -= (ssch->quant_spec[k+1] + cb_off) * cb_mod2;
++                    ssch->quant_spec[k+2] = (cb_idx / cb_mod)  - cb_off;
++                    cb_idx -= (ssch->quant_spec[k+2] + cb_off) * cb_mod;
++                    ssch->quant_spec[k+3] = cb_idx - cb_off;
++
++                    if (asf_codebook_unsigned[cb]) {
++                        if (ssch->quant_spec[k] && get_bits1(gb))
++                            ssch->quant_spec[k]   = -ssch->quant_spec[k];
++                        if (ssch->quant_spec[k+1] && get_bits1(gb))
++                            ssch->quant_spec[k+1] = -ssch->quant_spec[k+1];
++                        if (ssch->quant_spec[k+2] && get_bits1(gb))
++                            ssch->quant_spec[k+2] = -ssch->quant_spec[k+2];
++                        if (ssch->quant_spec[k+3] && get_bits1(gb))
++                            ssch->quant_spec[k+3] = -ssch->quant_spec[k+3];
++                    }
++                    x = ssch->offset2sfb[k];
++                    ssch->max_quant_idx[g][x] = FFMAX(ssch->max_quant_idx[g][x], FFABS(ssch->quant_spec[k]));
++                    x = ssch->offset2sfb[k+1];
++                    ssch->max_quant_idx[g][x] = FFMAX(ssch->max_quant_idx[g][x], FFABS(ssch->quant_spec[k+1]));
++                    x = ssch->offset2sfb[k+2];
++                    ssch->max_quant_idx[g][x] = FFMAX(ssch->max_quant_idx[g][x], FFABS(ssch->quant_spec[k+2]));
++                    x = ssch->offset2sfb[k+3];
++                    ssch->max_quant_idx[g][x] = FFMAX(ssch->max_quant_idx[g][x], FFABS(ssch->quant_spec[k+3]));
++                    k += 4;
++                } else { /* (asf_codebook_dim[ssch->sect_cb[g][i]] == 2) */
++                    int cb_idx = get_vlc2(gb, asf_codebook_vlc[cb].table, asf_codebook_vlc[cb].bits, 3);
++                    int sign0 = 0, sign1 = 0;
++
++                    if (cb_idx < 0) {
++                        av_log(s->avctx, AV_LOG_ERROR, "codebook_dim 2\n");
++                        return AVERROR_INVALIDDATA;
++                    }
++
++                    ssch->quant_spec[k]  = (cb_idx / cb_mod) - cb_off;
++                    cb_idx -= (ssch->quant_spec[k] + cb_off) * cb_mod;
++                    ssch->quant_spec[k+1] = cb_idx - cb_off;
++
++                    if (asf_codebook_unsigned[cb]) {
++                        if (ssch->quant_spec[k] && get_bits1(gb))
++                            sign0 = 1;
++                        if (ssch->quant_spec[k+1] && get_bits1(gb))
++                            sign1 = 1;
++                    }
++                    if (ssch->sect_cb[g][i] == 11) {
++                        if (ssch->quant_spec[k] == 16)
++                            ssch->quant_spec[k] = ext_decode(s);
++                        if (ssch->quant_spec[k+1] == 16)
++                            ssch->quant_spec[k+1] = ext_decode(s);
++                    }
++
++                    if (sign0)
++                        ssch->quant_spec[k] = -ssch->quant_spec[k];
++                    if (sign1)
++                        ssch->quant_spec[k+1] = -ssch->quant_spec[k+1];
++
++                    x = ssch->offset2sfb[k];
++                    ssch->max_quant_idx[g][x] = FFMAX(ssch->max_quant_idx[g][x], FFABS(ssch->quant_spec[k]));
++                    x = ssch->offset2sfb[k+1];
++                    ssch->max_quant_idx[g][x] = FFMAX(ssch->max_quant_idx[g][x], FFABS(ssch->quant_spec[k+1]));
++                    k += 2;
++                }
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int asf_scalefac_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++    int first_scf_found = 0;
++    int scale_factor;
++
++    scale_factor = get_bits(gb, 8);
++    memset(ssch->sf_gain, 0, sizeof(ssch->sf_gain));
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int max_sfb = FFMIN(get_max_sfb(s, ssch, g), num_sfb_48(get_transf_length(s, ssch, g, NULL)));
++
++        for (int sfb = 0; sfb < max_sfb; sfb++) {
++            if ((ssch->sfb_cb[g][sfb]) != 0 && (ssch->max_quant_idx[g][sfb] > 0)) {
++                if (first_scf_found == 1) {
++                    ssch->dpcm_sf[g][sfb] = get_vlc2(gb, scale_factors_vlc.table, scale_factors_vlc.bits, 3);
++                    if (ssch->dpcm_sf[g][sfb] < 0) {
++                        av_log(s->avctx, AV_LOG_ERROR, "scalefac data\n");
++                        return AVERROR_INVALIDDATA;
++                    }
++                    scale_factor += ssch->dpcm_sf[g][sfb] - 60;
++                } else {
++                    first_scf_found = 1;
++                }
++
++                ssch->sf_gain[g][sfb] = powf(2.f, 0.25f * (scale_factor - 100));
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int asf_snf_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ssch->snf_data_exists = get_bits1(gb);
++    if (ssch->snf_data_exists) {
++        for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++            int transf_length_g = get_transf_length(s, ssch, g, NULL);
++            int max_sfb = FFMIN(get_max_sfb(s, ssch, g), num_sfb_48(transf_length_g));
++
++            for (int sfb = 0; sfb < max_sfb; sfb++) {
++                if ((ssch->sfb_cb[g][sfb] == 0) || (ssch->max_quant_idx[g][sfb] == 0)) {
++                    ssch->dpcm_snf[g][sfb] = get_vlc2(gb, snf_vlc.table, snf_vlc.bits, 3);
++                    if (ssch->dpcm_snf[g][sfb] < 0) {
++                        av_log(s->avctx, AV_LOG_ERROR, "snf data\n");
++                        return AVERROR_INVALIDDATA;
++                    }
++                }
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int sf_data(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch,
++                   int iframe, int spec_frontend)
++{
++    int ret;
++
++    if (spec_frontend == SF_ASF) {
++        ret = asf_section_data(s, ss, ssch);
++        if (ret < 0)
++            return ret;
++        ret = asf_spectral_data(s, ss, ssch);
++        if (ret < 0)
++            return ret;
++        ret = asf_scalefac_data(s, ss, ssch);
++        if (ret < 0)
++            return ret;
++        ret = asf_snf_data(s, ss, ssch);
++        if (ret < 0)
++            return ret;
++    } else {
++        ret = ssf_data(s, ss, ssch, iframe);
++    }
++
++    return ret;
++}
++
++static int chparam_info(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ssch->sap_mode = get_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "sap_mode: %d\n", ssch->sap_mode);
++
++    if (ssch->sap_mode == 1) {
++        for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++            int max_sfb_g = get_max_sfb(s, ssch, g);
++
++            for (int sfb = 0; sfb < max_sfb_g; sfb++) {
++                ssch->ms_used[g][sfb] = get_bits1(gb);
++            }
++        }
++    }
++
++    if (ssch->sap_mode == 3) {
++        ret = sap_data(s, ss, ssch);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int stereo_data(AC4DecodeContext *s, Substream *ss, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ss->mdct_stereo_proc[0] = get_bits1(gb);
++    if (ss->mdct_stereo_proc[0]) {
++        ss->spec_frontend_l = SF_ASF;
++        ss->spec_frontend_r = SF_ASF;
++        ret = sf_info(s, ss, &ss->ssch[0], SF_ASF, 0, 0);
++        if (ret < 0)
++            return ret;
++
++        memcpy(&ss->ssch[1].scp, &ss->ssch[0].scp, sizeof(ss->ssch[0].scp));
++        memcpy(&ss->ssch[1].sect_sfb_offset, &ss->ssch[0].sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++        memcpy(&ss->ssch[1].offset2sfb, &ss->ssch[0].offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++        memcpy(&ss->ssch[1].offset2g, &ss->ssch[0].offset2g, sizeof(ss->ssch[0].offset2g));
++        memcpy(&ss->ssch[1].win_offset, &ss->ssch[0].win_offset, sizeof(ss->ssch[0].win_offset));
++
++        ret = chparam_info(s, ss, &ss->ssch[0]);
++        if (ret < 0)
++            return ret;
++    } else {
++        ss->spec_frontend_l = get_bits1(gb);
++        sf_info(s, ss, &ss->ssch[0], ss->spec_frontend_l, 0, 0);
++        ss->spec_frontend_r = get_bits1(gb);
++        sf_info(s, ss, &ss->ssch[1], ss->spec_frontend_r, 0, 0);
++    }
++
++    ret = sf_data(s, ss, &ss->ssch[0], iframe, ss->spec_frontend_l);
++    if (ret < 0)
++        return ret;
++    ret = sf_data(s, ss, &ss->ssch[1], iframe, ss->spec_frontend_r);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static int companding_control(AC4DecodeContext *s, Substream *ss, int num_chan)
++{
++    GetBitContext *gb = &s->gbc;
++    int sync_flag = 0;
++    int need_avg = 0;
++    int nc;
++
++    if (num_chan > 1)
++        sync_flag = get_bits1(gb);
++
++    nc = sync_flag ? 1 : num_chan;
++
++    for (int i = 0; i < nc; i++) {
++        ss->compand_on[i] = get_bits1(gb);
++        if (!ss->compand_on[i])
++            need_avg = 1;
++    }
++
++    if (need_avg == 1)
++        ss->compand_avg = get_bits1(gb);
++
++    return 0;
++}
++
++static int noise_mid_border(int aspx_tsg_ptr, int aspx_int_class, int num_atsg_sig)
++{
++    if (aspx_tsg_ptr == -1) {
++       if (aspx_int_class == VARFIX)
++           return 1;
++       else
++           return num_atsg_sig - 1;
++    } else if (aspx_tsg_ptr >= 0) {
++       if (aspx_int_class == VARFIX)
++           return num_atsg_sig - 1;
++       else
++           return FFMAX(1, FFMIN(num_atsg_sig - 1, aspx_tsg_ptr));
++    } else {
++        av_assert0(0);
++    }
++
++    return 0;
++}
++
++static int freq_res(int *atsg_sig, int atsg, int aspx_tsg_ptr,
++                    int num_aspx_timeslots, int aspx_freq_res_mode,
++                    int *aspx_freq_res)
++{
++    int freq_res;
++
++    switch (aspx_freq_res_mode) {
++    case 0:
++        freq_res = aspx_freq_res[atsg];
++        break;
++    case 1:
++        freq_res = 0;
++        break;
++    case 2:
++        if ((atsg < aspx_tsg_ptr && num_aspx_timeslots > 8) ||
++            (atsg_sig[atsg+1]-atsg_sig[atsg]) > (num_aspx_timeslots/6.0+3.25))
++            freq_res = 1;
++        else
++            freq_res = 0;
++        break;
++    case 3:
++        freq_res = 1;
++        break;
++    default:
++        av_assert0(0);
++    }
++
++    return freq_res;
++}
++
++static void get_tab_border(int *atsg_sig, int num_aspx_timeslots, int num_atsg)
++{
++    int size = (num_atsg + 1) * sizeof(int);
++
++    switch (num_aspx_timeslots) {
++    case 6:
++        memcpy(atsg_sig, tab_border[0][num_atsg >> 1], size);
++        break;
++    case 8:
++        memcpy(atsg_sig, tab_border[1][num_atsg >> 1], size);
++        break;
++    case 12:
++        memcpy(atsg_sig, tab_border[2][num_atsg >> 1], size);
++        break;
++    case 15:
++        memcpy(atsg_sig, tab_border[3][num_atsg >> 1], size);
++        break;
++    case 16:
++        memcpy(atsg_sig, tab_border[4][num_atsg >> 1], size);
++        break;
++    default:
++        av_assert0(0);
++    }
++}
++
++static int aspx_atsg(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch, int iframe)
++{
++    int num_atsg_sig = ssch->aspx_num_env;
++    int num_atsg_noise = ssch->aspx_num_noise;
++
++    if (ssch->aspx_int_class == FIXFIX) {
++        get_tab_border(ssch->atsg_sig, s->num_aspx_timeslots, num_atsg_sig);
++        get_tab_border(ssch->atsg_noise, s->num_aspx_timeslots, num_atsg_noise);
++        ssch->atsg_freqres[0] = freq_res(ssch->atsg_sig, 0, 0, s->num_aspx_timeslots,
++                                         ss->aspx_freq_res_mode, ssch->aspx_freq_res);
++        for (int atsg = 1; atsg < num_atsg_sig; atsg++)
++            ssch->atsg_freqres[atsg] = ssch->atsg_freqres[0];
++    } else {
++        switch (ssch->aspx_int_class) {
++        case FIXVAR:
++            ssch->atsg_sig[0] = 0;
++            ssch->atsg_sig[num_atsg_sig] = ssch->aspx_var_bord_right + s->num_aspx_timeslots;
++            for (int tsg = 0; tsg < ssch->aspx_num_rel_right; tsg++)
++                ssch->atsg_sig[num_atsg_sig-tsg-1] = ssch->atsg_sig[num_atsg_sig-tsg] - ssch->aspx_rel_bord_right[tsg];
++            break;
++        case VARFIX:
++            if (iframe)
++                ssch->atsg_sig[0] = ssch->aspx_var_bord_left;
++            else
++                ssch->atsg_sig[0] = ssch->previous_stop_pos - s->num_aspx_timeslots;
++            ssch->atsg_sig[num_atsg_sig] = s->num_aspx_timeslots;
++            for (int tsg = 0; tsg < ssch->aspx_num_rel_left; tsg++)
++                ssch->atsg_sig[tsg+1] = ssch->atsg_sig[tsg] + ssch->aspx_rel_bord_left[tsg];
++            break;
++        case VARVAR:
++            if (iframe)
++                ssch->atsg_sig[0] = ssch->aspx_var_bord_left;
++            else
++                ssch->atsg_sig[0] = ssch->previous_stop_pos - s->num_aspx_timeslots;
++            ssch->atsg_sig[num_atsg_sig] = ssch->aspx_var_bord_right + s->num_aspx_timeslots;
++            for (int tsg = 0; tsg < ssch->aspx_num_rel_left; tsg++)
++                ssch->atsg_sig[tsg+1] = ssch->atsg_sig[tsg] + ssch->aspx_rel_bord_left[tsg];
++            for (int tsg = 0; tsg < ssch->aspx_num_rel_right; tsg++)
++                ssch->atsg_sig[num_atsg_sig-tsg-1] = ssch->atsg_sig[num_atsg_sig-tsg] - ssch->aspx_rel_bord_right[tsg];
++            break;
++        }
++
++        ssch->atsg_noise[0] = ssch->atsg_sig[0];
++        ssch->atsg_noise[num_atsg_noise] = ssch->atsg_sig[num_atsg_sig];
++        if (num_atsg_noise > 1)
++            ssch->atsg_noise[1] = ssch->atsg_sig[noise_mid_border(ssch->aspx_tsg_ptr,
++                                                                  ssch->aspx_int_class,
++                                                                  num_atsg_sig)];
++        for (int atsg = 0; atsg < num_atsg_sig; atsg++)
++            ssch->atsg_freqres[atsg] = freq_res(ssch->atsg_sig, atsg, ssch->aspx_tsg_ptr,
++                                                s->num_aspx_timeslots, ss->aspx_freq_res_mode,
++                                                ssch->aspx_freq_res);
++    }
++
++    ssch->previous_stop_pos = ssch->atsg_sig[num_atsg_sig];
++
++    for (int atsg = 0; atsg < num_atsg_sig; atsg++) {
++        if (ssch->atsg_freqres[atsg]) {
++            ssch->num_sbg_sig[atsg] = ssch->num_sbg_sig_highres;
++            memcpy(ssch->sbg_sig[atsg], ssch->sbg_sig_highres, 24 * 4);
++        } else {
++            ssch->num_sbg_sig[atsg] = ssch->num_sbg_sig_lowres;
++            memcpy(ssch->sbg_sig[atsg], ssch->sbg_sig_lowres, 24 * 4);
++        }
++    }
++
++    return 0;
++}
++
++static int aspx_framing(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ssch->aspx_num_rel_left = 0;
++    ssch->aspx_num_rel_right = 0;
++
++    ssch->aspx_int_class = get_vlc2(gb, aspx_int_class_vlc.table, aspx_int_class_vlc.bits, 1);
++    if (ssch->aspx_int_class < 0) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid aspx int class: %d\n", ssch->aspx_int_class);
++        return AVERROR_INVALIDDATA;
++    }
++
++    ssch->aspx_num_env_prev = ssch->aspx_num_env;
++
++    switch (ssch->aspx_int_class) {
++    case FIXFIX:
++        ssch->aspx_num_env = 1 + get_bits(gb, 1 + ss->aspx_num_env_bits_fixfix);
++        if (ssch->aspx_num_env > 4) {
++            av_log(s->avctx, AV_LOG_ERROR, "invalid aspx num env in FIXFIX: %d\n", ssch->aspx_num_env);
++            return AVERROR_INVALIDDATA;
++        }
++
++        if (ss->aspx_freq_res_mode == 0)
++            ssch->aspx_freq_res[0] = get_bits1(gb);
++        break;
++    case FIXVAR:
++        ssch->aspx_var_bord_right = get_bits(gb, 2);
++        ssch->aspx_num_rel_right = get_bits(gb, 1 + (s->num_aspx_timeslots > 8));
++        for (int i = 0; i < ssch->aspx_num_rel_right; i++)
++            ssch->aspx_rel_bord_right[i] = 2 * get_bits(gb, 1 + (s->num_aspx_timeslots > 8)) + 2;
++        break;
++    case VARFIX:
++        if (iframe)
++            ssch->aspx_var_bord_left = get_bits(gb, 2);
++        ssch->aspx_num_rel_left = get_bits(gb, 1 + (s->num_aspx_timeslots > 8));
++        for (int i = 0; i < ssch->aspx_num_rel_left; i++)
++            ssch->aspx_rel_bord_left[i] = 2 * get_bits(gb, 1 + (s->num_aspx_timeslots > 8)) + 2;
++        break;
++    case VARVAR:
++        if (iframe)
++            ssch->aspx_var_bord_left = get_bits(gb, 2);
++        ssch->aspx_num_rel_left = get_bits(gb, 1 + (s->num_aspx_timeslots > 8));
++        for (int i = 0; i < ssch->aspx_num_rel_left; i++)
++            ssch->aspx_rel_bord_left[i] = 2 * get_bits(gb, 1 + (s->num_aspx_timeslots > 8)) + 2;
++        ssch->aspx_var_bord_right = get_bits(gb, 2);
++        ssch->aspx_num_rel_right = get_bits(gb, 1 + (s->num_aspx_timeslots > 8));
++        for (int i = 0; i < ssch->aspx_num_rel_right; i++)
++            ssch->aspx_rel_bord_right[i] = 2 * get_bits(gb, 1 + (s->num_aspx_timeslots > 8)) + 2;
++        break;
++    }
++
++    if (ssch->aspx_int_class != FIXFIX) {
++        int ptr_bits;
++
++        ssch->aspx_num_env = ssch->aspx_num_rel_left + ssch->aspx_num_rel_right + 1;
++        if (ssch->aspx_num_env > 5) {
++            av_log(s->avctx, AV_LOG_ERROR, "invalid aspx num env: %d (class %d)\n", ssch->aspx_num_env, ssch->aspx_int_class);
++            return AVERROR_INVALIDDATA;
++        }
++
++        ptr_bits = ceilf(logf(ssch->aspx_num_env + 2) / logf(2));
++        ssch->aspx_tsg_ptr_prev = ssch->aspx_tsg_ptr;
++        ssch->aspx_tsg_ptr = (int)get_bits(gb, ptr_bits) - 1;
++        if (ss->aspx_freq_res_mode == 0)
++            for (int env = 0; env < ssch->aspx_num_env; env++)
++                ssch->aspx_freq_res[env] = get_bits1(gb);
++    }
++
++    ssch->aspx_num_noise_prev = ssch->aspx_num_noise;
++
++    if (ssch->aspx_num_env > 1)
++        ssch->aspx_num_noise = 2;
++    else
++        ssch->aspx_num_noise = 1;
++
++    if (!ssch->aspx_num_env_prev)
++        ssch->aspx_num_env_prev = ssch->aspx_num_env;
++    if (!ssch->aspx_num_noise_prev)
++        ssch->aspx_num_noise_prev = ssch->aspx_num_noise;
++
++    return aspx_atsg(s, ss, ssch, iframe);
++}
++
++static void aspx_delta_dir(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    for (int env = 0; env < ssch->aspx_num_env; env++)
++        ssch->aspx_sig_delta_dir[env] = get_bits1(gb);
++
++    for (int env = 0; env < ssch->aspx_num_noise; env++)
++        ssch->aspx_noise_delta_dir[env] = get_bits1(gb);
++}
++
++static int aspx_hfgen_iwc_2ch(AC4DecodeContext *s, Substream *ss,
++                              SubstreamChannel *ssch0,
++                              SubstreamChannel *ssch1,
++                              int aspx_balance)
++{
++    GetBitContext *gb = &s->gbc;
++    int aspx_tic_left = 0, aspx_tic_right = 0;
++
++    memcpy(ssch0->aspx_tna_mode_prev, ssch0->aspx_tna_mode, sizeof(ssch0->aspx_tna_mode));
++    memcpy(ssch1->aspx_tna_mode_prev, ssch1->aspx_tna_mode, sizeof(ssch1->aspx_tna_mode));
++
++    for (int n = 0; n < ssch0->num_sbg_noise; n++)
++        ssch0->aspx_tna_mode[n] = get_bits(gb, 2);
++    if (aspx_balance == 0) {
++        for (int n = 0; n < ssch0->num_sbg_noise; n++)
++            ssch1->aspx_tna_mode[n] = get_bits(gb, 2);
++    } else {
++        for (int n = 0; n < ssch0->num_sbg_noise; n++)
++            ssch1->aspx_tna_mode[n] = ssch0->aspx_tna_mode[n];
++    }
++    if (get_bits1(gb)) {
++        for (int n = 0; n < ssch0->num_sbg_sig_highres; n++)
++            ssch0->aspx_add_harmonic[n] = get_bits1(gb);
++    }
++    if (get_bits1(gb)) {
++        for (int n = 0; n < ssch0->num_sbg_sig_highres; n++)
++            ssch1->aspx_add_harmonic[n] = get_bits1(gb);
++    }
++
++    for (int n = 0; n < ssch0->num_sbg_sig_highres; n++)
++        ssch0->aspx_fic_used_in_sfb[n] = ssch1->aspx_fic_used_in_sfb[n] = 0;
++
++    if (get_bits1(gb)) {
++        if (get_bits1(gb)) {
++            for (int n = 0; n < ssch0->num_sbg_sig_highres; n++)
++                ssch0->aspx_fic_used_in_sfb[n] = get_bits1(gb);
++        }
++
++        if (get_bits1(gb)) {
++            for (int n = 0; n < ssch0->num_sbg_sig_highres; n++)
++                ssch1->aspx_fic_used_in_sfb[n] = get_bits1(gb);
++        }
++    }
++
++    for (int n = 0; n < s->num_aspx_timeslots; n++)
++        ssch0->aspx_tic_used_in_slot[n] = ssch1->aspx_tic_used_in_slot[n] = 0;
++
++    if (get_bits1(gb)) {
++        int aspx_tic_copy = get_bits1(gb);
++
++        if (aspx_tic_copy == 0) {
++            aspx_tic_left = get_bits1(gb);
++            aspx_tic_right = get_bits1(gb);
++        }
++
++        if (aspx_tic_copy || aspx_tic_left) {
++            for (int n = 0; n < s->num_aspx_timeslots; n++)
++                ssch0->aspx_tic_used_in_slot[n] = get_bits1(gb);
++        }
++
++        if (aspx_tic_right) {
++            for (int n = 0; n < s->num_aspx_timeslots; n++)
++                ssch1->aspx_tic_used_in_slot[n] = get_bits1(gb);
++        }
++
++        if (aspx_tic_copy) {
++            for (int n = 0; n < s->num_aspx_timeslots; n++)
++                ssch1->aspx_tic_used_in_slot[n] = ssch0->aspx_tic_used_in_slot[n];
++        }
++    }
++
++    return 0;
++}
++
++static VLC *get_aspx_hcb(int data_type, int quant_mode, int stereo_mode, int hcb_type)
++{
++    VLC *aspx_cb;
++
++    if (data_type == DT_SIGNAL)
++        aspx_cb = &aspx_codebook_signal_vlc[stereo_mode][quant_mode][hcb_type];
++    else // NOISE
++        aspx_cb = &aspx_codebook_noise_vlc[stereo_mode][hcb_type];
++
++    return aspx_cb;
++}
++
++static int get_aspx_off(int data_type, int quant_mode, int stereo_mode, int hcb_type)
++{
++    int off;
++
++    if (data_type == DT_SIGNAL)
++        off = aspx_codebook_signal_off[stereo_mode][quant_mode][hcb_type];
++    else // NOISE
++        off = aspx_codebook_noise_off[stereo_mode][hcb_type];
++
++    return off;
++}
++
++static int aspx_huff_data(AC4DecodeContext *s,
++                          int data_type, int num_sbg,
++                          int quant_mode, int stereo_mode,
++                          int direction, int *data)
++{
++    GetBitContext *gb = &s->gbc;
++    VLC *aspx_cb;
++    int aspx_off;
++
++    if (direction == 0) { // FREQ
++        aspx_cb = get_aspx_hcb(data_type, quant_mode, stereo_mode, F0);
++        aspx_off = get_aspx_off(data_type, quant_mode, stereo_mode, F0);
++        data[0] = get_vlc2(gb, aspx_cb->table, aspx_cb->bits, 3);
++        if (data[0] < 0) {
++            av_log(s->avctx, AV_LOG_ERROR, "FREQ 1\n");
++            return AVERROR_INVALIDDATA;
++        }
++        data[0] -= aspx_off;
++        aspx_cb = get_aspx_hcb(data_type, quant_mode, stereo_mode, DF);
++        aspx_off = get_aspx_off(data_type, quant_mode, stereo_mode, DF);
++        for (int i = 1; i < num_sbg; i++) {
++            data[i] = get_vlc2(gb, aspx_cb->table, aspx_cb->bits, 3);
++            if (data[i] < 0) {
++                av_log(s->avctx, AV_LOG_ERROR, "FREQ 2\n");
++                return AVERROR_INVALIDDATA;
++            }
++            data[i] -= aspx_off;
++        }
++    } else { // TIME
++        aspx_cb = get_aspx_hcb(data_type, quant_mode, stereo_mode, DT);
++        aspx_off = get_aspx_off(data_type, quant_mode, stereo_mode, DT);
++        for (int i = 0; i < num_sbg; i++) {
++            data[i] = get_vlc2(gb, aspx_cb->table, aspx_cb->bits, 3);
++            if (data[i] < 0) {
++                av_log(s->avctx, AV_LOG_ERROR, "TIME\n");
++                return AVERROR_INVALIDDATA;
++            }
++            data[i] -= aspx_off;
++        }
++    }
++
++    return 0;
++}
++
++static int aspx_ec_data(AC4DecodeContext *s,
++                        Substream *ss,
++                        SubstreamChannel *ssch,
++                        int data_type, int num_env,
++                        uint8_t *freq_res, int quant_mode,
++                        int stereo_mode, int *direction)
++{
++    int dir, num_sbg, ret;
++
++    for (int env = 0; env < num_env; env++) {
++        if (data_type == DT_SIGNAL) {
++            if (freq_res[env])
++                num_sbg = ssch->num_sbg_sig_highres;
++            else
++                num_sbg = ssch->num_sbg_sig_lowres;
++        } else {
++            num_sbg = ssch->num_sbg_noise;
++        }
++        dir = direction[env];
++        ret = aspx_huff_data(s, data_type, num_sbg, quant_mode, stereo_mode, dir,
++                             ssch->aspx_data[data_type][env]);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int is_element_of_sbg_patches(int sbg_lim_sbg, int *sbg_patches,
++                                     int num_sbg_patches)
++{
++    for (int i = 0; i <= num_sbg_patches; i++) {
++        if (sbg_patches[i] == sbg_lim_sbg)
++            return 1;
++    }
++
++    return 0;
++}
++
++static void remove_element(int *sbg_lim, int num_sbg_lim, int sbg)
++{
++    for (int i = sbg; i < num_sbg_lim; i++)
++        sbg_lim[i] = sbg_lim[i + 1];
++}
++
++static int cmpints(const void *p1, const void *p2)
++{
++    int left  = *(const int *)p1;
++    int right = *(const int *)p2;
++    return FFDIFFSIGN(left, right);
++}
++
++static int aspx_elements(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch,
++                         int iframe)
++{
++    int sb, j, sbg = 0, goal_sb, msb, usb;
++    int source_band_low;
++    int idx[6];
++
++    ssch->master_reset = ((ss->prev_aspx_start_freq != ss->aspx_start_freq) +
++                          (ss->prev_aspx_stop_freq != ss->aspx_stop_freq) +
++                          (ss->prev_aspx_master_freq_scale != ss->aspx_master_freq_scale)) * iframe;
++    if (ssch->master_reset) {
++        if (ss->aspx_master_freq_scale == 1) {
++            ssch->num_sbg_master = 22 - 2 * ss->aspx_start_freq - 2 * ss->aspx_stop_freq;
++            for (int sbg = 0; sbg <= ssch->num_sbg_master; sbg++) {
++                ssch->sbg_master[sbg] = sbg_template_highres[2 * ss->aspx_start_freq + sbg];
++            }
++        } else {
++            ssch->num_sbg_master = 20 - 2 * ss->aspx_start_freq - 2 * ss->aspx_stop_freq;
++            for (int sbg = 0; sbg <= ssch->num_sbg_master; sbg++) {
++                ssch->sbg_master[sbg] = sbg_template_lowres[2 * ss->aspx_start_freq + sbg];
++            }
++        }
++    }
++
++    ssch->sba = ssch->sbg_master[0];
++    ssch->sbz = ssch->sbg_master[ssch->num_sbg_master];
++
++    ssch->num_sbg_sig_highres = ssch->num_sbg_master - ssch->aspx_xover_subband_offset;
++    for (int sbg = 0; sbg <= ssch->num_sbg_sig_highres; sbg++)
++        ssch->sbg_sig_highres[sbg] = ssch->sbg_master[sbg + ssch->aspx_xover_subband_offset];
++
++    ssch->sbx = ssch->sbg_sig_highres[0];
++    if (ssch->sbx <= 0)
++        return AVERROR_INVALIDDATA;
++    ssch->num_sb_aspx = ssch->sbg_sig_highres[ssch->num_sbg_sig_highres] - ssch->sbx;
++
++    ssch->num_sbg_sig_lowres = ssch->num_sbg_sig_highres - floorf(ssch->num_sbg_sig_highres / 2.);
++    ssch->sbg_sig_lowres[0] = ssch->sbg_sig_highres[0];
++    if ((ssch->num_sbg_sig_highres & 1) == 0) {
++        for (int sbg = 1; sbg <= ssch->num_sbg_sig_lowres; sbg++)
++            ssch->sbg_sig_lowres[sbg] = ssch->sbg_sig_highres[2*sbg];
++    } else {
++        for (int sbg = 1; sbg <= ssch->num_sbg_sig_lowres; sbg++)
++            ssch->sbg_sig_lowres[sbg] = ssch->sbg_sig_highres[2*sbg-1];
++    }
++
++    ssch->num_sbg_sig[0] = ssch->num_sbg_sig_lowres;
++    ssch->num_sbg_sig[1] = ssch->num_sbg_sig_highres;
++
++    ssch->num_sbg_noise = FFMAX(1, floorf(ss->aspx_noise_sbg * log2f(ssch->sbz / (float)ssch->sbx) + 0.5));
++    if (ssch->num_sbg_noise > 5) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid num sbg noise: %d\n", ssch->num_sbg_noise);
++        return AVERROR_INVALIDDATA;
++    }
++
++    idx[0] = 0;
++    ssch->sbg_noise[0] = ssch->sbg_sig_lowres[0];
++    for (int sbg = 1; sbg <= ssch->num_sbg_noise; sbg++) {
++        idx[sbg] = idx[sbg-1];
++        idx[sbg] += floorf((ssch->num_sbg_sig_lowres - idx[sbg - 1]) / (float)(ssch->num_sbg_noise + 1 - sbg));
++        ssch->sbg_noise[sbg] = ssch->sbg_sig_lowres[idx[sbg]];
++    }
++
++    msb = ssch->sba;
++    usb = ssch->sbx;
++    ssch->num_sbg_patches = 0;
++    if (s->fs_index)
++        goal_sb = 43;
++    else
++        goal_sb = 46;
++    if (ss->aspx_master_freq_scale == 1)
++        source_band_low = 4;
++    else
++        source_band_low = 2;
++
++    if (goal_sb < ssch->sbx + ssch->num_sb_aspx) {
++        for (int i = 0; ssch->sbg_master[i] < goal_sb; i++)
++            sbg = i + 1;
++    } else {
++        sbg = ssch->num_sbg_master;
++    }
++
++    do {
++        int odd;
++
++        j = sbg;
++        sb = ssch->sbg_master[j];
++        odd = (sb - 2 + ssch->sba) % 2;
++
++        while (sb > (ssch->sba - source_band_low + msb - odd) && j >= 1) {
++            j--;
++            sb = ssch->sbg_master[j];
++            odd = (sb - 2 + ssch->sba) % 2;
++        }
++
++        ssch->sbg_patch_num_sb[ssch->num_sbg_patches] = FFMAX(sb - usb, 0);
++        ssch->sbg_patch_start_sb[ssch->num_sbg_patches] = ssch->sba - odd - FFMAX(sb - usb, 0);
++        if (ssch->sbg_patch_num_sb[ssch->num_sbg_patches] > 0) {
++            usb = sb;
++            msb = sb;
++            ssch->num_sbg_patches++;
++        } else {
++            msb = ssch->sbx;
++        }
++
++        if (ssch->sbg_master[sbg] - sb < 3)
++            sbg = ssch->num_sbg_master;
++    } while (sb != (ssch->sbx + ssch->num_sb_aspx) && j > 0);
++
++    if ((ssch->num_sbg_patches > 1) && (ssch->sbg_patch_num_sb[ssch->num_sbg_patches - 1] < 3))
++        ssch->num_sbg_patches--;
++
++    if (ssch->num_sbg_patches > 6)
++        return AVERROR_INVALIDDATA;
++
++    ssch->sbg_patches[0] = ssch->sbx;
++    for (int i = 1; i <= ssch->num_sbg_patches; i++)
++        ssch->sbg_patches[i] = ssch->sbg_patches[i-1] + ssch->sbg_patch_num_sb[i-1];
++
++    /* Copy sbg_sig_lowres into lower part of limiter table */
++    for (int sbg = 0; sbg <= ssch->num_sbg_sig_lowres; sbg++)
++        ssch->sbg_lim[sbg] = ssch->sbg_sig_lowres[sbg];
++
++    /* Copy patch borders into higher part of limiter table */
++    for (int sbg = 1; sbg < ssch->num_sbg_patches; sbg++)
++        ssch->sbg_lim[sbg + ssch->num_sbg_sig_lowres] = ssch->sbg_patches[sbg];
++
++    /* Sort patch borders + low res sbg into temporary limiter table */
++    ssch->num_sbg_lim = ssch->num_sbg_sig_lowres + ssch->num_sbg_patches - 1;
++    AV_QSORT(ssch->sbg_lim, ssch->num_sbg_lim, int, cmpints);
++    sbg = 1;
++
++    while (sbg <= ssch->num_sbg_lim) {
++        float num_octaves = log2(ssch->sbg_lim[sbg] / (float)ssch->sbg_lim[sbg - 1]);
++
++        if (num_octaves < 0.245) {
++            if (ssch->sbg_lim[sbg] == ssch->sbg_lim[sbg-1]) {
++                remove_element(ssch->sbg_lim, ssch->num_sbg_lim, sbg);
++                ssch->num_sbg_lim--;
++                continue;
++            } else {
++                if (is_element_of_sbg_patches(ssch->sbg_lim[sbg],
++                                              ssch->sbg_patches,
++                                              ssch->num_sbg_patches)) {
++                    if (is_element_of_sbg_patches(ssch->sbg_lim[sbg - 1],
++                                                  ssch->sbg_patches,
++                                                  ssch->num_sbg_patches)) {
++                        sbg++;
++                        continue;
++                    } else {
++                        remove_element(ssch->sbg_lim, ssch->num_sbg_lim, sbg - 1);
++                        ssch->num_sbg_lim--;
++                        continue;
++                    }
++                } else {
++                    remove_element(ssch->sbg_lim, ssch->num_sbg_lim, sbg);
++                    ssch->num_sbg_lim--;
++                    continue;
++                }
++            }
++        } else {
++            sbg++;
++            continue;
++        }
++    }
++
++    return 0;
++}
++
++static int aspx_data_2ch(AC4DecodeContext *s, Substream *ss,
++                         SubstreamChannel *ssch0, SubstreamChannel *ssch1,
++                         int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    if (iframe) {
++        ssch0->aspx_xover_subband_offset = get_bits(gb, 3);
++        ssch1->aspx_xover_subband_offset = ssch0->aspx_xover_subband_offset;
++    }
++
++    ret = aspx_elements(s, ss, ssch0, iframe);
++    if (ret < 0)
++        return ret;
++    ret = aspx_elements(s, ss, ssch1, iframe);
++    if (ret < 0)
++        return ret;
++
++    ret = aspx_framing(s, ss, ssch0, iframe);
++    if (ret < 0)
++        return ret;
++
++    ssch0->aspx_qmode_env = ssch1->aspx_qmode_env = ss->aspx_quant_mode_env;
++    if (ssch0->aspx_int_class == FIXFIX && ssch0->aspx_num_env == 1)
++        ssch0->aspx_qmode_env = ssch1->aspx_qmode_env = 0;
++
++    ssch0->aspx_balance = ssch1->aspx_balance = get_bits1(gb);
++
++    if (ssch0->aspx_balance == 0) {
++        ret = aspx_framing(s, ss, ssch1, iframe);
++        if (ret < 0)
++            return ret;
++        ssch1->aspx_qmode_env = ss->aspx_quant_mode_env;
++        if (ssch1->aspx_int_class == FIXFIX && ssch1->aspx_num_env == 1)
++            ssch1->aspx_qmode_env = 0;
++    } else {
++        ssch1->aspx_num_env = ssch0->aspx_num_env;
++        ssch1->aspx_num_noise = ssch0->aspx_num_noise;
++        memcpy(ssch1->atsg_freqres, ssch0->atsg_freqres, sizeof(ssch0->atsg_freqres));
++    }
++
++    aspx_delta_dir(s, ssch0);
++    aspx_delta_dir(s, ssch1);
++    aspx_hfgen_iwc_2ch(s, ss, ssch0, ssch1, ssch0->aspx_balance);
++
++    ret = aspx_ec_data(s, ss, ssch0, DT_SIGNAL,
++                       ssch0->aspx_num_env,
++                       ssch0->atsg_freqres,
++                       ssch0->aspx_qmode_env,
++                       SM_LEVEL,
++                       ssch0->aspx_sig_delta_dir);
++    if (ret < 0)
++        return ret;
++    ret = aspx_ec_data(s, ss, ssch1, DT_SIGNAL,
++                       ssch1->aspx_num_env,
++                       ssch1->atsg_freqres,
++                       ssch1->aspx_qmode_env,
++                       ssch0->aspx_balance ? SM_BALANCE : SM_LEVEL,
++                       ssch1->aspx_sig_delta_dir);
++    if (ret < 0)
++        return ret;
++    ret = aspx_ec_data(s, ss, ssch0, DT_NOISE,
++                       ssch0->aspx_num_noise,
++                       0,
++                       0,
++                       SM_LEVEL,
++                       ssch0->aspx_noise_delta_dir);
++    if (ret < 0)
++        return ret;
++    ret = aspx_ec_data(s, ss, ssch1, DT_NOISE,
++                       ssch1->aspx_num_noise,
++                       0,
++                       0,
++                       ssch0->aspx_balance ? SM_BALANCE : SM_LEVEL,
++                       ssch1->aspx_noise_delta_dir);
++
++    return ret;
++}
++
++static int aspx_hfgen_iwc_1ch(AC4DecodeContext *s, Substream *ss,
++                              SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    memcpy(ssch->aspx_tna_mode_prev, ssch->aspx_tna_mode, sizeof(ssch->aspx_tna_mode));
++
++    for (int n = 0; n < ssch->num_sbg_noise; n++)
++        ssch->aspx_tna_mode[n] = get_bits(gb, 2);
++    if (get_bits1(gb)) {
++        for (int n = 0; n < ssch->num_sbg_sig_highres; n++)
++            ssch->aspx_add_harmonic[n] = get_bits1(gb);
++    }
++
++    for (int n = 0; n < ssch->num_sbg_sig_highres; n++)
++        ssch->aspx_fic_used_in_sfb[n] = 0;
++
++    if (get_bits1(gb)) {
++        for (int n = 0; n < ssch->num_sbg_sig_highres; n++)
++            ssch->aspx_fic_used_in_sfb[n] = get_bits1(gb);
++    }
++
++    for (int n = 0; n < s->num_aspx_timeslots; n++)
++        ssch->aspx_tic_used_in_slot[n] = 0;
++
++    if (get_bits1(gb)) {
++        for (int n = 0; n < s->num_aspx_timeslots; n++)
++            ssch->aspx_tic_used_in_slot[n] = get_bits1(gb);
++    }
++
++    return 0;
++}
++
++static int aspx_data_1ch(AC4DecodeContext *s, Substream *ss,
++                         SubstreamChannel *ssch, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    if (iframe)
++        ssch->aspx_xover_subband_offset = get_bits(gb, 3);
++
++    ssch->aspx_balance = 0;
++
++    ret = aspx_elements(s, ss, ssch, iframe);
++    if (ret < 0)
++        return ret;
++
++    ret = aspx_framing(s, ss, ssch, iframe);
++    if (ret < 0)
++        return ret;
++
++    ssch->aspx_qmode_env = ss->aspx_quant_mode_env;
++    if (ssch->aspx_int_class == FIXFIX && ssch->aspx_num_env == 1)
++        ssch->aspx_qmode_env = 0;
++
++    aspx_delta_dir(s, ssch);
++    aspx_hfgen_iwc_1ch(s, ss, ssch);
++
++    ret = aspx_ec_data(s, ss, ssch, DT_SIGNAL,
++                       ssch->aspx_num_env,
++                       ssch->atsg_freqres,
++                       ssch->aspx_qmode_env,
++                       0,
++                       ssch->aspx_sig_delta_dir);
++    if (ret < 0)
++        return ret;
++    ret = aspx_ec_data(s, ss, ssch, DT_NOISE,
++                       ssch->aspx_num_noise,
++                       0,
++                       0,
++                       0,
++                       ssch->aspx_noise_delta_dir);
++    return ret;
++}
++
++static int acpl_framing_data(AC4DecodeContext *s, Substream *ss,
++                             SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++
++    ssch->acpl_interpolation_type = get_bits1(gb);
++    ssch->acpl_num_param_sets_cod = get_bits1(gb);
++    if (ssch->acpl_interpolation_type) {
++        for (int ps = 0; ps < ssch->acpl_num_param_sets_cod + 1; ps++)
++            ssch->acpl_param_timeslot[ps] = get_bits(gb, 5);
++    }
++
++    return 0;
++}
++
++static VLC *get_acpl_hcb(int data_type, int quant_mode, int hcb_type)
++{
++    VLC *acpl_cb;
++
++    acpl_cb = &acpl_codebook_vlc[data_type][quant_mode][hcb_type];
++
++    return acpl_cb;
++}
++
++static int acpl_huff_data(AC4DecodeContext *s,
++                          int data_type, int data_bands,
++                          int start_band, int quant_mode,
++                          int *data)
++{
++    GetBitContext *gb = &s->gbc;
++    int diff_type;
++    VLC *acpl_cb;
++
++    switch (data_type) {
++    case ALPHA1:
++    case ALPHA2:
++        data_type = 0;
++        break;
++    case BETA1:
++    case BETA2:
++        data_type = 1;
++        break;
++    case BETA3:
++        data_type = 2;
++        break;
++    default:
++        data_type = 3;
++        break;
++    };
++
++    diff_type = get_bits1(gb);
++    if (diff_type == 0) { // DIFF_FREQ
++        acpl_cb = get_acpl_hcb(data_type, quant_mode, F0);
++        data[start_band] = get_vlc2(gb, acpl_cb->table, acpl_cb->bits, 3);
++        if (data[start_band] < 0) {
++            av_log(s->avctx, AV_LOG_ERROR, "DIFF_FREQ 1\n");
++            return AVERROR_INVALIDDATA;
++        }
++        acpl_cb = get_acpl_hcb(data_type, quant_mode, DF);
++        for (int i = start_band + 1; i < data_bands; i++) {
++            data[i] = get_vlc2(gb, acpl_cb->table, acpl_cb->bits, 3);
++            if (data[i] < 0) {
++                av_log(s->avctx, AV_LOG_ERROR, "DIFF_FREQ 2\n");
++                return AVERROR_INVALIDDATA;
++            }
++        }
++    } else { // DIFF_TIME
++        acpl_cb = get_acpl_hcb(data_type, quant_mode, DT);
++        for (int i = start_band; i < data_bands; i++) {
++            data[i] = get_vlc2(gb, acpl_cb->table, acpl_cb->bits, 3);
++            if (data[i] < 0) {
++                av_log(s->avctx, AV_LOG_ERROR, "DIFF_TIME\n");
++                return AVERROR_INVALIDDATA;
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int acpl_ec_data(AC4DecodeContext *s, Substream *ss,
++                        SubstreamChannel *ssch,
++                        int data_type, int data_bands,
++                        int start_band, int quant_mode)
++{
++    int ret;
++
++    for (int ps = 0; ps < ssch->acpl_num_param_sets_cod + 1; ps++) {
++        ret = acpl_huff_data(s, data_type, data_bands,
++                             start_band, quant_mode,
++                             ssch->acpl_data[data_type]);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int acpl_data_2ch(AC4DecodeContext *s, Substream *ss,
++                         SubstreamChannel *ssch0,
++                         SubstreamChannel *ssch1)
++{
++    int ret, num_bands, st;
++
++    acpl_framing_data(s, ss, ssch0);
++
++    num_bands = acpl_num_param_bands[ss->acpl_num_param_bands_id];
++    st = ss->acpl_param_band;
++
++    ret = acpl_ec_data(s, ss, ssch0, ALPHA1, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch0, ALPHA2, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch0, BETA1, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch0, BETA2, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch0, BETA3, num_bands, st, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA1, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA2, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA3, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA4, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA5, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++    ret = acpl_ec_data(s, ss, ssch1, GAMMA6, num_bands, st, ss->acpl_quant_mode[1]);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static int acpl_data_1ch(AC4DecodeContext *s, Substream *ss,
++                         SubstreamChannel *ssch)
++{
++    int ret, num_bands, start;
++
++    acpl_framing_data(s, ss, ssch);
++
++    num_bands = acpl_num_param_bands[ss->acpl_num_param_bands_id];
++    start = ss->acpl_param_band;
++
++    ret = acpl_ec_data(s, ss, ssch, ALPHA1, num_bands, start, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++
++    ret = acpl_ec_data(s, ss, ssch, BETA1, num_bands, start, ss->acpl_quant_mode[0]);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static int channel_pair_element(AC4DecodeContext *s, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int spec_frontend;
++    int ret;
++
++    ss->codec_mode = get_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (iframe) {
++        if (ss->codec_mode != CM_SIMPLE)
++            aspx_config(s, ss);
++        if (ss->codec_mode == CM_ASPX_ACPL_1)
++            acpl_config_1ch(s, ss, ACPL_PARTIAL);
++        if (ss->codec_mode == CM_ASPX_ACPL_2)
++            acpl_config_1ch(s, ss, ACPL_FULL);
++    }
++
++    switch (ss->codec_mode) {
++    case CM_SIMPLE:
++        ret = stereo_data(s, ss, iframe);
++        if (ret < 0)
++            return ret;
++        break;
++    case CM_ASPX:
++        companding_control(s, ss, 2);
++        ret = stereo_data(s, ss, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_2ch(s, ss, &ss->ssch[0], &ss->ssch[1], iframe);
++        if (ret < 0)
++            return ret;
++        break;
++    case CM_ASPX_ACPL_1:
++        companding_control(s, ss, 1);
++        ss->mdct_stereo_proc[0] = get_bits1(gb);
++        if (ss->mdct_stereo_proc[0]) {
++            ss->spec_frontend_m = SF_ASF;
++            ss->spec_frontend_s = SF_ASF;
++            ret = sf_info(s, ss, &ss->ssch[0], SF_ASF, 1, 0);
++            if (ret < 0)
++                return ret;
++
++            memcpy(&ss->ssch[1].scp, &ss->ssch[0].scp, sizeof(ss->ssch[0].scp));
++            memcpy(&ss->ssch[1].sect_sfb_offset, &ss->ssch[0].sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++            memcpy(&ss->ssch[1].offset2sfb, &ss->ssch[0].offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++            memcpy(&ss->ssch[1].offset2g, &ss->ssch[0].offset2g, sizeof(ss->ssch[0].offset2g));
++            memcpy(&ss->ssch[1].win_offset, &ss->ssch[0].win_offset, sizeof(ss->ssch[0].win_offset));
++
++            ret = chparam_info(s, ss, &ss->ssch[0]);
++            if (ret < 0)
++                return ret;
++        } else {
++            ss->spec_frontend_m = get_bits1(gb);
++            ret = sf_info(s, ss, &ss->ssch[0], ss->spec_frontend_m, 0, 0);
++            if (ret < 0)
++                return ret;
++            ss->spec_frontend_s = get_bits1(gb);
++            ret = sf_info(s, ss, &ss->ssch[1], ss->spec_frontend_s, 0, 1);
++            if (ret < 0)
++                return ret;
++        }
++        ret = sf_data(s, ss, &ss->ssch[0], iframe, ss->spec_frontend_m);
++        if (ret < 0)
++            return ret;
++        ret = sf_data(s, ss, &ss->ssch[1], iframe, ss->spec_frontend_m);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, &ss->ssch[0], iframe);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, &ss->ssch[0]);
++        if (ret < 0)
++            return ret;
++        break;
++    case CM_ASPX_ACPL_2:
++        companding_control(s, ss, 1);
++        spec_frontend = get_bits1(gb);
++        ret = sf_info(s, ss, &ss->ssch[0], spec_frontend, 0, 0);
++        if (ret < 0)
++            return ret;
++        ret = sf_data(s, ss, &ss->ssch[0], iframe, spec_frontend);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, &ss->ssch[0], iframe);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, &ss->ssch[0]);
++        if (ret < 0)
++            return ret;
++        break;
++    }
++
++    return 0;
++}
++
++static int four_channel_data(AC4DecodeContext *s, Substream *ss, int iframe)
++{
++    int ret;
++
++    ret = sf_info(s, ss, &ss->ssch[0], SF_ASF, 0, 0);
++    if (ret < 0)
++        return ret;
++
++    for (int i = 1; i < 4; i++) {
++        memcpy(&ss->ssch[i], &ss->ssch[0], sizeof(ss->ssch[0]));
++    }
++
++    for (int i = 0; i < 4; i++) {
++        ret = chparam_info(s, ss, &ss->ssch[i]);
++        if (ret < 0)
++            return ret;
++    }
++
++    for (int i = 0; i < 4; i++) {
++        av_log(s->avctx, AV_LOG_DEBUG, "channel: %d/4\n", i);
++        ret = sf_data(s, ss, &ss->ssch[i], iframe, SF_ASF);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int five_channel_info(AC4DecodeContext *s, Substream *ss)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ss->chel_matsel = get_bits(gb, 4);
++
++    for (int i = 0; i < 5; i++) {
++        ret = chparam_info(s, ss, &ss->ssch[i]);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int five_channel_data(AC4DecodeContext *s, Substream *ss, int iframe)
++{
++    int ret;
++
++    ret = sf_info(s, ss, &ss->ssch[0], SF_ASF, 0, 0);
++    if (ret < 0)
++        return ret;
++
++    for (int i = 1; i < 5; i++) {
++        memcpy(&ss->ssch[i].scp, &ss->ssch[0].scp, sizeof(ss->ssch[0].scp));
++        memcpy(&ss->ssch[i].sect_sfb_offset, &ss->ssch[0].sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++        memcpy(&ss->ssch[i].offset2sfb, &ss->ssch[0].offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++        memcpy(&ss->ssch[i].offset2g, &ss->ssch[0].offset2g, sizeof(ss->ssch[0].offset2g));
++        memcpy(&ss->ssch[i].win_offset, &ss->ssch[0].win_offset, sizeof(ss->ssch[0].win_offset));
++    }
++
++    ret = five_channel_info(s, ss);
++    if (ret < 0)
++        return ret;
++
++    for (int i = 0; i < 5; i++) {
++        av_log(s->avctx, AV_LOG_DEBUG, "channel: %d/5\n", i);
++        ret = sf_data(s, ss, &ss->ssch[i], iframe, SF_ASF);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int sf_info_lfe(AC4DecodeContext *s, Substream *ss,
++                        SubstreamChannel *ssch)
++{
++    GetBitContext *gb = &s->gbc;
++    int n_msfbl_bits = get_msfbl_bits(s->frame_len_base);
++    int n_grp_bits = get_grp_bits(s, ssch);
++
++    ssch->scp.long_frame = 1;
++    ssch->scp.max_sfb[0] = get_bits(gb, n_msfbl_bits);
++    ssch->scp.num_window_groups = 1;
++    ssch->scp.transf_length_idx[0] = 4;
++
++    return asf_psy_elements(s, ss, ssch, n_grp_bits);
++}
++
++static int mono_data(AC4DecodeContext *s, Substream *ss,
++                     SubstreamChannel *ssch, int lfe, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int spec_frontend;
++    int ret;
++
++    if (lfe) {
++        spec_frontend = SF_ASF;
++        ret = sf_info_lfe(s, ss, ssch);
++    } else {
++        spec_frontend = get_bits1(gb);
++        ret = sf_info(s, ss, ssch, spec_frontend, 0, 0);
++    }
++    if (ret < 0)
++        return ret;
++    av_log(s->avctx, AV_LOG_DEBUG, "channel: %d/1\n", 0);
++    return sf_data(s, ss, ssch, iframe, spec_frontend);
++}
++
++static int channel_element_7x(AC4DecodeContext *s, int channel_mode, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int ret = 0;
++
++    ss->codec_mode = get_bits(gb, 2);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (iframe) {
++        if (ss->codec_mode != CM_SIMPLE)
++            aspx_config(s, ss);
++        if (ss->codec_mode == CM_ASPX_ACPL_1)
++            acpl_config_1ch(s, ss, ACPL_PARTIAL);
++        if (ss->codec_mode == CM_ASPX_ACPL_2)
++            acpl_config_1ch(s, ss, ACPL_FULL);
++    }
++
++    if (channel_mode == 6) {
++        ret = mono_data(s, ss, &ss->ssch[7], 1, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    if (ss->codec_mode == CM_ASPX_ACPL_1 ||
++        ss->codec_mode == CM_ASPX_ACPL_2)
++        companding_control(s, ss, 5);
++
++    ss->coding_config = get_bits(gb, 2);
++    switch (ss->coding_config) {
++    case 0:
++        break;
++    case 1:
++        break;
++    case 2:
++        ret = four_channel_data(s, ss, iframe);
++        break;
++    case 3:
++        ret = five_channel_data(s, ss, iframe);
++        break;
++    default:
++        av_assert0(0);
++    }
++
++    return ret;
++}
++
++static int three_channel_info(AC4DecodeContext *s, Substream *ss,
++                              SubstreamChannel *ssch0,
++                              SubstreamChannel *ssch1,
++                              SubstreamChannel *ssch2)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    ss->chel_matsel = get_bits(gb, 4);
++    ret = chparam_info(s, ss, ssch0);
++    if (ret < 0)
++        return ret;
++    return chparam_info(s, ss, ssch1);
++}
++
++static int three_channel_data(AC4DecodeContext *s, Substream *ss,
++                              SubstreamChannel *ssch0,
++                              SubstreamChannel *ssch1,
++                              SubstreamChannel *ssch2)
++{
++    int ret;
++
++    ret = sf_info(s, ss, ssch0, SF_ASF, 0, 0);
++    if (ret < 0)
++        return ret;
++
++    memcpy(&ssch1->scp, &ssch0->scp, sizeof(ss->ssch[0].scp));
++    memcpy(&ssch1->sect_sfb_offset, &ssch0->sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++    memcpy(&ssch1->offset2sfb, &ssch0->offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++    memcpy(&ssch1->offset2g, &ssch0->offset2g, sizeof(ss->ssch[0].offset2g));
++    memcpy(&ssch1->win_offset, &ssch0->win_offset, sizeof(ss->ssch[0].win_offset));
++
++    memcpy(&ssch2->scp, &ssch0->scp, sizeof(ss->ssch[0].scp));
++    memcpy(&ssch2->sect_sfb_offset, &ssch0->sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++    memcpy(&ssch2->offset2sfb, &ssch0->offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++    memcpy(&ssch2->offset2g, &ssch0->offset2g, sizeof(ss->ssch[0].offset2g));
++    memcpy(&ssch2->win_offset, &ssch0->win_offset, sizeof(ss->ssch[0].win_offset));
++
++    ret = three_channel_info(s, ss, ssch0, ssch1, ssch2);
++    if (ret < 0)
++        return ret;
++    av_log(s->avctx, AV_LOG_DEBUG, "channel: %d/3\n", 0);
++    ret = sf_data(s, ss, ssch0, 0, SF_ASF);
++    if (ret < 0)
++        return ret;
++    av_log(s->avctx, AV_LOG_DEBUG, "channel: %d/3\n", 1);
++    ret = sf_data(s, ss, ssch1, 0, SF_ASF);
++    if (ret < 0)
++        return ret;
++    av_log(s->avctx, AV_LOG_DEBUG, "channel: %d/3\n", 2);
++    ret = sf_data(s, ss, ssch2, 0, SF_ASF);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static int two_channel_data(AC4DecodeContext *s, Substream *ss,
++                            SubstreamChannel *ssch0,
++                            SubstreamChannel *ssch1,
++                            int x)
++{
++    GetBitContext *gb = &s->gbc;
++    int ret;
++
++    if (get_bits_left(gb) <= 0) {
++        av_log(s->avctx, AV_LOG_ERROR, "two_channel_data underflow\n");
++        return AVERROR_INVALIDDATA;
++    }
++
++    ss->mdct_stereo_proc[x] = get_bits1(gb);
++    if (ss->mdct_stereo_proc[x]) {
++        ret = sf_info(s, ss, ssch0, SF_ASF, 0, 0);
++        if (ret < 0)
++            return ret;
++
++        memcpy(&ssch1->scp, &ssch0->scp, sizeof(ss->ssch[0].scp));
++        memcpy(&ssch1->sect_sfb_offset, &ssch0->sect_sfb_offset, sizeof(ss->ssch[0].sect_sfb_offset));
++        memcpy(&ssch1->offset2sfb, &ssch0->offset2sfb, sizeof(ss->ssch[0].offset2sfb));
++        memcpy(&ssch1->offset2g, &ssch0->offset2g, sizeof(ss->ssch[0].offset2g));
++        memcpy(&ssch1->win_offset, &ssch0->win_offset, sizeof(ss->ssch[0].win_offset));
++
++        ret = chparam_info(s, ss, ssch0);
++        if (ret < 0)
++            return ret;
++    } else {
++        ret = sf_info(s, ss, ssch0, SF_ASF, 0, 0);
++        if (ret < 0)
++            return ret;
++        ret = sf_info(s, ss, ssch1, SF_ASF, 0, 0);
++        if (ret < 0)
++            return ret;
++    }
++    av_log(s->avctx, AV_LOG_DEBUG, "channel: %d/2\n", 0);
++    ret = sf_data(s, ss, ssch0, 0, SF_ASF);
++    if (ret < 0)
++        return ret;
++    av_log(s->avctx, AV_LOG_DEBUG, "channel: %d/2\n", 1);
++    ret = sf_data(s, ss, ssch1, 0, SF_ASF);
++    if (ret < 0)
++        return ret;
++
++    return 0;
++}
++
++static int channel_element_3x(AC4DecodeContext *s, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int ret;
++
++    ss->codec_mode = get_bits1(gb);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (ss->codec_mode == CM_ASPX) {
++        if (iframe)
++            aspx_config(s, ss);
++        companding_control(s, ss, 3);
++    }
++
++    ss->coding_config = get_bits1(gb);
++    switch (ss->coding_config) {
++    case 0:
++        ret = stereo_data(s, ss, iframe);
++        if (ret < 0)
++            return ret;
++        ret = mono_data(s, ss, &ss->ssch[2], 0, iframe);
++        if (ret < 0)
++            return ret;
++        break;
++    case 1:
++        ret = three_channel_data(s, ss,
++                                 &ss->ssch[0],
++                                 &ss->ssch[1],
++                                 &ss->ssch[2]);
++        if (ret < 0)
++            return ret;
++        break;
++    }
++
++    if (ss->codec_mode == CM_ASPX) {
++        ret = aspx_data_2ch(s, ss, &ss->ssch[0], &ss->ssch[1], iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, &ss->ssch[2], iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    return 0;
++}
++
++static int channel_element_5x(AC4DecodeContext *s, int lfe, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int ret = 0;
++
++    ss->codec_mode = get_bits(gb, 3);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (iframe) {
++        if (ss->codec_mode != CM_SIMPLE)
++            aspx_config(s, ss);
++        if (ss->codec_mode == CM_ASPX_ACPL_1)
++            acpl_config_1ch(s, ss, ACPL_PARTIAL);
++        if (ss->codec_mode == CM_ASPX_ACPL_2)
++            acpl_config_1ch(s, ss, ACPL_FULL);
++        if (ss->codec_mode == CM_ASPX_ACPL_3)
++            acpl_config_2ch(s, ss);
++    }
++
++    if (lfe) {
++        ret = mono_data(s, ss, &ss->ssch[5], 1, iframe);
++        if (ret < 0)
++            return ret;
++    }
++
++    switch (ss->codec_mode) {
++    case CM_SIMPLE:
++    case CM_ASPX:
++        if (ss->codec_mode == CM_ASPX)
++            companding_control(s, ss, 5);
++
++        ss->coding_config = get_bits(gb, 2);
++        av_log(s->avctx, AV_LOG_DEBUG, "coding_config: %d\n", ss->coding_config);
++        switch (ss->coding_config) {
++        case 0:
++            ss->mode_2ch = get_bits1(gb);
++            ret = two_channel_data(s, ss, &ss->ssch[0], &ss->ssch[1], 0);
++            if (ret < 0)
++                return ret;
++            ret = two_channel_data(s, ss, &ss->ssch[2], &ss->ssch[3], 1);
++            if (ret < 0)
++                return ret;
++            ret = mono_data(s, ss, &ss->ssch[4], 0, iframe);
++            if (ret < 0)
++                return ret;
++            break;
++        case 1:
++            ret = three_channel_data(s, ss, &ss->ssch[0], &ss->ssch[1], &ss->ssch[2]);
++            if (ret < 0)
++                return ret;
++            ret = two_channel_data(s, ss, &ss->ssch[3], &ss->ssch[4], 0);
++            if (ret < 0)
++                return ret;
++            break;
++        case 2:
++            ret = four_channel_data(s, ss, iframe);
++            if (ret < 0)
++                return ret;
++            ret = mono_data(s, ss, &ss->ssch[4], 0, iframe);
++            if (ret < 0)
++                return ret;
++            break;
++        case 3:
++            ret = five_channel_data(s, ss, iframe);
++            if (ret < 0)
++                return ret;
++            break;
++        }
++
++        if (ss->codec_mode == CM_ASPX) {
++            ret = aspx_data_2ch(s, ss, &ss->ssch[0], &ss->ssch[1], iframe);
++            if (ret < 0)
++                return ret;
++            ret = aspx_data_2ch(s, ss, &ss->ssch[2], &ss->ssch[3], iframe);
++            if (ret < 0)
++                return ret;
++            ret = aspx_data_1ch(s, ss, &ss->ssch[4], iframe);
++            if (ret < 0)
++                return ret;
++        }
++        break;
++    case CM_ASPX_ACPL_1:
++    case CM_ASPX_ACPL_2:
++        companding_control(s, ss, 3);
++        ss->coding_config = get_bits1(gb);
++        if (ss->coding_config)
++            ret = three_channel_data(s, ss, &ss->ssch[0], &ss->ssch[1], &ss->ssch[2]);
++        else
++            ret = two_channel_data(s, ss, &ss->ssch[0], &ss->ssch[1], 0);
++        if (ret < 0)
++            return ret;
++
++        if (ss->codec_mode == CM_ASPX_ACPL_1) {
++            ss->max_sfb_master = get_bits(gb, 5); // XXX
++            ret = chparam_info(s, ss, &ss->ssch[3]);
++            if (ret < 0)
++                return ret;
++            ret = chparam_info(s, ss, &ss->ssch[4]);
++            if (ret < 0)
++                return ret;
++            ret = sf_data(s, ss, &ss->ssch[3], iframe, SF_ASF);
++            if (ret < 0)
++                return ret;
++            ret = sf_data(s, ss, &ss->ssch[4], iframe, SF_ASF);
++            if (ret < 0)
++                return ret;
++        }
++        if (ss->coding_config == 0) {
++           ret = mono_data(s, ss, &ss->ssch[2], 0, iframe);
++           if (ret < 0)
++               return ret;
++        }
++
++        ret = aspx_data_2ch(s, ss, &ss->ssch[0], &ss->ssch[1], iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, &ss->ssch[2], iframe);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, &ss->ssch[0]);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_1ch(s, ss, &ss->ssch[1]);
++        if (ret < 0)
++            return ret;
++        break;
++    case CM_ASPX_ACPL_3:
++        companding_control(s, ss, 2);
++        ret = stereo_data(s, ss, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_2ch(s, ss, &ss->ssch[0], &ss->ssch[1], iframe);
++        if (ret < 0)
++            return ret;
++        ret = acpl_data_2ch(s, ss, &ss->ssch[0], &ss->ssch[1]);
++        if (ret < 0)
++            return ret;
++        break;
++    default:
++        av_log(s->avctx, AV_LOG_ERROR, "invalid codec mode: %d\n", ss->codec_mode);
++        return AVERROR_INVALIDDATA;
++    }
++
++    return ret;
++}
++
++static int single_channel_element(AC4DecodeContext *s, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    Substream *ss = &s->substream;
++    int ret = 0;
++
++    ss->codec_mode = get_bits1(gb);
++    av_log(s->avctx, AV_LOG_DEBUG, "codec_mode: %d\n", ss->codec_mode);
++    if (iframe) {
++        if (ss->codec_mode == CM_ASPX)
++            aspx_config(s, ss);
++    }
++    if (ss->codec_mode == CM_SIMPLE) {
++        ret = mono_data(s, ss, &ss->ssch[0], 0, iframe);
++    } else {
++        companding_control(s, ss, 1);
++        ret = mono_data(s, ss, &ss->ssch[0], 0, iframe);
++        if (ret < 0)
++            return ret;
++        ret = aspx_data_1ch(s, ss, &ss->ssch[0], iframe);
++    }
++
++    return ret;
++}
++
++static int audio_data(AC4DecodeContext *s, int channel_mode, int iframe)
++{
++    int ret = 0;
++
++    av_log(s->avctx, AV_LOG_DEBUG, "channel_mode: %d\n", channel_mode);
++    switch (channel_mode) {
++    case 0:
++        ret = single_channel_element(s, iframe);
++        break;
++    case 1:
++        ret = channel_pair_element(s, iframe);
++        break;
++    case 2:
++        ret = channel_element_3x(s, iframe);
++        break;
++    case 3:
++        ret = channel_element_5x(s, 0, iframe);
++        break;
++    case 4:
++        ret = channel_element_5x(s, 1, iframe);
++        break;
++    case 5:
++        ret = channel_element_7x(s, channel_mode, iframe);
++        break;
++    case 6:
++        ret = channel_element_7x(s, channel_mode, iframe);
++        break;
++    default:
++        av_assert0(0);
++        break;
++    }
++
++    return ret;
++}
++
++static int further_loudness_info(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    GetBitContext *gb = &s->gbc;
++    Metadata *m = &ssi->meta;
++
++    m->loudness_version = get_bits(gb, 2);
++    if (m->loudness_version == 3)
++        m->loudness_version += get_bits(gb, 4);
++
++    m->loud_prac_type = get_bits(gb, 4);
++    if (m->loud_prac_type != 0) {
++        if (get_bits1(gb))
++            m->dialgate_prac_type = get_bits(gb, 3);
++        m->loudcorr_type = get_bits1(gb);
++    }
++
++    if (get_bits1(gb))
++        m->loudrelgat = get_bits(gb, 11);
++
++    if (get_bits1(gb)) {
++        m->loudspchgat = get_bits(gb, 11);
++        m->dialgate_prac_type = get_bits(gb, 3);
++    }
++
++    if (get_bits1(gb))
++        m->loudstrm3s = get_bits(gb, 11);
++
++    if (get_bits1(gb))
++        m->max_loudstrm3s = get_bits(gb, 11);
++
++    if (get_bits1(gb))
++        m->truepk = get_bits(gb, 11);
++
++    if (get_bits1(gb))
++        m->max_truepk = get_bits(gb, 11);
++
++    if (get_bits1(gb)) {
++        int prgmbndy_bit = 0;
++
++        m->prgmbndy = 1;
++        while (prgmbndy_bit == 0) {
++            m->prgmbndy <<= 1;
++            prgmbndy_bit = get_bits1(gb);
++        }
++
++        m->end_or_start = get_bits1(gb);
++        if (get_bits1(gb))
++            m->prgmbndy_offset = get_bits(gb, 11);
++    }
++
++    if (get_bits1(gb)) {
++        m->lra = get_bits(gb, 10);
++        m->lra_prac_type = get_bits(gb, 3);
++    }
++
++    if (get_bits1(gb))
++        m->loudmntry = get_bits(gb, 11);
++
++    if (get_bits1(gb))
++        m->max_loudmntry = get_bits(gb, 11);
++
++    if (get_bits1(gb)) {
++        int e_bits_size = get_bits(gb, 5);
++        if (e_bits_size == 31)
++            e_bits_size += variable_bits(gb, 4);
++        skip_bits_long(gb, e_bits_size);
++    }
++
++    return 0;
++}
++
++static int channel_mode_contains_lfe(int channel_mode)
++{
++    if (channel_mode == 4 ||
++        channel_mode == 6 ||
++        channel_mode == 8 ||
++        channel_mode == 10)
++        return 1;
++    return 0;
++}
++
++static int basic_metadata(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    GetBitContext *gb = &s->gbc;
++    Metadata *m = &ssi->meta;
++
++    if (ssi->sus_ver == 0)
++        m->dialnorm_bits = get_bits(gb, 7);
++
++    if (get_bits1(gb)) {
++        if (get_bits1(gb))
++            further_loudness_info(s, ssi);
++        if (ssi->channel_mode == 1) {
++            if (get_bits1(gb)) {
++                m->pre_dmixtyp_2ch = get_bits(gb, 3);
++                m->phase90_info_2ch = get_bits(gb, 2);
++            }
++        }
++
++        if (ssi->channel_mode > 1) {
++            if (get_bits1(gb)) {
++                m->loro_center_mixgain = get_bits(gb, 3);
++                m->loro_surround_mixgain = get_bits(gb, 3);
++                if (get_bits1(gb))
++                    m->loro_dmx_loud_corr = get_bits(gb, 5);
++                if (get_bits1(gb)) {
++                    m->ltrt_center_mixgain = get_bits(gb, 3);
++                    m->ltrt_surround_mixgain = get_bits(gb, 3);
++                }
++                if (get_bits1(gb))
++                    m->ltrt_dmx_loud_corr = get_bits(gb, 5);
++                if (channel_mode_contains_lfe(ssi->channel_mode)) {
++                    if (get_bits1(gb))
++                        m->lfe_mixgain = get_bits(gb, 5);
++                }
++                m->preferred_dmx_method = get_bits(gb, 2);
++            }
++            if (ssi->channel_mode == 3 ||
++                ssi->channel_mode == 4) {
++                if (get_bits1(gb))
++                    m->pre_dmixtyp_5ch = get_bits(gb, 3);
++                if (get_bits1(gb))
++                    m->pre_upmixtyp_5ch = get_bits(gb, 4);
++            }
++
++            if (ssi->channel_mode >= 5 && ssi->channel_mode <= 10) {
++                if (get_bits1(gb)) {
++                    if (ssi->channel_mode >= 5 && ssi->channel_mode <= 6) {
++                        m->pre_upmixtyp_3_4 = get_bits(gb, 2);
++                    } else if (ssi->channel_mode >= 9 && ssi->channel_mode <= 10) {
++                        m->pre_upmixtyp_3_2_2 = get_bits(gb, 1);
++                    }
++                }
++            }
++            m->phase90_info_mc = get_bits(gb, 2);
++            m->surround_attenuation_known = get_bits1(gb);
++            m->lfe_attenuation_known = get_bits1(gb);
++        }
++
++        if (get_bits1(gb))
++            m->dc_block_on = get_bits1(gb);
++    }
++    return 0;
++}
++
++static int extended_metadata(AC4DecodeContext *s)
++{
++    return 0;
++}
++
++static int drc_decoder_mode_config(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    return 0;
++}
++
++static int drc_config(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    GetBitContext *gb = &s->gbc;
++    Metadata *m = &ssi->meta;
++
++    m->drc_decoder_nr_modes = get_bits(gb, 3);
++    for (int i = 0; i <= m->drc_decoder_nr_modes; i++)
++        drc_decoder_mode_config(s, ssi);
++    m->drc_eac3_profile = get_bits(gb, 3);
++
++    return 0;
++}
++
++static int drc_data(AC4DecodeContext *s, SubstreamInfo *ssi)
++{
++    return 0;
++}
++
++static int drc_frame(AC4DecodeContext *s, SubstreamInfo *ssi, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++
++    if (get_bits1(gb)) {
++        if (iframe)
++            drc_config(s, ssi);
++
++        drc_data(s, ssi);
++    }
++
++    return 0;
++}
++
++static int dialog_enhancement(AC4DecodeContext *s, int iframe)
++{
++    return 0;
++}
++
++static int emdf_payloads_substream(AC4DecodeContext *s)
++{
++    return 0;
++}
++
++static int metadata(AC4DecodeContext *s, SubstreamInfo *ssi, int iframe)
++{
++    GetBitContext *gb = &s->gbc;
++    int tools_metadata_size;
++
++    basic_metadata(s, ssi);
++    extended_metadata(s);
++    tools_metadata_size = get_bits(gb, 7);
++    if (get_bits1(gb))
++        tools_metadata_size += variable_bits(gb, 3) << 7;
++
++    drc_frame(s, ssi, iframe);
++
++    dialog_enhancement(s, iframe);
++
++    if (get_bits1(gb))
++        emdf_payloads_substream(s);
++
++    return 0;
++}
++
++static int ac4_substream(AC4DecodeContext *s, SubstreamInfo *ssinfo)
++{
++    GetBitContext *gb = &s->gbc;
++    int audio_size, offset, consumed;
++    int ret;
++
++    audio_size = get_bits(gb, 15);
++    if (get_bits1(gb))
++        audio_size += variable_bits(gb, 7) << 15;
++    if (audio_size > 131072) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid audio_size: %d\n", audio_size);
++        return AVERROR_INVALIDDATA;
++    }
++
++    av_log(s->avctx, AV_LOG_DEBUG, "audio_size: %d\n", audio_size);
++
++    align_get_bits(gb);
++
++    offset = get_bits_count(gb) >> 3;
++    ret = audio_data(s, ssinfo->channel_mode, ssinfo->iframe[0]);
++    if (ret < 0)
++        return ret;
++
++    align_get_bits(gb);
++    consumed = (get_bits_count(gb) >> 3) - offset;
++    if (consumed > audio_size) {
++        av_log(s->avctx, AV_LOG_ERROR, "substream audio data overread: %d\n", consumed - audio_size);
++        return AVERROR_INVALIDDATA;
++    }
++    if (consumed < audio_size) {
++        int non_zero = 0;
++
++        for (int i = consumed; i < audio_size; i++)
++            non_zero += !!get_bits(gb, 8);
++        if (non_zero)
++            av_log(s->avctx, AV_LOG_WARNING, "substream audio data underread: %d\n", non_zero);
++    }
++
++    metadata(s, ssinfo, s->iframe_global);
++
++    align_get_bits(gb);
++
++    return 0;
++}
++
++static void spectral_reordering(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    float *scaled_spec = ssch->scaled_spec;
++    float *spec_reord = ssch->spec_reord;
++    int *win_offset = ssch->win_offset;
++    int k, win;
++
++    k = 0;
++    win = 0;
++    memset(ssch->spec_reord, 0, sizeof(ssch->spec_reord));
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int transf_length_g = get_transf_length(s, ssch, g, NULL);
++        const uint16_t *sfb_offset = get_sfb_offset(transf_length_g);
++        int max_sfb = get_max_sfb(s, ssch, g);
++
++        for (int sfb = 0; sfb < max_sfb; sfb++) {
++            for (int w = 0; w < ssch->scp.num_win_in_group[g]; w++) {
++                for (int l = sfb_offset[sfb]; l < sfb_offset[sfb+1]; l++)
++                    spec_reord[win_offset[win+w] + l] = scaled_spec[k++];
++            }
++        }
++        win += ssch->scp.num_win_in_group[g];
++    }
++}
++
++static int compute_window(AC4DecodeContext *s, float *w, int N,
++                          int N_prev, int Nfull, int dir)
++{
++    const uint16_t *transf_lengths = transf_length_48khz[s->frame_len_base_idx];
++    float *kernel;
++    int i, idx, N_w, N_skip;
++
++    if (N <= N_prev)
++        N_w = N;
++    if (N > N_prev)
++        N_w = N_prev;
++
++    for (i = 0; i < 5; i++) {
++        if (transf_lengths[i] == N_w) {
++            idx = i;
++            break;
++        }
++    }
++
++    av_assert0(i < 5);
++
++    N_skip = (N - N_w) / 2;
++    kernel = s->kbd_window[s->frame_len_base_idx][idx];
++
++    for (int n = 0; n < N; n++) {
++        if (n >= 0 && n < N_skip)
++            w[n] =  dir;
++        else if (n >= N_skip && n < N_w + N_skip)
++            w[n] = !dir ? kernel[n - N_skip] : kernel[N_w - n + N_skip - 1];
++        else if (n >= N_w + N_skip && n < N_w + 2 * N_skip)
++            w[n] = !dir;
++        else
++            av_assert0(0);
++    }
++
++    return 0;
++}
++
++static void scale_spec(AC4DecodeContext *s, int ch)
++{
++    Substream *ss = &s->substream;
++    SubstreamChannel *ssch = &ss->ssch[ch];
++    const float *quant_lut = s->quant_lut;
++
++    memset(ssch->scaled_spec, 0, sizeof(ssch->scaled_spec));
++
++    for (int k = 0; k < s->frame_len_base; k++) {
++        int x = ssch->quant_spec[k];
++        int sfb = ssch->offset2sfb[k];
++        int g = ssch->offset2g[k];
++
++        ssch->scaled_spec[k] = ssch->sf_gain[g][sfb] * copysignf(quant_lut[FFABS(x)], x);
++    }
++}
++
++static int two_channel_processing(AC4DecodeContext *s, Substream *ss,
++                                  SubstreamChannel *ssch0,
++                                  SubstreamChannel *ssch1)
++{
++    int max_sfb_prev;
++    float sap_gain;
++
++    memset(&ss->alpha_q, 0, sizeof(ss->alpha_q));
++
++    max_sfb_prev = get_max_sfb(s, ssch0, 0);
++    for (int g = 0; g < ssch0->scp.num_window_groups; g++) {
++        int max_sfb_g = get_max_sfb(s, ssch0, g);
++
++        for (int sfb = 0; sfb < max_sfb_g; sfb++) {
++            float m[2][2];
++
++            if (ssch0->sap_mode == 0 ||
++                (ssch0->sap_mode == 1 && ssch0->ms_used[g][sfb] == 0)) {
++                m[0][0] = m[1][1] = 1;
++                m[0][1] = m[1][0] = 0;
++            } else if (ssch0->sap_mode == 2 ||
++                       ((ssch0->sap_mode == 1 && ssch0->ms_used[g][sfb] == 1))) {
++                m[0][0] =
++                m[0][1] =
++                m[1][0] =  1;
++                m[1][1] = -1;
++            } else { // sap_mode == 3
++                if (ssch0->sap_coeff_used[g][sfb]) { // setup alpha_q[g][sfb]
++                    if (sfb & 1) {
++                        ss->alpha_q[g][sfb] = ss->alpha_q[g][sfb-1];
++                    } else {
++                        float delta = ssch0->dpcm_alpha_q[g][sfb] - 60;
++                        int code_delta;
++
++                        if ((g == 0) || (max_sfb_g != max_sfb_prev)) {
++                            code_delta = 0;
++                        } else {
++                            code_delta = ssch0->delta_code_time;
++                        }
++
++                        if (code_delta) {
++                            ss->alpha_q[g][sfb] = ss->alpha_q[g-1][sfb] + delta;
++                        } else if (sfb == 0) {
++                            ss->alpha_q[g][sfb] = delta;
++                        } else {
++                            ss->alpha_q[g][sfb] = ss->alpha_q[g][sfb-2] + delta;
++                        }
++                    }
++                    // inverse quantize alpha_q[g][sfb]
++                    sap_gain = ss->alpha_q[g][sfb] * 0.1f;
++                    m[0][0] =  1 + sap_gain;
++                    m[0][1] =  1;
++                    m[1][0] =  1 - sap_gain;
++                    m[1][1] = -1;
++                } else {
++                    m[0][0] = 1;
++                    m[0][1] = 0;
++                    m[1][0] = 0;
++                    m[1][1] = 1;
++                }
++            }
++
++            memcpy(&ss->matrix_stereo[g][sfb], m, sizeof(m));
++        }
++
++        max_sfb_prev = max_sfb_g;
++    }
++
++    for (int k = 0; k < s->frame_len_base; k++) {
++        int sfb = ssch0->offset2sfb[k];
++        int g = ssch0->offset2g[k];
++        float a = ss->matrix_stereo[g][sfb][0][0];
++        float b = ss->matrix_stereo[g][sfb][0][1];
++        float c = ss->matrix_stereo[g][sfb][1][0];
++        float d = ss->matrix_stereo[g][sfb][1][1];
++        float i0 = ssch0->scaled_spec[k];
++        float i1 = ssch1->scaled_spec[k];
++        float o0, o1;
++
++        o0 = i0 * a + i1 * b;
++        o1 = i0 * c + i1 * d;
++
++        ssch0->scaled_spec[k] = o0;
++        ssch1->scaled_spec[k] = o1;
++    }
++
++    return 0;
++}
++
++static int stereo_processing(AC4DecodeContext *s, Substream *ss)
++{
++    if (ss->mdct_stereo_proc[0])
++        two_channel_processing(s, ss, &ss->ssch[0], &ss->ssch[1]);
++
++    return 0;
++}
++
++static int m5channel_processing(AC4DecodeContext *s, Substream *ss)
++{
++    switch (ss->codec_mode) {
++    case CM_SIMPLE:
++    case CM_ASPX:
++        switch (ss->coding_config) {
++        case 0:
++            if (ss->mdct_stereo_proc[0])
++                two_channel_processing(s, ss, &ss->ssch[0], &ss->ssch[1]);
++            if (ss->mdct_stereo_proc[1])
++                two_channel_processing(s, ss, &ss->ssch[2], &ss->ssch[3]);
++            break;
++        }
++        break;
++    case CM_ASPX_ACPL_1:
++    case CM_ASPX_ACPL_2:
++        switch (ss->coding_config) {
++        case 0:
++            if (ss->mdct_stereo_proc[0])
++                two_channel_processing(s, ss, &ss->ssch[0], &ss->ssch[1]);
++            break;
++        }
++        break;
++    }
++
++    return 0;
++}
++
++static void qmf_analysis(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    float *qmf_filt = ssch->qmf_filt;
++    float *pcm = ssch->pcm;
++    LOCAL_ALIGNED_32(float, u, [128]);
++    LOCAL_ALIGNED_32(float, z, [640]);
++
++    for (int ts = 0; ts < s->num_qmf_timeslots; ts++) {
++        /* shift time-domain input samples by 64 */
++        memmove(qmf_filt + 64, qmf_filt, sizeof(*qmf_filt) * (640 - 64));
++
++        /* feed new audio samples */
++        for (int sb = 63; sb >= 0; sb--)
++            qmf_filt[sb] = pcm[ts * 64 + 63 - sb] / 32768.f;
++
++        /* multiply input samples by window coefficients */
++        s->fdsp->vector_fmul(z, qmf_filt, qwin, 640);
++
++        /* sum the samples to create vector u */
++        for (int n = 0; n < 128; n++) {
++            u[n] = z[n];
++            for (int k = 1; k < 5; k++)
++                u[n] += z[n + k * 128];
++        }
++
++        /* compute 64 new subband samples */
++        for (int sb = 0; sb < 64; sb++) {
++            float *cos_atab = s->cos_atab[sb];
++            float *sin_atab = s->sin_atab[sb];
++
++            ssch->Q[0][ts][sb] = s->fdsp->scalarproduct_float(u, cos_atab, 128);
++            ssch->Q[1][ts][sb] = s->fdsp->scalarproduct_float(u, sin_atab, 128);
++        }
++    }
++}
++
++static void qmf_synthesis(AC4DecodeContext *s, SubstreamChannel *ssch, float *pcm)
++{
++    float *qsyn_filt = ssch->qsyn_filt;
++    LOCAL_ALIGNED_32(float, g, [640]);
++    LOCAL_ALIGNED_32(float, w, [640]);
++
++    for (int ts = 0; ts < s->num_qmf_timeslots; ts++) {
++        /* shift samples by 128 */
++        memmove(qsyn_filt + 128, qsyn_filt, sizeof(*qsyn_filt) * (1280 - 128));
++
++        for (int n = 0; n < 128; n++) {
++            float *cos_stab = s->cos_stab[n];
++            float *sin_stab = s->sin_stab[n];
++
++            qsyn_filt[n] = s->fdsp->scalarproduct_float(ssch->Q[0][ts], cos_stab, 64) -
++                           s->fdsp->scalarproduct_float(ssch->Q[1][ts], sin_stab, 64);
++        }
++
++        for (int n = 0; n < 5; n++) {
++            memcpy(g + 128 * n, qsyn_filt + 256 * n, 64 * sizeof(float));
++            memcpy(g + 128 * n + 64, qsyn_filt + 256 * n + 192, 64 * sizeof(float));
++        }
++        /* multiply by window coefficients */
++        s->fdsp->vector_fmul(w, g, qwin, 640);
++
++        /* compute 64 new time-domain output samples */
++        for (int sb = 0; sb < 64; sb++) {
++            float temp = 0;
++
++            for (int n = 0; n < 10; n++)
++                temp += w[64*n + sb];
++            pcm[ts*64 + sb] = temp;
++        }
++    }
++}
++
++static void spectral_synthesis(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    LOCAL_ALIGNED_32(float, in, [2048]);
++    LOCAL_ALIGNED_32(float, x, [4096]);
++    const int *win_offset = ssch->win_offset;
++    float *overlap = ssch->overlap;
++    float *winl = s->winl;
++    float *winr = s->winr;
++    float *pcm = ssch->pcm;
++    int Nfull = s->frame_len_base;
++    int nskip, nskip_prev;
++    int win = 0;
++
++    for (int g = 0; g < ssch->scp.num_window_groups; g++) {
++        int midx = s->frame_len_base_idx;
++        int idx;
++        int N = get_transf_length(s, ssch, g, &idx);
++
++        if (!ssch->N_prev)
++            ssch->N_prev = Nfull;
++
++        compute_window(s, winl, N, ssch->N_prev, Nfull, 0);
++        compute_window(s, winr, ssch->N_prev, N, Nfull, 1);
++
++        for (int w = 0; w < ssch->scp.num_win_in_group[g]; w++) {
++            nskip = (Nfull - N) / 2;
++            nskip_prev = (Nfull - ssch->N_prev) / 2;
++
++            memcpy(in, ssch->spec_reord + win_offset[win + w], N * 4);
++
++#if 0
++            s->tx_fn[midx][idx](s->tx_ctx[midx][idx], x, in, sizeof(float));
++
++            s->fdsp->vector_fmul_window(pcm + win_offset[win + w], overlap + nskip, x,
++                                        s->kbd_window[midx][idx], N >> 1);
++            memcpy(overlap + nskip, x + (N >> 1), (sizeof(float) * N) >> 1);
++#else
++            s->tx_fn[midx][idx](s->tx_ctx[midx][idx], x + (N >> 1), in, sizeof(float));
++
++            for (int n = 0; n < N >> 1; n++) {
++                x[n]       = -x[N-n-1];
++                x[N*2-n-1] =  x[N+n];
++            }
++
++            for (int n = 0; n < N / 4; n++) {
++                x[2*n  ]     *= winl[2*n  ];
++                x[2*n+1]     *= winl[2*n+1];
++                x[N/2+2*n  ] *= winl[N/2+2*n  ];
++                x[N/2+2*n+1] *= winl[N/2+2*n+1];
++            }
++
++            /* window second half of previous block */
++            for (int n = 0; n < ssch->N_prev; n++)
++                overlap[nskip_prev + n] *= winr[n];
++
++            /* overlap/add using first N samples from x[n] */
++            for (int n = 0; n < N; n++)
++                overlap[nskip + n] += x[n];
++
++            /* output pcm */
++            for (int n = 0; n < N; n++)
++                pcm[win_offset[win + w] + n] = overlap[n];
++            /* move samples in overlap[] not stored in pcm[] */
++            for (int n = 0; n < nskip; n++)
++                overlap[n] = overlap[N+n];
++
++            /* store second N samples from x[n] for next overlap/add */
++            for (int n = 0; n < N; n++)
++                overlap[nskip + n] = x[N+n];
++#endif
++        }
++
++        ssch->N_prev = N;
++
++        win += ssch->scp.num_win_in_group[g];
++    }
++}
++
++static int polyfit(int order,
++                   int countOfElements,
++                   const float *const dependentValues,
++                   const float *const independentValues,
++                   float *coefficients)
++{
++    enum {maxOrder = 5};
++    float B[maxOrder+1] = {0.0f};
++    float P[((maxOrder+1) * 2)+1] = {0.0f};
++    float A[(maxOrder + 1)*2*(maxOrder + 1)] = {0.0f};
++    float x, y, powx;
++    int ii, jj, kk;
++
++    // This method requires that the countOfElements >
++    // (order+1)
++    if (countOfElements <= order)
++        return -1;
++
++    // This method has imposed an arbitrary bound of
++    // order <= maxOrder.  Increase maxOrder if necessary.
++    if (order > maxOrder)
++        return -1;
++
++    // Identify the column vector
++    for (ii = 0; ii < countOfElements; ii++) {
++        x    = dependentValues[ii];
++        y    = independentValues[ii];
++        powx = 1;
++
++        for (jj = 0; jj < (order + 1); jj++) {
++            B[jj] = B[jj] + (y * powx);
++            powx  = powx * x;
++        }
++    }
++
++    // Initialize the PowX array
++    P[0] = countOfElements;
++    // Compute the sum of the Powers of X
++    for (ii = 0; ii < countOfElements; ii++) {
++        x    = dependentValues[ii];
++        powx = dependentValues[ii];
++
++        for (jj = 1; jj < (2 * (order + 1)) + 1; jj++) {
++            P[jj] = P[jj] + powx;
++            powx  = powx * x;
++        }
++    }
++
++    // Initialize the reduction matrix
++    //
++    for (ii = 0; ii < (order + 1); ii++) {
++        for (jj = 0; jj < (order + 1); jj++) {
++            A[(ii * (2 * (order + 1))) + jj] = P[ii+jj];
++        }
++        A[(ii*(2 * (order + 1))) + (ii + (order + 1))] = 1;
++    }
++
++    // Move the Identity matrix portion of the redux matrix
++    // to the left side (find the inverse of the left side
++    // of the redux matrix
++    for (ii = 0; ii < (order + 1); ii++) {
++        x = A[(ii * (2 * (order + 1))) + ii];
++        if (x != 0) {
++            for (kk = 0; kk < (2 * (order + 1)); kk++) {
++                A[(ii * (2 * (order + 1))) + kk] =
++                    A[(ii * (2 * (order + 1))) + kk] / x;
++            }
++
++            for (jj = 0; jj < (order + 1); jj++) {
++                if ((jj - ii) != 0) {
++                    y = A[(jj * (2 * (order + 1))) + ii];
++                    for (kk = 0; kk < (2 * (order + 1)); kk++) {
++                        A[(jj * (2 * (order + 1))) + kk] =
++                            A[(jj * (2 * (order + 1))) + kk] -
++                            y * A[(ii * (2 * (order + 1))) + kk];
++                    }
++                }
++            }
++        } else { // Cannot work with singular matrices
++            return -1;
++        }
++    }
++
++    // Calculate and Identify the coefficients
++    for (ii = 0; ii < order + 1; ii++) {
++        for (jj = 0; jj < order + 1; jj++) {
++            x = 0;
++            for (kk = 0; kk < (order + 1); kk++) {
++                x = x + (A[(ii * (2 * (order + 1))) + (kk + (order + 1))] *
++                         B[kk]);
++            }
++            coefficients[ii] = x;
++        }
++    }
++
++    return 0;
++}
++
++static int get_qsignal_scale_factors(AC4DecodeContext *s, SubstreamChannel *ssch, int ch)
++{
++    int sbg_idx_high2low[24] = { 0 };
++    int sbg_idx_low2high[24] = { 0 };
++    int sbg_low = 0;
++    int delta;
++
++    for (int sbg = 0; sbg < ssch->num_sbg_sig_highres; sbg++) {
++        if (ssch->sbg_sig_lowres[sbg_low+1] == ssch->sbg_sig_highres[sbg]) {
++            sbg_low++;
++            sbg_idx_low2high[sbg_low] = sbg;
++        }
++        sbg_idx_high2low[sbg] = sbg_low;
++    }
++
++    delta = ((ch == 1) && (ssch->aspx_balance == 1)) + 1;
++
++    memcpy(ssch->qscf_sig_sbg_prev, ssch->qscf_sig_sbg, sizeof(ssch->qscf_sig_sbg));
++    memset(ssch->qscf_sig_sbg, 0, sizeof(ssch->qscf_sig_sbg));
++
++    /* Loop over Envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over scale factor subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_sig[atsg]; sbg++) {
++            if (atsg == 0) {
++                ssch->atsg_freqres_prev[atsg] = ssch->atsg_freqres[ssch->aspx_num_env_prev - 1];
++                ssch->qscf_prev[atsg][sbg] = ssch->qscf_sig_sbg_prev[ssch->aspx_num_env_prev - 1][sbg];
++            } else {
++                ssch->atsg_freqres_prev[atsg] = ssch->atsg_freqres[atsg-1];
++                ssch->qscf_prev[atsg][sbg] = ssch->qscf_sig_sbg[atsg-1][sbg];
++            }
++            if (ssch->aspx_sig_delta_dir[atsg] == 0) { /* FREQ */
++                ssch->qscf_sig_sbg[atsg][sbg] = 0;
++                for (int i = 0; i <= sbg; i++) {
++                    ssch->qscf_sig_sbg[atsg][sbg] += delta * ssch->aspx_data[0][atsg][i];
++                }
++            } else { /* TIME */
++                if (ssch->atsg_freqres[atsg] == ssch->atsg_freqres_prev[atsg]) {
++                    ssch->qscf_sig_sbg[atsg][sbg]  = ssch->qscf_prev[atsg][sbg];
++                    ssch->qscf_sig_sbg[atsg][sbg] += delta * ssch->aspx_data[0][atsg][sbg];
++                } else if ((ssch->atsg_freqres[atsg] == 0) && (ssch->atsg_freqres_prev[atsg] == 1)) {
++                    ssch->qscf_sig_sbg[atsg][sbg]  = ssch->qscf_prev[atsg][sbg_idx_low2high[sbg]];
++                    ssch->qscf_sig_sbg[atsg][sbg] += delta * ssch->aspx_data[0][atsg][sbg];
++                } else if ((ssch->atsg_freqres[atsg] == 1) && (ssch->atsg_freqres_prev[atsg] == 0)) {
++                    ssch->qscf_sig_sbg[atsg][sbg]  = ssch->qscf_prev[atsg][sbg_idx_high2low[sbg]];
++                    ssch->qscf_sig_sbg[atsg][sbg] += delta * ssch->aspx_data[0][atsg][sbg];
++                }
++            }
++        }
++    }
++
++    return 0;
++}
++
++static int get_qnoise_scale_factors(AC4DecodeContext *s, SubstreamChannel *ssch, int ch)
++{
++    int delta;
++
++    delta = ((ch == 1) && (ssch->aspx_balance == 1)) + 1;
++
++    memcpy(ssch->qscf_noise_prev, ssch->qscf_noise_sbg, sizeof(ssch->qscf_noise_sbg));
++    memset(ssch->qscf_noise_sbg, 0, sizeof(ssch->qscf_noise_sbg));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_noise; atsg++) {
++        /* Loop over noise subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_noise; sbg++) {
++            if (ssch->aspx_noise_delta_dir[atsg] == 0) { /* FREQ */
++                for (int i = 0; i <= sbg; i++) {
++                    ssch->qscf_noise_sbg[atsg][sbg] += delta * ssch->aspx_data[1][atsg][sbg];
++                }
++            } else { /* TIME */
++                if (atsg == 0) {
++                    ssch->qscf_noise_sbg[atsg][sbg]  = ssch->qscf_noise_prev[ssch->aspx_num_noise_prev-1][sbg];
++                    ssch->qscf_noise_sbg[atsg][sbg] += delta * ssch->aspx_data[1][atsg][sbg];
++                } else {
++                    ssch->qscf_noise_sbg[atsg][sbg]  = ssch->qscf_noise_sbg[atsg-1][sbg];
++                    ssch->qscf_noise_sbg[atsg][sbg] += delta * ssch->aspx_data[1][atsg][sbg];
++                }
++            }
++        }
++    }
++
++    return 0;
++}
++
++static void prepare_channel(AC4DecodeContext *s, int ch)
++{
++    Substream *ss = &s->substream;
++    SubstreamChannel *ssch = &ss->ssch[ch];
++
++    spectral_reordering(s, ssch);
++    spectral_synthesis(s, ssch);
++
++    qmf_analysis(s, ssch);
++}
++
++static void aspx_processing(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    memcpy(ssch->Q_low_prev, ssch->Q_low, sizeof(ssch->Q_low));
++
++    for (int ts = 0; ts < s->ts_offset_hfgen; ts++) {
++        for (int sb = 0; sb < 64; sb++) {
++            if (sb < ssch->sbx) {
++                ssch->Q_low[0][ts][sb] = ssch->Q_prev[0][ts + s->num_qmf_timeslots - s->ts_offset_hfgen][sb];
++                ssch->Q_low[1][ts][sb] = ssch->Q_prev[1][ts + s->num_qmf_timeslots - s->ts_offset_hfgen][sb];
++            }
++        }
++    }
++
++    for (int ts = s->ts_offset_hfgen; ts < s->num_qmf_timeslots + s->ts_offset_hfgen; ts++) {
++        for (int sb = 0; sb < 64; sb++) {
++            if (sb < ssch->sbx) {
++                ssch->Q_low[0][ts][sb] = ssch->Q[0][ts - s->ts_offset_hfgen][sb];
++                ssch->Q_low[1][ts][sb] = ssch->Q[1][ts - s->ts_offset_hfgen][sb];
++            }
++        }
++    }
++}
++
++static void mono_deq_signal_factors(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    float a = (ssch->aspx_qmode_env == 0) + 1;
++
++    memset(ssch->scf_sig_sbg, 0, sizeof(ssch->scf_sig_sbg));
++
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        for (int sbg = 0; sbg < ssch->num_sbg_sig[atsg]; sbg++)
++            ssch->scf_sig_sbg[atsg][sbg] = 64.f * powf(2, ssch->qscf_sig_sbg[atsg][sbg] / a);
++
++        if (ssch->aspx_sig_delta_dir[atsg] == 0 &&
++            ssch->qscf_sig_sbg[atsg][0] == 0 &&
++            ssch->scf_sig_sbg[atsg][1] < 0) {
++            ssch->scf_sig_sbg[atsg][0] = ssch->scf_sig_sbg[atsg][1];
++        }
++    }
++}
++
++static void mono_deq_noise_factors(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++#define NOISE_FLOOR_OFFSET 6
++
++    memset(ssch->scf_noise_sbg, 0, sizeof(ssch->scf_noise_sbg));
++
++    for (int atsg = 0; atsg < ssch->aspx_num_noise; atsg++) {
++        for (int sbg = 0; sbg < ssch->num_sbg_noise; sbg++)
++            ssch->scf_noise_sbg[atsg][sbg] = powf(2, NOISE_FLOOR_OFFSET - ssch->qscf_noise_sbg[atsg][sbg]);
++    }
++}
++
++static void stereo_deq_signoise_factors(AC4DecodeContext *s,
++                                        SubstreamChannel *ssch0,
++                                        SubstreamChannel *ssch1)
++{
++#define PAN_OFFSET 12
++
++    float a = 1 + (ssch0->aspx_qmode_env == 0);
++
++    for (int atsg = 0; atsg < ssch0->aspx_num_env; atsg++) {
++        for (int sbg = 0; sbg < ssch0->num_sbg_sig[atsg]; sbg++) {
++            float nom = 64.f * powf(2, ssch0->qscf_sig_sbg[atsg][sbg] / a + 1);
++            float denom_a = 1 + powf(2, PAN_OFFSET - ssch1->qscf_sig_sbg[atsg][sbg] / a);
++            float denom_b = 1 + powf(2, ssch1->qscf_sig_sbg[atsg][sbg] / a - PAN_OFFSET);
++
++            ssch0->scf_sig_sbg[atsg][sbg] = nom / denom_a;
++            ssch1->scf_sig_sbg[atsg][sbg] = nom / denom_b;
++        }
++    }
++
++    for (int atsg = 0; atsg < ssch0->aspx_num_noise; atsg++) {
++        for (int sbg = 0; sbg < ssch0->num_sbg_noise; sbg++) {
++            float nom = powf(2, NOISE_FLOOR_OFFSET - ssch0->qscf_noise_sbg[atsg][sbg] + 1);
++            float denom_a = 1 + powf(2, PAN_OFFSET - ssch1->qscf_noise_sbg[atsg][sbg]);
++            float denom_b = 1 + powf(2, ssch1->qscf_noise_sbg[atsg][sbg] - PAN_OFFSET);
++
++            ssch0->scf_noise_sbg[atsg][sbg] = nom / denom_a;
++            ssch1->scf_noise_sbg[atsg][sbg] = nom / denom_b;
++        }
++    }
++}
++
++static void preflattening(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    float mean_energy = 0;
++    int polynomial_order = 3;
++    int num_qmf_subbands = ssch->sbx;
++    float poly_array[64];
++    float pow_env[64];
++    float slope[64];
++    float x[64];
++
++    for (int i = 0; i < num_qmf_subbands; i++) {
++        x[i] = i;
++        slope[i] = 0;
++    }
++    /* Calculate the spectral signal envelope in dB over the current interval. */
++    for (int sb = 0; sb < num_qmf_subbands; sb++) {
++        pow_env[sb] = 0;
++        for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats; ts < ssch->atsg_sig[ssch->aspx_num_env] * s->num_ts_in_ats; ts++) {
++            pow_env[sb] += powf(ssch->Q_low[0][ts][sb], 2);
++            pow_env[sb] += powf(ssch->Q_low[1][ts][sb], 2);
++        }
++        pow_env[sb] /= (ssch->atsg_sig[ssch->aspx_num_env] - ssch->atsg_sig[0]) * s->num_ts_in_ats;
++        pow_env[sb] = 10 * log10f(pow_env[sb] + 1);
++        mean_energy += pow_env[sb];
++    }
++
++    mean_energy /= num_qmf_subbands;
++    polyfit(polynomial_order, num_qmf_subbands, x, pow_env, poly_array);
++
++    /* Transform polynomial into slope */
++    for (int k = polynomial_order; k >= 0; k--) {
++        for (int sb = 0; sb < num_qmf_subbands; sb++)
++            slope[sb] += powf(x[sb], k) * poly_array[k];
++    }
++
++    /* Derive a gain vector from the slope */
++    for (int sb = 0; sb < num_qmf_subbands; sb++) {
++        ssch->gain_vec[sb] = powf(10, (mean_energy - slope[sb]) / 20.f);
++    }
++}
++
++static void get_chirps(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    memcpy(ssch->chirp_arr_prev, ssch->chirp_arr, sizeof(ssch->chirp_arr));
++
++    for (int sbg = 0; sbg < ssch->num_sbg_noise; sbg++) {
++        float new_chirp = new_chirp_tab[ssch->aspx_tna_mode[sbg]][ssch->aspx_tna_mode_prev[sbg]];
++
++        if (new_chirp < ssch->chirp_arr_prev[sbg]) {
++            new_chirp = 0.75000f * new_chirp + 0.25000f * ssch->chirp_arr_prev[sbg];
++        } else {
++            new_chirp = 0.90625f * new_chirp + 0.09375f * ssch->chirp_arr_prev[sbg];
++        }
++
++        if (new_chirp < 0.015625f) {
++            ssch->chirp_arr[sbg] = 0.f;
++        } else {
++            ssch->chirp_arr[sbg] = new_chirp;
++        }
++    }
++}
++
++static void fcomplex_mul(float *r, float *i, float x, float yi, float u, float vi)
++{
++    *r = x*u - yi*vi;
++    *i = x*vi + u*yi;
++}
++
++static void get_covariance(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    int num_ts_ext;
++    int ts_offset_hfadj = 4;
++
++    /* Create an additional delay of ts_offset_hfadj QMF time slots */
++    for (int sb = 0; sb < ssch->sba; sb++) {
++        int ts_offset_prev = s->num_qmf_timeslots - ts_offset_hfadj;
++
++        for (int ts = 0; ts < ts_offset_hfadj; ts++) {
++            ssch->Q_low_ext[0][ts][sb] = ssch->Q_low_prev[0][ts + ts_offset_prev][sb];
++            ssch->Q_low_ext[1][ts][sb] = ssch->Q_low_prev[1][ts + ts_offset_prev][sb];
++        }
++
++        for (int ts = 0; ts < s->num_qmf_timeslots + s->ts_offset_hfgen; ts++) {
++            ssch->Q_low_ext[0][ts + ts_offset_hfadj][sb] = ssch->Q_low[0][ts][sb];
++            ssch->Q_low_ext[1][ts + ts_offset_hfadj][sb] = ssch->Q_low[1][ts][sb];
++        }
++    }
++
++    num_ts_ext = s->num_qmf_timeslots + s->ts_offset_hfgen + ts_offset_hfadj;
++    /* Loop over QMF subbands */
++    for (int sb = 0; sb < ssch->sba; sb++) {
++        for (int i = 0; i < 3; i++) {
++            for (int j = 1; j < 3; j++) {
++                ssch->cov[sb][i][j][0] = 0;
++                ssch->cov[sb][i][j][1] = 0;
++                /* Loop over QMF time slots */
++                for (int ts = ts_offset_hfadj; ts < num_ts_ext; ts += 2) {
++                    float re, im;
++
++                    fcomplex_mul(&re, &im,
++                                 ssch->Q_low_ext[0][ts - 2*i][sb],  ssch->Q_low_ext[1][ts - 2*i][sb],
++                                 ssch->Q_low_ext[0][ts - 2*j][sb], -ssch->Q_low_ext[1][ts - 2*j][sb]);
++
++                    ssch->cov[sb][i][j][0] += re;
++                    ssch->cov[sb][i][j][1] += im;
++                }
++            }
++        }
++    }
++}
++
++static float sqr(float a, float b)
++{
++    return a * a + b * b;
++}
++
++static void fcomplex_div(float *r, float *i, float x, float yi, float u, float vi)
++{
++    *r = (x*u + yi*vi) / sqr(u, vi);
++    *i = (x*vi - u*yi) / sqr(u, vi);
++}
++
++static void get_alphas(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    float EPSILON_INV = powf(2.f, -20.f);
++
++    for (int sb = 0; sb < ssch->sba; sb++) {
++        float denom[2];
++
++        fcomplex_mul(&denom[0], &denom[1], ssch->cov[sb][2][2][0], ssch->cov[sb][2][2][1], ssch->cov[sb][1][1][0], ssch->cov[sb][1][1][1]);
++        denom[0] -= sqr(ssch->cov[sb][1][2][0], ssch->cov[sb][1][2][1]) / (1.f+EPSILON_INV);
++        if (sqr(denom[0], denom[1]) <= 1e-6f) {
++            ssch->alpha1[sb][0] = 0;
++            ssch->alpha1[sb][1] = 0;
++        } else {
++            ssch->alpha1[sb][0]  = (ssch->cov[sb][0][1][0] * ssch->cov[sb][1][2][0] - ssch->cov[sb][0][1][1] * ssch->cov[sb][1][2][1]) -
++                                   (ssch->cov[sb][0][2][0] * ssch->cov[sb][1][1][0] - ssch->cov[sb][0][2][1] * ssch->cov[sb][1][1][1]);
++            ssch->alpha1[sb][1]  = (ssch->cov[sb][0][1][0] * ssch->cov[sb][1][2][1] + ssch->cov[sb][0][1][1] * ssch->cov[sb][1][2][0]) -
++                                   (ssch->cov[sb][0][2][0] * ssch->cov[sb][1][1][1] + ssch->cov[sb][0][2][1] * ssch->cov[sb][1][1][0]);
++            fcomplex_div(&ssch->alpha1[sb][0], &ssch->alpha1[sb][1], ssch->alpha1[sb][0], ssch->alpha1[sb][1], denom[0], denom[1]);
++        }
++
++        if (sqr(ssch->cov[sb][1][1][0], ssch->cov[sb][1][1][1]) <= 1e-6f) {
++            ssch->alpha0[sb][0] = 0;
++            ssch->alpha0[sb][1] = 0;
++        } else {
++            ssch->alpha0[sb][0]  = -ssch->cov[sb][0][1][0] + ssch->alpha1[sb][0] * ssch->cov[sb][1][2][0] + ssch->alpha1[sb][1] * ssch->cov[sb][1][2][1];
++            ssch->alpha0[sb][1]  = -ssch->cov[sb][0][1][1] + ssch->alpha1[sb][1] * ssch->cov[sb][1][2][0] - ssch->alpha1[sb][0] * ssch->cov[sb][1][2][1];
++            fcomplex_div(&ssch->alpha0[sb][0], &ssch->alpha0[sb][1], ssch->alpha0[sb][0], ssch->alpha0[sb][1], ssch->cov[sb][1][1][0], ssch->cov[sb][1][1][1]);
++        }
++    }
++}
++
++static void create_high_signal(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    int ts_offset_hfadj = 4;
++
++    /* Loop over QMF time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats;
++         ts < ssch->atsg_sig[ssch->aspx_num_env] * s->num_ts_in_ats; ts++) {
++        int sum_sb_patches = 0;
++        int g = 0;
++        /* Loop over number of patches */
++        for (int i = 0; i < ssch->num_sbg_patches; i++) {
++            /* Loop over number of subbands per patch */
++            for (int sb = 0; sb < ssch->sbg_patch_num_sb[i]; sb++) {
++                float cplx[2] = { 0 };
++                /* Map to High QMF Subband */
++                int n, p;
++                int sb_high = ssch->sbx + sum_sb_patches + sb;
++
++                /* Map to current noise envelope */
++                if (ssch->sbg_noise[g+1] == sb_high)
++                    g++;
++
++                n = ts + ts_offset_hfadj;
++                /* Current low QMF Subband */
++                p = ssch->sbg_patch_start_sb[i] + sb;
++                ssch->Q_high[0][ts][sb_high] = ssch->Q_low_ext[0][n][p];
++                ssch->Q_high[1][ts][sb_high] = ssch->Q_low_ext[1][n][p];
++
++                fcomplex_mul(&cplx[0], &cplx[1], ssch->alpha0[p][0], ssch->alpha0[p][1], ssch->Q_low_ext[0][n-2][p], ssch->Q_low_ext[1][n-2][p]);
++                fcomplex_mul(&cplx[0], &cplx[1], cplx[0], cplx[1], ssch->chirp_arr[g], 0);
++                ssch->Q_high[0][ts][sb_high] += cplx[0];
++                ssch->Q_high[1][ts][sb_high] += cplx[1];
++                fcomplex_mul(&cplx[0], &cplx[1], ssch->alpha1[p][0], ssch->alpha1[p][1], ssch->Q_low_ext[0][n-4][p], ssch->Q_low_ext[1][n-4][p]);
++                fcomplex_mul(&cplx[0], &cplx[1], cplx[0], cplx[1], powf(ssch->chirp_arr[g], 2), 0);
++                ssch->Q_high[0][ts][sb_high] += cplx[0];
++                ssch->Q_high[1][ts][sb_high] += cplx[1];
++                if (ss->aspx_preflat)
++                    fcomplex_mul(&ssch->Q_high[0][ts][sb_high], &ssch->Q_high[1][ts][sb_high], ssch->Q_high[0][ts][sb_high], ssch->Q_high[1][ts][sb_high], 1.f / ssch->gain_vec[p], 0);
++            }
++            sum_sb_patches += ssch->sbg_patch_num_sb[i];
++        }
++    }
++}
++
++static void estimate_spectral_envelopes(AC4DecodeContext *s, Substream *ss, SubstreamChannel *ssch)
++{
++    int ts_offset_hfadj = 4;
++
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        int sbg = 0;
++        /* Loop over QMF subbands in A-SPX range */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            int tsa, tsz;
++            float est_sig = 0;
++
++            /* Update current subband group */
++            if (sb == ssch->sbg_sig[atsg][sbg+1])
++                sbg++;
++
++            tsa = ssch->atsg_sig[atsg]*s->num_ts_in_ats + ts_offset_hfadj;
++            tsz = ssch->atsg_sig[atsg+1]*s->num_ts_in_ats + ts_offset_hfadj;
++            for (int ts = tsa; ts < tsz; ts++) {
++                if (ss->aspx_interpolation == 0) {
++                    for (int j = ssch->sbg_sig[atsg][sbg]; j < ssch->sbg_sig[atsg][sbg+1]; j++) {
++                        est_sig += hypotf(ssch->Q_high[0][ts][j], ssch->Q_high[1][ts][j]);
++                    }
++                } else {
++                    est_sig += hypotf(ssch->Q_high[0][ts][sb+ssch->sbx], ssch->Q_high[1][ts][sb+ssch->sbx]);
++                }
++            }
++
++            if (ss->aspx_interpolation == 0) {
++                est_sig /= ssch->sbg_sig[atsg][sbg+1] - ssch->sbg_sig[atsg][sbg];
++                est_sig /= ssch->atsg_sig[atsg+1] - ssch->atsg_sig[atsg];
++            } else {
++                est_sig /= ssch->atsg_sig[atsg+1] - ssch->atsg_sig[atsg];
++            }
++            ssch->est_sig_sb[atsg][sb] = est_sig;
++        }
++    }
++}
++
++static void map_signoise(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    int atsg_noise = 0;
++
++    memset(ssch->scf_noise_sb, 0, sizeof(ssch->scf_noise_sb));
++    memset(ssch->scf_sig_sb, 0, sizeof(ssch->scf_sig_sb));
++
++    /* Loop over Signal Envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Map Signal Envelopes from subband groups to QMF subbands */
++
++        for (int sbg = 0; sbg < ssch->num_sbg_sig[atsg]; sbg++) {
++            for (int sb = ssch->sbg_sig[atsg][sbg]-ssch->sbx; sb < ssch->sbg_sig[atsg][sbg+1]-ssch->sbx; sb++)
++                ssch->scf_sig_sb[atsg][sb] = ssch->scf_sig_sbg[atsg][sbg];
++        }
++
++        if (ssch->atsg_sig[atsg] == ssch->atsg_noise[atsg_noise + 1])
++            atsg_noise++;
++
++        /* Map Noise Floors from subband groups to QMF subbands, and to signal envelopes */
++        for (int sbg = 0; sbg < ssch->num_sbg_noise; sbg++) {
++            for (int sb = ssch->sbg_noise[sbg] - ssch->sbx; sb < ssch->sbg_noise[sbg + 1] - ssch->sbx; sb++)
++                ssch->scf_noise_sb[atsg][sb] = ssch->scf_noise_sbg[atsg_noise][sbg];
++        }
++    }
++}
++
++static void add_sinusoids(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    float EPSILON = 1.0f;
++    float LIM_GAIN = 1.41254f;
++    float EPSILON0 = powf(10.f, -12.f);
++    float MAX_SIG_GAIN = powf(10.f, 5.f);
++    float MAX_BOOST_FACT = 1.584893192f;
++    int p_sine_at_end;
++
++    if (ssch->aspx_tsg_ptr_prev == ssch->aspx_num_env_prev)
++        p_sine_at_end = 0;
++    else
++        p_sine_at_end = -1;
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over high resolution signal envelope subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_sig_highres; sbg++) {
++            int sba = ssch->sbg_sig_highres[sbg] - ssch->sbx;
++            int sbz = ssch->sbg_sig_highres[sbg+1] - ssch->sbx;
++            int sb_mid = (int)(0.5f*(sbz + sba) + 0.5f);
++            /* Map sinusoid markers to QMF subbands */
++            for (int sb = ssch->sbg_sig_highres[sbg]-ssch->sbx; sb < ssch->sbg_sig_highres[sbg+1]-ssch->sbx; sb++) {
++                if ((sb == sb_mid) && ((atsg >= ssch->aspx_tsg_ptr) || (p_sine_at_end == 0)
++                                       || ssch->sine_idx_sb_prev[ssch->aspx_num_env_prev-1][sb])) {
++                    ssch->sine_idx_sb[atsg][sb] = ssch->aspx_add_harmonic[sbg];
++                } else {
++                    ssch->sine_idx_sb[atsg][sb] = 0;
++                }
++            }
++        }
++    }
++
++    memcpy(ssch->sine_idx_sb_prev, ssch->sine_idx_sb, sizeof(ssch->sine_idx_sb));
++
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_sig[atsg]; sbg++) {
++            int sine_present = 0;
++            /* Additional sinusoid present in SF band? */
++            for (int sb = ssch->sbg_sig[atsg][sbg]-ssch->sbx; sb < ssch->sbg_sig[atsg][sbg+1]-ssch->sbx; sb++) {
++                if (ssch->sine_idx_sb[atsg][sb] == 1)
++                    sine_present = 1;
++            }
++
++            /* Mark all subbands in current subband group accordingly */
++            for (int sb = ssch->sbg_sig[atsg][sbg]-ssch->sbx; sb < ssch->sbg_sig[atsg][sbg+1]-ssch->sbx; sb++) {
++                ssch->sine_area_sb[atsg][sb] = sine_present;
++            }
++        }
++    }
++
++    memset(ssch->noise_lev_sb, 0, sizeof(ssch->noise_lev_sb));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over QMF subbands in A-SPX range */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            float sig_noise_fact = ssch->scf_sig_sb[atsg][sb] / (1+ssch->scf_noise_sb[atsg][sb]);
++
++            ssch->sine_lev_sb[atsg][sb]  = sqrtf(sig_noise_fact * ssch->sine_idx_sb[atsg][sb]);
++            ssch->noise_lev_sb[atsg][sb] = sqrtf(sig_noise_fact * ssch->scf_noise_sb[atsg][sb]);
++        }
++    }
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over QMF subbands in A-SPX range */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            if (ssch->sine_area_sb[atsg][sb] == 0) {
++                float denom = EPSILON + ssch->est_sig_sb[atsg][sb];
++                if (!(atsg == ssch->aspx_tsg_ptr || atsg == p_sine_at_end))
++                    denom *= (1 + ssch->scf_noise_sb[atsg][sb]);
++                ssch->sig_gain_sb[atsg][sb] = sqrtf(ssch->scf_sig_sb[atsg][sb] / denom);
++            } else {
++                float denom = EPSILON + ssch->est_sig_sb[atsg][sb];
++                denom *= 1 + ssch->scf_noise_sb[atsg][sb];
++                ssch->sig_gain_sb[atsg][sb] = sqrtf(ssch->scf_sig_sb[atsg][sb] * ssch->scf_noise_sb[atsg][sb] / denom);
++            }
++        }
++    }
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over limiter subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_lim; sbg++) {
++            float nom = 0;
++            float denom = EPSILON0;
++            for (int sb = ssch->sbg_lim[sbg]-ssch->sbx; sb < ssch->sbg_lim[sbg+1]-1-ssch->sbx; sb++) {
++                nom += ssch->scf_sig_sb[atsg][sb];
++                denom += ssch->est_sig_sb[atsg][sb];
++            }
++
++            ssch->max_sig_gain_sbg[atsg][sbg] = sqrtf(nom/denom) * LIM_GAIN;
++        }
++
++        /* Map to QMF subbands */
++        for (int sb = 0, sbg = 0; sb < ssch->num_sb_aspx; sb++) {
++            if (sb == ssch->sbg_lim[sbg+1]-ssch->sbx)
++                sbg++;
++            ssch->max_sig_gain_sb[atsg][sb] = FFMIN(ssch->max_sig_gain_sbg[atsg][sbg], MAX_SIG_GAIN);
++        }
++    }
++
++    memset(ssch->noise_lev_sb_lim, 0, sizeof(ssch->noise_lev_sb_lim));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            float tmp = ssch->noise_lev_sb[atsg][sb];
++
++            tmp *= ssch->max_sig_gain_sb[atsg][sb] / ssch->sig_gain_sb[atsg][sb];
++            ssch->noise_lev_sb_lim[atsg][sb] = FFMIN(ssch->noise_lev_sb[atsg][sb], tmp);
++        }
++    }
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            ssch->sig_gain_sb_lim[atsg][sb] = FFMIN(ssch->sig_gain_sb[atsg][sb],
++                                                    ssch->max_sig_gain_sb[atsg][sb]);
++        }
++    }
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over limiter subband groups */
++        for (int sbg = 0; sbg < ssch->num_sbg_lim; sbg++) {
++            float nom, denom;
++
++            nom = denom = EPSILON0;
++            /* Loop over subbands */
++            for (int sb = ssch->sbg_lim[sbg]-ssch->sbx; sb < ssch->sbg_lim[sbg+1]-1-ssch->sbx; sb++) {
++                nom   += ssch->scf_sig_sb[atsg][sb];
++                denom += ssch->est_sig_sb[atsg][sb] * powf(ssch->sig_gain_sb_lim[atsg][sb], 2);
++                denom += powf(ssch->sine_lev_sb[atsg][sb], 2);
++                if (!((ssch->sine_lev_sb[atsg][sb] != 0)
++                      || (atsg == ssch->aspx_tsg_ptr) || (atsg == p_sine_at_end)))
++                    denom += powf(ssch->noise_lev_sb_lim[atsg][sb], 2);
++            }
++            ssch->boost_fact_sbg[atsg][sbg] = sqrtf(nom/denom);
++        }
++    }
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        int sbg = 0;
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            if (sb == ssch->sbg_lim[sbg+1]-ssch->sbx)
++                sbg++;
++            ssch->boost_fact_sb[atsg][sb] = FFMIN(ssch->boost_fact_sbg[atsg][sbg], MAX_BOOST_FACT);
++        }
++    }
++
++    memset(ssch->noise_lev_sb_adj, 0, sizeof(ssch->noise_lev_sb_adj));
++
++    /* Loop over envelopes */
++    for (int atsg = 0; atsg < ssch->aspx_num_env; atsg++) {
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            float boost_fact                 = ssch->boost_fact_sb[atsg][sb];
++            ssch->sig_gain_sb_adj[atsg][sb]  = ssch->sig_gain_sb_lim[atsg][sb] * boost_fact;
++            ssch->noise_lev_sb_adj[atsg][sb] = ssch->noise_lev_sb_lim[atsg][sb] * boost_fact;
++            ssch->sine_lev_sb_adj[atsg][sb]  = ssch->sine_lev_sb[atsg][sb] * boost_fact;
++        }
++    }
++}
++
++static int sine_idx(int sb, int ts, AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    int index;
++
++    if (s->first_frame) {
++        index = 1;
++        s->first_frame = 0;
++    } else {
++        index = (ssch->sine_idx_prev[ts][sb] + 1) % 4;
++    }
++    index += ts - ssch->atsg_sig[0];
++
++    return index % 4;
++}
++
++static int noise_idx(int sb, int ts, AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    int index;
++
++    if (ssch->master_reset) {
++        index = 0;
++    } else {
++        index = ssch->noise_idx_prev[ts][sb];
++    }
++    index += ssch->num_sb_aspx * (ts - ssch->atsg_sig[0]);
++    index += sb + 1;
++
++    return index % 512;
++}
++
++static void generate_noise(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    int atsg = 0;
++
++    memset(ssch->qmf_noise, 0, sizeof(ssch->qmf_noise));
++
++    /* Loop over QMF time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats;
++         ts < ssch->atsg_sig[ssch->aspx_num_env] * s->num_ts_in_ats; ts++) {
++        if (ts == ssch->atsg_sig[atsg+1] * s->num_ts_in_ats)
++            atsg++;
++        /* Loop over QMF subbands in A-SPX */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            int idx;
++
++            ssch->noise_idx_prev[ts][sb] = idx = noise_idx(sb, ts, s, ssch);
++            ssch->qmf_noise[0][ts][sb] = ssch->noise_lev_sb_adj[atsg][sb] * aspx_noise[idx][0];
++            ssch->qmf_noise[1][ts][sb] = ssch->noise_lev_sb_adj[atsg][sb] * aspx_noise[idx][1];
++        }
++    }
++}
++
++static void generate_tones(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    int atsg = 0;
++
++    /* Loop over QMF time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats;
++         ts < ssch->atsg_sig[ssch->aspx_num_env] * s->num_ts_in_ats; ts++) {
++        if (ts == ssch->atsg_sig[atsg+1] * s->num_ts_in_ats)
++            atsg++;
++        /* Loop over QMF subbands in A-SPX */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            int idx;
++
++            ssch->sine_idx_prev[ts][sb] = idx = sine_idx(sb, ts, s, ssch);
++            ssch->qmf_sine[0][ts][sb]  = ssch->sine_lev_sb_adj[atsg][sb];
++            ssch->qmf_sine[0][ts][sb] *= aspx_sine[0][idx];
++            ssch->qmf_sine[1][ts][sb]  = ssch->sine_lev_sb_adj[atsg][sb] * powf(-1, sb + ssch->sbx);
++            ssch->qmf_sine[1][ts][sb] *= aspx_sine[1][idx];
++        }
++    }
++}
++
++static void assemble_hf_signal(AC4DecodeContext *s, SubstreamChannel *ssch)
++{
++    int ts_offset_hfadj = 4;
++    int atsg = 0;
++
++    memcpy(ssch->Y_prev, ssch->Y, sizeof(ssch->Y));
++    memset(ssch->Y, 0, sizeof(ssch->Y));
++
++    /* Get delayed QMF subsamples from delay buffer */
++    for (int ts = 0; ts < ssch->atsg_sig[0] * s->num_ts_in_ats; ts++) {
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            ssch->Y[0][ts][sb] = ssch->Y_prev[0][s->num_qmf_timeslots + ts][sb];
++            ssch->Y[1][ts][sb] = ssch->Y_prev[1][s->num_qmf_timeslots + ts][sb];
++        }
++    }
++
++    /* Loop over QMF time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats;
++         ts < ssch->atsg_sig[ssch->aspx_num_env] * s->num_ts_in_ats; ts++) {
++        if (ts == ssch->atsg_sig[atsg+1] * s->num_ts_in_ats)
++            atsg++;
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            ssch->Y[0][ts][sb] = ssch->sig_gain_sb_adj[atsg][sb];
++            ssch->Y[1][ts][sb] = 0;
++            fcomplex_mul(&ssch->Y[0][ts][sb], &ssch->Y[1][ts][sb],
++                         ssch->Y[0][ts][sb], ssch->Y[1][ts][sb],
++                         ssch->Q_high[0][ts + ts_offset_hfadj][sb + ssch->sbx],
++                         ssch->Q_high[1][ts + ts_offset_hfadj][sb + ssch->sbx]);
++        }
++    }
++
++    /* Loop over time slots */
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats;
++         ts < ssch->atsg_sig[ssch->aspx_num_env] * s->num_ts_in_ats; ts++) {
++        /* Loop over QMF subbands */
++        for (int sb = 0; sb < ssch->num_sb_aspx; sb++) {
++            ssch->Y[0][ts][sb] += ssch->qmf_sine[0][ts][sb];
++            ssch->Y[1][ts][sb] += ssch->qmf_sine[1][ts][sb];
++            ssch->Y[0][ts][sb] += ssch->qmf_noise[0][ts][sb];
++            ssch->Y[1][ts][sb] += ssch->qmf_noise[1][ts][sb];
++        }
++    }
++
++    for (int ts = ssch->atsg_sig[0] * s->num_ts_in_ats;
++         ts < ssch->atsg_sig[ssch->aspx_num_env] * s->num_ts_in_ats; ts++) {
++        /* Loop over QMF subbands */
++        for (int sb = ssch->sbx; sb < 64; sb++) {
++            ssch->Q[0][ts][sb] += ssch->Y[0][ts][sb-ssch->sbx] / 32768.f;
++            ssch->Q[1][ts][sb] += ssch->Y[1][ts][sb-ssch->sbx] / 32768.f;
++        }
++    }
++
++    memcpy(ssch->Q_prev, ssch->Q, sizeof(ssch->Q));
++}
++
++static int mono_aspx_processing(AC4DecodeContext *s, Substream *ss)
++{
++    if (ss->codec_mode == CM_ASPX) {
++        aspx_processing(s, &ss->ssch[0]);
++        get_qsignal_scale_factors(s, &ss->ssch[0], 0);
++        get_qnoise_scale_factors(s, &ss->ssch[0], 0);
++        mono_deq_signal_factors(s, &ss->ssch[0]);
++        mono_deq_noise_factors(s, &ss->ssch[0]);
++        preflattening(s, &ss->ssch[0]);
++        get_covariance(s, &ss->ssch[0]);
++        get_alphas(s, &ss->ssch[0]);
++        get_chirps(s, &ss->ssch[0]);
++        create_high_signal(s, ss, &ss->ssch[0]);
++        estimate_spectral_envelopes(s, ss, &ss->ssch[0]);
++        map_signoise(s, &ss->ssch[0]);
++        add_sinusoids(s, &ss->ssch[0]);
++        generate_tones(s, &ss->ssch[0]);
++        generate_noise(s, &ss->ssch[0]);
++        assemble_hf_signal(s, &ss->ssch[0]);
++    }
++
++    return 0;
++}
++
++static int stereo_aspx_processing(AC4DecodeContext *s, Substream *ss)
++{
++    if (ss->codec_mode == CM_ASPX) {
++        aspx_processing(s, &ss->ssch[0]);
++        aspx_processing(s, &ss->ssch[1]);
++        get_qsignal_scale_factors(s, &ss->ssch[0], 0);
++        get_qsignal_scale_factors(s, &ss->ssch[1], 1);
++        get_qnoise_scale_factors(s, &ss->ssch[0], 0);
++        get_qnoise_scale_factors(s, &ss->ssch[1], 1);
++        if (ss->ssch[0].aspx_balance == 0) {
++            mono_deq_signal_factors(s, &ss->ssch[0]);
++            mono_deq_signal_factors(s, &ss->ssch[1]);
++            mono_deq_noise_factors(s, &ss->ssch[0]);
++            mono_deq_noise_factors(s, &ss->ssch[1]);
++        } else {
++            stereo_deq_signoise_factors(s, &ss->ssch[0], &ss->ssch[1]);
++        }
++        preflattening(s, &ss->ssch[0]);
++        preflattening(s, &ss->ssch[1]);
++        get_covariance(s, &ss->ssch[0]);
++        get_covariance(s, &ss->ssch[1]);
++        get_alphas(s, &ss->ssch[0]);
++        get_alphas(s, &ss->ssch[1]);
++        get_chirps(s, &ss->ssch[0]);
++        get_chirps(s, &ss->ssch[1]);
++        create_high_signal(s, ss, &ss->ssch[0]);
++        create_high_signal(s, ss, &ss->ssch[1]);
++        estimate_spectral_envelopes(s, ss, &ss->ssch[0]);
++        estimate_spectral_envelopes(s, ss, &ss->ssch[1]);
++        map_signoise(s, &ss->ssch[0]);
++        map_signoise(s, &ss->ssch[1]);
++        add_sinusoids(s, &ss->ssch[0]);
++        add_sinusoids(s, &ss->ssch[1]);
++        generate_tones(s, &ss->ssch[0]);
++        generate_tones(s, &ss->ssch[1]);
++        generate_noise(s, &ss->ssch[0]);
++        generate_noise(s, &ss->ssch[1]);
++        assemble_hf_signal(s, &ss->ssch[0]);
++        assemble_hf_signal(s, &ss->ssch[1]);
++    }
++
++    return 0;
++}
++
++static void decode_channel(AC4DecodeContext *s, int ch, float *pcm)
++{
++    Substream *ss = &s->substream;
++    SubstreamChannel *ssch = &ss->ssch[ch];
++
++    qmf_synthesis(s, ssch, pcm);
++}
++
++static int ac4_decode_frame(AVCodecContext *avctx, void *data,
++                            int *got_frame_ptr, AVPacket *avpkt)
++{
++    AC4DecodeContext *s = avctx->priv_data;
++    AVFrame *frame = data;
++    GetBitContext *gb = &s->gbc;
++    int ret, start_offset = 0;
++    SubstreamInfo *ssinfo;
++    int presentation;
++    uint32_t header;
++
++    if (avpkt->size < 8) {
++        av_log(s->avctx, AV_LOG_ERROR, "invalid packet size: %d\n", avpkt->size);
++        return AVERROR_INVALIDDATA;
++    }
++
++    header = AV_RB16(avpkt->data);
++    if (header == 0xAC40 || header == 0xAC41) {
++        int size = AV_RB16(avpkt->data + 2);
++
++        start_offset = 4;
++        if (size == 0xFFFF)
++            start_offset += 3;
++    }
++
++    if ((ret = init_get_bits8(gb, avpkt->data, avpkt->size)) < 0)
++        return ret;
++    av_log(s->avctx, AV_LOG_DEBUG, "packet_size: %d\n", avpkt->size);
++    skip_bits_long(gb, start_offset * 8);
++
++    ret = ac4_toc(s);
++    if (ret < 0)
++        return ret;
++
++    if (!s->have_iframe)
++        return avpkt->size;
++
++    presentation = FFMIN(s->target_presentation, FFMAX(0, s->nb_presentations - 1));
++    ssinfo = s->version == 2 ? &s->ssgroup[0].ssinfo : &s->pinfo[presentation].ssinfo;
++    avctx->sample_rate = s->fs_index ? 48000 : 44100;
++    avctx->channels = channel_mode_nb_channels[ssinfo->channel_mode];
++    avctx->channel_layout = channel_mode_layouts[ssinfo->channel_mode];
++    frame->nb_samples = av_rescale(s->frame_len_base,
++                                   s->resampling_ratio.num,
++                                   s->resampling_ratio.den);
++    frame->nb_samples = s->frame_len_base;
++    if ((ret = ff_get_buffer(avctx, frame, 0)) < 0)
++        return ret;
++
++    skip_bits_long(gb, s->payload_base * 8);
++
++    for (int i = 0; i < s->nb_substreams; i++) {
++        int substream_type = s->substream_type[i];
++
++        switch (substream_type) {
++        case ST_SUBSTREAM:
++            ret = ac4_substream(s, ssinfo);
++            break;
++        case ST_PRESENTATION:
++            skip_bits_long(gb, s->substream_size[i] * 8);
++            break;
++        default:
++            av_assert0(0);
++        }
++
++        if (ret < 0)
++            return ret;
++        if (substream_type == ST_SUBSTREAM)
++            break;
++    }
++
++    if (get_bits_left(gb) < 0)
++        av_log(s->avctx, AV_LOG_WARNING, "overread\n");
++
++    for (int ch = 0; ch < avctx->channels; ch++)
++        scale_spec(s, ch);
++
++    switch (ssinfo->channel_mode) {
++    case 0:
++        /* nothing to do */
++        break;
++    case 1:
++        stereo_processing(s, &s->substream);
++        break;
++    case 3:
++    case 4:
++        m5channel_processing(s, &s->substream);
++        break;
++    }
++
++    for (int ch = 0; ch < avctx->channels; ch++)
++        prepare_channel(s, ch);
++
++    switch (ssinfo->channel_mode) {
++    case 0:
++        mono_aspx_processing(s, &s->substream);
++        break;
++    case 1:
++        stereo_aspx_processing(s, &s->substream);
++        break;
++    case 3:
++    case 4:
++        break;
++    }
++
++    for (int ch = 0; ch < avctx->channels; ch++)
++        decode_channel(s, ch, (float *)frame->extended_data[ch]);
++
++    frame->key_frame = s->iframe_global;
++
++    *got_frame_ptr = 1;
++
++    return avpkt->size;
++}
++
++static av_cold void ac4_flush(AVCodecContext *avctx)
++{
++    AC4DecodeContext *s = avctx->priv_data;
++
++    s->have_iframe = 0;
++    s->sequence_counter_prev = 0;
++}
++
++static av_cold int ac4_decode_end(AVCodecContext *avctx)
++{
++    AC4DecodeContext *s = avctx->priv_data;
++
++    av_freep(&s->fdsp);
++
++    for (int j = 0; j < 8; j++)
++        for (int i = 0; i < 5; i++)
++            av_tx_uninit(&s->tx_ctx[j][i]);
++
++    return 0;
++}
++
++#define OFFSET(param) offsetof(AC4DecodeContext, param)
++#define FLAGS AV_OPT_FLAG_DECODING_PARAM | AV_OPT_FLAG_AUDIO_PARAM
++
++static const AVOption options[] = {
++    { "presentation", "select presentation", OFFSET(target_presentation), AV_OPT_TYPE_INT, {.i64 = 0 }, 0, INT_MAX, FLAGS },
++    { NULL},
++};
++
++static const AVClass ac4_decoder_class = {
++    .class_name = "AC4 decoder",
++    .item_name  = av_default_item_name,
++    .option     = options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
++
++AVCodec ff_ac4_decoder = {
++    .name           = "ac4",
++    .type           = AVMEDIA_TYPE_AUDIO,
++    .id             = AV_CODEC_ID_AC4,
++    .priv_class     = &ac4_decoder_class,
++    .priv_data_size = sizeof (AC4DecodeContext),
++    .init           = ac4_decode_init,
++    .close          = ac4_decode_end,
++    .decode         = ac4_decode_frame,
++    .flush          = ac4_flush,
++    .capabilities   = AV_CODEC_CAP_DR1 | AV_CODEC_CAP_CHANNEL_CONF,
++    .long_name      = NULL_IF_CONFIG_SMALL("AC-4"),
++    .sample_fmts    = (const enum AVSampleFormat[]) { AV_SAMPLE_FMT_FLTP,
++                                                      AV_SAMPLE_FMT_NONE },
++};
+--- /dev/null
++++ jellyfin-ffmpeg-4.4.1/libavcodec/ac4dec_data.h
+@@ -0,0 +1,1664 @@
++/*
++ * AC-4 Audio Decoder
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#ifndef AVCODEC_AC4DECDATA_H
++#define AVCODEC_AC4DECDATA_H
++
++#include <stdint.h>
++
++static const uint8_t aspx_hcb_env_level_15_f0_bits[71] = {
++     7,  9,  9,  9,  9,  8,  8,  7,  7,  7,  7,  7,  6,  6,  6,  6,
++     6,  6,  6,  6,  6,  6,  5,  5,  5,  5,  5,  5,  5,  5,  4,  5,
++     5,  5,  5,  5,  5,  5,  4,  5,  5,  5,  5,  6,  6,  6,  7,  8,
++     9, 10, 11, 12, 14, 14, 16, 16, 17, 17, 18, 18, 18, 18, 18, 18,
++    18, 18, 17, 17, 17, 17, 16,
++};
++
++static const uint32_t aspx_hcb_env_level_15_f0_codes[71] = {
++    0x0003e, 0x0007e, 0x0007f, 0x000be, 0x000bf, 0x0003e, 0x0005e, 0x00016,
++    0x00017, 0x0001e, 0x0002e, 0x0005e, 0x00012, 0x0000a, 0x0000c, 0x0000e,
++    0x00013, 0x00016, 0x0001a, 0x0001b, 0x00022, 0x00023, 0x00004, 0x00008,
++    0x0000c, 0x0000e, 0x00012, 0x00014, 0x00015, 0x0001a, 0x00000, 0x00016,
++    0x00018, 0x0001e, 0x0001c, 0x00019, 0x0001d, 0x0001f, 0x00001, 0x0001b,
++    0x00013, 0x00010, 0x0000a, 0x0002e, 0x0001e, 0x0000d, 0x0003f, 0x000be,
++    0x0017e, 0x002fe, 0x005fe, 0x00bfe, 0x02ffe, 0x02ffc, 0x0bffc, 0x0bff6,
++    0x17ffa, 0x17ffb, 0x2fff8, 0x2fff9, 0x2fffa, 0x2fffb, 0x2fffc, 0x2fffd,
++    0x2fffe, 0x2ffff, 0x17fe8, 0x17fe9, 0x17fea, 0x17feb, 0x0bff7,
++};
++
++static const uint8_t aspx_hcb_env_level_15_df_bits[141] = {
++    21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
++    21, 21, 17, 18, 19, 19, 21, 19, 19, 19, 21, 20, 20, 20, 16, 17,
++    19, 19, 18, 18, 17, 15, 15, 15, 15, 14, 14, 14, 14, 13, 13, 13,
++    13, 13, 13, 13, 12, 12, 12, 12, 12, 11, 10, 10,  9,  8,  8,  7,
++     6,  6,  5,  4,  3,  2,  2,  3,  4,  6,  7,  7,  8,  9, 10, 11,
++    11, 12, 13, 13, 14, 14, 15, 15, 15, 16, 16, 16, 17, 17, 17, 17,
++    17, 18, 17, 17, 16, 17, 18, 19, 20, 21, 19, 19, 18, 16, 19, 21,
++    16, 20, 20, 21, 21, 20, 20, 19, 20, 19, 17, 21, 21, 21, 21, 21,
++    21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
++};
++
++static const uint32_t aspx_hcb_env_level_15_df_codes[141] = {
++    0xfeff2, 0xfeff3, 0xfeff4, 0xfeff5, 0xfeff6, 0xfeff7, 0xfeff8, 0xfeff9,
++    0xfeffa, 0xfeffb, 0xfeffc, 0xfeffd, 0xfeffe, 0xfefff, 0xff5e4, 0xff5e5,
++    0xff5e6, 0xff5e7, 0x0fef4, 0x1fefe, 0x3fdea, 0x3ffde, 0xff7b6, 0x3fdec,
++    0x3fdee, 0x3fd78, 0xff5ee, 0x7f798, 0x7faf6, 0x7f799, 0x07ffa, 0x0fef6,
++    0x3fdef, 0x3ffdf, 0x1fdee, 0x1ffee, 0x0ff7e, 0x03d7e, 0x03fba, 0x03fbe,
++    0x03ffe, 0x01ebe, 0x01fdc, 0x01fee, 0x01ff6, 0x00f5c, 0x00f5d, 0x00f7e,
++    0x00f7f, 0x00ff4, 0x00ff6, 0x00ffe, 0x007bc, 0x007bd, 0x007f6, 0x007fc,
++    0x007fe, 0x003fa, 0x001ea, 0x001fc, 0x000f6, 0x00076, 0x0007e, 0x0003c,
++    0x0001c, 0x0003e, 0x0001e, 0x0000e, 0x00006, 0x00002, 0x00000, 0x00002,
++    0x00006, 0x0003f, 0x0003e, 0x0003a, 0x00077, 0x000f4, 0x001ee, 0x003fc,
++    0x003d6, 0x007be, 0x00ffa, 0x00f5e, 0x01ff7, 0x01fea, 0x03ffc, 0x03fd6,
++    0x03fbb, 0x07fbe, 0x07fae, 0x07f7e, 0x0fff6, 0x0fffe, 0x0fef5, 0x0fef2,
++    0x0f5fe, 0x1fffe, 0x0ff78, 0x0fefe, 0x07afe, 0x0ff79, 0x1fef4, 0x3fd7a,
++    0x7f79a, 0xff5ef, 0x3fdfe, 0x3fffe, 0x1fdef, 0x07ffe, 0x3fdff, 0xff5f2,
++    0x07f78, 0x7f79b, 0x7f79e, 0xff5f3, 0xff5f4, 0x7f79f, 0x7faf8, 0x3ffff,
++    0x7f7f8, 0x3fbce, 0x0f5ff, 0xff5f5, 0xff5f6, 0xff5f7, 0xff5f8, 0xff5f9,
++    0xff5fa, 0xff5fb, 0xff5fc, 0xff5fd, 0xff5fe, 0xff5ff, 0xff7ac, 0xff7ad,
++    0xff7ae, 0xff7af, 0xff7b4, 0xff7b5, 0xff7b7,
++};
++
++static const uint8_t aspx_hcb_env_level_15_dt_bits[141] = {
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 18, 18, 18, 18, 18,
++    17, 19, 17, 16, 17, 17, 17, 16, 15, 16, 15, 15, 14, 14, 14, 13,
++    12, 10,  8,  6,  4,  2,  1,  3,  5,  7, 10, 11, 12, 14, 14, 15,
++    15, 16, 16, 17, 16, 17, 17, 18, 16, 17, 18, 18, 19, 18, 19, 19,
++    17, 18, 18, 19, 19, 19, 19, 19, 19, 19, 19, 19, 18, 19, 19, 19,
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
++    19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19,
++};
++
++static const uint32_t aspx_hcb_env_level_15_dt_codes[141] = {
++    0x7ffa0, 0x7ffa1, 0x7ffa2, 0x7ffa3, 0x7ffa4, 0x7ffa5, 0x7ffa6, 0x7ffa7,
++    0x7ffa8, 0x7ffa9, 0x7ffaa, 0x7ffab, 0x7ffac, 0x7ffad, 0x7ffae, 0x7ffaf,
++    0x7ffb0, 0x7ffb1, 0x7ffb2, 0x7ffb3, 0x7ffb4, 0x7ffb5, 0x7ffb6, 0x7ffb7,
++    0x7ffb8, 0x7ffb9, 0x7ffba, 0x7ffbb, 0x7ffbc, 0x7ffbd, 0x7ffbe, 0x7ffbf,
++    0x7ffc0, 0x7ffc1, 0x7ffc2, 0x7ffc3, 0x7ffc4, 0x7ffc5, 0x7ffc6, 0x7ffc7,
++    0x7ffcc, 0x7ffcd, 0x7ffce, 0x3ff16, 0x3ff17, 0x3ff1e, 0x3ff1f, 0x3ff3c,
++    0x1fefa, 0x7ffcf, 0x1ffb6, 0x0ff7c, 0x1ff8e, 0x1ffbe, 0x1fefb, 0x0ffc4,
++    0x07fba, 0x0ffc6, 0x07fbb, 0x07fee, 0x03fdc, 0x03ff0, 0x03ff2, 0x01ffa,
++    0x00ffe, 0x003fc, 0x000fe, 0x0003e, 0x0000e, 0x00002, 0x00000, 0x00006,
++    0x0001e, 0x0007e, 0x003fe, 0x007fa, 0x00ff6, 0x03ffc, 0x03fde, 0x07fe6,
++    0x07fec, 0x0ffda, 0x0ffde, 0x1fefe, 0x0ffce, 0x1fff2, 0x1ffbf, 0x3ff3d,
++    0x0ff7e, 0x1feff, 0x3ff3e, 0x3ff3f, 0x7ffd2, 0x3ffe8, 0x7ffd3, 0x7ffd4,
++    0x1ff8a, 0x3ff6e, 0x3ff6f, 0x7ffd5, 0x7ffd6, 0x7ffd7, 0x7ffd8, 0x7ffd9,
++    0x7ffda, 0x7ffdb, 0x7ffde, 0x7ffdf, 0x3ffee, 0x7ffe0, 0x7ffe1, 0x7ffe2,
++    0x7ffe3, 0x7ffe4, 0x7ffe5, 0x7ffe6, 0x7ffe7, 0x7ffe8, 0x7ffe9, 0x7ffea,
++    0x7ffeb, 0x7ffec, 0x7ffed, 0x7ffee, 0x7ffef, 0x7fff0, 0x7fff1, 0x7fff2,
++    0x7fff3, 0x7fff4, 0x7fff5, 0x7fff6, 0x7fff7, 0x7fff8, 0x7fff9, 0x7fffa,
++    0x7fffb, 0x7fffc, 0x7fffd, 0x7fffe, 0x7ffff,
++};
++
++static const uint8_t aspx_hcb_env_balance_15_f0_bits[25] = {
++    13, 16, 15, 15, 13, 12, 11,  9,  8,  7,  5,  3,  1,  2,  4,  7,
++     8,  9, 10, 10, 11, 12, 13, 15, 16,
++};
++
++static const uint32_t aspx_hcb_env_balance_15_f0_codes[25] = {
++    0x01ffe, 0x0ffea, 0x07ff6, 0x07ff7, 0x01fff, 0x00ffc, 0x007de, 0x001f6,
++    0x000fa, 0x0007c, 0x0001e, 0x00006, 0x00000, 0x00002, 0x0000e, 0x0007e,
++    0x000fe, 0x001fe, 0x003fe, 0x003ee, 0x007df, 0x00ffd, 0x01ffc, 0x07ff4,
++    0x0ffeb,
++};
++
++static const uint8_t aspx_hcb_env_balance_15_df_bits[49] = {
++    19, 19, 19, 19, 19, 18, 18, 17, 16, 16, 16, 15, 13, 13, 12, 12,
++    12, 11, 10,  9,  8,  7,  5,  3,  1,  2,  4,  7,  8, 10, 10, 11,
++    12, 12, 13, 13, 14, 15, 16, 18, 18, 17, 18, 18, 18, 19, 19, 18,
++    19,
++};
++
++static const uint32_t aspx_hcb_env_balance_15_df_codes[49] = {
++    0x7def6, 0x7def7, 0x7defa, 0x7defb, 0x7dffe, 0x3ef7c, 0x3ef7e, 0x1f7b2,
++    0x0fbd8, 0x0fbda, 0x0fbfe, 0x07dfe, 0x01f6e, 0x01f7a, 0x00f9e, 0x00fb6,
++    0x00fbc, 0x007da, 0x003ec, 0x001f2, 0x000fa, 0x0007e, 0x0001e, 0x00006,
++    0x00000, 0x00002, 0x0000e, 0x0007f, 0x000f8, 0x003ee, 0x003e6, 0x007ce,
++    0x00fbe, 0x00f9f, 0x01f7e, 0x01f6f, 0x03efe, 0x07dee, 0x0fbdb, 0x3ef78,
++    0x3ef7f, 0x1f7b3, 0x3effc, 0x3effd, 0x3ef79, 0x7dffc, 0x7dffd, 0x3ef7a,
++    0x7dfff,
++};
++
++static const uint8_t aspx_hcb_env_balance_15_dt_bits[49] = {
++    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 14, 13, 13, 12, 12,
++    11, 12, 11,  9,  8,  7,  4,  2,  1,  3,  5,  7,  9,  9, 10, 11,
++    11, 12, 12, 12, 12, 13, 15, 14, 15, 14, 15, 15, 15, 14, 14, 15,
++    15,
++};
++
++static const uint32_t aspx_hcb_env_balance_15_dt_codes[49] = {
++    0x07dce, 0x07dcf, 0x07ddc, 0x07ddd, 0x07dde, 0x07ddf, 0x07dec, 0x07ded,
++    0x07dee, 0x07def, 0x07df8, 0x03ebe, 0x01f5e, 0x01f7a, 0x00fb8, 0x00fba,
++    0x007cc, 0x00fbe, 0x007d6, 0x001f2, 0x000f8, 0x0007e, 0x0000e, 0x00002,
++    0x00000, 0x00006, 0x0001e, 0x0007f, 0x001f6, 0x001f4, 0x003ea, 0x007cd,
++    0x007ce, 0x00f9e, 0x00fae, 0x00fbc, 0x00f9f, 0x01f76, 0x07df9, 0x03ebf,
++    0x07dfa, 0x03ee4, 0x07dfb, 0x07dfc, 0x07dfd, 0x03ee5, 0x03ee6, 0x07dfe,
++    0x07dff,
++};
++
++static const uint8_t aspx_hcb_env_level_30_f0_bits[36] = {
++    11, 13, 11, 11, 10, 10,  9,  8,  8,  7,  7,  7,  6,  6,  5,  5,
++     4,  4,  4,  4,  3,  3,  3,  3,  4,  5,  6,  7,  9, 12, 14, 16,
++    17, 16, 17, 16,
++};
++
++static const uint32_t aspx_hcb_env_level_30_f0_codes[36] = {
++    0x007fe, 0x01ffe, 0x001de, 0x001df, 0x000ee, 0x003fe, 0x001fe, 0x0003a,
++    0x000fe, 0x0001c, 0x0001e, 0x0007e, 0x0002e, 0x0003e, 0x00006, 0x00016,
++    0x00002, 0x0000a, 0x0000c, 0x0000e, 0x00002, 0x00003, 0x00004, 0x00000,
++    0x0000d, 0x0001e, 0x0002f, 0x0001f, 0x00076, 0x00ffe, 0x03ffe, 0x0fffc,
++    0x1fffe, 0x0fffe, 0x1ffff, 0x0fffd,
++};
++
++static const uint8_t aspx_hcb_env_level_30_df_bits[71] = {
++    23, 23, 23, 23, 22, 22, 22, 22, 20, 19, 19, 20, 19, 18, 17, 16,
++    16, 15, 14, 14, 14, 13, 13, 13, 13, 12, 12, 12, 11, 10,  9,  8,
++     5,  4,  2,  1,  3,  6,  8,  9, 11, 12, 14, 14, 15, 16, 17, 17,
++    17, 18, 18, 19, 21, 19, 17, 20, 19, 20, 20, 20, 19, 19, 19, 22,
++    22, 22, 22, 22, 22, 22, 22,
++};
++
++static const uint32_t aspx_hcb_env_level_30_df_codes[71] = {
++    0x7ffbfc, 0x7ffbfd, 0x7ffbfe, 0x7ffbff, 0x3f7f6c, 0x3f7f6d, 0x3f7f6e,
++    0x3f7f6f, 0x0fdfee, 0x07effe, 0x07efec, 0x0fff7e, 0x07ffbe, 0x03f7fe,
++    0x01fbfe, 0x00fdfc, 0x00fff6, 0x007ffa, 0x003f7e, 0x003ffc, 0x003ffe,
++    0x001fba, 0x001fbe, 0x001ffa, 0x001ffb, 0x000fdc, 0x000ffc, 0x000ffe,
++    0x0007fc, 0x0003f6, 0x0001fe, 0x0000fe, 0x00001e, 0x00000e, 0x000002,
++    0x000000, 0x000006, 0x00003e, 0x0000fc, 0x0001fa, 0x0007fd, 0x000fde,
++    0x003fff, 0x003f76, 0x007eee, 0x00fdde, 0x01ffee, 0x01fbfc, 0x01fbfa,
++    0x03ffde, 0x03f77e, 0x07efee, 0x1ffefe, 0x07eefe, 0x01fbbe, 0x0fdfea,
++    0x07eff6, 0x0fdfda, 0x0fdfde, 0x0fdfef, 0x07eff4, 0x07efff, 0x07eeff,
++    0x3f7fae, 0x3f7f7c, 0x3f7f7d, 0x3f7f7e, 0x3f7f7f, 0x3f7fac, 0x3f7fad,
++    0x3f7faf,
++};
++
++static const uint8_t aspx_hcb_env_level_30_dt_bits[71] = {
++    20, 20, 20, 20, 20, 20, 20, 20, 20, 19, 19, 20, 20, 18, 16, 16,
++    15, 16, 15, 14, 14, 14, 13, 13, 13, 12, 12, 11, 11, 10, 10,  8,
++     6,  4,  2,  1,  3,  5,  8,  9, 11, 11, 12, 13, 13, 14, 14, 14,
++    15, 15, 16, 17, 18, 19, 18, 18, 18, 18, 20, 19, 20, 20, 20, 20,
++    20, 20, 20, 20, 20, 20, 19,
++};
++
++static const uint32_t aspx_hcb_env_level_30_dt_codes[71] = {
++    0x0ff7d6, 0x0ff7d7, 0x0ff7d8, 0x0ff7d9, 0x0ff7da, 0x0ff7db, 0x0ff7dc,
++    0x0ff7dd, 0x0ff7de, 0x07fbfe, 0x07ed7a, 0x0ff7df, 0x0ff7f2, 0x03fdf4,
++    0x00ff7c, 0x00fdae, 0x007ede, 0x00ff7e, 0x007ed2, 0x003f68, 0x003f6e,
++    0x003ffa, 0x001fb6, 0x001ffe, 0x001fff, 0x000fde, 0x000ff6, 0x0007ec,
++    0x0007fa, 0x0003fc, 0x0003fe, 0x0000fc, 0x00003e, 0x00000e, 0x000002,
++    0x000000, 0x000006, 0x00001e, 0x0000fe, 0x0001fa, 0x0007fe, 0x0007ee,
++    0x000fdf, 0x001ffc, 0x001fee, 0x003ffb, 0x003fde, 0x003f6a, 0x007ed6,
++    0x007ed3, 0x00fdbe, 0x01fb7e, 0x03f6bc, 0x07fbf8, 0x03f6be, 0x03f6bf,
++    0x03f6fe, 0x03f6ff, 0x0ff7f3, 0x07fbea, 0x0ff7f4, 0x0ff7f5, 0x0ff7f6,
++    0x0ff7f7, 0x0ff7f8, 0x0ff7f9, 0x0ff7fa, 0x0ff7fb, 0x0ff7fe, 0x0ff7ff,
++    0x07ed7b,
++};
++
++static const uint8_t aspx_hcb_env_balance_30_f0_bits[13] = {
++    12, 11,  9,  7,  4,  3,  1,  2,  5,  6,  8, 10, 12,
++};
++
++static const uint16_t aspx_hcb_env_balance_30_f0_codes[13] = {
++    0x000ffe, 0x0007fe, 0x0001fe, 0x00007e, 0x00000e, 0x000006, 0x000000,
++    0x000002, 0x00001e, 0x00003e, 0x0000fe, 0x0003fe, 0x000fff,
++};
++
++static const uint8_t aspx_hcb_env_balance_30_df_bits[25] = {
++    17, 17, 17, 15, 14, 12,  9,  9,  8,  7,  5,  2,  1,  3,  4,  7,
++     8,  9, 10, 11, 14, 15, 16, 16, 17,
++};
++
++static const uint32_t aspx_hcb_env_balance_30_df_codes[25] = {
++    0x01fffc, 0x01fffd, 0x01fffe, 0x007ffa, 0x003ffc, 0x000ffe, 0x0001fc,
++    0x0001fe, 0x0000fa, 0x00007e, 0x00001e, 0x000002, 0x000000, 0x000006,
++    0x00000e, 0x00007c, 0x0000fb, 0x0001fd, 0x0003fe, 0x0007fe, 0x003ffe,
++    0x007ffb, 0x00fffc, 0x00fffd, 0x01ffff,
++};
++
++static const uint8_t aspx_hcb_env_balance_30_dt_bits[25] = {
++    15, 15, 15, 14, 13, 13, 10,  8,  8,  7,  4,  2,  1,  3,  5,  7,
++     9,  9,  9, 12, 14, 13, 14, 15, 14,
++};
++
++static const uint16_t aspx_hcb_env_balance_30_dt_codes[25] = {
++    0x007ff2, 0x007ff3, 0x007ff6, 0x003ff6, 0x001ffe, 0x001fff, 0x0003fe,
++    0x0000fa, 0x0000fe, 0x00007e, 0x00000e, 0x000002, 0x000000, 0x000006,
++    0x00001e, 0x00007c, 0x0001fe, 0x0001f6, 0x0001f7, 0x000ffc, 0x003ffa,
++    0x001ffa, 0x003ff7, 0x007ff7, 0x003ff8,
++};
++
++static const uint8_t aspx_hcb_noise_level_f0_bits[30] = {
++    12, 12,  9,  7,  6,  6,  5,  1,  2,  3,  5,  7,  8,  8,  9, 10,
++    11, 12, 12, 12, 13, 13, 14, 12, 14, 14, 11, 16, 16, 15,
++};
++
++static const uint16_t aspx_hcb_noise_level_f0_codes[30] = {
++    0x000efe, 0x000eff, 0x0001fe, 0x000076, 0x00003a, 0x00003e, 0x00001e,
++    0x000000, 0x000002, 0x000006, 0x00001c, 0x00007e, 0x0000fe, 0x0000ee,
++    0x0001ff, 0x0003bc, 0x00077c, 0x000efa, 0x000ef4, 0x000ef6, 0x001df6,
++    0x001dee, 0x003bee, 0x000ef5, 0x003bde, 0x003bef, 0x00077e, 0x00ef7e,
++    0x00ef7f, 0x0077be,
++};
++
++static const uint8_t aspx_hcb_noise_level_df_bits[59] = {
++    17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 13, 14, 16, 16, 15, 15,
++    16, 15, 14, 14, 14, 14, 13, 11, 10,  9,  8,  7,  3,  1,  2,  4,
++     5,  7,  8,  9, 10, 12, 13, 13, 14, 16, 17, 17, 17, 17, 17, 17,
++    16, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
++};
++
++static const uint32_t aspx_hcb_noise_level_df_codes[59] = {
++    0x01f19e, 0x01f19f, 0x01f1dc, 0x01f1dd, 0x01f1de, 0x01f1df, 0x01f1e8,
++    0x01f1e9, 0x01f1ea, 0x01f1eb, 0x001f1a, 0x003e7e, 0x00f9fe, 0x00f8f6,
++    0x007c76, 0x007c66, 0x00f8f7, 0x007c7c, 0x003e3c, 0x003e36, 0x003e37,
++    0x003e3a, 0x001f3e, 0x0007ce, 0x0003e6, 0x0001f0, 0x0000fa, 0x00007e,
++    0x000006, 0x000000, 0x000002, 0x00000e, 0x00001e, 0x00007f, 0x0000fb,
++    0x0001f2, 0x0003e2, 0x000f9e, 0x001f1c, 0x001f18, 0x003e32, 0x00f8fa,
++    0x01f3fe, 0x01f1f6, 0x01f1f7, 0x01f1f8, 0x01f1f9, 0x01f1fa, 0x00f8ce,
++    0x01f1fb, 0x01f1fc, 0x01f1fd, 0x01f1fe, 0x01f1ff, 0x01f3f8, 0x01f3f9,
++    0x01f3fa, 0x01f3fb, 0x01f3ff,
++};
++
++static const uint8_t aspx_hcb_noise_level_dt_bits[59] = {
++    16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
++    16, 16, 16, 16, 16, 14, 16, 13, 11,  8,  6,  4,  3,  1,  2,  5,
++     7, 10, 10, 12, 13, 13, 14, 15, 14, 15, 15, 16, 16, 16, 16, 16,
++    16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16,
++};
++
++static const uint16_t aspx_hcb_noise_level_dt_codes[59] = {
++    0x00ff70, 0x00ff71, 0x00ff72, 0x00ff73, 0x00ff74, 0x00ff75, 0x00ff76,
++    0x00ff77, 0x00ff78, 0x00ff79, 0x00ff7a, 0x00ff7b, 0x00ff7c, 0x00ff7d,
++    0x00ff7e, 0x00ff7f, 0x00ffe0, 0x00ffe1, 0x00ffe2, 0x00ffe3, 0x00ffe6,
++    0x003fd6, 0x00ffe7, 0x001ffe, 0x0007fe, 0x0000fe, 0x00003e, 0x00000e,
++    0x000006, 0x000000, 0x000002, 0x00001e, 0x00007e, 0x0003fe, 0x0003fc,
++    0x000ff6, 0x001fe8, 0x001fea, 0x003fd2, 0x007fae, 0x003fd3, 0x007ff2,
++    0x007faf, 0x00ffe8, 0x00ffe9, 0x00ffea, 0x00ffeb, 0x00ffec, 0x00ffed,
++    0x00ffee, 0x00ffef, 0x00fff8, 0x00fff9, 0x00fffa, 0x00fffb, 0x00fffc,
++    0x00fffd, 0x00fffe, 0x00ffff,
++};
++
++static const uint8_t aspx_hcb_noise_balance_f0_bits[13] = {
++    10, 10,  9,  7,  5,  3,  2,  1,  4,  6,  9, 10, 10,
++};
++
++static const uint16_t aspx_hcb_noise_balance_f0_codes[13] = {
++    0x0003fa, 0x0003fe, 0x0001fc, 0x00007e, 0x00001e, 0x000006,
++    0x000002, 0x000000, 0x00000e, 0x00003e, 0x0001fe, 0x0003ff,
++    0x0003fb,
++};
++
++static const uint8_t aspx_hcb_noise_balance_df_bits[25] = {
++    13, 13, 13, 13, 13, 12, 13, 10,  9,  7,  4,  2,  1,  3,  5,  6,
++     9, 11, 13, 13, 12, 12, 12, 12, 12,
++};
++
++static const uint16_t aspx_hcb_noise_balance_df_codes[25] = {
++    0x001fd8, 0x001fd9, 0x001fda, 0x001fdb, 0x001fdc, 0x000fea, 0x001fdd,
++    0x0003f8, 0x0001fe, 0x00007e, 0x00000e, 0x000002, 0x000000, 0x000006,
++    0x00001e, 0x00003e, 0x0001ff, 0x0007f4, 0x001fde, 0x001fdf, 0x000fe4,
++    0x000fe5, 0x000fe6, 0x000fe7, 0x000feb,
++};
++
++static const uint8_t aspx_hcb_noise_balance_dt_bits[25] = {
++    11, 11, 11, 11, 11, 11, 11, 10, 10,  6,  4,  3,  1,  2,  5,  8,
++     9, 11, 10, 11, 11, 11, 11, 11, 11,
++};
++
++static const uint16_t aspx_hcb_noise_balance_dt_codes[25] = {
++    0x0007e6, 0x0007e7, 0x0007e8, 0x0007e9, 0x0007ea, 0x0007eb, 0x0007ec,
++    0x0003fe, 0x0003ff, 0x00003e, 0x00000e, 0x000006, 0x000000, 0x000002,
++    0x00001e, 0x0000fe, 0x0001f8, 0x0007ed, 0x0003f2, 0x0007ee, 0x0007ef,
++    0x0007f8, 0x0007f9, 0x0007fa, 0x0007fb,
++};
++
++static uint8_t aspx_codebook_signal_off[2][2][3] = {
++    {
++        {  0, 70, 70, },
++        { 36, 35, 35, },
++    },
++    {
++        { 25, 24, 24, },
++        { 13, 12, 12, },
++    },
++};
++
++static uint8_t aspx_codebook_noise_off[2][3] = {
++        { 30, 29, 29, },
++        { 13, 12, 12, },
++};
++
++static const uint8_t scale_factors_bits[121] = {
++    17, 14, 14, 14, 14, 14, 14, 15, 14, 14, 14, 14, 14, 14, 14, 14,
++    13, 13, 14, 14, 14, 14, 14, 13, 14, 13, 13, 14, 14, 13, 14, 13,
++    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 12, 12, 12, 12, 11,
++    11, 11, 10,  9,  9,  8,  8,  6,  6,  4,  4,  3,  1,  4,  4,  5,
++     6,  7,  8,  8,  9,  9, 10, 10, 11, 11, 11, 11, 12, 11, 12, 12,
++    12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14, 14,
++    14, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14, 14,
++    14, 14, 14, 14, 14, 16, 14, 14, 17,
++};
++
++static const uint8_t scale_factors_codes[121] = {
++    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x01,
++    0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
++    0x19, 0x1a, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x1b,
++    0x14, 0x1c, 0x1d, 0x15, 0x16, 0x1e, 0x17, 0x1f,
++    0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27,
++    0x28, 0x29, 0x2a, 0x1b, 0x1c, 0x1d, 0x1e, 0x12,
++    0x13, 0x14, 0x0d, 0x08, 0x09, 0x06, 0x07, 0x03,
++    0x04, 0x02, 0x03, 0x03, 0x01, 0x04, 0x05, 0x03,
++    0x05, 0x05, 0x08, 0x09, 0x0a, 0x0b, 0x0e, 0x0f,
++    0x15, 0x16, 0x17, 0x18, 0x1f, 0x19, 0x20, 0x21,
++    0x22, 0x23, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
++    0x31, 0x32, 0x33, 0x34, 0x18, 0x19, 0x1a, 0x1b,
++    0x1c, 0x35, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22,
++    0x23, 0x24, 0x25, 0x26, 0x27, 0x28, 0x29, 0x2a,
++    0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x01, 0x30, 0x31,
++    0x01,
++};
++
++static const uint16_t frame_len_base_48khz[] = {
++    1920, 1920, 2048, 1536, 1536, 960, 960, 1024,
++    768, 768, 512, 384, 384, 2048, 0, 0,
++};
++
++static const uint8_t frame_len_base_idx_48khz[] = {
++    1, 1, 0, 2, 2, 4, 4, 3, 5, 5, 6, 7, 7, 0, 0, 0,
++};
++
++static const uint16_t transf_length_48khz_2048[] = {
++    128, 256, 512, 1024, 2048,
++};
++
++static const uint16_t transf_length_48khz_1920[] = {
++    120, 240, 480, 960, 1920,
++};
++
++static const uint16_t transf_length_48khz_1536[] = {
++    96, 192, 384, 768, 1536,
++};
++
++static const uint16_t transf_length_48khz_1024[] = {
++    128, 256, 512, 1024, 1024,
++};
++
++static const uint16_t transf_length_48khz_960[] = {
++    120, 240, 480, 960, 960,
++};
++
++static const uint16_t transf_length_48khz_768[] = {
++    96, 192, 384, 768, 768,
++};
++
++static const uint16_t transf_length_48khz_512[] = {
++    128, 256, 512, 512, 512,
++};
++
++static const uint16_t transf_length_48khz_384[] = {
++    96, 192, 384, 384, 384,
++};
++
++static const uint16_t *transf_length_48khz[8] = {
++    transf_length_48khz_2048,
++    transf_length_48khz_1920,
++    transf_length_48khz_1536,
++    transf_length_48khz_1024,
++    transf_length_48khz_960,
++    transf_length_48khz_768,
++    transf_length_48khz_512,
++    transf_length_48khz_384,
++};
++
++static const float kbd_window_alpha[8][5] = {
++    { 6.f, 5.f, 4.5f, 4.f, 3.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 3.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 3.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 4.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 4.0f },
++    { 6.f, 5.f, 4.5f, 4.f, 4.0f },
++    { 6.f, 5.f, 4.5f, 0.f, 4.5f },
++    { 6.f, 5.f, 4.5f, 0.f, 4.5f },
++};
++
++static const uint8_t n_grp_bits_a[4][4] = {
++    { 15, 10, 8, 7 },
++    { 10,  7, 4, 3 },
++    {  8,  4, 3, 1 },
++    {  7,  3, 1, 1 },
++};
++
++static const uint8_t n_grp_bits_b[4] = {
++    7, 3, 1, 0,
++};
++
++static const uint8_t n_grp_bits_c[4] = {
++    3, 1, 0, 0,
++};
++
++static const uint8_t channel_mode_bits[] = {
++    1, 2, 4, 4, 4, 7, 7, 7, 7, 7, 7, 8, 8, 9, 9, 9, 9,
++};
++
++static const uint16_t channel_mode_codes[] = {
++    0, 2, 12, 13, 14, 120, 121, 122, 123, 124, 125, 252, 253, 508, 509, 510, 511,
++};
++
++static const uint8_t bitrate_indicator_bits[] = {
++    3, 3, 3, 3, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
++};
++
++static const uint8_t bitrate_indicator_codes[] = {
++    0, 2, 4, 6, 4, 5, 6, 7, 12, 13, 14, 15, 20, 21, 22, 23, 28, 29, 30, 31,
++};
++
++static const uint8_t asf_codebook_dim[] = {
++    4, 4, 4, 4, 2, 2, 2, 2, 2, 2, 2,
++};
++
++static const uint8_t asf_codebook_unsigned[] = {
++    0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1,
++};
++
++static const uint8_t asf_codebook_off[] = {
++    1, 1, 0, 0, 4, 4, 0, 0, 0, 0, 0,
++};
++
++static const uint8_t asf_codebook_mod[] = {
++    3, 3, 3, 3, 9, 9, 8, 8, 13, 13, 17,
++};
++
++static const uint8_t asf_codebook_1_bits[81] = {
++     9,  9, 12, 10,  7, 10, 12, 10, 11, 10,  7, 10,  7,  5,  7,  9,
++     7, 10, 11,  8,  9,  9,  7,  9, 11, 10, 12,  9,  7, 10,  7,  5,
++     7,  9,  7, 10,  7,  5,  7,  5,  1,  5,  7,  5,  7, 10,  7,  8,
++     7,  5,  7, 10,  7,  9, 12, 10, 11,  9,  7, 10,  9,  8, 12, 10,
++     7,  9,  7,  5,  7,  9,  7, 10, 12, 10, 12, 10,  7, 10, 12,  9,
++     9,
++};
++
++static const uint8_t asf_codebook_1_codes[81] = {
++    0x0b, 0x0c, 0x00, 0x04, 0x08, 0x05, 0x01, 0x06, 0x04, 0x07, 0x09, 0x08, 0x0a, 0x08, 0x0b, 0x0d,
++    0x0c, 0x09, 0x05, 0x0d, 0x0e, 0x0f, 0x0d, 0x10, 0x06, 0x0a, 0x02, 0x11, 0x0e, 0x0b, 0x0f, 0x09,
++    0x10, 0x12, 0x11, 0x0c, 0x12, 0x0a, 0x13, 0x0b, 0x01, 0x0c, 0x14, 0x0d, 0x15, 0x0d, 0x16, 0x0e,
++    0x17, 0x0e, 0x18, 0x0e, 0x19, 0x13, 0x03, 0x0f, 0x07, 0x14, 0x1a, 0x10, 0x15, 0x0f, 0x04, 0x11,
++    0x1b, 0x16, 0x1c, 0x0f, 0x1d, 0x17, 0x1e, 0x12, 0x05, 0x13, 0x06, 0x14, 0x1f, 0x15, 0x07, 0x18,
++    0x19,
++};
++
++static const uint8_t asf_codebook_2_bits[81] = {
++     8,  7,  9,  8,  6,  8,  9,  8,  9,  8,  6,  7,  6,  5,  6,  7,
++     6,  8,  9,  7,  7,  7,  6,  7,  9,  8,  9,  8,  6,  8,  6,  5,
++     6,  7,  6,  8,  6,  5,  6,  5,  3,  5,  6,  5,  6,  8,  6,  7,
++     6,  5,  6,  8,  6,  8,  9,  8,  9,  8,  6,  7,  7,  7,  9,  8,
++     6,  7,  6,  4,  6,  8,  6,  8,  9,  8,  9,  8,  6,  8,  9,  7,
++     8,
++};
++
++static const uint8_t asf_codebook_2_codes[81] = {
++    0x06, 0x0e, 0x00, 0x07, 0x0e, 0x08, 0x01, 0x09, 0x02, 0x0a, 0x0f, 0x0f, 0x10, 0x13, 0x11, 0x10,
++    0x12, 0x0b, 0x03, 0x11, 0x12, 0x13, 0x13, 0x14, 0x04, 0x0c, 0x05, 0x0d, 0x14, 0x0e, 0x15, 0x14,
++    0x16, 0x15, 0x17, 0x0f, 0x18, 0x15, 0x19, 0x16, 0x07, 0x17, 0x1a, 0x18, 0x1b, 0x10, 0x1c, 0x16,
++    0x1d, 0x19, 0x1e, 0x11, 0x1f, 0x12, 0x06, 0x13, 0x07, 0x14, 0x20, 0x17, 0x18, 0x19, 0x08, 0x15,
++    0x21, 0x1a, 0x22, 0x0d, 0x23, 0x16, 0x24, 0x17, 0x09, 0x18, 0x0a, 0x19, 0x25, 0x1a, 0x0b, 0x1b,
++    0x1b,
++};
++
++static const uint8_t asf_codebook_3_bits[81] = {
++     1,  4,  9,  4,  5,  9, 10, 10, 12,  4,  6, 10,  5,  6,  9, 10,
++     9, 11, 10, 11, 14, 10, 10, 12, 12, 11, 13,  4,  6, 11,  6,  7,
++    10, 11, 10, 12,  5,  7, 11,  6,  6, 10, 10,  9, 11,  9, 10, 13,
++     9,  9, 12, 11, 11, 12,  9, 10, 15, 10, 11, 15, 14, 13, 15,  9,
++    10, 14,  9, 10, 13, 13, 12, 14, 11, 12, 15, 11, 11, 14, 13, 12,
++    14,
++};
++
++static const uint8_t asf_codebook_3_codes[81] = {
++    0x01, 0x04, 0x0d, 0x05, 0x05, 0x0e, 0x0a, 0x0b, 0x05, 0x06, 0x04, 0x0c, 0x06, 0x05, 0x0f, 0x0d,
++    0x10, 0x07, 0x0e, 0x08, 0x02, 0x0f, 0x10, 0x06, 0x07, 0x09, 0x04, 0x07, 0x06, 0x0a, 0x07, 0x06,
++    0x11, 0x0b, 0x12, 0x08, 0x07, 0x07, 0x0c, 0x08, 0x09, 0x13, 0x14, 0x11, 0x0d, 0x12, 0x15, 0x05,
++    0x13, 0x14, 0x09, 0x0e, 0x0f, 0x0a, 0x15, 0x16, 0x00, 0x17, 0x10, 0x01, 0x03, 0x06, 0x02, 0x16,
++    0x18, 0x04, 0x17, 0x19, 0x07, 0x08, 0x0b, 0x05, 0x11, 0x0c, 0x03, 0x12, 0x13, 0x06, 0x09, 0x0d,
++    0x07,
++};
++
++static const uint8_t asf_codebook_4_bits[81] = {
++     4,  4,  9,  5,  4,  8,  9,  8, 11,  4,  5,  8,  5,  4,  8,  8,
++     8, 10,  9,  9, 11,  8,  8, 10, 11, 10, 12,  4,  5,  8,  5,  4,
++     8,  9,  8, 10,  4,  4,  8,  4,  4,  7,  8,  7,  9,  8,  8, 11,
++     8,  7, 10, 10,  9, 10,  9,  8, 11,  8,  8, 11, 11, 10, 12,  8,
++     8, 11,  8,  7, 10, 10,  9, 11, 11, 10, 12, 10,  9, 11, 12, 10,
++    11,
++};
++
++static const uint8_t asf_codebook_4_codes[81] = {
++    0x05, 0x06, 0x0a, 0x05, 0x07, 0x0a, 0x0b, 0x0b, 0x02, 0x08, 0x06, 0x0c, 0x07, 0x09, 0x0d, 0x0e,
++    0x0f, 0x07, 0x0c, 0x0d, 0x03, 0x10, 0x11, 0x08, 0x04, 0x09, 0x00, 0x0a, 0x08, 0x12, 0x09, 0x0b,
++    0x13, 0x0e, 0x14, 0x0a, 0x0c, 0x0d, 0x15, 0x0e, 0x0f, 0x10, 0x16, 0x11, 0x0f, 0x17, 0x18, 0x05,
++    0x19, 0x12, 0x0b, 0x0c, 0x10, 0x0d, 0x11, 0x1a, 0x06, 0x1b, 0x1c, 0x07, 0x08, 0x0e, 0x01, 0x1d,
++    0x1e, 0x09, 0x1f, 0x13, 0x0f, 0x10, 0x12, 0x0a, 0x0b, 0x11, 0x02, 0x12, 0x13, 0x0c, 0x03, 0x13,
++    0x0d,
++};
++
++static const uint8_t asf_codebook_5_bits[81] = {
++    14, 13, 12, 12, 11, 11, 12, 13, 14, 13, 12, 10,  9,  9,  9, 10,
++    11, 13, 13, 10,  9,  8,  7,  7,  9, 10, 12, 12,  9,  8,  5,  4,
++     5,  7,  9, 12, 12,  9,  7,  4,  1,  4,  7,  9, 12, 11,  9,  7,
++     5,  4,  5,  8,  9, 12, 12, 10,  9,  7,  7,  8,  9, 10, 12, 13,
++    11, 10,  9,  9, 10, 10, 12, 13, 14, 12, 12, 12, 11, 11, 12, 13,
++    14,
++};
++
++static const uint8_t asf_codebook_5_codes[81] = {
++    0x00, 0x02, 0x05, 0x06, 0x0b, 0x0c, 0x07, 0x03, 0x01, 0x04, 0x08, 0x09, 0x09, 0x0a, 0x0b, 0x0a,
++    0x0d, 0x05, 0x06, 0x0b, 0x0c, 0x0c, 0x08, 0x09, 0x0d, 0x0c, 0x09, 0x0a, 0x0e, 0x0d, 0x04, 0x04,
++    0x05, 0x0a, 0x0f, 0x0b, 0x0c, 0x10, 0x0b, 0x05, 0x01, 0x06, 0x0c, 0x11, 0x0d, 0x0e, 0x12, 0x0d,
++    0x06, 0x07, 0x07, 0x0e, 0x13, 0x0e, 0x0f, 0x0d, 0x14, 0x0e, 0x0f, 0x0f, 0x15, 0x0e, 0x10, 0x07,
++    0x0f, 0x0f, 0x16, 0x17, 0x10, 0x11, 0x11, 0x08, 0x02, 0x12, 0x13, 0x14, 0x10, 0x11, 0x15, 0x09,
++    0x03,
++};
++
++static const uint8_t asf_codebook_6_bits[81] = {
++    12, 11, 10, 10, 10, 10, 10, 11, 12, 11,  9,  8,  8,  8,  8,  8,
++     9, 11, 10,  8,  6,  6,  6,  5,  6,  8, 10, 10,  8,  6,  4,  4,
++     4,  5,  8, 10, 10,  8,  6,  4,  4,  4,  6,  8, 10, 10,  8,  5,
++     4,  4,  4,  6,  8, 10, 10,  8,  6,  5,  6,  5,  6,  8, 11, 11,
++     9,  8,  8,  8,  8,  8,  9, 11, 12, 11, 10, 10, 11, 10, 10, 11,
++    12,
++};
++
++static const uint8_t asf_codebook_6_codes[81] = {
++    0x00, 0x02, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x03, 0x01, 0x04, 0x0c, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
++    0x0d, 0x05, 0x0b, 0x0d, 0x07, 0x08, 0x09, 0x09, 0x0a, 0x0e, 0x0c, 0x0d, 0x0f, 0x0b, 0x07, 0x08,
++    0x09, 0x0a, 0x10, 0x0e, 0x0f, 0x11, 0x0c, 0x0a, 0x0b, 0x0c, 0x0d, 0x12, 0x10, 0x11, 0x13, 0x0b,
++    0x0d, 0x0e, 0x0f, 0x0e, 0x14, 0x12, 0x13, 0x15, 0x0f, 0x0c, 0x10, 0x0d, 0x11, 0x16, 0x06, 0x07,
++    0x0e, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x0f, 0x08, 0x02, 0x09, 0x14, 0x15, 0x0a, 0x16, 0x17, 0x0b,
++    0x03,
++};
++
++static const uint8_t asf_codebook_7_bits[64] = {
++     1,  3,  6,  8,  9,  9, 10, 11,  3,  4,  6,  7,  8,  8,  9, 10,
++     6,  5,  7,  8,  8,  9, 10, 11,  8,  7,  8,  8,  9,  9, 10, 11,
++     9,  8,  8,  9, 10, 10, 10, 11,  9,  8,  9,  9, 10, 10, 11, 12,
++    10,  9, 10, 10, 10, 11, 12, 12, 12, 10, 11, 11, 12, 12, 12, 12,
++};
++
++static const uint8_t asf_codebook_7_codes[64] = {
++    0x01, 0x02, 0x07, 0x0b, 0x0a, 0x0b, 0x06, 0x04, 0x03, 0x03, 0x08, 0x0b, 0x0c, 0x0d, 0x0c, 0x07,
++    0x09, 0x05, 0x0c, 0x0e, 0x0f, 0x0d, 0x08, 0x05, 0x10, 0x0d, 0x11, 0x12, 0x0e, 0x0f, 0x09, 0x06,
++    0x10, 0x13, 0x14, 0x11, 0x0a, 0x0b, 0x0c, 0x07, 0x12, 0x15, 0x13, 0x14, 0x0d, 0x0e, 0x08, 0x00,
++    0x0f, 0x15, 0x10, 0x11, 0x12, 0x09, 0x01, 0x02, 0x03, 0x13, 0x0a, 0x0b, 0x04, 0x05, 0x06, 0x07,
++};
++
++static const uint8_t asf_codebook_8_bits[64] = {
++     4,  4,  5,  6,  7,  8,  9, 10,  4,  3,  4,  5,  6,  7,  8,  9,
++     5,  4,  4,  5,  6,  7,  8,  9,  6,  5,  5,  5,  6,  7,  8,  9,
++     7,  6,  6,  6,  7,  7,  9, 10,  8,  7,  7,  7,  7,  8,  9, 10,
++     9,  8,  8,  8,  8,  9,  9, 10, 11,  9,  9,  9, 10, 10, 10, 11,
++};
++
++static const uint8_t asf_codebook_8_codes[64] = {
++    0x08, 0x09, 0x09, 0x0a, 0x09, 0x08, 0x04, 0x01, 0x0a, 0x07, 0x0b, 0x0a, 0x0b, 0x0a, 0x09, 0x05,
++    0x0b, 0x0c, 0x0d, 0x0c, 0x0c, 0x0b, 0x0a, 0x06, 0x0d, 0x0d, 0x0e, 0x0f, 0x0e, 0x0c, 0x0b, 0x07,
++    0x0d, 0x0f, 0x10, 0x11, 0x0e, 0x0f, 0x08, 0x02, 0x0c, 0x10, 0x11, 0x12, 0x13, 0x0d, 0x09, 0x03,
++    0x0a, 0x0e, 0x0f, 0x10, 0x11, 0x0b, 0x0c, 0x04, 0x00, 0x0d, 0x0e, 0x0f, 0x05, 0x06, 0x07, 0x01,
++};
++
++static const uint8_t asf_codebook_9_bits[169] = {
++     1,  3,  6,  8,  9, 10, 10, 11, 11, 12, 12, 12, 13,  3,  4,  6,
++     7,  8,  9,  9, 10, 10, 11, 11, 11, 12,  6,  6,  7,  8,  9,  9,
++    10, 10, 10, 11, 11, 12, 12,  8,  7,  8,  9,  9, 10, 10, 11, 11,
++    11, 12, 12, 12,  9,  8,  9,  9, 10, 10, 11, 11, 11, 12, 12, 12,
++    13, 10,  9,  9, 10, 10, 10, 11, 11, 11, 12, 12, 12, 13, 10,  9,
++    10, 10, 11, 11, 11, 12, 12, 12, 12, 13, 13, 11, 10, 10, 11, 11,
++    12, 12, 12, 12, 12, 13, 13, 13, 11, 10, 10, 11, 11, 11, 12, 12,
++    12, 13, 13, 13, 14, 12, 11, 11, 11, 11, 12, 12, 12, 13, 13, 13,
++    14, 14, 12, 11, 11, 12, 12, 12, 12, 13, 13, 13, 13, 14, 14, 12,
++    11, 11, 12, 12, 12, 13, 13, 13, 13, 13, 14, 14, 13, 12, 12, 12,
++    13, 13, 13, 13, 14, 14, 14, 14, 14,
++};
++
++static const uint8_t asf_codebook_9_codes[169] = {
++    0x01, 0x02, 0x08, 0x14, 0x1b, 0x20, 0x21, 0x1e, 0x1f, 0x11, 0x12, 0x13, 0x06, 0x03, 0x03, 0x09,
++    0x0d, 0x15, 0x1c, 0x1d, 0x22, 0x23, 0x20, 0x21, 0x22, 0x14, 0x0a, 0x0b, 0x0e, 0x16, 0x1e, 0x1f,
++    0x24, 0x25, 0x26, 0x23, 0x24, 0x15, 0x16, 0x17, 0x0f, 0x18, 0x20, 0x21, 0x27, 0x28, 0x25, 0x26,
++    0x27, 0x17, 0x18, 0x19, 0x22, 0x19, 0x23, 0x24, 0x29, 0x2a, 0x28, 0x29, 0x2a, 0x1a, 0x1b, 0x1c,
++    0x07, 0x2b, 0x25, 0x26, 0x2c, 0x2d, 0x2e, 0x2b, 0x2c, 0x2d, 0x1d, 0x1e, 0x1f, 0x08, 0x2f, 0x27,
++    0x30, 0x31, 0x2e, 0x2f, 0x30, 0x20, 0x21, 0x22, 0x23, 0x09, 0x0a, 0x31, 0x32, 0x33, 0x32, 0x33,
++    0x24, 0x25, 0x26, 0x27, 0x28, 0x0b, 0x0c, 0x0d, 0x34, 0x34, 0x35, 0x35, 0x36, 0x37, 0x29, 0x2a,
++    0x2b, 0x0e, 0x0f, 0x10, 0x00, 0x2c, 0x38, 0x39, 0x3a, 0x3b, 0x2d, 0x2e, 0x2f, 0x11, 0x12, 0x13,
++    0x01, 0x02, 0x30, 0x3c, 0x3d, 0x31, 0x32, 0x33, 0x34, 0x14, 0x15, 0x16, 0x17, 0x03, 0x04, 0x35,
++    0x3e, 0x3f, 0x36, 0x37, 0x38, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x05, 0x06, 0x1d, 0x39, 0x3a, 0x3b,
++    0x1e, 0x1f, 0x20, 0x21, 0x07, 0x08, 0x09, 0x0a, 0x0b,
++};
++
++static const uint8_t asf_codebook_10_bits[169] = {
++     6,  5,  6,  6,  7,  8,  9, 10, 10, 11, 11, 12, 12,  5,  4,  4,
++     5,  6,  7,  7,  8,  9, 10, 10, 10, 11,  6,  4,  4,  5,  6,  6,
++     7,  8,  9,  9, 10, 10, 11,  6,  5,  5,  5,  6,  7,  7,  8,  8,
++     9, 10, 10, 11,  7,  6,  6,  6,  6,  7,  7,  8,  9,  9, 10, 10,
++    11,  8,  7,  6,  7,  7,  7,  8,  8,  9,  9, 10, 10, 11,  9,  7,
++     7,  7,  7,  8,  8,  9,  9, 10, 10, 10, 12, 10,  8,  8,  8,  8,
++     8,  9,  9,  9, 10, 10, 11, 12, 10,  8,  8,  8,  8,  9,  9,  9,
++    10, 10, 10, 11, 12, 11,  9,  9,  9,  9,  9, 10, 10, 10, 10, 11,
++    11, 13, 11, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 13, 12,
++    10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 12, 12, 12, 11, 11, 11,
++    11, 11, 11, 11, 12, 12, 13, 12, 13,
++};
++
++static const uint8_t asf_codebook_10_codes[169] = {
++    0x14, 0x11, 0x15, 0x16, 0x17, 0x1a, 0x1d, 0x11, 0x12, 0x07, 0x08, 0x02, 0x03, 0x12, 0x0c, 0x0d,
++    0x13, 0x17, 0x18, 0x19, 0x1b, 0x1e, 0x13, 0x14, 0x15, 0x09, 0x18, 0x0e, 0x0f, 0x14, 0x19, 0x1a,
++    0x1a, 0x1c, 0x1f, 0x20, 0x16, 0x17, 0x0a, 0x1b, 0x15, 0x16, 0x17, 0x1c, 0x1b, 0x1c, 0x1d, 0x1e,
++    0x21, 0x18, 0x19, 0x0b, 0x1d, 0x1d, 0x1e, 0x1f, 0x20, 0x1e, 0x1f, 0x1f, 0x22, 0x23, 0x1a, 0x1b,
++    0x0c, 0x20, 0x20, 0x21, 0x21, 0x22, 0x23, 0x21, 0x22, 0x24, 0x25, 0x1c, 0x1d, 0x0d, 0x26, 0x24,
++    0x25, 0x26, 0x27, 0x23, 0x24, 0x27, 0x28, 0x1e, 0x1f, 0x20, 0x04, 0x21, 0x25, 0x26, 0x27, 0x28,
++    0x29, 0x29, 0x2a, 0x2b, 0x22, 0x23, 0x0e, 0x05, 0x24, 0x2a, 0x2b, 0x2c, 0x2d, 0x2c, 0x2d, 0x2e,
++    0x25, 0x26, 0x27, 0x0f, 0x06, 0x10, 0x2f, 0x30, 0x31, 0x32, 0x33, 0x28, 0x29, 0x2a, 0x2b, 0x11,
++    0x12, 0x00, 0x13, 0x2c, 0x2d, 0x2e, 0x2f, 0x30, 0x31, 0x32, 0x14, 0x15, 0x16, 0x17, 0x01, 0x07,
++    0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x18, 0x19, 0x1a, 0x08, 0x09, 0x0a, 0x1b, 0x1c, 0x1d,
++    0x1e, 0x1f, 0x20, 0x21, 0x0b, 0x0c, 0x02, 0x0d, 0x03,
++};
++
++static const uint8_t asf_codebook_11_bits[289] = {
++     3,  4,  6,  7,  8,  9,  9, 10, 10, 11, 11, 11, 12, 12, 12, 12,
++    10,  4,  4,  5,  6,  7,  8,  8,  9,  9,  9,  9, 10, 10, 10, 11,
++    11,  9,  6,  5,  6,  6,  7,  7,  8,  8,  9,  9,  9,  9, 10, 10,
++    10, 11,  8,  7,  6,  6,  7,  7,  7,  8,  8,  9,  9,  9,  9, 10,
++    10, 10, 11,  8,  8,  7,  7,  7,  7,  8,  8,  9,  9,  9,  9, 10,
++    10, 10, 10, 11,  8,  9,  7,  7,  7,  8,  8,  8,  9,  9,  9, 10,
++    10, 10, 10, 11, 11,  8,  9,  8,  8,  8,  8,  8,  9,  9,  9, 10,
++    10, 10, 10, 10, 11, 11,  8, 10,  9,  8,  8,  8,  9,  9,  9,  9,
++    10, 10, 10, 11, 11, 11, 11,  9, 10,  9,  9,  9,  9,  9,  9,  9,
++    10, 10, 10, 10, 11, 11, 11, 11,  9, 11,  9,  9,  9,  9,  9, 10,
++    10, 10, 10, 10, 10, 11, 11, 11, 12,  9, 11,  9,  9,  9,  9, 10,
++    10, 10, 10, 10, 10, 11, 11, 11, 11, 12,  9, 11, 10,  9,  9,  9,
++    10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12,  9, 12, 10, 10, 10,
++    10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 12, 12,  9, 11, 10, 10,
++    10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12, 12, 12,  9, 12, 11,
++    10, 10, 10, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12,  9, 12,
++    11, 11, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12,  9,
++    10,  8,  8,  8,  8,  8,  8,  8,  9,  9,  9,  9,  9,  9,  9,  9,
++     5,
++};
++
++static const uint8_t asf_codebook_11_codes[289] = {
++    0x07, 0x0b, 0x1f, 0x2f, 0x3d, 0x36, 0x37, 0x26, 0x27, 0x0d, 0x0e, 0x0f, 0x00, 0x01, 0x02, 0x03,
++    0x28, 0x0c, 0x0d, 0x13, 0x20, 0x30, 0x3e, 0x3f, 0x38, 0x39, 0x3a, 0x3b, 0x29, 0x2a, 0x2b, 0x10,
++    0x11, 0x3c, 0x21, 0x14, 0x22, 0x23, 0x31, 0x32, 0x40, 0x41, 0x3d, 0x3e, 0x3f, 0x40, 0x2c, 0x2d,
++    0x2e, 0x12, 0x42, 0x33, 0x24, 0x25, 0x34, 0x35, 0x36, 0x43, 0x44, 0x41, 0x42, 0x43, 0x44, 0x2f,
++    0x30, 0x31, 0x13, 0x45, 0x46, 0x37, 0x38, 0x39, 0x3a, 0x47, 0x48, 0x45, 0x46, 0x47, 0x48, 0x32,
++    0x33, 0x34, 0x35, 0x14, 0x49, 0x49, 0x3b, 0x3c, 0x3d, 0x4a, 0x4b, 0x4c, 0x4a, 0x4b, 0x4c, 0x36,
++    0x37, 0x38, 0x39, 0x15, 0x16, 0x4d, 0x4d, 0x4e, 0x4f, 0x50, 0x51, 0x52, 0x4e, 0x4f, 0x50, 0x3a,
++    0x3b, 0x3c, 0x3d, 0x3e, 0x17, 0x18, 0x53, 0x3f, 0x51, 0x54, 0x55, 0x56, 0x52, 0x53, 0x54, 0x55,
++    0x40, 0x41, 0x42, 0x19, 0x1a, 0x1b, 0x1c, 0x56, 0x43, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d,
++    0x44, 0x45, 0x46, 0x47, 0x1d, 0x1e, 0x1f, 0x20, 0x5e, 0x21, 0x5f, 0x60, 0x61, 0x62, 0x63, 0x48,
++    0x49, 0x4a, 0x4b, 0x4c, 0x4d, 0x22, 0x23, 0x24, 0x04, 0x64, 0x25, 0x65, 0x66, 0x67, 0x68, 0x4e,
++    0x4f, 0x50, 0x51, 0x52, 0x53, 0x26, 0x27, 0x28, 0x29, 0x05, 0x69, 0x2a, 0x54, 0x6a, 0x6b, 0x6c,
++    0x55, 0x56, 0x57, 0x58, 0x59, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x06, 0x6d, 0x07, 0x5a, 0x5b, 0x5c,
++    0x5d, 0x5e, 0x5f, 0x60, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x08, 0x09, 0x6e, 0x36, 0x61, 0x62,
++    0x63, 0x64, 0x65, 0x66, 0x67, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x0a, 0x0b, 0x0c, 0x6f, 0x0d, 0x3c,
++    0x68, 0x69, 0x6a, 0x3d, 0x3e, 0x3f, 0x40, 0x41, 0x42, 0x43, 0x0e, 0x0f, 0x10, 0x11, 0x70, 0x12,
++    0x44, 0x45, 0x46, 0x47, 0x48, 0x49, 0x4a, 0x4b, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x71,
++    0x6b, 0x57, 0x58, 0x59, 0x5a, 0x5b, 0x5c, 0x5d, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78, 0x79,
++    0x15,
++};
++
++static const uint16_t sfb_offset_48khz_2048[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40,
++    44, 52, 60, 68, 76, 84, 92, 100, 108, 116,
++    124, 136, 148, 160, 172, 188, 204, 220, 240,
++    260, 284, 308, 336, 364, 396, 432, 468, 508,
++    552, 600, 652, 704, 768, 832, 896, 960, 1024,
++    1088, 1152, 1216, 1280, 1344, 1408, 1472, 1536,
++    1600, 1664, 1728, 1792, 1856, 1920, 1984, 2048,
++    2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072,
++    3200, 3328, 3456, 3584, 3712, 3840, 3968, 4096,
++    4224, 4352, 4480, 4608, 4736, 4864, 4992, 5120,
++    5248, 5376, 5504, 5632, 5760, 5888, 6016, 6144,
++    6272, 6400, 6528, 6656, 6784, 6912, 7040, 7168,
++    7296, 7424, 7552, 7680, 7808, 7936, 8064, 8192,
++};
++
++static const uint16_t sfb_offset_48khz_1920[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 52, 60, 68,
++    76, 84, 92, 100, 108, 116, 124, 136, 148, 160, 172, 188,
++    204, 220, 240, 260, 284, 308, 336, 364, 396, 432, 468,
++    508, 552, 600, 652, 704, 768, 832, 896, 960, 1024, 1088,
++    1152, 1216, 1280, 1344, 1408, 1472, 1536, 1600, 1664, 1728,
++    1792, 1856, 1920, 2048, 2176, 2304, 2432, 2560, 2688, 2816,
++    2944, 3072, 3200, 3328, 3456, 3584, 3712, 3840, 3968, 4096,
++    4224, 4352, 4480, 4608, 4736, 4864, 4992, 5120, 5248, 5376,
++    5504, 5632, 5760, 5888, 6016, 6144, 6272, 6400, 6528, 6656,
++    6784, 6912, 7040, 7168, 7296, 7424, 7552, 7680,
++};
++
++static const uint16_t sfb_offset_48khz_1536[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40,
++    44, 52, 60, 68, 76, 84, 92, 100, 108, 116,
++    124, 136, 148, 160, 172, 188, 204, 220, 240,
++    260, 284, 308, 336, 364, 396, 432, 468, 508,
++    552, 600, 652, 704, 768, 832, 896, 960, 1024,
++    1088, 1152, 1216, 1280, 1344, 1408, 1472, 1536,
++    1664, 1792, 1920, 2048, 2176, 2304, 2432, 2560,
++    2688, 2816, 2944, 3072, 3200, 3328, 3456, 3584,
++    3712, 3840, 3968, 4096, 4224, 4352, 4480, 4608,
++    4736, 4864, 4992, 5120, 5248, 5376, 5504, 5632,
++    5760, 5888, 6016, 6144,
++};
++
++static const uint16_t sfb_offset_48khz_1024[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48,
++    56, 64, 72, 80, 88, 96, 108, 120, 132, 144,
++    160, 176, 196, 216, 240, 264, 292, 320, 352,
++    384, 416, 448, 480, 512, 544, 576, 608, 640,
++    672, 704, 736, 768, 800, 832, 864, 896, 928,
++    1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920,
++    2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944,
++    3072, 3200, 3328, 3456, 3584, 3712, 3840, 3968,
++    4096,
++};
++
++static const uint16_t sfb_offset_48khz_960[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48, 56, 64, 72,
++    80, 88, 96, 108, 120, 132, 144, 160, 176, 196, 216, 240,
++    264, 292, 320, 352, 384, 416, 448, 480, 512, 544,
++    576, 608, 640, 672, 704, 736, 768, 800, 832, 864, 896,
++    928, 960, 1024, 1152, 1280, 1408, 1536, 1664, 1792, 1920,
++    2048, 2176, 2304, 2432, 2560, 2688, 2816, 2944, 3072,
++    3200, 3328, 3456, 3584, 3712, 3840,
++};
++
++static const uint16_t sfb_offset_48khz_768[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 48,
++    56, 64, 72, 80, 88, 96, 108, 120, 132, 144,
++    160, 176, 196, 216, 240, 264, 292, 320, 352,
++    384, 416, 448, 480, 512, 544, 576, 608, 640,
++    672, 704, 736, 768, 896, 1024, 1152, 1280, 1408,
++    1536, 1664, 1792, 1920, 2048, 2176, 2304, 2432,
++    2560, 2688, 2816, 2944, 3072,
++};
++
++static const uint16_t sfb_offset_48khz_512[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52,
++    56, 60, 68, 76, 84, 92, 100, 112, 124, 136, 148, 164,
++    184, 208, 236, 268, 300, 332, 364, 396, 428, 460, 512,
++    576, 640, 704, 768, 832, 896, 960, 1024, 1088, 1152,
++    1216, 1280, 1344, 1408, 1472, 1536, 1600, 1664, 1728,
++    1792, 1856, 1920, 1984, 2048,
++};
++
++static const uint16_t sfb_offset_48khz_480[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56,
++    60, 68, 76, 84, 92, 100, 112, 124, 136, 148, 164, 184,
++    208, 236, 268, 300, 332, 364, 396, 428, 460, 480, 512,
++    576, 640, 704, 768, 832, 896, 960, 1024, 1088, 1152,
++    1216, 1280, 1344, 1408, 1472, 1536, 1600, 1664, 1728,
++    1792, 1856, 1920,
++};
++
++static const uint16_t sfb_offset_48khz_384[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52,
++    56, 60, 68, 76, 84, 92, 100, 112, 124, 136, 148, 164,
++    184, 208, 236, 268, 300, 332, 364, 384, 448, 512, 576,
++    640, 704, 768, 832, 896, 960, 1024, 1088, 1152,
++    1216, 1280, 1344, 1408, 1472, 1536,
++};
++
++static const uint16_t sfb_offset_48khz_256[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 36, 44, 52, 64, 76,
++    92, 108, 128, 148, 172, 196, 224, 256, 288, 320,
++    352, 384, 416, 448, 480, 512, 576, 640, 704, 768,
++    832, 896, 960, 1024,
++};
++
++static const uint16_t sfb_offset_48khz_240[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 36, 44, 52, 64, 76, 92, 108,
++    128, 148, 172, 196, 224, 240, 256, 288, 320, 352, 384, 416,
++    448, 480, 512, 576, 640, 704, 768, 832, 896, 960,
++};
++
++static const uint16_t sfb_offset_48khz_192[] = {
++    0, 4, 8, 12, 16, 20, 24, 28, 36, 44, 52, 64, 76,
++    92, 108, 128, 148, 172, 192, 224, 256, 288, 320,
++    352, 384, 448, 512, 576, 640, 704, 768,
++};
++
++static const uint16_t sfb_offset_48khz_128[] = {
++    0, 4, 8, 12, 16, 20, 28, 36, 44, 56, 68, 80, 96, 112,
++    128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320,
++    352, 384, 416, 448, 480, 512,
++};
++
++static const uint16_t sfb_offset_48khz_120[] = {
++    0, 4, 8, 12, 16, 20, 28, 36, 44, 56, 68, 80, 96, 112,
++    120, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288,
++    320, 352, 384, 416, 448, 480,
++};
++
++static const uint16_t sfb_offset_48khz_96[] = {
++    0, 4, 8, 12, 16, 20, 28, 36, 44, 56, 68, 80, 96, 112,
++    128, 144, 160, 176, 192, 224, 256, 288, 320, 352, 384,
++};
++
++static const uint8_t snf_bits[22] = {
++    4, 7, 8, 8, 7, 6, 6, 6, 6, 5, 5, 4, 4, 3, 3, 3, 3, 4, 4, 6, 7, 6,
++};
++
++static const uint8_t snf_codes[22] = {
++    0x03, 0x01, 0x00, 0x01, 0x02, 0x02, 0x03, 0x04,
++    0x05, 0x04, 0x05, 0x04, 0x05, 0x04, 0x05, 0x06,
++    0x07, 0x06, 0x07, 0x06, 0x03, 0x07,
++};
++
++static const uint8_t aspx_int_class_bits[4] = {
++    1, 2, 3, 3,
++};
++
++static const uint8_t aspx_int_class_codes[4] = {
++    0, 2, 6, 7,
++};
++
++static const uint8_t sbg_template_lowres[] = {
++    10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
++    22, 24, 26, 28, 30, 32, 35, 38, 42, 46,
++};
++
++static const uint8_t sbg_template_highres[] = {
++    18, 19, 20, 21, 22, 23, 24, 26, 28, 30, 32, 34,
++    36, 38, 40, 42, 44, 47, 50, 53, 56, 59, 62,
++};
++
++static const int tab_border[5][3][5] = {
++    {
++        { 0, 6, 0, 0, 0, },
++        { 0, 3, 6, 0, 0, },
++        { 0, 2, 3, 4, 6, },
++    },
++    {
++        { 0, 8, 0, 0, 0, },
++        { 0, 4, 8, 0, 0, },
++        { 0, 2, 4, 6, 8, },
++    },
++    {
++        { 0,12, 0, 0, 0, },
++        { 0, 6,12, 0, 0, },
++        { 0, 3, 6, 9,12, },
++    },
++    {
++        { 0,15, 0, 0, 0, },
++        { 0, 8,15, 0, 0, },
++        { 0, 4, 8,12,15, },
++    },
++    {
++        { 0,16, 0, 0, 0, },
++        { 0, 8,16, 0, 0, },
++        { 0, 4, 8,12,16, },
++    },
++};
++
++static const uint8_t qmf_subbands[][4] = {
++    { 0, 0, 0, 0 },
++    { 1, 1, 1, 1 },
++    { 2, 2, 2, 2 },
++    { 3, 3, 3, 2 },
++    { 4, 4, 3, 3 },
++    { 5, 4, 4, 3 },
++    { 6, 5, 4, 3 },
++    { 7, 5, 5, 3 },
++    { 8, 6, 5, 4 },
++    { 9, 6, 6, 4 },
++    {10, 7, 6, 4 },
++    {11, 8, 7, 5 },
++    {12, 9, 7, 5 },
++    {13,10, 8, 6 },
++    {14,11, 8, 6 },
++};
++
++static const uint8_t acpl_num_param_bands[] = {
++    15, 12, 9, 7,
++};
++
++static const uint8_t acpl_hcb_alpha_coarse_f0_bits[17] = {
++    10, 10,  9,  8,  6,  6,  5,  2,  1,  3,  5,  7,  7,  8,  9, 10,
++    10,
++};
++
++static const uint16_t acpl_hcb_alpha_coarse_f0_codes[17] = {
++    0x0003be, 0x0003fe, 0x0001fe, 0x0000fe, 0x00003e, 0x00003a,
++    0x00001e, 0x000002, 0x000000, 0x000006, 0x00001c, 0x00007e,
++    0x000076, 0x0000ee, 0x0001de, 0x0003ff, 0x0003bf,
++};
++
++static const uint8_t acpl_hcb_alpha_fine_f0_bits[33] = {
++    10, 12, 11, 11, 10, 10,  9,  8,  7,  7,  8,  7,  6,  6,  4,  3,
++     1,  3,  4,  6,  6,  7,  8,  8,  9,  9, 10, 10, 10, 10, 11, 12,
++    10,
++};
++
++static const uint16_t acpl_hcb_alpha_fine_f0_codes[33] = {
++    0x0002ce, 0x000b5e, 0x0004fe, 0x0005ae, 0x00027e, 0x0002de,
++    0x00016a, 0x0000b2, 0x00004a, 0x00004b, 0x0000b6, 0x00004e,
++    0x000024, 0x00002e, 0x00000a, 0x000006, 0x000000, 0x000007,
++    0x000008, 0x00002f, 0x000026, 0x000058, 0x0000b4, 0x00009e,
++    0x00016e, 0x000166, 0x0002df, 0x0002cf, 0x00027c, 0x00027d,
++    0x0004ff, 0x000b5f, 0x0002d6,
++};
++
++static const uint8_t acpl_hcb_alpha_coarse_df_bits[33] = {
++    15, 18, 17, 17, 16, 15, 15, 13, 12, 11, 10,  9,  8,  7,  4,  3,
++     1,  2,  5,  7,  8,  9, 10, 11, 12, 13, 15, 16, 16, 17, 16, 18,
++    15,
++};
++
++static const uint32_t acpl_hcb_alpha_coarse_df_codes[33] = {
++    0x007c76, 0x03e3fe, 0x01f1f6, 0x01f1f7, 0x00f8ea, 0x007c74, 0x007c7c,
++    0x001f1c, 0x000f9e, 0x0007ce, 0x0003e2, 0x0001f0, 0x0000fa, 0x00007e,
++    0x00000e, 0x000006, 0x000000, 0x000002, 0x00001e, 0x00007f, 0x0000fb,
++    0x0001f2, 0x0003e6, 0x0007c6, 0x000f9f, 0x001f1e, 0x007c7e, 0x00f8fe,
++    0x00f8fa, 0x01f1fe, 0x00f8eb, 0x03e3ff, 0x007c77,
++};
++
++static const uint8_t acpl_hcb_alpha_fine_df_bits[65] = {
++    13, 17, 17, 17, 16, 17, 17, 17, 17, 16, 16, 16, 15, 15, 14, 13,
++    13, 12, 12, 11, 11, 11, 10, 10, 10,  9,  8,  7,  7,  5,  4,  3,
++     1,  3,  4,  5,  6,  7,  8,  9,  9, 10, 10, 11, 11, 12, 12, 12,
++    13, 13, 14, 15, 15, 16, 16, 17, 16, 16, 17, 16, 16, 17, 17, 17,
++    13,
++};
++
++static const uint32_t acpl_hcb_alpha_fine_df_codes[65] = {
++    0x0011de, 0x011ffe, 0x013dea, 0x013df6, 0x008eea, 0x013df7, 0x013dee,
++    0x013deb, 0x013dec, 0x008eee, 0x008ffe, 0x009efe, 0x0047fe, 0x004f7c,
++    0x0023fe, 0x0011fe, 0x0013fe, 0x0008f6, 0x0009ee, 0x000476, 0x00047a,
++    0x0004f6, 0x00023a, 0x00027a, 0x00027e, 0x00013e, 0x00009a, 0x00004c,
++    0x00004e, 0x000012, 0x00000a, 0x000006, 0x000000, 0x000007, 0x00000b,
++    0x000010, 0x000022, 0x000046, 0x00009b, 0x00013c, 0x00011c, 0x00023e,
++    0x00023c, 0x0004fe, 0x00047e, 0x0009fe, 0x0008fe, 0x0008f7, 0x0013ff,
++    0x0011df, 0x0027bc, 0x004f7e, 0x004776, 0x009efa, 0x009ef4, 0x013dfe,
++    0x008eeb, 0x008ee8, 0x013dff, 0x008ee9, 0x008eef, 0x011fff, 0x013ded,
++    0x013def, 0x0011dc,
++};
++
++static const uint8_t acpl_hcb_alpha_coarse_dt_bits[33] = {
++    14, 16, 15, 16, 15, 15, 14, 13, 12, 12, 10,  9,  8,  7,  5,  3,
++     1,  2,  4,  7,  8,  9, 10, 11, 12, 13, 14, 15, 15, 16, 15, 16,
++    14,
++};
++
++static const uint32_t acpl_hcb_alpha_coarse_dt_codes[33] = {
++    0x003efc, 0x00fbfa, 0x007ddc, 0x00fbfe, 0x007dde, 0x007dfc, 0x003ef6,
++    0x001f76, 0x000fba, 0x000fbe, 0x0003ec, 0x0001f2, 0x0000f8, 0x00007e,
++    0x00001e, 0x000006, 0x000000, 0x000002, 0x00000e, 0x00007f, 0x0000fa,
++    0x0001f3, 0x0003ed, 0x0007dc, 0x000fbc, 0x001f7a, 0x003ef7, 0x007dfe,
++    0x007ddf, 0x00fbff, 0x007ddd, 0x00fbfb, 0x003efd,
++};
++
++static const uint8_t acpl_hcb_alpha_fine_dt_bits[65] = {
++    16, 18, 18, 18, 17, 17, 17, 18, 17, 17, 17, 16, 16, 16, 15, 15,
++    14, 14, 13, 13, 13, 12, 11, 11, 10, 10,  9,  9,  7,  6,  5,  3,
++     1,  2,  5,  6,  7,  9,  9, 10, 10, 11, 11, 12, 12, 13, 13, 14,
++    14, 15, 15, 16, 16, 16, 17, 17, 17, 17, 17, 18, 17, 18, 18, 18,
++    16,
++};
++
++static const uint32_t acpl_hcb_alpha_fine_dt_codes[65] = {
++    0x00eeee, 0x03b3ee, 0x03b3f6, 0x03b3fc, 0x01d9bc, 0x01d9bd, 0x01d9b2,
++    0x03b3fe, 0x01d9be, 0x01d9f6, 0x01d9fc, 0x00ecda, 0x00ecfa, 0x00eeef,
++    0x00766e, 0x007776, 0x003b3a, 0x003bba, 0x001d9a, 0x001ddc, 0x001dde,
++    0x000eec, 0x000764, 0x000772, 0x0003b0, 0x0003b8, 0x0001da, 0x0001de,
++    0x000072, 0x000038, 0x00001e, 0x000006, 0x000000, 0x000002, 0x00001f,
++    0x00003a, 0x000073, 0x0001df, 0x0001db, 0x0003ba, 0x0003b1, 0x000773,
++    0x000765, 0x000eed, 0x000ecc, 0x001d9e, 0x001d9c, 0x003bbe, 0x003b3b,
++    0x00777e, 0x00767c, 0x00eefe, 0x00ecfc, 0x00ecd8, 0x01d9fd, 0x01d9fa,
++    0x01d9bf, 0x01d9b6, 0x01d9b3, 0x03b3fd, 0x01d9b7, 0x03b3ff, 0x03b3ef,
++    0x03b3f7, 0x00eeff,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_f0_bits[5] = {
++     1,  2,  3,  4,  4,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_f0_codes[5] = {
++    0x000000, 0x000002, 0x000006, 0x00000e, 0x00000f,
++};
++
++static const uint8_t acpl_hcb_beta_fine_f0_bits[9] = {
++     1,  2,  3,  4,  5,  6,  7,  8,  8,
++};
++
++static const uint8_t acpl_hcb_beta_fine_f0_codes[9] = {
++    0x000000, 0x000002, 0x000006, 0x00000e, 0x00001e, 0x00003e, 0x00007e, 0x0000fe, 0x0000ff,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_df_bits[9] = {
++     8,  6,  4,  3,  1,  2,  5,  7,  8,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_df_codes[9] = {
++    0x0000fe, 0x00003e, 0x00000e, 0x000006, 0x000000, 0x000002, 0x00001e, 0x00007e, 0x0000ff,
++};
++
++static const uint8_t acpl_hcb_beta_fine_df_bits[17] = {
++    13, 12, 10,  9,  8,  7,  5,  3,  1,  2,  4,  7,  8,  9,  9, 11,
++    13,
++};
++
++static const uint32_t acpl_hcb_beta_fine_df_codes[17] = {
++    0x001f1e, 0x000f8e, 0x0003e2, 0x0001f2, 0x0000fa, 0x00007e,
++    0x00001e, 0x000006, 0x000000, 0x000002, 0x00000e, 0x00007f,
++    0x0000fb, 0x0001f3, 0x0001f0, 0x0007c6, 0x001f1f,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_dt_bits[9] = {
++     8,  7,  5,  3,  1,  2,  4,  6,  8,
++};
++
++static const uint8_t acpl_hcb_beta_coarse_dt_codes[9] = {
++    0x0000fe, 0x00007e, 0x00001e, 0x000006, 0x000000, 0x000002, 0x00000e, 0x00003e, 0x0000ff,
++};
++
++static const uint8_t acpl_hcb_beta_fine_dt_bits[17] = {
++    15, 14, 12, 10,  8,  7,  5,  3,  1,  2,  4,  7,  7,  9, 11, 13,
++    15,
++};
++
++static const uint32_t acpl_hcb_beta_fine_dt_codes[17] = {
++    0x007dfe, 0x003efe, 0x000fbe, 0x0003ee, 0x0000fa,
++    0x00007e, 0x00001e, 0x000006, 0x000000, 0x000002,
++    0x00000e, 0x00007f, 0x00007c, 0x0001f6, 0x0007de,
++    0x001f7e, 0x007dff,
++};
++
++static const uint8_t acpl_hcb_beta3_coarse_f0_bits[9] = {
++     5,  3,  3,  2,  2,  3,  4,  6,  6,
++};
++
++static const uint8_t acpl_hcb_beta3_coarse_f0_codes[9] = {
++    0x000001, 0x000006, 0x000007, 0x000001, 0x000002, 0x000001, 0x000001, 0x000001, 0x000000,
++};
++
++static const uint8_t acpl_hcb_beta3_fine_f0_bits[17] = {
++     7,  5,  4,  4,  4,  3,  3,  3,  3,  3,  4,  5,  6,  6,  7,  7,
++     7,
++};
++
++static const uint8_t acpl_hcb_beta3_fine_f0_codes[17] = {
++    0x00000d, 0x000002, 0x000000, 0x00000c, 0x00000e, 0x000001, 0x000003,
++    0x000005, 0x000004, 0x000002, 0x00000d, 0x00001f, 0x00003d, 0x000007,
++    0x000078, 0x00000c, 0x000079,
++};
++
++static const uint8_t acpl_hcb_beta3_coarse_df_bits[17] = {
++    13, 12, 12, 11,  9,  6,  4,  2,  1,  3,  5,  7,  9, 11, 12, 13,
++     9,
++};
++
++static const uint32_t acpl_hcb_beta3_coarse_df_codes[17] = {
++    0x000a93, 0x000548, 0x00054b, 0x0002a7, 0x0000ab, 0x000014,
++    0x000004, 0x000000, 0x000001, 0x000003, 0x00000b, 0x00002b,
++    0x0000aa, 0x0002a6, 0x00054a, 0x000a92, 0x0000a8,
++};
++
++static const uint8_t acpl_hcb_beta3_fine_df_bits[33] = {
++    14, 15, 14, 13, 13, 12, 11, 11,  9,  8,  7,  6,  5,  4,  3,  2,
++     2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 12, 13, 14, 14, 14,
++    15,
++};
++
++static const uint32_t acpl_hcb_beta3_fine_df_codes[33] = {
++    0x0019e9, 0x0033f7, 0x0019f3, 0x000cf5, 0x000cfc, 0x00067d, 0x00033c,
++    0x0007ff, 0x0000ce, 0x000066, 0x000032, 0x000018, 0x00000d, 0x000007,
++    0x000002, 0x000000, 0x000002, 0x000006, 0x00000e, 0x00001e, 0x00003e,
++    0x00007e, 0x0000fe, 0x0001fe, 0x0003fe, 0x0007fe, 0x00067f, 0x00067b,
++    0x000cf8, 0x0019fa, 0x0019f2, 0x0019e8, 0x0033f6,
++};
++
++static const uint8_t acpl_hcb_beta3_coarse_dt_bits[17] = {
++    15, 15, 14, 12, 10,  7,  5,  3,  1,  2,  4,  6,  8, 11, 14, 14,
++     9,
++};
++
++static const uint16_t acpl_hcb_beta3_coarse_dt_codes[17] = {
++    0x000adc, 0x000add, 0x00056c, 0x00015a, 0x000057, 0x00000b, 0x000003,
++    0x000001, 0x000001, 0x000001, 0x000000, 0x000004, 0x000014, 0x0000ac,
++    0x00056f, 0x00056d, 0x00002a,
++};
++
++static const uint8_t acpl_hcb_beta3_fine_dt_bits[33] = {
++    16, 16, 16, 16, 16, 16, 15, 14, 12, 11, 10,  9,  8,  7,  5,  3,
++     1,  2,  4,  7,  8,  9, 10, 11, 12, 13, 14, 15, 15, 16, 16, 16,
++    16,
++};
++
++static const uint32_t acpl_hcb_beta3_fine_dt_codes[33] = {
++    0x00501e, 0x00501d, 0x00501c, 0x00501b, 0x00510e, 0x00510d, 0x002809,
++    0x001442, 0x000500, 0x000281, 0x000141, 0x0000a1, 0x000052, 0x00002a,
++    0x00000b, 0x000003, 0x000001, 0x000000, 0x000004, 0x00002b, 0x000053,
++    0x0000a3, 0x000145, 0x000289, 0x000511, 0x000a20, 0x001405, 0x00280c,
++    0x002808, 0x00510f, 0x00510c, 0x00501f, 0x00501a,
++};
++
++static const uint8_t acpl_hcb_gamma_coarse_f0_bits[21] = {
++    13, 13, 13, 13, 11,  9,  7,  6,  5,  3,  2,  3,  3,  4,  3,  3,
++     8, 11, 12, 13, 13,
++};
++
++static const uint16_t acpl_hcb_gamma_coarse_f0_codes[21] = {
++    0x000af4, 0x000af8, 0x000af9, 0x000afb, 0x0002bc, 0x0000ae, 0x00002a, 0x000014,
++    0x00000b, 0x000001, 0x000003, 0x000005, 0x000000, 0x000004, 0x000004, 0x000003,
++    0x000056, 0x0002bf, 0x00057b, 0x000af5, 0x000afa,
++};
++
++static const uint8_t acpl_hcb_gamma_fine_f0_bits[41] = {
++    12, 13, 13, 12, 12, 12, 12, 11,  9, 10,  9,  8,  8,  7,  7,  6,
++     5,  5,  4,  4,  3,  3,  4,  4,  5,  5,  5,  5,  4,  3,  4,  7,
++     8,  9, 10, 11, 11, 12, 12, 12, 12,
++};
++
++static const uint32_t acpl_hcb_gamma_fine_f0_codes[41] = {
++    0x0004b6, 0x001c6d, 0x001c6c, 0x00049b, 0x0004b5, 0x0004b7, 0x000e35, 0x00024e,
++    0x0001c7, 0x00038c, 0x000097, 0x000048, 0x0000e2, 0x000070, 0x000073, 0x000013,
++    0x000008, 0x000017, 0x000005, 0x00000c, 0x000004, 0x000001, 0x00000d, 0x00000a,
++    0x00001f, 0x00001e, 0x000016, 0x00001d, 0x000006, 0x000000, 0x000007, 0x000072,
++    0x00004a, 0x000092, 0x00012c, 0x00024f, 0x00024c, 0x000e34, 0x0004b4, 0x00049a,
++    0x000e37,
++};
++
++static const uint8_t acpl_hcb_gamma_coarse_df_bits[41] = {
++    16, 16, 16, 16, 16, 16, 16, 16, 16, 15, 15, 14, 13, 13, 11, 10,
++     8,  7,  4,  2,  1,  3,  5,  7,  8, 10, 11, 13, 13, 14, 15, 16,
++    16, 16, 16, 16, 16, 16, 16, 16,  8,
++};
++
++static const uint32_t acpl_hcb_gamma_coarse_df_codes[41] = {
++    0x0053e1, 0x0053e0, 0x0053db, 0x0053da, 0x0053d9, 0x0053e2, 0x0053e4, 0x0053ea,
++    0x0053eb, 0x0029ea, 0x0029f4, 0x0014f4, 0x000a78, 0x000a7f, 0x000299, 0x00014d,
++    0x000051, 0x00002a, 0x000004, 0x000000, 0x000001, 0x000003, 0x00000b, 0x00002b,
++    0x000052, 0x00014e, 0x000298, 0x000a7e, 0x000a79, 0x0014f7, 0x0029f6, 0x0053ef,
++    0x0053ee, 0x0053e7, 0x0053e6, 0x0053e3, 0x0053e5, 0x0053d8, 0x0053d7, 0x0053d6,
++    0x000050,
++};
++
++static const uint8_t acpl_hcb_gamma_fine_df_bits[81] = {
++    17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
++    17, 17, 16, 16, 16, 15, 15, 15, 14, 14, 13, 13, 13, 12, 11, 11,
++    10,  9,  8,  7,  6,  5,  4,  3,  1,  3,  4,  5,  6,  7,  9,  9,
++    10, 11, 11, 12, 13, 13, 14, 14, 14, 15, 15, 15, 16, 16, 16, 17,
++    17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17, 17,
++    17,
++};
++
++static const uint32_t acpl_hcb_gamma_fine_df_codes[81] = {
++    0x013e1f, 0x013e35, 0x013e1e, 0x013e1d, 0x013e1c, 0x013e1b, 0x013e1a, 0x013e19,
++    0x013e34, 0x013e33, 0x013e18, 0x013ec2, 0x013ec1, 0x013ece, 0x013edf, 0x013e17,
++    0x013ede, 0x013edd, 0x009d52, 0x009f18, 0x009f1b, 0x004eaa, 0x004ea8, 0x004fb1,
++    0x002753, 0x002757, 0x0013a8, 0x0013e0, 0x0013ee, 0x0009d6, 0x0004e9, 0x0004fa,
++    0x00027b, 0x00013c, 0x00009c, 0x00004d, 0x000021, 0x000012, 0x00000b, 0x000007,
++    0x000000, 0x000006, 0x00000a, 0x000011, 0x000020, 0x00004c, 0x00013f, 0x00013b,
++    0x00027a, 0x0004f9, 0x0004e8, 0x0009d7, 0x0013ef, 0x0013e2, 0x0027da, 0x0027c7,
++    0x002752, 0x004fb6, 0x004eac, 0x004eab, 0x009f65, 0x009d5a, 0x009d53, 0x013ecd,
++    0x013edc, 0x013ecc, 0x013ecf, 0x013ec9, 0x013e32, 0x013ec3, 0x013e16, 0x013ec0,
++    0x013ec8, 0x013e15, 0x013e14, 0x013e13, 0x013e12, 0x013e11, 0x013e10, 0x013ab7,
++    0x013ab6,
++};
++
++static const uint8_t acpl_hcb_gamma_coarse_dt_bits[41] = {
++    17, 17, 17, 17, 16, 17, 16, 16, 16, 15, 14, 13, 12, 12, 10,  9,
++     8,  7,  5,  3,  1,  2,  4,  7,  8, 10, 11, 12, 13, 13, 14, 15,
++    16, 16, 16, 17, 17, 17, 17, 17,  9,
++};
++
++static const uint32_t acpl_hcb_gamma_coarse_dt_codes[41] = {
++    0x00a7f3, 0x00a7f1, 0x00a7f9, 0x00a7f8, 0x0050e1, 0x00a7fe, 0x0050e8, 0x0050eb,
++    0x0053fe, 0x0029fd, 0x00143b, 0x000a1b, 0x00050c, 0x00053e, 0x000142, 0x0000a0,
++    0x000052, 0x00002b, 0x00000b, 0x000003, 0x000001, 0x000000, 0x000004, 0x00002a,
++    0x000051, 0x00014e, 0x00029e, 0x00050f, 0x000a7e, 0x000a1a, 0x001439, 0x002871,
++    0x0050ea, 0x0050e9, 0x0050e0, 0x00a7ff, 0x00a7fb, 0x00a7fa, 0x00a7f2, 0x00a7f0,
++    0x0000a6,
++};
++
++static const uint8_t acpl_hcb_gamma_fine_dt_bits[81] = {
++    18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 17,
++    17, 17, 17, 17, 16, 16, 16, 15, 15, 15, 14, 14, 13, 13, 12, 12,
++    11, 10,  9,  8,  7,  6,  5,  2,  1,  3,  5,  6,  7,  8, 10, 10,
++    11, 12, 13, 13, 14, 14, 15, 15, 15, 15, 16, 16, 17, 17, 17, 17,
++    17, 17, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18, 18,
++    18,
++};
++
++static const uint32_t acpl_hcb_gamma_fine_dt_codes[81] = {
++    0x031e44, 0x031d1d, 0x031e42, 0x031e16, 0x031e41, 0x031e47, 0x031d1c, 0x031e43,
++    0x031e73, 0x031e72, 0x031e15, 0x031e70, 0x031e75, 0x031e7f, 0x031e7e, 0x018e88,
++    0x018d8b, 0x018e8f, 0x018f0e, 0x018f3e, 0x00c746, 0x00c796, 0x00c79e, 0x006361,
++    0x0063c9, 0x0063d8, 0x0031d0, 0x0031e6, 0x0018d9, 0x0018f1, 0x000c6d, 0x000c7a,
++    0x00063b, 0x00031c, 0x00018c, 0x0000c1, 0x000062, 0x000033, 0x00001b, 0x000002,
++    0x000000, 0x000007, 0x00001a, 0x000032, 0x000061, 0x0000c0, 0x00031f, 0x00031a,
++    0x000637, 0x000c75, 0x0018f7, 0x0018e9, 0x0031ed, 0x0031e0, 0x0063d9, 0x0063ca,
++    0x006363, 0x006360, 0x00c786, 0x00c745, 0x018f3b, 0x018f2e, 0x018e89, 0x018d88,
++    0x018d8a, 0x018d89, 0x031e5f, 0x031e74, 0x031e40, 0x031e71, 0x031e46, 0x031e5e,
++    0x031e1f, 0x031e45, 0x031e1e, 0x031e14, 0x031e17, 0x031e13, 0x031e12, 0x031e11,
++    0x031e10,
++};
++
++static const float qwin[640] = {
++    0,
++    1.990318758627504e-004,  2.494762615491542e-004,  3.021769445225078e-004,
++    3.548460080857985e-004,  4.058915811480806e-004,  4.546408052001889e-004,
++    5.012680176678405e-004,  5.464958142195282e-004,  5.912073950641334e-004,
++    6.361178026937039e-004,  6.816060488244358e-004,  7.277257095064290e-004,
++    7.743418255606097e-004,  8.212990636826637e-004,  8.685363488152327e-004,
++    9.161071539925993e-004,  9.641168291303352e-004,  1.012630507392736e-003,
++    1.061605258108620e-003,  1.110882587090581e-003,  1.160236901298543e-003,
++    1.209448942573337e-003,  1.258362795150757e-003,  1.306902381715039e-003,
++    1.355046337751365e-003,  1.402784629568410e-003,  1.450086694843816e-003,
++    1.496898951224534e-003,  1.543170821958483e-003,  1.588889089195869e-003,
++    1.634098242730728e-003,  1.678892372493930e-003,  1.723381173920660e-003,
++    1.767651163797991e-003,  1.811741998614740e-003,  1.855650606587200e-003,
++    1.899360915083620e-003,  1.942876625831283e-003,  1.986241654706626e-003,
++    2.029534125962055e-003,  2.072840712410525e-003,  2.116229103721749e-003,
++    2.159738034390673e-003,  2.203392976200947e-003,  2.247239773881968e-003,
++    2.291373966775394e-003,  2.335946110021889e-003,  2.381132815654862e-003,
++    2.427086732976290e-003,  2.473891839822582e-003,  2.521550367974952e-003,
++    2.570013995199655e-003,  2.619244058999978e-003,  2.669265893796866e-003,
++    2.720177146231281e-003,  2.772088849679780e-003,  2.825009494162980e-003,
++    2.878716544061140e-003,  2.932677076291194e-003,  2.986067366389476e-003,
++    3.037905983043366e-003,  3.087269477594307e-003,  3.133519274378684e-003,
++    3.176460810085721e-003,  3.216374095471449e-003,  3.253902493849856e-003,
++    3.289837867273167e-003,  3.324873276103132e-003,  3.359407689115599e-003,
++    3.393454084675361e-003,  3.426668323773391e-003,  3.458465815999750e-003,
++    3.488171121469781e-003,  3.515141351338780e-003,  3.538827383683883e-003,
++    3.558767785536742e-003,  3.574539247363964e-003,  3.585697968628984e-003,
++    3.591743339500398e-003,  3.592116764752254e-003,  3.586228204993297e-003,
++    3.573492966885132e-003,  3.553356715665694e-003,  3.525300399274114e-003,
++    3.488824092931520e-003,  3.443423145747434e-003,  3.388568319085867e-003,
++    3.323699442173841e-003,  3.248231770523395e-003,  3.161568930730635e-003,
++    3.063113666967670e-003,  2.952270973359112e-003,  2.828441943181057e-003,
++    2.691016173288500e-003,  2.539366102140493e-003,  2.372848583221744e-003,
++    2.190814088754598e-003,  1.992618085548526e-003,  1.777631090142623e-003,
++    1.545242163079598e-003,  1.294855985911958e-003,  1.025885587325796e-003,
++    7.377456851538827e-004,  4.298496740962311e-004,  1.016113723823784e-004,
++   -2.475493814535340e-004, -6.181972580227641e-004, -1.010876063031582e-003,
++   -1.426108207321696e-003, -1.864392667409557e-003, -2.326207721179968e-003,
++   -2.812013688448634e-003, -3.322252633537029e-003, -3.857344314546718e-003,
++   -4.417678415707104e-003, -5.003604409245843e-003, -5.615422427540850e-003,
++   -6.253382198869787e-003, -6.917691380307223e-003, -7.608536937561301e-003,
++   -8.326113472848559e-003, -9.070651572928327e-003, -9.842433610911637e-003,
++   -1.064178450184536e-002, -1.146903570409307e-002, -1.232446526717138e-002,
++   -1.320822893615923e-002,  1.412030102138547e-002,  1.506045143737221e-002,
++    1.602824700934038e-002,  1.702310507234504e-002,  1.804435938034114e-002,
++    1.909132707403387e-002,  2.016335321815832e-002,  2.125982139139435e-002,
++    2.238013015948307e-002,  2.352365148441367e-002,  2.468968228813486e-002,
++    2.587741357605385e-002,  2.708591966384863e-002,  2.831416731612567e-002,
++    2.956103453432552e-002,  3.082532788511644e-002,  3.210578787607558e-002,
++    3.340108247607704e-002,  3.470979250147262e-002,  3.603039785904666e-002,
++    3.736126987823528e-002,  3.870067428980750e-002,  4.004677994303860e-002,
++    4.139766786359423e-002,  4.275134353925827e-002,  4.410572893128047e-002,
++    4.545866171224587e-002,  4.680788921400311e-002,  4.815106534667384e-002,
++    4.948575188369231e-002,  5.080942296260306e-002,  5.211947012173918e-002,
++    5.341320372603929e-002,  5.468785186395163e-002,  5.594055607104873e-002,
++    5.716836923188953e-002,  5.836825629443718e-002,  5.953709945765930e-002,
++    6.067170625396996e-002,  6.176881705202805e-002,  6.282510999827461e-002,
++    6.383720245755561e-002,  6.480165083585107e-002,  6.571495100350305e-002,
++    6.657354346196487e-002,  6.737381445564891e-002,  6.811211000439976e-002,
++    6.878473991370719e-002,  6.938797895654626e-002,  6.991806618580000e-002,
++    7.037120381110623e-002,  7.074355866301176e-002,  7.103126866531538e-002,
++    7.123045563399449e-002,  7.133723888151840e-002,  7.134774334517399e-002,
++    7.125810128129656e-002,  7.106444395777428e-002,  7.076288963679085e-002,
++    7.034953453342756e-002,  6.982045490146145e-002,  6.917172452383333e-002,
++    6.839944399575645e-002,  6.749977716975542e-002,  6.646898181809889e-002,
++    6.530342654389224e-002,  6.399958984339946e-002,  6.255404354954748e-002,
++    6.096342863203985e-002,  5.922443337469448e-002,  5.733378365410422e-002,
++    5.528824660015738e-002,  5.308464739461209e-002,  5.071989148277166e-002,
++    4.819098634672628e-002,  4.549505579582869e-002,  4.262934676625042e-002,
++    3.959122947020497e-002,  3.637819581239452e-002,  3.298786054608736e-002,
++    2.941796954479800e-002,  2.566640058060906e-002,  2.173117939155709e-002,
++    1.761048656968719e-002,  1.330266415707108e-002,  8.806217289921706e-003,
++    4.119815918461287e-003, -7.577038291607129e-004, -5.827337082489678e-003,
++   -1.108990619665782e-002, -1.654605559674886e-002, -2.219624707735291e-002,
++   -2.804075556277473e-002, -3.407966641908426e-002, -4.031287253355741e-002,
++   -4.674007190475649e-002, -5.336076390182971e-002, -6.017424526940620e-002,
++   -6.717960594283154e-002, -7.437572538762392e-002, -8.176127022450692e-002,
++   -8.933469320120192e-002, -9.709423309043450e-002, -1.050379143754414e-001,
++   -1.131635475471188e-001, -1.214687284677367e-001, -1.299508386078101e-001,
++   -1.386070430802319e-001, -1.474342913196958e-001, -1.564293167898782e-001,
++   -1.655886374953163e-001, -1.749085568711785e-001, -1.843851642116290e-001,
++   -1.940143360850268e-001, -2.037917371113644e-001, -2.137128217101543e-001,
++   -2.237728356363325e-001, -2.339668182208061e-001, -2.442896055908444e-001,
++   -2.547358344658102e-001, -2.652999476893712e-001, -2.759762003673840e-001,
++   -2.867586659726799e-001, -2.976412485679301e-001, -3.086176827721830e-001,
++   -3.196815399704708e-001, -3.308262316588501e-001, -3.420450091826495e-001,
++    3.533309414505971e-001,  3.646770149404552e-001,  3.760759747758828e-001,
++    3.875204555118187e-001,  3.990029533969267e-001,  4.105158411581483e-001,
++    4.220513789540003e-001,  4.336017251305980e-001,  4.451589452332786e-001,
++    4.567150149423557e-001,  4.682618290579831e-001,  4.797912086537587e-001,
++    4.912949058677955e-001,  5.027646134968753e-001,  5.141919746376279e-001,
++    5.255685924518015e-001,  5.368860394090674e-001,  5.481358656081351e-001,
++    5.593096071830315e-001,  5.703987947306394e-001,  5.813949615434598e-001,
++    5.922896536434017e-001,  6.030744392774144e-001,  6.137409201916185e-001,
++    6.242807411441345e-001,  6.346855991963545e-001,  6.449472531836600e-001,
++    6.550575323798634e-001,  6.650083455855346e-001,  6.747916901830467e-001,
++    6.843996616799759e-001,  6.938244627003839e-001,  7.030584122393319e-001,
++    7.120939537241190e-001,  7.209236637533725e-001,  7.295402599029810e-001,
++    7.379366091028713e-001,  7.461057359576386e-001,  7.540408314942230e-001,
++    7.617352611504460e-001,  7.691825714586890e-001,  7.763765020733762e-001,
++    7.833109874824341e-001,  7.899801646390305e-001,  7.963783815797485e-001,
++    8.025002033685581e-001,  8.083404191294724e-001,  8.138940486031526e-001,
++    8.191563476989879e-001,  8.241228138607196e-001,  8.287891904413357e-001,
++    8.331514714928793e-001,  8.372059062705359e-001,  8.409490040631689e-001,
++    8.443775395556067e-001,  8.474885573145614e-001,  8.502793750759253e-001,
++    8.527475863595390e-001,  8.548910606594570e-001,  8.567079441260879e-001,
++    8.581966597760032e-001,  8.593559096378087e-001,  8.601846769933608e-001,
++    8.606822313166693e-001,  8.608481078185764e-001,  8.606822313166693e-001,
++    8.601846769933608e-001,  8.593559096378087e-001,  8.581966597760032e-001,
++    8.567079441260879e-001,  8.548910606594570e-001,  8.527475863595390e-001,
++    8.502793750759253e-001,  8.474885573145614e-001,  8.443775395556067e-001,
++    8.409490040631689e-001,  8.372059062705359e-001,  8.331514714928793e-001,
++    8.287891904413357e-001,  8.241228138607196e-001,  8.191563476989879e-001,
++    8.138940486031526e-001,  8.083404191294724e-001,  8.025002033685581e-001,
++    7.963783815797485e-001,  7.899801646390305e-001,  7.833109874824341e-001,
++    7.763765020733762e-001,  7.691825714586890e-001,  7.617352611504460e-001,
++    7.540408314942230e-001,  7.461057359576386e-001,  7.379366091028713e-001,
++    7.295402599029810e-001,  7.209236637533725e-001,  7.120939537241190e-001,
++    7.030584122393319e-001,  6.938244627003839e-001,  6.843996616799759e-001,
++    6.747916901830467e-001,  6.650083455855346e-001,  6.550575323798634e-001,
++    6.449472531836600e-001,  6.346855991963545e-001,  6.242807411441345e-001,
++    6.137409201916185e-001,  6.030744392774144e-001,  5.922896536434017e-001,
++    5.813949615434598e-001,  5.703987947306394e-001,  5.593096071830315e-001,
++    5.481358656081351e-001,  5.368860394090674e-001,  5.255685924518015e-001,
++    5.141919746376279e-001,  5.027646134968753e-001,  4.912949058677955e-001,
++    4.797912086537587e-001,  4.682618290579831e-001,  4.567150149423557e-001,
++    4.451589452332786e-001,  4.336017251305980e-001,  4.220513789540003e-001,
++    4.105158411581483e-001,  3.990029533969267e-001,  3.875204555118187e-001,
++    3.760759747758828e-001,  3.646770149404552e-001, -3.533309414505971e-001,
++   -3.420450091826495e-001, -3.308262316588501e-001, -3.196815399704708e-001,
++   -3.086176827721830e-001, -2.976412485679301e-001, -2.867586659726799e-001,
++   -2.759762003673840e-001, -2.652999476893712e-001, -2.547358344658102e-001,
++   -2.442896055908444e-001, -2.339668182208061e-001, -2.237728356363325e-001,
++   -2.137128217101543e-001, -2.037917371113644e-001, -1.940143360850268e-001,
++   -1.843851642116290e-001, -1.749085568711785e-001, -1.655886374953163e-001,
++   -1.564293167898782e-001, -1.474342913196958e-001, -1.386070430802319e-001,
++   -1.299508386078101e-001, -1.214687284677367e-001, -1.131635475471188e-001,
++   -1.050379143754414e-001, -9.709423309043450e-002, -8.933469320120192e-002,
++   -8.176127022450692e-002, -7.437572538762392e-002, -6.717960594283154e-002,
++   -6.017424526940620e-002, -5.336076390182971e-002, -4.674007190475649e-002,
++   -4.031287253355741e-002, -3.407966641908426e-002, -2.804075556277473e-002,
++   -2.219624707735291e-002, -1.654605559674886e-002, -1.108990619665782e-002,
++   -5.827337082489678e-003, -7.577038291607129e-004,  4.119815918461287e-003,
++    8.806217289921706e-003,  1.330266415707108e-002,  1.761048656968719e-002,
++    2.173117939155709e-002,  2.566640058060906e-002,  2.941796954479800e-002,
++    3.298786054608736e-002,  3.637819581239452e-002,  3.959122947020497e-002,
++    4.262934676625042e-002,  4.549505579582869e-002,  4.819098634672628e-002,
++    5.071989148277166e-002,  5.308464739461209e-002,  5.528824660015738e-002,
++    5.733378365410422e-002,  5.922443337469448e-002,  6.096342863203985e-002,
++    6.255404354954748e-002,  6.399958984339946e-002,  6.530342654389224e-002,
++    6.646898181809889e-002,  6.749977716975542e-002,  6.839944399575645e-002,
++    6.917172452383333e-002,  6.982045490146145e-002,  7.034953453342756e-002,
++    7.076288963679085e-002,  7.106444395777428e-002,  7.125810128129656e-002,
++    7.134774334517399e-002,  7.133723888151840e-002,  7.123045563399449e-002,
++    7.103126866531538e-002,  7.074355866301176e-002,  7.037120381110623e-002,
++    6.991806618580000e-002,  6.938797895654626e-002,  6.878473991370719e-002,
++    6.811211000439976e-002,  6.737381445564891e-002,  6.657354346196487e-002,
++    6.571495100350305e-002,  6.480165083585107e-002,  6.383720245755561e-002,
++    6.282510999827461e-002,  6.176881705202805e-002,  6.067170625396996e-002,
++    5.953709945765930e-002,  5.836825629443718e-002,  5.716836923188953e-002,
++    5.594055607104873e-002,  5.468785186395163e-002,  5.341320372603929e-002,
++    5.211947012173918e-002,  5.080942296260306e-002,  4.948575188369231e-002,
++    4.815106534667384e-002,  4.680788921400311e-002,  4.545866171224587e-002,
++    4.410572893128047e-002,  4.275134353925827e-002,  4.139766786359423e-002,
++    4.004677994303860e-002,  3.870067428980750e-002,  3.736126987823528e-002,
++    3.603039785904666e-002,  3.470979250147262e-002,  3.340108247607704e-002,
++    3.210578787607558e-002,  3.082532788511644e-002,  2.956103453432552e-002,
++    2.831416731612567e-002,  2.708591966384863e-002,  2.587741357605385e-002,
++    2.468968228813486e-002,  2.352365148441367e-002,  2.238013015948307e-002,
++    2.125982139139435e-002,  2.016335321815832e-002,  1.909132707403387e-002,
++    1.804435938034114e-002,  1.702310507234504e-002,  1.602824700934038e-002,
++    1.506045143737221e-002, -1.412030102138547e-002, -1.320822893615923e-002,
++   -1.232446526717138e-002, -1.146903570409307e-002, -1.064178450184536e-002,
++   -9.842433610911637e-003, -9.070651572928327e-003, -8.326113472848559e-003,
++   -7.608536937561301e-003, -6.917691380307223e-003, -6.253382198869787e-003,
++   -5.615422427540850e-003, -5.003604409245843e-003, -4.417678415707104e-003,
++   -3.857344314546718e-003, -3.322252633537029e-003, -2.812013688448634e-003,
++   -2.326207721179968e-003, -1.864392667409557e-003, -1.426108207321696e-003,
++   -1.010876063031582e-003, -6.181972580227641e-004, -2.475493814535340e-004,
++    1.016113723823784e-004,  4.298496740962311e-004,  7.377456851538827e-004,
++    1.025885587325796e-003,  1.294855985911958e-003,  1.545242163079598e-003,
++    1.777631090142623e-003,  1.992618085548526e-003,  2.190814088754598e-003,
++    2.372848583221744e-003,  2.539366102140493e-003,  2.691016173288500e-003,
++    2.828441943181057e-003,  2.952270973359112e-003,  3.063113666967670e-003,
++    3.161568930730635e-003,  3.248231770523395e-003,  3.323699442173841e-003,
++    3.388568319085867e-003,  3.443423145747434e-003,  3.488824092931520e-003,
++    3.525300399274114e-003,  3.553356715665694e-003,  3.573492966885132e-003,
++    3.586228204993297e-003,  3.592116764752254e-003,  3.591743339500398e-003,
++    3.585697968628984e-003,  3.574539247363964e-003,  3.558767785536742e-003,
++    3.538827383683883e-003,  3.515141351338780e-003,  3.488171121469781e-003,
++    3.458465815999750e-003,  3.426668323773391e-003,  3.393454084675361e-003,
++    3.359407689115599e-003,  3.324873276103132e-003,  3.289837867273167e-003,
++    3.253902493849856e-003,  3.216374095471449e-003,  3.176460810085721e-003,
++    3.133519274378684e-003,  3.087269477594307e-003,  3.037905983043366e-003,
++    2.986067366389476e-003,  2.932677076291194e-003,  2.878716544061140e-003,
++    2.825009494162980e-003,  2.772088849679780e-003,  2.720177146231281e-003,
++    2.669265893796866e-003,  2.619244058999978e-003,  2.570013995199655e-003,
++    2.521550367974952e-003,  2.473891839822582e-003,  2.427086732976290e-003,
++    2.381132815654862e-003,  2.335946110021889e-003,  2.291373966775394e-003,
++    2.247239773881968e-003,  2.203392976200947e-003,  2.159738034390673e-003,
++    2.116229103721749e-003,  2.072840712410525e-003,  2.029534125962055e-003,
++    1.986241654706626e-003,  1.942876625831283e-003,  1.899360915083620e-003,
++    1.855650606587200e-003,  1.811741998614740e-003,  1.767651163797991e-003,
++    1.723381173920660e-003,  1.678892372493930e-003,  1.634098242730728e-003,
++    1.588889089195869e-003,  1.543170821958483e-003,  1.496898951224534e-003,
++    1.450086694843816e-003,  1.402784629568410e-003,  1.355046337751365e-003,
++    1.306902381715039e-003,  1.258362795150757e-003,  1.209448942573337e-003,
++    1.160236901298543e-003,  1.110882587090581e-003,  1.061605258108620e-003,
++    1.012630507392736e-003,  9.641168291303352e-004,  9.161071539925993e-004,
++    8.685363488152327e-004,  8.212990636826637e-004,  7.743418255606097e-004,
++    7.277257095064290e-004,  6.816060488244358e-004,  6.361178026937039e-004,
++    5.912073950641334e-004,  5.464958142195282e-004,  5.012680176678405e-004,
++    4.546408052001889e-004,  4.058915811480806e-004,  3.548460080857985e-004,
++    3.021769445225078e-004,  2.494762615491542e-004,  1.990318758627504e-004,
++};
++
++static const float new_chirp_tab[4][4] = {
++    { 0.0,  0.6,  0.0,  0.0,  },
++    { 0.6,  0.75, 0.75, 0.75, },
++    { 0.9,  0.9,  0.9,  0.9,  },
++    { 0.98, 0.98, 0.98, 0.98, },
++};
++
++static const int8_t aspx_sine[2][4] = {
++    { 1, 0, -1,  0 }, { 0, 1,  0, -1 },
++};
++
++static const float aspx_noise[512][2] = {
++    {-0.782083, -0.623174}, { 0.705088, -0.70912}, { 0.268786, -0.9632},
++    { 0.689305, -0.724471}, {-0.0430946, -0.999071}, {-0.998077, -0.0619922},
++    { 0.867875, -0.496783}, { 0.814907, -0.579591}, { 0.880168, 0.474663},
++    {-0.39062, -0.920552}, { 0.0434465, 0.999056}, { 0.610173, -0.792268},
++    {-0.942195, 0.335065}, {-0.911161, 0.412052}, {-0.999084, -0.0427925},
++    {-0.811795, 0.583942}, { 0.836524, 0.54793}, { 0.475443, 0.879747},
++    { 0.961597, -0.274466}, { 0.820146, 0.572155}, {-0.498318, -0.866994},
++    { 0.825586, -0.564277}, { 0.999973, 0.00730176}, { 0.895923, 0.44421},
++    {-0.80517, -0.593044}, { 0.277753, 0.960652}, {-0.999688, 0.0249582},
++    {-0.802608, -0.596507}, { 0.936737, -0.350035}, {-0.997477, -0.0709933},
++    {-0.674713, -0.73808}, {-0.957686, -0.287817}, { 0.983532, 0.180732},
++    { 0.634759, -0.77271}, {-0.150723, -0.988576}, {-0.113979, 0.993483},
++    {-0.993827, -0.110942}, { 0.781536, 0.62386}, {-0.615104, -0.788446},
++    {-0.586834, 0.809707}, {-0.226253, 0.974069}, { 0.949896, -0.312565},
++    { 0.830084, 0.557638}, { 0.60415, 0.796871}, { 0.655412, 0.755272},
++    {-0.916524, -0.399979}, { 0.763757, -0.645503}, { 0.822298, 0.569058},
++    {-0.0283442, -0.999598}, {-0.644058, -0.764977}, {-0.390833, -0.920462},
++    {-0.984217, -0.176967}, { 0.719987, 0.693987}, { 0.999088, -0.042707},
++    { 0.754487, 0.656315}, { 0.498312, 0.866998}, { 0.999389, 0.0349481},
++    {-0.811845, -0.583873}, { 0.532015, -0.846735}, {-0.463781, 0.88595},
++    {-0.819481, -0.573106}, { 0.637789, 0.770211}, { 0.814253, -0.58051},
++    { 0.180489, -0.983577}, { 0.988691, -0.149968}, { 0.606847, -0.794819},
++    {-0.061914, 0.998081}, { 0.627066, 0.778966}, {-0.544097, -0.839023},
++    {-0.859249, -0.511558}, {-0.91818, 0.396163}, {-0.165942, 0.986136},
++    { 0.992322, 0.123685}, { 0.758555, 0.651609}, { 0.985543, -0.169427},
++    {-0.154971, -0.987919}, { 0.245336, 0.969438}, {-0.522038, -0.852922},
++    {-0.33027, -0.943886}, { 0.998067, -0.0621421}, { 0.516758, 0.856132},
++    { 0.843123, -0.537721}, { 0.44306, 0.896492}, {-0.814913, 0.579584},
++    {-0.336464, -0.941696}, { 0.732896, 0.68034}, { 0.201774, -0.979432},
++    { 0.741954, 0.670451}, {-0.469083, 0.883154}, { 0.867784, 0.496941},
++    { 0.494202, -0.869347}, { 0.9367, -0.350134}, { 0.906328, 0.422575},
++    { 0.764111, 0.645085}, { 0.631052, -0.77574}, {-0.0498248, -0.998758},
++    { 0.974691, -0.223555}, { 0.361405, -0.932409}, {-0.748625, 0.662994},
++    { 0.811839, -0.583881}, { 0.303931, 0.952694}, {-0.992668, -0.120876},
++    {-0.996672, -0.0815161}, {-0.324622, 0.945844}, {-0.0246385, -0.999696},
++    {-0.588361, 0.808598}, {-0.49898, 0.866613}, { 0.924578, -0.380994},
++    {-0.755619, 0.655011}, { 0.92214, -0.386857}, { 0.818638, 0.57431},
++    {-0.920451, 0.390857}, { 0.0380205, -0.999277}, { 0.446606, -0.894731},
++    { 0.722557, -0.691312}, { 0.762113, -0.647444}, {-0.256731, -0.966483},
++    { 0.471301, -0.881972}, {-0.530869, -0.847454}, {-0.749876, 0.661579},
++    {-0.593767, -0.804637}, {-0.834805, 0.550545}, { 0.748843, 0.662747},
++    {-0.70794, 0.706273}, {-0.0503228, -0.998733}, { 0.402884, -0.915251},
++    { 0.0945791, -0.995517}, {-0.390889, -0.920438}, {-0.0994705, -0.995041},
++    {-0.767207, -0.641399}, {-0.563485, -0.826126}, {-0.521859, 0.853032},
++    { 0.503637, 0.863915}, {-0.739851, -0.672771}, { 0.442624, -0.896707},
++    {-0.997671, 0.0682121}, { 0.776117, -0.630589}, {-0.964601, -0.263713},
++    {-0.656053, 0.754715}, {-0.865578, 0.500775}, {-0.586255, -0.810127},
++    { 0.0425286, -0.999095}, { 0.656339, 0.754466}, {-0.341906, 0.939734},
++    {-0.605904, 0.795538}, {-0.658238, -0.752809}, {-0.652856, 0.757482},
++    {-0.994554, 0.104219}, { 0.176725, -0.98426}, {-0.231945, 0.972729},
++    {-0.997717, -0.0675303}, {-0.997805, 0.0662198}, { 0.661155, 0.75025},
++    { 0.999669, -0.02573}, {-0.946982, -0.321287}, {-0.587897, 0.808936},
++    { 0.957862, -0.28723}, { 0.613392, -0.789779}, {-0.956489, 0.291768},
++    { 0.169829, -0.985474}, {-0.943551, -0.331226}, { 0.416834, 0.908983},
++    { 0.684727, -0.7288}, { 0.952329, 0.305074}, {-0.328392, 0.944541},
++    { 0.943344, 0.331816}, { 0.650872, 0.759187}, {-0.59941, -0.800442},
++    {-0.768448, -0.639912}, { 0.539894, 0.841733}, { 0.606048, -0.795428},
++    { 0.403588, 0.914941}, {-0.838111, 0.545499}, { 0.976157, -0.217066},
++    {-0.995495, -0.0948107}, {-0.943792, 0.330539}, {-0.990415, 0.138123},
++    { 0.281355, 0.959604}, { 0.371208, 0.92855}, {-0.4711, 0.88208},
++    {-0.999459, -0.0328787}, {-0.988179, 0.153305}, {-0.843124, -0.537718},
++    { 0.997108, 0.0759971}, {-0.268201, -0.963363}, { 0.0457651, 0.998952},
++    {-0.983762, 0.179479}, {-0.439728, -0.898131}, { 0.162945, -0.986635},
++    {-0.055868, 0.998438}, {-0.384381, 0.923174}, { 0.744138, -0.668026},
++    {-0.0706482, -0.997501}, { 0.831219, 0.555945}, { 0.711624, 0.70256},
++    { 0.161772, -0.986828}, { 0.8387, 0.544593}, {-0.418108, 0.908397},
++    { 0.412208, 0.91109}, {-0.986564, 0.163375}, { 0.925222, 0.379427},
++    { 0.411092, -0.911594}, {-0.103885, -0.994589}, {-0.923358, -0.383941},
++    {-0.761339, 0.648355}, {-0.887774, -0.46028}, { 0.755699, -0.654919},
++    { 0.597832, -0.801622}, { 0.542946, -0.839768}, { 0.999842, -0.0177525},
++    {-0.954864, 0.297044}, {-0.999961, -0.00886517}, { 0.929688, -0.368347},
++    { 0.699205, 0.714921}, {-0.894118, 0.447831}, {-0.903496, 0.428597},
++    { 0.362774, -0.931877}, { 0.850158, -0.526527}, { 0.523993, -0.851722},
++    {-0.735767, 0.677235}, {-0.999673, -0.02558}, {-0.954685, 0.297619},
++    {-0.195193, -0.980765}, { 0.0672577, -0.997736}, {-0.659842, -0.751405},
++    { 0.779366, 0.626569}, { 0.751561, -0.659663}, {-0.34458, -0.938757},
++    { 0.316872, 0.948468}, { 0.953601, 0.301074}, { 0.363243, 0.931694},
++    {-0.537299, -0.843392}, { 0.996839, 0.0794518}, { 0.950462, -0.310842},
++    { 0.224973, 0.974365}, {-0.772894, -0.634535}, {-0.94373, -0.330718},
++    { 0.930603, 0.36603}, { 0.994059, 0.10884}, { 0.845518, -0.533947},
++    { 0.988122, -0.15367}, { 0.880641, -0.473785}, { 0.783488, -0.621407},
++    { 0.72854, 0.685004}, {-0.772294, 0.635265}, { 0.662444, 0.749111},
++    {-0.0649291, 0.99789}, {-0.285125, 0.95849}, {-0.673637, -0.739062},
++    {-0.394791, -0.918771}, {-0.938677, -0.344798}, {-0.708925, -0.705284},
++    { 0.31416, 0.94937}, {-0.113645, 0.993521}, {-0.296446, 0.95505},
++    { 0.670712, -0.741718}, {-0.605825, 0.795598}, { 0.996229, 0.0867643},
++    { 0.686613, -0.727023}, {-0.740136, 0.672457}, { 0.876977, 0.480532},
++    {-0.561046, 0.827785}, { 0.414562, -0.910021}, {-0.645953, -0.763377},
++    { 0.802263, 0.596971}, {-0.854981, 0.51866}, {-0.769916, 0.638145}, { 0.648047, 0.7616},
++    {-0.773406, 0.633911}, {-0.252579, -0.967576}, { 0.962561, -0.271064},
++    { 0.959193, -0.282751}, { 0.727508, 0.686099}, {-0.667916, 0.744236},
++    {-0.599333, 0.8005}, { 0.622504, 0.782616}, { 0.375433, -0.92685},
++    {-0.9972, 0.0747742}, {-0.879355, 0.476166}, { 0.409574, 0.912277},
++    { 0.747405, -0.664369}, {-0.940177, -0.340687}, { 0.562532, 0.826776},
++    {-0.929015, 0.370041}, { 0.0978642, 0.9952}, { 0.916896, -0.399125},
++    {-0.608038, -0.793908}, {-0.845653, -0.533732}, {-0.455945, -0.890008},
++    { 0.923484, -0.383637}, { 0.354901, 0.934904}, { 0.319134, -0.94771},
++    { 0.769603, -0.638523}, {-0.899207, 0.437524}, { 0.666669, -0.745354},
++    { 0.142655, -0.989772}, {-0.892, -0.452035}, {-0.999915, -0.0130018},
++    {-0.87033, 0.492469}, { 0.156511, 0.987676}, {-0.146752, 0.989173},
++    {-0.809057, 0.58773}, {-0.497325, -0.867565}, {-0.258455, -0.966023},
++    {-0.863292, -0.504705}, {-0.976343, -0.216225}, {-0.257626, -0.966245},
++    { 0.809568, -0.587027}, { 0.582491, 0.812837}, {-0.997088, -0.0762565},
++    {-0.878262, 0.47818}, {-0.165343, -0.986236}, { 0.0455161, 0.998964},
++    {-0.570664, 0.821184}, { 0.658564, 0.752525}, { 0.319839, -0.947472},
++    {-0.643905, -0.765106}, {-0.590256, 0.807216}, { 0.512137, 0.858904},
++    {-0.998558, 0.0536785}, { 0.373964, -0.927443}, { 0.633108, -0.774063},
++    {-0.968108, 0.250531}, { 0.787337, 0.616523}, { 0.698247, -0.715857},
++    { 0.98937, 0.145419}, { 0.582241, -0.813016}, { 0.359617, 0.9331},
++    {-0.758164, -0.652064}, { 0.635102, 0.772429}, {-0.0254028, -0.999677},
++    { 0.266382, -0.963868}, { 0.660974, -0.750409}, { 0.585176, -0.810906},
++    {-0.98243, 0.186631}, { 0.777252, -0.629189}, {-0.0267382, 0.999642},
++    {-0.95591, 0.293661}, { 0.70368, -0.710517}, { 0.732467, -0.680803},
++    { 0.854099, -0.52011}, { 0.536151, 0.844122}, {-0.00781503, 0.999969},
++    {-0.534447, 0.845202}, { 0.297782, 0.954634}, { 0.905724, 0.423868},
++    { 0.115617, -0.993294}, {-0.993408, -0.114636}, { 0.156977, 0.987602},
++    { 0.639408, -0.768868}, {-0.995898, 0.0904832}, {-0.956372, 0.29215},
++    { 0.990545, 0.137189}, { 0.659118, 0.75204}, {-0.0398563, -0.999205},
++    {-0.679682, -0.733507}, {-0.540035, 0.841643}, {-0.0501135, -0.998744},
++    {-0.196305, -0.980543}, { 0.56964, 0.821894}, {-0.703653, 0.710544},
++    { 0.162676, -0.98668}, {-0.919545, 0.392984}, { 0.805179, 0.593031},
++    { 0.998757, 0.0498406}, { 0.358168, 0.933657}, {-0.611152, -0.791513},
++    {-0.440479, 0.897763}, { 0.292587, 0.956239}, {-0.217415, -0.976079},
++    {-0.252622, -0.967565}, {-0.679998, -0.733214}, { 0.402652, -0.915353},
++    {-0.993189, 0.116516}, { 0.0634956, 0.997982}, { 0.432309, -0.901725},
++    { 0.923434, 0.383756}, {-0.502058, 0.864834}, { 0.935584, -0.353105},
++    { 0.912111, -0.409944}, {-0.298643, 0.954365}, {-0.796165, 0.60508},
++    {-0.741295, -0.671179}, { 0.856386, 0.516336}, {-0.515876, -0.856663},
++    { 0.994745, -0.102384}, { 0.648698, -0.761046}, {-0.999675, -0.0254761},
++    {-0.130115, 0.991499}, {-0.998787, 0.0492413}, { 0.27449, -0.96159},
++    {-0.996501, -0.0835749}, {-0.387182, 0.922003}, { 0.701006, -0.713156},
++    { 0.98733, -0.158679}, {-0.713847, 0.700302}, {-0.329606, 0.944118},
++    { 0.279362, 0.960186}, {-0.968574, -0.248726}, {-0.68131, 0.731995},
++    { 0.220789, -0.975322}, {-0.985566, -0.169292}, { 0.0132834, 0.999912},
++    {-0.422317, 0.906448}, {-0.772023, -0.635594}, { 0.842036, -0.539421},
++    {-0.803312, 0.595558}, { 0.725035, 0.688712}, { 0.328206, 0.944606},
++    { 0.711898, 0.702283}, {-0.691674, 0.72221}, {-0.871274, 0.490797},
++    { 0.213736, 0.976891}, { 0.255845, 0.966718}, { 0.883381, 0.468656}, {-0.596736, 0.802437},
++    { 0.779861, 0.625953}, {-0.607233, 0.794524}, {-0.944679, -0.327996},
++    { 0.851219, -0.52481}, {-0.859337, -0.51141}, { 0.953486, -0.301437},
++    { 0.512244, -0.85884}, { 0.160393, 0.987053}, { 0.752002, 0.659161},
++    { 0.999882, 0.0153624}, { 0.778011, -0.628251}, { 0.9293, -0.369326},
++    {-0.605896, 0.795544}, { 0.633164, 0.774017}, {-0.923382, -0.383883},
++    {-0.790911, 0.611931}, { 0.673492, 0.739195}, {-0.784902, 0.61962},
++    { 0.289472, 0.957187}, { 0.605387, -0.795931}, {-0.459844, -0.888},
++    {-0.990035, 0.140822}, {-0.686367, -0.727256}, {-0.549857, 0.835259},
++    { 0.90982, 0.415003}, {-0.42105, 0.907037}, {-0.07295, 0.997336},
++    {-0.24021, 0.970721}, { 0.993154, -0.116813}, {-0.59563, -0.803259},
++    { 0.526545, -0.850147}, { 0.9987, -0.0509667}, {-0.85017, -0.526508},
++    {-0.818838, -0.574025}, { 0.982094, 0.188394}, { 0.577634, -0.816296},
++    {-0.418394, -0.908265}, { 0.62868, -0.777664}, {-0.118173, -0.992993},
++    { 0.896113, 0.443827}, {-0.159857, -0.98714}, { 0.750036, 0.661397},
++    { 0.745659, 0.666328}, {-0.938865, -0.344285}, {-0.583143, 0.812369},
++    { 0.479122, 0.877748}, {-0.869898, -0.493231}, {-0.791797, 0.610784}, { 0.35785, 0.933779},
++    { 0.25248, -0.967602}, {-0.573942, -0.818896}, {-0.930426, -0.366479},
++    {-0.378158, 0.925741}, {-0.942114, 0.335293}, { 0.647836, -0.76178},
++    { 0.814174, 0.580622}, { 0.023769, 0.999717}, { 0.112026, -0.993705},
++    { 0.659378, -0.751811}, {-0.615064, -0.788477}, {-0.00328067, 0.999995},
++    { 0.902263, -0.431186}, { 0.201174, -0.979556}, { 0.541589, 0.840644},
++    {-0.996013, 0.0892081}, { 0.987237, 0.159261}, {-0.692353, 0.721559},
++    { 0.940855, -0.338809}, { 0.164224, -0.986423}, { 0.0618662, 0.998084},
++    { 0.784694, 0.619883}, { 0.156281, -0.987713}, {-0.424548, -0.905405},
++    { 0.927622, 0.37352}, {-0.923711, 0.383089}, { 0.708767, -0.705442},
++    {-0.941076, 0.338195}, {-0.268226, 0.963356}, { 0.653964, 0.756526},
++    { 0.983767, -0.179452}, {-0.480029, 0.877253}, {-0.845565, -0.533873},
++    {-0.768586, -0.639746}, { 0.208936, 0.977929}, { 0.512539, -0.858664},
++    { 0.988163, -0.153409}, { 0.780816, 0.624761}, {-0.232748, 0.972537},
++    { 0.988528, -0.151035}, {-0.106602, -0.994302}, {-0.633295, 0.773911},
++    { 0.322068, -0.946717}, { 0.989632, -0.143627}, { 0.973492, -0.228721},
++    { 0.998266, 0.0588631}, {-0.145619, 0.989341}
++};
++
++#endif /* AVCODEC_AC4DECDATA_H */
+--- jellyfin-ffmpeg-4.4.1.orig/libavcodec/allcodecs.c
++++ jellyfin-ffmpeg-4.4.1/libavcodec/allcodecs.c
+@@ -407,6 +407,7 @@ extern AVCodec ff_ac3_encoder;
+ extern AVCodec ff_ac3_decoder;
+ extern AVCodec ff_ac3_fixed_encoder;
+ extern AVCodec ff_ac3_fixed_decoder;
++extern AVCodec ff_ac4_decoder;
+ extern AVCodec ff_acelp_kelvin_decoder;
+ extern AVCodec ff_alac_encoder;
+ extern AVCodec ff_alac_decoder;
+--- jellyfin-ffmpeg-4.4.1.orig/libavcodec/codec_desc.c
++++ jellyfin-ffmpeg-4.4.1/libavcodec/codec_desc.c
+@@ -3216,6 +3216,13 @@ static const AVCodecDescriptor codec_des
+         .long_name = NULL_IF_CONFIG_SMALL("MobiClip FastAudio"),
+         .props     = AV_CODEC_PROP_INTRA_ONLY | AV_CODEC_PROP_LOSSY,
+     },
++    {
++        .id        = AV_CODEC_ID_AC4,
++        .type      = AVMEDIA_TYPE_AUDIO,
++        .name      = "ac4",
++        .long_name = NULL_IF_CONFIG_SMALL("AC-4"),
++        .props     = AV_CODEC_PROP_LOSSY,
++    },
+ 
+     /* subtitle codecs */
+     {
+--- jellyfin-ffmpeg-4.4.1.orig/libavcodec/codec_id.h
++++ jellyfin-ffmpeg-4.4.1/libavcodec/codec_id.h
+@@ -517,6 +517,7 @@ enum AVCodecID {
+     AV_CODEC_ID_SIREN,
+     AV_CODEC_ID_HCA,
+     AV_CODEC_ID_FASTAUDIO,
++    AV_CODEC_ID_AC4,
+ 
+     /* subtitle codecs */
+     AV_CODEC_ID_FIRST_SUBTITLE = 0x17000,          ///< A dummy ID pointing at the start of subtitle codecs.
+--- jellyfin-ffmpeg-4.4.1.orig/libavcodec/kbdwin.h
++++ jellyfin-ffmpeg-4.4.1/libavcodec/kbdwin.h
+@@ -24,7 +24,7 @@
+ /**
+  * Maximum window size for ff_kbd_window_init.
+  */
+-#define FF_KBD_WINDOW_MAX 1024
++#define FF_KBD_WINDOW_MAX 2048
+ 
+ /**
+  * Generate a Kaiser-Bessel Derived Window.
+--- jellyfin-ffmpeg-4.4.1.orig/libavformat/Makefile
++++ jellyfin-ffmpeg-4.4.1/libavformat/Makefile
+@@ -69,6 +69,7 @@ OBJS-$(CONFIG_AAC_DEMUXER)
+ OBJS-$(CONFIG_AAX_DEMUXER)               += aaxdec.o
+ OBJS-$(CONFIG_AC3_DEMUXER)               += ac3dec.o rawdec.o
+ OBJS-$(CONFIG_AC3_MUXER)                 += rawenc.o
++OBJS-$(CONFIG_AC4_DEMUXER)               += ac4dec.o
+ OBJS-$(CONFIG_ACE_DEMUXER)               += acedec.o
+ OBJS-$(CONFIG_ACM_DEMUXER)               += acm.o rawdec.o
+ OBJS-$(CONFIG_ACT_DEMUXER)               += act.o
+--- /dev/null
++++ jellyfin-ffmpeg-4.4.1/libavformat/ac4dec.c
+@@ -0,0 +1,104 @@
++/*
++ * RAW AC-4 demuxer
++ * Copyright (c) 2019 Paul B Mahol
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "libavutil/avassert.h"
++#include "libavutil/crc.h"
++#include "avformat.h"
++#include "rawdec.h"
++
++static int ac4_probe(const AVProbeData *p)
++{
++    const uint8_t *buf = p->buf;
++    int left = p->buf_size;
++    int max_frames = 0;
++
++    while (left > 7) {
++        int size;
++
++        if (buf[0] == 0xAC &&
++            (buf[1] == 0x40 ||
++             buf[1] == 0x41)) {
++            size = (buf[2] << 8) | buf[3];
++            if (size == 0xFFFF)
++                size = 3 + (buf[4] << 16) | (buf[5] << 8) | buf[6];
++            size += 4;
++            if (buf[1] == 0x41)
++                size += 2;
++            max_frames++;
++            left -= size;
++            buf += size;
++        } else {
++            break;
++        }
++    }
++
++    return FFMIN(AVPROBE_SCORE_MAX, max_frames * 7);
++}
++
++static int ac4_read_header(AVFormatContext *s)
++{
++    AVStream *st;
++
++    st = avformat_new_stream(s, NULL);
++    if (!st)
++        return AVERROR(ENOMEM);
++
++    st->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;
++    st->codecpar->codec_id   = AV_CODEC_ID_AC4;
++
++    return 0;
++}
++
++static int ac4_read_packet(AVFormatContext *s, AVPacket *pkt)
++{
++    AVIOContext *pb = s->pb;
++    int64_t pos;
++    uint16_t sync;
++    int ret, size;
++
++    if (avio_feof(s->pb))
++        return AVERROR_EOF;
++
++    pos   = avio_tell(s->pb);
++    sync = avio_rb16(pb);
++    size = avio_rb16(pb);
++    if (size == 0xffff)
++        size = avio_rb24(pb);
++
++    ret = av_get_packet(pb, pkt, size);
++    pkt->pos = pos;
++    pkt->stream_index = 0;
++
++    if (sync == 0xAC41)
++        avio_skip(pb, 2);
++
++    return ret;
++}
++
++AVInputFormat ff_ac4_demuxer = {
++    .name           = "ac4",
++    .long_name      = NULL_IF_CONFIG_SMALL("raw AC-4"),
++    .read_probe     = ac4_probe,
++    .read_header    = ac4_read_header,
++    .read_packet    = ac4_read_packet,
++    .flags          = AVFMT_GENERIC_INDEX,
++    .extensions     = "ac4",
++};
+--- jellyfin-ffmpeg-4.4.1.orig/libavformat/allformats.c
++++ jellyfin-ffmpeg-4.4.1/libavformat/allformats.c
+@@ -34,6 +34,7 @@ extern AVInputFormat  ff_aac_demuxer;
+ extern AVInputFormat  ff_aax_demuxer;
+ extern AVInputFormat  ff_ac3_demuxer;
+ extern AVOutputFormat ff_ac3_muxer;
++extern AVInputFormat  ff_ac4_demuxer;
+ extern AVInputFormat  ff_ace_demuxer;
+ extern AVInputFormat  ff_acm_demuxer;
+ extern AVInputFormat  ff_act_demuxer;
+--- jellyfin-ffmpeg-4.4.1.orig/libavformat/mpegts.c
++++ jellyfin-ffmpeg-4.4.1/libavformat/mpegts.c
+@@ -956,8 +956,8 @@ static int mpegts_set_stream_info(AVStre
+             (st->internal->request_probe > 0 && st->internal->request_probe < AVPROBE_SCORE_STREAM_RETRY / 5)) &&
+         st->probe_packets > 0 &&
+         stream_type == STREAM_TYPE_PRIVATE_DATA) {
+-        st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
+-        st->codecpar->codec_id   = AV_CODEC_ID_BIN_DATA;
++        st->codecpar->codec_type = pes->stream_type == 6 ? AVMEDIA_TYPE_AUDIO : AVMEDIA_TYPE_DATA;
++        st->codecpar->codec_id   = pes->stream_type == 6 ? AV_CODEC_ID_AC4 : AV_CODEC_ID_BIN_DATA;
+         st->internal->request_probe = AVPROBE_SCORE_STREAM_RETRY / 5;
+     }
+ 
+@@ -2075,6 +2075,13 @@ int ff_parse_mpeg2_descriptor(AVFormatCo
+                     av_dict_set(&st->metadata, "language", language, 0);
+             }
+         }
++        if (ext_desc_tag == 0x15) { /* AC-4 descriptor */
++            st->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;
++            st->codecpar->codec_id = AV_CODEC_ID_AC4;
++            st->internal->request_probe = 0;
++
++            st->internal->need_context_update = 1;
++        }
+         break;
+     case 0x6a: /* ac-3_descriptor */
+         {
+--- /dev/null
++++ jellyfin-ffmpeg-4.4.1/libavformat/mpegts.c.orig
+@@ -0,0 +1,3414 @@
++/*
++ * MPEG-2 transport stream (aka DVB) demuxer
++ * Copyright (c) 2002-2003 Fabrice Bellard
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "libavutil/buffer.h"
++#include "libavutil/common.h"
++#include "libavutil/crc.h"
++#include "libavutil/internal.h"
++#include "libavutil/intreadwrite.h"
++#include "libavutil/log.h"
++#include "libavutil/dict.h"
++#include "libavutil/mathematics.h"
++#include "libavutil/opt.h"
++#include "libavutil/avassert.h"
++#include "libavutil/dovi_meta.h"
++#include "libavcodec/bytestream.h"
++#include "libavcodec/get_bits.h"
++#include "libavcodec/opus.h"
++#include "avformat.h"
++#include "mpegts.h"
++#include "internal.h"
++#include "avio_internal.h"
++#include "mpeg.h"
++#include "isom.h"
++#if CONFIG_ICONV
++#include <iconv.h>
++#endif
++
++/* maximum size in which we look for synchronization if
++ * synchronization is lost */
++#define MAX_RESYNC_SIZE 65536
++
++#define MAX_PES_PAYLOAD 200 * 1024
++
++#define MAX_MP4_DESCR_COUNT 16
++
++#define MOD_UNLIKELY(modulus, dividend, divisor, prev_dividend)                \
++    do {                                                                       \
++        if ((prev_dividend) == 0 || (dividend) - (prev_dividend) != (divisor)) \
++            (modulus) = (dividend) % (divisor);                                \
++        (prev_dividend) = (dividend);                                          \
++    } while (0)
++
++#define PROBE_PACKET_MAX_BUF 8192
++#define PROBE_PACKET_MARGIN 5
++
++enum MpegTSFilterType {
++    MPEGTS_PES,
++    MPEGTS_SECTION,
++    MPEGTS_PCR,
++};
++
++typedef struct MpegTSFilter MpegTSFilter;
++
++typedef int PESCallback (MpegTSFilter *f, const uint8_t *buf, int len,
++                         int is_start, int64_t pos);
++
++typedef struct MpegTSPESFilter {
++    PESCallback *pes_cb;
++    void *opaque;
++} MpegTSPESFilter;
++
++typedef void SectionCallback (MpegTSFilter *f, const uint8_t *buf, int len);
++
++typedef void SetServiceCallback (void *opaque, int ret);
++
++typedef struct MpegTSSectionFilter {
++    int section_index;
++    int section_h_size;
++    int last_ver;
++    unsigned crc;
++    unsigned last_crc;
++    uint8_t *section_buf;
++    unsigned int check_crc : 1;
++    unsigned int end_of_section_reached : 1;
++    SectionCallback *section_cb;
++    void *opaque;
++} MpegTSSectionFilter;
++
++struct MpegTSFilter {
++    int pid;
++    int es_id;
++    int last_cc; /* last cc code (-1 if first packet) */
++    int64_t last_pcr;
++    int discard;
++    enum MpegTSFilterType type;
++    union {
++        MpegTSPESFilter pes_filter;
++        MpegTSSectionFilter section_filter;
++    } u;
++};
++
++struct Stream {
++    int idx;
++    int stream_identifier;
++};
++
++#define MAX_STREAMS_PER_PROGRAM 128
++#define MAX_PIDS_PER_PROGRAM (MAX_STREAMS_PER_PROGRAM + 2)
++struct Program {
++    unsigned int id; // program id/service id
++    unsigned int nb_pids;
++    unsigned int pids[MAX_PIDS_PER_PROGRAM];
++    unsigned int nb_streams;
++    struct Stream streams[MAX_STREAMS_PER_PROGRAM];
++
++    /** have we found pmt for this program */
++    int pmt_found;
++};
++
++struct MpegTSContext {
++    const AVClass *class;
++    /* user data */
++    AVFormatContext *stream;
++    /** raw packet size, including FEC if present */
++    int raw_packet_size;
++
++    int64_t pos47_full;
++
++    /** if true, all pids are analyzed to find streams */
++    int auto_guess;
++
++    /** compute exact PCR for each transport stream packet */
++    int mpeg2ts_compute_pcr;
++
++    /** fix dvb teletext pts                                 */
++    int fix_teletext_pts;
++
++    int64_t cur_pcr;    /**< used to estimate the exact PCR */
++    int64_t pcr_incr;   /**< used to estimate the exact PCR */
++
++    /* data needed to handle file based ts */
++    /** stop parsing loop */
++    int stop_parse;
++    /** packet containing Audio/Video data */
++    AVPacket *pkt;
++    /** to detect seek */
++    int64_t last_pos;
++
++    int skip_changes;
++    int skip_clear;
++    int skip_unknown_pmt;
++
++    int scan_all_pmts;
++
++    int resync_size;
++    int merge_pmt_versions;
++
++    /******************************************/
++    /* private mpegts data */
++    /* scan context */
++    /** structure to keep track of Program->pids mapping */
++    unsigned int nb_prg;
++    struct Program *prg;
++
++    int8_t crc_validity[NB_PID_MAX];
++    /** filters for various streams specified by PMT + for the PAT and PMT */
++    MpegTSFilter *pids[NB_PID_MAX];
++    int current_pid;
++
++    AVStream *epg_stream;
++    AVBufferPool* pools[32];
++};
++
++#define MPEGTS_OPTIONS \
++    { "resync_size",   "set size limit for looking up a new synchronization", offsetof(MpegTSContext, resync_size), AV_OPT_TYPE_INT,  { .i64 =  MAX_RESYNC_SIZE}, 0, INT_MAX,  AV_OPT_FLAG_DECODING_PARAM }
++
++static const AVOption options[] = {
++    MPEGTS_OPTIONS,
++    {"fix_teletext_pts", "try to fix pts values of dvb teletext streams", offsetof(MpegTSContext, fix_teletext_pts), AV_OPT_TYPE_BOOL,
++     {.i64 = 1}, 0, 1, AV_OPT_FLAG_DECODING_PARAM },
++    {"ts_packetsize", "output option carrying the raw packet size", offsetof(MpegTSContext, raw_packet_size), AV_OPT_TYPE_INT,
++     {.i64 = 0}, 0, 0, AV_OPT_FLAG_DECODING_PARAM | AV_OPT_FLAG_EXPORT | AV_OPT_FLAG_READONLY },
++    {"scan_all_pmts", "scan and combine all PMTs", offsetof(MpegTSContext, scan_all_pmts), AV_OPT_TYPE_BOOL,
++     {.i64 = -1}, -1, 1, AV_OPT_FLAG_DECODING_PARAM },
++    {"skip_unknown_pmt", "skip PMTs for programs not advertised in the PAT", offsetof(MpegTSContext, skip_unknown_pmt), AV_OPT_TYPE_BOOL,
++     {.i64 = 0}, 0, 1, AV_OPT_FLAG_DECODING_PARAM },
++    {"merge_pmt_versions", "re-use streams when PMT's version/pids change", offsetof(MpegTSContext, merge_pmt_versions), AV_OPT_TYPE_BOOL,
++     {.i64 = 0}, 0, 1,  AV_OPT_FLAG_DECODING_PARAM },
++    {"skip_changes", "skip changing / adding streams / programs", offsetof(MpegTSContext, skip_changes), AV_OPT_TYPE_BOOL,
++     {.i64 = 0}, 0, 1, 0 },
++    {"skip_clear", "skip clearing programs", offsetof(MpegTSContext, skip_clear), AV_OPT_TYPE_BOOL,
++     {.i64 = 0}, 0, 1, 0 },
++    { NULL },
++};
++
++static const AVClass mpegts_class = {
++    .class_name = "mpegts demuxer",
++    .item_name  = av_default_item_name,
++    .option     = options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
++
++static const AVOption raw_options[] = {
++    MPEGTS_OPTIONS,
++    { "compute_pcr",   "compute exact PCR for each transport stream packet",
++          offsetof(MpegTSContext, mpeg2ts_compute_pcr), AV_OPT_TYPE_BOOL,
++          { .i64 = 0 }, 0, 1,  AV_OPT_FLAG_DECODING_PARAM },
++    { "ts_packetsize", "output option carrying the raw packet size",
++      offsetof(MpegTSContext, raw_packet_size), AV_OPT_TYPE_INT,
++      { .i64 = 0 }, 0, 0,
++      AV_OPT_FLAG_DECODING_PARAM | AV_OPT_FLAG_EXPORT | AV_OPT_FLAG_READONLY },
++    { NULL },
++};
++
++static const AVClass mpegtsraw_class = {
++    .class_name = "mpegtsraw demuxer",
++    .item_name  = av_default_item_name,
++    .option     = raw_options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
++
++/* TS stream handling */
++
++enum MpegTSState {
++    MPEGTS_HEADER = 0,
++    MPEGTS_PESHEADER,
++    MPEGTS_PESHEADER_FILL,
++    MPEGTS_PAYLOAD,
++    MPEGTS_SKIP,
++};
++
++/* enough for PES header + length */
++#define PES_START_SIZE  6
++#define PES_HEADER_SIZE 9
++#define MAX_PES_HEADER_SIZE (9 + 255)
++
++typedef struct PESContext {
++    int pid;
++    int pcr_pid; /**< if -1 then all packets containing PCR are considered */
++    int stream_type;
++    MpegTSContext *ts;
++    AVFormatContext *stream;
++    AVStream *st;
++    AVStream *sub_st; /**< stream for the embedded AC3 stream in HDMV TrueHD */
++    enum MpegTSState state;
++    /* used to get the format */
++    int data_index;
++    int flags; /**< copied to the AVPacket flags */
++    int total_size;
++    int pes_header_size;
++    int extended_stream_id;
++    uint8_t stream_id;
++    int64_t pts, dts;
++    int64_t ts_packet_pos; /**< position of first TS packet of this PES packet */
++    uint8_t header[MAX_PES_HEADER_SIZE];
++    AVBufferRef *buffer;
++    SLConfigDescr sl;
++    int merged_st;
++} PESContext;
++
++extern AVInputFormat ff_mpegts_demuxer;
++
++static struct Program * get_program(MpegTSContext *ts, unsigned int programid)
++{
++    int i;
++    for (i = 0; i < ts->nb_prg; i++) {
++        if (ts->prg[i].id == programid) {
++            return &ts->prg[i];
++        }
++    }
++    return NULL;
++}
++
++static void clear_avprogram(MpegTSContext *ts, unsigned int programid)
++{
++    AVProgram *prg = NULL;
++    int i;
++
++    for (i = 0; i < ts->stream->nb_programs; i++)
++        if (ts->stream->programs[i]->id == programid) {
++            prg = ts->stream->programs[i];
++            break;
++        }
++    if (!prg)
++        return;
++    prg->nb_stream_indexes = 0;
++}
++
++static void clear_program(struct Program *p)
++{
++    if (!p)
++        return;
++    p->nb_pids = 0;
++    p->nb_streams = 0;
++    p->pmt_found = 0;
++}
++
++static void clear_programs(MpegTSContext *ts)
++{
++    av_freep(&ts->prg);
++    ts->nb_prg = 0;
++}
++
++static struct Program * add_program(MpegTSContext *ts, unsigned int programid)
++{
++    struct Program *p = get_program(ts, programid);
++    if (p)
++        return p;
++    if (av_reallocp_array(&ts->prg, ts->nb_prg + 1, sizeof(*ts->prg)) < 0) {
++        ts->nb_prg = 0;
++        return NULL;
++    }
++    p = &ts->prg[ts->nb_prg];
++    p->id = programid;
++    clear_program(p);
++    ts->nb_prg++;
++    return p;
++}
++
++static void add_pid_to_program(struct Program *p, unsigned int pid)
++{
++    int i;
++    if (!p)
++        return;
++
++    if (p->nb_pids >= MAX_PIDS_PER_PROGRAM)
++        return;
++
++    for (i = 0; i < p->nb_pids; i++)
++        if (p->pids[i] == pid)
++            return;
++
++    p->pids[p->nb_pids++] = pid;
++}
++
++static void update_av_program_info(AVFormatContext *s, unsigned int programid,
++                                   unsigned int pid, int version)
++{
++    int i;
++    for (i = 0; i < s->nb_programs; i++) {
++        AVProgram *program = s->programs[i];
++        if (program->id == programid) {
++            int old_pcr_pid = program->pcr_pid,
++                old_version = program->pmt_version;
++            program->pcr_pid = pid;
++            program->pmt_version = version;
++
++            if (old_version != -1 && old_version != version) {
++                av_log(s, AV_LOG_VERBOSE,
++                       "detected PMT change (program=%d, version=%d/%d, pcr_pid=0x%x/0x%x)\n",
++                       programid, old_version, version, old_pcr_pid, pid);
++            }
++            break;
++        }
++    }
++}
++
++/**
++ * @brief discard_pid() decides if the pid is to be discarded according
++ *                      to caller's programs selection
++ * @param ts    : - TS context
++ * @param pid   : - pid
++ * @return 1 if the pid is only comprised in programs that have .discard=AVDISCARD_ALL
++ *         0 otherwise
++ */
++static int discard_pid(MpegTSContext *ts, unsigned int pid)
++{
++    int i, j, k;
++    int used = 0, discarded = 0;
++    struct Program *p;
++
++    if (pid == PAT_PID)
++        return 0;
++
++    /* If none of the programs have .discard=AVDISCARD_ALL then there's
++     * no way we have to discard this packet */
++    for (k = 0; k < ts->stream->nb_programs; k++)
++        if (ts->stream->programs[k]->discard == AVDISCARD_ALL)
++            break;
++    if (k == ts->stream->nb_programs)
++        return 0;
++
++    for (i = 0; i < ts->nb_prg; i++) {
++        p = &ts->prg[i];
++        for (j = 0; j < p->nb_pids; j++) {
++            if (p->pids[j] != pid)
++                continue;
++            // is program with id p->id set to be discarded?
++            for (k = 0; k < ts->stream->nb_programs; k++) {
++                if (ts->stream->programs[k]->id == p->id) {
++                    if (ts->stream->programs[k]->discard == AVDISCARD_ALL)
++                        discarded++;
++                    else
++                        used++;
++                }
++            }
++        }
++    }
++
++    return !used && discarded;
++}
++
++/**
++ *  Assemble PES packets out of TS packets, and then call the "section_cb"
++ *  function when they are complete.
++ */
++static void write_section_data(MpegTSContext *ts, MpegTSFilter *tss1,
++                               const uint8_t *buf, int buf_size, int is_start)
++{
++    MpegTSSectionFilter *tss = &tss1->u.section_filter;
++    uint8_t *cur_section_buf = NULL;
++    int len, offset;
++
++    if (is_start) {
++        memcpy(tss->section_buf, buf, buf_size);
++        tss->section_index = buf_size;
++        tss->section_h_size = -1;
++        tss->end_of_section_reached = 0;
++    } else {
++        if (tss->end_of_section_reached)
++            return;
++        len = MAX_SECTION_SIZE - tss->section_index;
++        if (buf_size < len)
++            len = buf_size;
++        memcpy(tss->section_buf + tss->section_index, buf, len);
++        tss->section_index += len;
++    }
++
++    offset = 0;
++    cur_section_buf = tss->section_buf;
++    while (cur_section_buf - tss->section_buf < MAX_SECTION_SIZE && cur_section_buf[0] != 0xff) {
++        /* compute section length if possible */
++        if (tss->section_h_size == -1 && tss->section_index - offset >= 3) {
++            len = (AV_RB16(cur_section_buf + 1) & 0xfff) + 3;
++            if (len > MAX_SECTION_SIZE)
++                return;
++            tss->section_h_size = len;
++        }
++
++        if (tss->section_h_size != -1 &&
++            tss->section_index >= offset + tss->section_h_size) {
++            int crc_valid = 1;
++            tss->end_of_section_reached = 1;
++
++            if (tss->check_crc) {
++                crc_valid = !av_crc(av_crc_get_table(AV_CRC_32_IEEE), -1, cur_section_buf, tss->section_h_size);
++                if (tss->section_h_size >= 4)
++                    tss->crc = AV_RB32(cur_section_buf + tss->section_h_size - 4);
++
++                if (crc_valid) {
++                    ts->crc_validity[ tss1->pid ] = 100;
++                }else if (ts->crc_validity[ tss1->pid ] > -10) {
++                    ts->crc_validity[ tss1->pid ]--;
++                }else
++                    crc_valid = 2;
++            }
++            if (crc_valid) {
++                tss->section_cb(tss1, cur_section_buf, tss->section_h_size);
++                if (crc_valid != 1)
++                    tss->last_ver = -1;
++            }
++
++            cur_section_buf += tss->section_h_size;
++            offset += tss->section_h_size;
++            tss->section_h_size = -1;
++        } else {
++            tss->section_h_size = -1;
++            tss->end_of_section_reached = 0;
++            break;
++        }
++    }
++}
++
++static MpegTSFilter *mpegts_open_filter(MpegTSContext *ts, unsigned int pid,
++                                        enum MpegTSFilterType type)
++{
++    MpegTSFilter *filter;
++
++    av_log(ts->stream, AV_LOG_TRACE, "Filter: pid=0x%x type=%d\n", pid, type);
++
++    if (pid >= NB_PID_MAX || ts->pids[pid])
++        return NULL;
++    filter = av_mallocz(sizeof(MpegTSFilter));
++    if (!filter)
++        return NULL;
++    ts->pids[pid] = filter;
++
++    filter->type    = type;
++    filter->pid     = pid;
++    filter->es_id   = -1;
++    filter->last_cc = -1;
++    filter->last_pcr= -1;
++
++    return filter;
++}
++
++static MpegTSFilter *mpegts_open_section_filter(MpegTSContext *ts,
++                                                unsigned int pid,
++                                                SectionCallback *section_cb,
++                                                void *opaque,
++                                                int check_crc)
++{
++    MpegTSFilter *filter;
++    MpegTSSectionFilter *sec;
++    uint8_t *section_buf = av_mallocz(MAX_SECTION_SIZE);
++
++    if (!section_buf)
++        return NULL;
++
++    if (!(filter = mpegts_open_filter(ts, pid, MPEGTS_SECTION))) {
++        av_free(section_buf);
++        return NULL;
++    }
++    sec = &filter->u.section_filter;
++    sec->section_cb  = section_cb;
++    sec->opaque      = opaque;
++    sec->section_buf = section_buf;
++    sec->check_crc   = check_crc;
++    sec->last_ver    = -1;
++
++    return filter;
++}
++
++static MpegTSFilter *mpegts_open_pes_filter(MpegTSContext *ts, unsigned int pid,
++                                            PESCallback *pes_cb,
++                                            void *opaque)
++{
++    MpegTSFilter *filter;
++    MpegTSPESFilter *pes;
++
++    if (!(filter = mpegts_open_filter(ts, pid, MPEGTS_PES)))
++        return NULL;
++
++    pes = &filter->u.pes_filter;
++    pes->pes_cb = pes_cb;
++    pes->opaque = opaque;
++    return filter;
++}
++
++static MpegTSFilter *mpegts_open_pcr_filter(MpegTSContext *ts, unsigned int pid)
++{
++    return mpegts_open_filter(ts, pid, MPEGTS_PCR);
++}
++
++static void mpegts_close_filter(MpegTSContext *ts, MpegTSFilter *filter)
++{
++    int pid;
++
++    pid = filter->pid;
++    if (filter->type == MPEGTS_SECTION)
++        av_freep(&filter->u.section_filter.section_buf);
++    else if (filter->type == MPEGTS_PES) {
++        PESContext *pes = filter->u.pes_filter.opaque;
++        av_buffer_unref(&pes->buffer);
++        /* referenced private data will be freed later in
++         * avformat_close_input (pes->st->priv_data == pes) */
++        if (!pes->st || pes->merged_st) {
++            av_freep(&filter->u.pes_filter.opaque);
++        }
++    }
++
++    av_free(filter);
++    ts->pids[pid] = NULL;
++}
++
++static int analyze(const uint8_t *buf, int size, int packet_size,
++                   int probe)
++{
++    int stat[TS_MAX_PACKET_SIZE];
++    int stat_all = 0;
++    int i;
++    int best_score = 0;
++
++    memset(stat, 0, packet_size * sizeof(*stat));
++
++    for (i = 0; i < size - 3; i++) {
++        if (buf[i] == 0x47) {
++            int pid = AV_RB16(buf+1) & 0x1FFF;
++            int asc = buf[i + 3] & 0x30;
++            if (!probe || pid == 0x1FFF || asc) {
++                int x = i % packet_size;
++                stat[x]++;
++                stat_all++;
++                if (stat[x] > best_score) {
++                    best_score = stat[x];
++                }
++            }
++        }
++    }
++
++    return best_score - FFMAX(stat_all - 10*best_score, 0)/10;
++}
++
++/* autodetect fec presence */
++static int get_packet_size(AVFormatContext* s)
++{
++    int score, fec_score, dvhs_score;
++    int margin;
++    int ret;
++
++    /*init buffer to store stream for probing */
++    uint8_t buf[PROBE_PACKET_MAX_BUF] = {0};
++    int buf_size = 0;
++    int max_iterations = 16;
++
++    while (buf_size < PROBE_PACKET_MAX_BUF && max_iterations--) {
++        ret = avio_read_partial(s->pb, buf + buf_size, PROBE_PACKET_MAX_BUF - buf_size);
++        if (ret < 0)
++            return AVERROR_INVALIDDATA;
++        buf_size += ret;
++
++        score      = analyze(buf, buf_size, TS_PACKET_SIZE,      0);
++        dvhs_score = analyze(buf, buf_size, TS_DVHS_PACKET_SIZE, 0);
++        fec_score  = analyze(buf, buf_size, TS_FEC_PACKET_SIZE,  0);
++        av_log(s, AV_LOG_TRACE, "Probe: %d, score: %d, dvhs_score: %d, fec_score: %d \n",
++            buf_size, score, dvhs_score, fec_score);
++
++        margin = mid_pred(score, fec_score, dvhs_score);
++
++        if (buf_size < PROBE_PACKET_MAX_BUF)
++            margin += PROBE_PACKET_MARGIN; /*if buffer not filled */
++
++        if (score > margin)
++            return TS_PACKET_SIZE;
++        else if (dvhs_score > margin)
++            return TS_DVHS_PACKET_SIZE;
++        else if (fec_score > margin)
++            return TS_FEC_PACKET_SIZE;
++    }
++    return AVERROR_INVALIDDATA;
++}
++
++typedef struct SectionHeader {
++    uint8_t tid;
++    uint16_t id;
++    uint8_t version;
++    uint8_t sec_num;
++    uint8_t last_sec_num;
++} SectionHeader;
++
++static int skip_identical(const SectionHeader *h, MpegTSSectionFilter *tssf)
++{
++    if (h->version == tssf->last_ver && tssf->last_crc == tssf->crc)
++        return 1;
++
++    tssf->last_ver = h->version;
++    tssf->last_crc = tssf->crc;
++
++    return 0;
++}
++
++static inline int get8(const uint8_t **pp, const uint8_t *p_end)
++{
++    const uint8_t *p;
++    int c;
++
++    p = *pp;
++    if (p >= p_end)
++        return AVERROR_INVALIDDATA;
++    c   = *p++;
++    *pp = p;
++    return c;
++}
++
++static inline int get16(const uint8_t **pp, const uint8_t *p_end)
++{
++    const uint8_t *p;
++    int c;
++
++    p = *pp;
++    if (1 >= p_end - p)
++        return AVERROR_INVALIDDATA;
++    c   = AV_RB16(p);
++    p  += 2;
++    *pp = p;
++    return c;
++}
++
++/* read and allocate a DVB string preceded by its length */
++static char *getstr8(const uint8_t **pp, const uint8_t *p_end)
++{
++    int len;
++    const uint8_t *p;
++    char *str;
++
++    p   = *pp;
++    len = get8(&p, p_end);
++    if (len < 0)
++        return NULL;
++    if (len > p_end - p)
++        return NULL;
++#if CONFIG_ICONV
++    if (len) {
++        const char *encodings[] = {
++            "ISO6937", "ISO-8859-5", "ISO-8859-6", "ISO-8859-7",
++            "ISO-8859-8", "ISO-8859-9", "ISO-8859-10", "ISO-8859-11",
++            "", "ISO-8859-13", "ISO-8859-14", "ISO-8859-15", "", "", "", "",
++            "", "UCS-2BE", "KSC_5601", "GB2312", "UCS-2BE", "UTF-8", "", "",
++            "", "", "", "", "", "", "", ""
++        };
++        iconv_t cd;
++        char *in, *out;
++        size_t inlen = len, outlen = inlen * 6 + 1;
++        if (len >= 3 && p[0] == 0x10 && !p[1] && p[2] && p[2] <= 0xf && p[2] != 0xc) {
++            char iso8859[12];
++            snprintf(iso8859, sizeof(iso8859), "ISO-8859-%d", p[2]);
++            inlen -= 3;
++            in = (char *)p + 3;
++            cd = iconv_open("UTF-8", iso8859);
++        } else if (p[0] < 0x20) {
++            inlen -= 1;
++            in = (char *)p + 1;
++            cd = iconv_open("UTF-8", encodings[*p]);
++        } else {
++            in = (char *)p;
++            cd = iconv_open("UTF-8", encodings[0]);
++        }
++        if (cd == (iconv_t)-1)
++            goto no_iconv;
++        str = out = av_malloc(outlen);
++        if (!str) {
++            iconv_close(cd);
++            return NULL;
++        }
++        if (iconv(cd, &in, &inlen, &out, &outlen) == -1) {
++            iconv_close(cd);
++            av_freep(&str);
++            goto no_iconv;
++        }
++        iconv_close(cd);
++        *out = 0;
++        *pp = p + len;
++        return str;
++    }
++no_iconv:
++#endif
++    str = av_malloc(len + 1);
++    if (!str)
++        return NULL;
++    memcpy(str, p, len);
++    str[len] = '\0';
++    p  += len;
++    *pp = p;
++    return str;
++}
++
++static int parse_section_header(SectionHeader *h,
++                                const uint8_t **pp, const uint8_t *p_end)
++{
++    int val;
++
++    val = get8(pp, p_end);
++    if (val < 0)
++        return val;
++    h->tid = val;
++    *pp += 2;
++    val  = get16(pp, p_end);
++    if (val < 0)
++        return val;
++    h->id = val;
++    val = get8(pp, p_end);
++    if (val < 0)
++        return val;
++    h->version = (val >> 1) & 0x1f;
++    val = get8(pp, p_end);
++    if (val < 0)
++        return val;
++    h->sec_num = val;
++    val = get8(pp, p_end);
++    if (val < 0)
++        return val;
++    h->last_sec_num = val;
++    return 0;
++}
++
++typedef struct StreamType {
++    uint32_t stream_type;
++    enum AVMediaType codec_type;
++    enum AVCodecID codec_id;
++} StreamType;
++
++static const StreamType ISO_types[] = {
++    { 0x01, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_MPEG2VIDEO },
++    { 0x02, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_MPEG2VIDEO },
++    { 0x03, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_MP3        },
++    { 0x04, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_MP3        },
++    { 0x0f, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AAC        },
++    { 0x10, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_MPEG4      },
++    /* Makito encoder sets stream type 0x11 for AAC,
++     * so auto-detect LOAS/LATM instead of hardcoding it. */
++#if !CONFIG_LOAS_DEMUXER
++    { 0x11, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AAC_LATM   }, /* LATM syntax */
++#endif
++    { 0x1b, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_H264       },
++    { 0x1c, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AAC        },
++    { 0x20, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_H264       },
++    { 0x21, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_JPEG2000   },
++    { 0x24, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_HEVC       },
++    { 0x42, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_CAVS       },
++    { 0xd1, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_DIRAC      },
++    { 0xd2, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_AVS2       },
++    { 0xea, AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_VC1        },
++    { 0 },
++};
++
++static const StreamType HDMV_types[] = {
++    { 0x80, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_PCM_BLURAY        },
++    { 0x81, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_AC3               },
++    { 0x82, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_DTS               },
++    { 0x83, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_TRUEHD            },
++    { 0x84, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_EAC3              },
++    { 0x85, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_DTS               }, /* DTS HD */
++    { 0x86, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_DTS               }, /* DTS HD MASTER*/
++    { 0xa1, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_EAC3              }, /* E-AC3 Secondary Audio */
++    { 0xa2, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_DTS               }, /* DTS Express Secondary Audio */
++    { 0x90, AVMEDIA_TYPE_SUBTITLE, AV_CODEC_ID_HDMV_PGS_SUBTITLE },
++    { 0x92, AVMEDIA_TYPE_SUBTITLE, AV_CODEC_ID_HDMV_TEXT_SUBTITLE },
++    { 0 },
++};
++
++/* SCTE types */
++static const StreamType SCTE_types[] = {
++    { 0x86, AVMEDIA_TYPE_DATA,  AV_CODEC_ID_SCTE_35    },
++    { 0 },
++};
++
++/* ATSC ? */
++static const StreamType MISC_types[] = {
++    { 0x81, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC3 },
++    { 0x8a, AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_DTS },
++    { 0 },
++};
++
++static const StreamType REGD_types[] = {
++    { MKTAG('d', 'r', 'a', 'c'), AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_DIRAC },
++    { MKTAG('A', 'C', '-', '3'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_AC3   },
++    { MKTAG('B', 'S', 'S', 'D'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_S302M },
++    { MKTAG('D', 'T', 'S', '1'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_DTS   },
++    { MKTAG('D', 'T', 'S', '2'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_DTS   },
++    { MKTAG('D', 'T', 'S', '3'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_DTS   },
++    { MKTAG('E', 'A', 'C', '3'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_EAC3  },
++    { MKTAG('H', 'E', 'V', 'C'), AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_HEVC  },
++    { MKTAG('K', 'L', 'V', 'A'), AVMEDIA_TYPE_DATA,  AV_CODEC_ID_SMPTE_KLV },
++    { MKTAG('I', 'D', '3', ' '), AVMEDIA_TYPE_DATA,  AV_CODEC_ID_TIMED_ID3 },
++    { MKTAG('V', 'C', '-', '1'), AVMEDIA_TYPE_VIDEO, AV_CODEC_ID_VC1   },
++    { MKTAG('O', 'p', 'u', 's'), AVMEDIA_TYPE_AUDIO, AV_CODEC_ID_OPUS  },
++    { 0 },
++};
++
++static const StreamType METADATA_types[] = {
++    { MKTAG('K','L','V','A'), AVMEDIA_TYPE_DATA, AV_CODEC_ID_SMPTE_KLV },
++    { MKTAG('I','D','3',' '), AVMEDIA_TYPE_DATA, AV_CODEC_ID_TIMED_ID3 },
++    { 0 },
++};
++
++/* descriptor present */
++static const StreamType DESC_types[] = {
++    { 0x6a, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_AC3          }, /* AC-3 descriptor */
++    { 0x7a, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_EAC3         }, /* E-AC-3 descriptor */
++    { 0x7b, AVMEDIA_TYPE_AUDIO,    AV_CODEC_ID_DTS          },
++    { 0x56, AVMEDIA_TYPE_SUBTITLE, AV_CODEC_ID_DVB_TELETEXT },
++    { 0x59, AVMEDIA_TYPE_SUBTITLE, AV_CODEC_ID_DVB_SUBTITLE }, /* subtitling descriptor */
++    { 0 },
++};
++
++static void mpegts_find_stream_type(AVStream *st,
++                                    uint32_t stream_type,
++                                    const StreamType *types)
++{
++    for (; types->stream_type; types++)
++        if (stream_type == types->stream_type) {
++            if (st->codecpar->codec_type != types->codec_type ||
++                st->codecpar->codec_id   != types->codec_id) {
++                st->codecpar->codec_type = types->codec_type;
++                st->codecpar->codec_id   = types->codec_id;
++                st->internal->need_context_update = 1;
++            }
++            st->internal->request_probe        = 0;
++            return;
++        }
++}
++
++static int mpegts_set_stream_info(AVStream *st, PESContext *pes,
++                                  uint32_t stream_type, uint32_t prog_reg_desc)
++{
++    int old_codec_type = st->codecpar->codec_type;
++    int old_codec_id   = st->codecpar->codec_id;
++    int old_codec_tag  = st->codecpar->codec_tag;
++
++    if (avcodec_is_open(st->internal->avctx)) {
++        av_log(pes->stream, AV_LOG_DEBUG, "cannot set stream info, internal codec is open\n");
++        return 0;
++    }
++
++    avpriv_set_pts_info(st, 33, 1, 90000);
++    st->priv_data         = pes;
++    st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
++    st->codecpar->codec_id   = AV_CODEC_ID_NONE;
++    st->need_parsing      = AVSTREAM_PARSE_FULL;
++    pes->st          = st;
++    pes->stream_type = stream_type;
++
++    av_log(pes->stream, AV_LOG_DEBUG,
++           "stream=%d stream_type=%x pid=%x prog_reg_desc=%.4s\n",
++           st->index, pes->stream_type, pes->pid, (char *)&prog_reg_desc);
++
++    st->codecpar->codec_tag = pes->stream_type;
++
++    mpegts_find_stream_type(st, pes->stream_type, ISO_types);
++    if (pes->stream_type == 4 || pes->stream_type == 0x0f)
++        st->internal->request_probe = 50;
++    if ((prog_reg_desc == AV_RL32("HDMV") ||
++         prog_reg_desc == AV_RL32("HDPR")) &&
++        st->codecpar->codec_id == AV_CODEC_ID_NONE) {
++        mpegts_find_stream_type(st, pes->stream_type, HDMV_types);
++        if (pes->stream_type == 0x83) {
++            // HDMV TrueHD streams also contain an AC3 coded version of the
++            // audio track - add a second stream for this
++            AVStream *sub_st;
++            // priv_data cannot be shared between streams
++            PESContext *sub_pes = av_malloc(sizeof(*sub_pes));
++            if (!sub_pes)
++                return AVERROR(ENOMEM);
++            memcpy(sub_pes, pes, sizeof(*sub_pes));
++
++            sub_st = avformat_new_stream(pes->stream, NULL);
++            if (!sub_st) {
++                av_free(sub_pes);
++                return AVERROR(ENOMEM);
++            }
++
++            sub_st->id = pes->pid;
++            avpriv_set_pts_info(sub_st, 33, 1, 90000);
++            sub_st->priv_data         = sub_pes;
++            sub_st->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;
++            sub_st->codecpar->codec_id   = AV_CODEC_ID_AC3;
++            sub_st->need_parsing      = AVSTREAM_PARSE_FULL;
++            sub_pes->sub_st           = pes->sub_st = sub_st;
++        }
++    }
++    if (st->codecpar->codec_id == AV_CODEC_ID_NONE)
++        mpegts_find_stream_type(st, pes->stream_type, MISC_types);
++    if (st->codecpar->codec_id == AV_CODEC_ID_NONE) {
++        st->codecpar->codec_id  = old_codec_id;
++        st->codecpar->codec_type = old_codec_type;
++    }
++    if ((st->codecpar->codec_id == AV_CODEC_ID_NONE ||
++            (st->internal->request_probe > 0 && st->internal->request_probe < AVPROBE_SCORE_STREAM_RETRY / 5)) &&
++        st->probe_packets > 0 &&
++        stream_type == STREAM_TYPE_PRIVATE_DATA) {
++        st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
++        st->codecpar->codec_id   = AV_CODEC_ID_BIN_DATA;
++        st->internal->request_probe = AVPROBE_SCORE_STREAM_RETRY / 5;
++    }
++
++    /* queue a context update if properties changed */
++    if (old_codec_type != st->codecpar->codec_type ||
++        old_codec_id   != st->codecpar->codec_id   ||
++        old_codec_tag  != st->codecpar->codec_tag)
++        st->internal->need_context_update = 1;
++
++    return 0;
++}
++
++static void reset_pes_packet_state(PESContext *pes)
++{
++    pes->pts        = AV_NOPTS_VALUE;
++    pes->dts        = AV_NOPTS_VALUE;
++    pes->data_index = 0;
++    pes->flags      = 0;
++    av_buffer_unref(&pes->buffer);
++}
++
++static void new_data_packet(const uint8_t *buffer, int len, AVPacket *pkt)
++{
++    av_packet_unref(pkt);
++    pkt->data = (uint8_t *)buffer;
++    pkt->size = len;
++}
++
++static int new_pes_packet(PESContext *pes, AVPacket *pkt)
++{
++    uint8_t *sd;
++
++    av_packet_unref(pkt);
++
++    pkt->buf  = pes->buffer;
++    pkt->data = pes->buffer->data;
++    pkt->size = pes->data_index;
++
++    if (pes->total_size != MAX_PES_PAYLOAD &&
++        pes->pes_header_size + pes->data_index != pes->total_size +
++        PES_START_SIZE) {
++        av_log(pes->stream, AV_LOG_WARNING, "PES packet size mismatch\n");
++        pes->flags |= AV_PKT_FLAG_CORRUPT;
++    }
++    memset(pkt->data + pkt->size, 0, AV_INPUT_BUFFER_PADDING_SIZE);
++
++    // Separate out the AC3 substream from an HDMV combined TrueHD/AC3 PID
++    if (pes->sub_st && pes->stream_type == 0x83 && pes->extended_stream_id == 0x76)
++        pkt->stream_index = pes->sub_st->index;
++    else
++        pkt->stream_index = pes->st->index;
++    pkt->pts = pes->pts;
++    pkt->dts = pes->dts;
++    /* store position of first TS packet of this PES packet */
++    pkt->pos   = pes->ts_packet_pos;
++    pkt->flags = pes->flags;
++
++    pes->buffer = NULL;
++    reset_pes_packet_state(pes);
++
++    sd = av_packet_new_side_data(pkt, AV_PKT_DATA_MPEGTS_STREAM_ID, 1);
++    if (!sd)
++        return AVERROR(ENOMEM);
++    *sd = pes->stream_id;
++
++    return 0;
++}
++
++static uint64_t get_ts64(GetBitContext *gb, int bits)
++{
++    if (get_bits_left(gb) < bits)
++        return AV_NOPTS_VALUE;
++    return get_bits64(gb, bits);
++}
++
++static int read_sl_header(PESContext *pes, SLConfigDescr *sl,
++                          const uint8_t *buf, int buf_size)
++{
++    GetBitContext gb;
++    int au_start_flag = 0, au_end_flag = 0, ocr_flag = 0, idle_flag = 0;
++    int padding_flag = 0, padding_bits = 0, inst_bitrate_flag = 0;
++    int dts_flag = -1, cts_flag = -1;
++    int64_t dts = AV_NOPTS_VALUE, cts = AV_NOPTS_VALUE;
++    uint8_t buf_padded[128 + AV_INPUT_BUFFER_PADDING_SIZE];
++    int buf_padded_size = FFMIN(buf_size, sizeof(buf_padded) - AV_INPUT_BUFFER_PADDING_SIZE);
++
++    memcpy(buf_padded, buf, buf_padded_size);
++
++    init_get_bits(&gb, buf_padded, buf_padded_size * 8);
++
++    if (sl->use_au_start)
++        au_start_flag = get_bits1(&gb);
++    if (sl->use_au_end)
++        au_end_flag = get_bits1(&gb);
++    if (!sl->use_au_start && !sl->use_au_end)
++        au_start_flag = au_end_flag = 1;
++    if (sl->ocr_len > 0)
++        ocr_flag = get_bits1(&gb);
++    if (sl->use_idle)
++        idle_flag = get_bits1(&gb);
++    if (sl->use_padding)
++        padding_flag = get_bits1(&gb);
++    if (padding_flag)
++        padding_bits = get_bits(&gb, 3);
++
++    if (!idle_flag && (!padding_flag || padding_bits != 0)) {
++        if (sl->packet_seq_num_len)
++            skip_bits_long(&gb, sl->packet_seq_num_len);
++        if (sl->degr_prior_len)
++            if (get_bits1(&gb))
++                skip_bits(&gb, sl->degr_prior_len);
++        if (ocr_flag)
++            skip_bits_long(&gb, sl->ocr_len);
++        if (au_start_flag) {
++            if (sl->use_rand_acc_pt)
++                get_bits1(&gb);
++            if (sl->au_seq_num_len > 0)
++                skip_bits_long(&gb, sl->au_seq_num_len);
++            if (sl->use_timestamps) {
++                dts_flag = get_bits1(&gb);
++                cts_flag = get_bits1(&gb);
++            }
++        }
++        if (sl->inst_bitrate_len)
++            inst_bitrate_flag = get_bits1(&gb);
++        if (dts_flag == 1)
++            dts = get_ts64(&gb, sl->timestamp_len);
++        if (cts_flag == 1)
++            cts = get_ts64(&gb, sl->timestamp_len);
++        if (sl->au_len > 0)
++            skip_bits_long(&gb, sl->au_len);
++        if (inst_bitrate_flag)
++            skip_bits_long(&gb, sl->inst_bitrate_len);
++    }
++
++    if (dts != AV_NOPTS_VALUE)
++        pes->dts = dts;
++    if (cts != AV_NOPTS_VALUE)
++        pes->pts = cts;
++
++    if (sl->timestamp_len && sl->timestamp_res)
++        avpriv_set_pts_info(pes->st, sl->timestamp_len, 1, sl->timestamp_res);
++
++    return (get_bits_count(&gb) + 7) >> 3;
++}
++
++static AVBufferRef *buffer_pool_get(MpegTSContext *ts, int size)
++{
++    int index = av_log2(size + AV_INPUT_BUFFER_PADDING_SIZE);
++    if (!ts->pools[index]) {
++        int pool_size = FFMIN(MAX_PES_PAYLOAD + AV_INPUT_BUFFER_PADDING_SIZE, 2 << index);
++        ts->pools[index] = av_buffer_pool_init(pool_size, NULL);
++        if (!ts->pools[index])
++            return NULL;
++    }
++    return av_buffer_pool_get(ts->pools[index]);
++}
++
++/* return non zero if a packet could be constructed */
++static int mpegts_push_data(MpegTSFilter *filter,
++                            const uint8_t *buf, int buf_size, int is_start,
++                            int64_t pos)
++{
++    PESContext *pes   = filter->u.pes_filter.opaque;
++    MpegTSContext *ts = pes->ts;
++    const uint8_t *p;
++    int ret, len, code;
++
++    if (!ts->pkt)
++        return 0;
++
++    if (is_start) {
++        if (pes->state == MPEGTS_PAYLOAD && pes->data_index > 0) {
++            ret = new_pes_packet(pes, ts->pkt);
++            if (ret < 0)
++                return ret;
++            ts->stop_parse = 1;
++        } else {
++            reset_pes_packet_state(pes);
++        }
++        pes->state         = MPEGTS_HEADER;
++        pes->ts_packet_pos = pos;
++    }
++    p = buf;
++    while (buf_size > 0) {
++        switch (pes->state) {
++        case MPEGTS_HEADER:
++            len = PES_START_SIZE - pes->data_index;
++            if (len > buf_size)
++                len = buf_size;
++            memcpy(pes->header + pes->data_index, p, len);
++            pes->data_index += len;
++            p += len;
++            buf_size -= len;
++            if (pes->data_index == PES_START_SIZE) {
++                /* we got all the PES or section header. We can now
++                 * decide */
++                if (pes->header[0] == 0x00 && pes->header[1] == 0x00 &&
++                    pes->header[2] == 0x01) {
++                    /* it must be an MPEG-2 PES stream */
++                    code = pes->header[3] | 0x100;
++                    av_log(pes->stream, AV_LOG_TRACE, "pid=%x pes_code=%#x\n", pes->pid,
++                            code);
++                    pes->stream_id = pes->header[3];
++
++                    if ((pes->st && pes->st->discard == AVDISCARD_ALL &&
++                         (!pes->sub_st ||
++                          pes->sub_st->discard == AVDISCARD_ALL)) ||
++                        code == 0x1be) /* padding_stream */
++                        goto skip;
++
++                    /* stream not present in PMT */
++                    if (!pes->st) {
++                        if (ts->skip_changes)
++                            goto skip;
++                        if (ts->merge_pmt_versions)
++                            goto skip; /* wait for PMT to merge new stream */
++
++                        pes->st = avformat_new_stream(ts->stream, NULL);
++                        if (!pes->st)
++                            return AVERROR(ENOMEM);
++                        pes->st->id = pes->pid;
++                        mpegts_set_stream_info(pes->st, pes, 0, 0);
++                    }
++
++                    pes->total_size = AV_RB16(pes->header + 4);
++                    /* NOTE: a zero total size means the PES size is
++                     * unbounded */
++                    if (!pes->total_size)
++                        pes->total_size = MAX_PES_PAYLOAD;
++
++                    /* allocate pes buffer */
++                    pes->buffer = buffer_pool_get(ts, pes->total_size);
++                    if (!pes->buffer)
++                        return AVERROR(ENOMEM);
++
++                    if (code != 0x1bc && code != 0x1bf && /* program_stream_map, private_stream_2 */
++                        code != 0x1f0 && code != 0x1f1 && /* ECM, EMM */
++                        code != 0x1ff && code != 0x1f2 && /* program_stream_directory, DSMCC_stream */
++                        code != 0x1f8) {                  /* ITU-T Rec. H.222.1 type E stream */
++                        pes->state = MPEGTS_PESHEADER;
++                        if (pes->st->codecpar->codec_id == AV_CODEC_ID_NONE && !pes->st->internal->request_probe) {
++                            av_log(pes->stream, AV_LOG_TRACE,
++                                    "pid=%x stream_type=%x probing\n",
++                                    pes->pid,
++                                    pes->stream_type);
++                            pes->st->internal->request_probe = 1;
++                        }
++                    } else {
++                        pes->pes_header_size = 6;
++                        pes->state      = MPEGTS_PAYLOAD;
++                        pes->data_index = 0;
++                    }
++                } else {
++                    /* otherwise, it should be a table */
++                    /* skip packet */
++skip:
++                    pes->state = MPEGTS_SKIP;
++                    continue;
++                }
++            }
++            break;
++        /**********************************************/
++        /* PES packing parsing */
++        case MPEGTS_PESHEADER:
++            len = PES_HEADER_SIZE - pes->data_index;
++            if (len < 0)
++                return AVERROR_INVALIDDATA;
++            if (len > buf_size)
++                len = buf_size;
++            memcpy(pes->header + pes->data_index, p, len);
++            pes->data_index += len;
++            p += len;
++            buf_size -= len;
++            if (pes->data_index == PES_HEADER_SIZE) {
++                pes->pes_header_size = pes->header[8] + 9;
++                pes->state           = MPEGTS_PESHEADER_FILL;
++            }
++            break;
++        case MPEGTS_PESHEADER_FILL:
++            len = pes->pes_header_size - pes->data_index;
++            if (len < 0)
++                return AVERROR_INVALIDDATA;
++            if (len > buf_size)
++                len = buf_size;
++            memcpy(pes->header + pes->data_index, p, len);
++            pes->data_index += len;
++            p += len;
++            buf_size -= len;
++            if (pes->data_index == pes->pes_header_size) {
++                const uint8_t *r;
++                unsigned int flags, pes_ext, skip;
++
++                flags = pes->header[7];
++                r = pes->header + 9;
++                pes->pts = AV_NOPTS_VALUE;
++                pes->dts = AV_NOPTS_VALUE;
++                if ((flags & 0xc0) == 0x80) {
++                    pes->dts = pes->pts = ff_parse_pes_pts(r);
++                    r += 5;
++                } else if ((flags & 0xc0) == 0xc0) {
++                    pes->pts = ff_parse_pes_pts(r);
++                    r += 5;
++                    pes->dts = ff_parse_pes_pts(r);
++                    r += 5;
++                }
++                pes->extended_stream_id = -1;
++                if (flags & 0x01) { /* PES extension */
++                    pes_ext = *r++;
++                    /* Skip PES private data, program packet sequence counter and P-STD buffer */
++                    skip  = (pes_ext >> 4) & 0xb;
++                    skip += skip & 0x9;
++                    r    += skip;
++                    if ((pes_ext & 0x41) == 0x01 &&
++                        (r + 2) <= (pes->header + pes->pes_header_size)) {
++                        /* PES extension 2 */
++                        if ((r[0] & 0x7f) > 0 && (r[1] & 0x80) == 0)
++                            pes->extended_stream_id = r[1];
++                    }
++                }
++
++                /* we got the full header. We parse it and get the payload */
++                pes->state = MPEGTS_PAYLOAD;
++                pes->data_index = 0;
++                if (pes->stream_type == 0x12 && buf_size > 0) {
++                    int sl_header_bytes = read_sl_header(pes, &pes->sl, p,
++                                                         buf_size);
++                    pes->pes_header_size += sl_header_bytes;
++                    p += sl_header_bytes;
++                    buf_size -= sl_header_bytes;
++                }
++                if (pes->stream_type == 0x15 && buf_size >= 5) {
++                    /* skip metadata access unit header */
++                    pes->pes_header_size += 5;
++                    p += 5;
++                    buf_size -= 5;
++                }
++                if (   pes->ts->fix_teletext_pts
++                    && (   pes->st->codecpar->codec_id == AV_CODEC_ID_DVB_TELETEXT
++                        || pes->st->codecpar->codec_id == AV_CODEC_ID_DVB_SUBTITLE)
++                    ) {
++                    AVProgram *p = NULL;
++                    int pcr_found = 0;
++                    while ((p = av_find_program_from_stream(pes->stream, p, pes->st->index))) {
++                        if (p->pcr_pid != -1 && p->discard != AVDISCARD_ALL) {
++                            MpegTSFilter *f = pes->ts->pids[p->pcr_pid];
++                            if (f) {
++                                AVStream *st = NULL;
++                                if (f->type == MPEGTS_PES) {
++                                    PESContext *pcrpes = f->u.pes_filter.opaque;
++                                    if (pcrpes)
++                                        st = pcrpes->st;
++                                } else if (f->type == MPEGTS_PCR) {
++                                    int i;
++                                    for (i = 0; i < p->nb_stream_indexes; i++) {
++                                        AVStream *pst = pes->stream->streams[p->stream_index[i]];
++                                        if (pst->codecpar->codec_type == AVMEDIA_TYPE_VIDEO)
++                                            st = pst;
++                                    }
++                                }
++                                if (f->last_pcr != -1 && !f->discard) {
++                                    // teletext packets do not always have correct timestamps,
++                                    // the standard says they should be handled after 40.6 ms at most,
++                                    // and the pcr error to this packet should be no more than 100 ms.
++                                    // TODO: we should interpolate the PCR, not just use the last one
++                                    int64_t pcr = f->last_pcr / 300;
++                                    pcr_found = 1;
++                                    if (st) {
++                                        pes->st->internal->pts_wrap_reference = st->internal->pts_wrap_reference;
++                                        pes->st->internal->pts_wrap_behavior = st->internal->pts_wrap_behavior;
++                                    }
++                                    if (pes->dts == AV_NOPTS_VALUE || pes->dts < pcr) {
++                                        pes->pts = pes->dts = pcr;
++                                    } else if (pes->st->codecpar->codec_id == AV_CODEC_ID_DVB_TELETEXT &&
++                                               pes->dts > pcr + 3654 + 9000) {
++                                        pes->pts = pes->dts = pcr + 3654 + 9000;
++                                    } else if (pes->st->codecpar->codec_id == AV_CODEC_ID_DVB_SUBTITLE &&
++                                               pes->dts > pcr + 10*90000) { //10sec
++                                        pes->pts = pes->dts = pcr + 3654 + 9000;
++                                    }
++                                    break;
++                                }
++                            }
++                        }
++                    }
++
++                    if (pes->st->codecpar->codec_id == AV_CODEC_ID_DVB_TELETEXT &&
++                        !pcr_found) {
++                        av_log(pes->stream, AV_LOG_VERBOSE,
++                               "Forcing DTS/PTS to be unset for a "
++                               "non-trustworthy PES packet for PID %d as "
++                               "PCR hasn't been received yet.\n",
++                               pes->pid);
++                        pes->dts = pes->pts = AV_NOPTS_VALUE;
++                    }
++                }
++            }
++            break;
++        case MPEGTS_PAYLOAD:
++            if (pes->buffer) {
++                if (pes->data_index > 0 &&
++                    pes->data_index + buf_size > pes->total_size) {
++                    ret = new_pes_packet(pes, ts->pkt);
++                    if (ret < 0)
++                        return ret;
++                    pes->total_size = MAX_PES_PAYLOAD;
++                    pes->buffer = buffer_pool_get(ts, pes->total_size);
++                    if (!pes->buffer)
++                        return AVERROR(ENOMEM);
++                    ts->stop_parse = 1;
++                } else if (pes->data_index == 0 &&
++                           buf_size > pes->total_size) {
++                    // pes packet size is < ts size packet and pes data is padded with 0xff
++                    // not sure if this is legal in ts but see issue #2392
++                    buf_size = pes->total_size;
++                }
++                memcpy(pes->buffer->data + pes->data_index, p, buf_size);
++                pes->data_index += buf_size;
++                /* emit complete packets with known packet size
++                 * decreases demuxer delay for infrequent packets like subtitles from
++                 * a couple of seconds to milliseconds for properly muxed files.
++                 * total_size is the number of bytes following pes_packet_length
++                 * in the pes header, i.e. not counting the first PES_START_SIZE bytes */
++                if (!ts->stop_parse && pes->total_size < MAX_PES_PAYLOAD &&
++                    pes->pes_header_size + pes->data_index == pes->total_size + PES_START_SIZE) {
++                    ts->stop_parse = 1;
++                    ret = new_pes_packet(pes, ts->pkt);
++                    if (ret < 0)
++                        return ret;
++                }
++            }
++            buf_size = 0;
++            break;
++        case MPEGTS_SKIP:
++            buf_size = 0;
++            break;
++        }
++    }
++
++    return 0;
++}
++
++static PESContext *add_pes_stream(MpegTSContext *ts, int pid, int pcr_pid)
++{
++    MpegTSFilter *tss;
++    PESContext *pes;
++
++    /* if no pid found, then add a pid context */
++    pes = av_mallocz(sizeof(PESContext));
++    if (!pes)
++        return 0;
++    pes->ts      = ts;
++    pes->stream  = ts->stream;
++    pes->pid     = pid;
++    pes->pcr_pid = pcr_pid;
++    pes->state   = MPEGTS_SKIP;
++    pes->pts     = AV_NOPTS_VALUE;
++    pes->dts     = AV_NOPTS_VALUE;
++    tss          = mpegts_open_pes_filter(ts, pid, mpegts_push_data, pes);
++    if (!tss) {
++        av_free(pes);
++        return 0;
++    }
++    return pes;
++}
++
++#define MAX_LEVEL 4
++typedef struct MP4DescrParseContext {
++    AVFormatContext *s;
++    AVIOContext pb;
++    Mp4Descr *descr;
++    Mp4Descr *active_descr;
++    int descr_count;
++    int max_descr_count;
++    int level;
++    int predefined_SLConfigDescriptor_seen;
++} MP4DescrParseContext;
++
++static int init_MP4DescrParseContext(MP4DescrParseContext *d, AVFormatContext *s,
++                                     const uint8_t *buf, unsigned size,
++                                     Mp4Descr *descr, int max_descr_count)
++{
++    int ret;
++    if (size > (1 << 30))
++        return AVERROR_INVALIDDATA;
++
++    if ((ret = ffio_init_context(&d->pb, (unsigned char *)buf, size, 0,
++                                 NULL, NULL, NULL, NULL)) < 0)
++        return ret;
++
++    d->s               = s;
++    d->level           = 0;
++    d->descr_count     = 0;
++    d->descr           = descr;
++    d->active_descr    = NULL;
++    d->max_descr_count = max_descr_count;
++
++    return 0;
++}
++
++static void update_offsets(AVIOContext *pb, int64_t *off, int *len)
++{
++    int64_t new_off = avio_tell(pb);
++    (*len) -= new_off - *off;
++    *off    = new_off;
++}
++
++static int parse_mp4_descr(MP4DescrParseContext *d, int64_t off, int len,
++                           int target_tag);
++
++static int parse_mp4_descr_arr(MP4DescrParseContext *d, int64_t off, int len)
++{
++    while (len > 0) {
++        int ret = parse_mp4_descr(d, off, len, 0);
++        if (ret < 0)
++            return ret;
++        update_offsets(&d->pb, &off, &len);
++    }
++    return 0;
++}
++
++static int parse_MP4IODescrTag(MP4DescrParseContext *d, int64_t off, int len)
++{
++    avio_rb16(&d->pb); // ID
++    avio_r8(&d->pb);
++    avio_r8(&d->pb);
++    avio_r8(&d->pb);
++    avio_r8(&d->pb);
++    avio_r8(&d->pb);
++    update_offsets(&d->pb, &off, &len);
++    return parse_mp4_descr_arr(d, off, len);
++}
++
++static int parse_MP4ODescrTag(MP4DescrParseContext *d, int64_t off, int len)
++{
++    int id_flags;
++    if (len < 2)
++        return 0;
++    id_flags = avio_rb16(&d->pb);
++    if (!(id_flags & 0x0020)) { // URL_Flag
++        update_offsets(&d->pb, &off, &len);
++        return parse_mp4_descr_arr(d, off, len); // ES_Descriptor[]
++    } else {
++        return 0;
++    }
++}
++
++static int parse_MP4ESDescrTag(MP4DescrParseContext *d, int64_t off, int len)
++{
++    int es_id = 0;
++    int ret   = 0;
++
++    if (d->descr_count >= d->max_descr_count)
++        return AVERROR_INVALIDDATA;
++    ff_mp4_parse_es_descr(&d->pb, &es_id);
++    d->active_descr = d->descr + (d->descr_count++);
++
++    d->active_descr->es_id = es_id;
++    update_offsets(&d->pb, &off, &len);
++    if ((ret = parse_mp4_descr(d, off, len, MP4DecConfigDescrTag)) < 0)
++        return ret;
++    update_offsets(&d->pb, &off, &len);
++    if (len > 0)
++        ret = parse_mp4_descr(d, off, len, MP4SLDescrTag);
++    d->active_descr = NULL;
++    return ret;
++}
++
++static int parse_MP4DecConfigDescrTag(MP4DescrParseContext *d, int64_t off,
++                                      int len)
++{
++    Mp4Descr *descr = d->active_descr;
++    if (!descr)
++        return AVERROR_INVALIDDATA;
++    d->active_descr->dec_config_descr = av_malloc(len);
++    if (!descr->dec_config_descr)
++        return AVERROR(ENOMEM);
++    descr->dec_config_descr_len = len;
++    avio_read(&d->pb, descr->dec_config_descr, len);
++    return 0;
++}
++
++static int parse_MP4SLDescrTag(MP4DescrParseContext *d, int64_t off, int len)
++{
++    Mp4Descr *descr = d->active_descr;
++    int predefined;
++    if (!descr)
++        return AVERROR_INVALIDDATA;
++
++#define R8_CHECK_CLIP_MAX(dst, maxv) do {                       \
++    descr->sl.dst = avio_r8(&d->pb);                            \
++    if (descr->sl.dst > maxv) {                                 \
++        descr->sl.dst = maxv;                                   \
++        return AVERROR_INVALIDDATA;                             \
++    }                                                           \
++} while (0)
++
++    predefined = avio_r8(&d->pb);
++    if (!predefined) {
++        int lengths;
++        int flags = avio_r8(&d->pb);
++        descr->sl.use_au_start    = !!(flags & 0x80);
++        descr->sl.use_au_end      = !!(flags & 0x40);
++        descr->sl.use_rand_acc_pt = !!(flags & 0x20);
++        descr->sl.use_padding     = !!(flags & 0x08);
++        descr->sl.use_timestamps  = !!(flags & 0x04);
++        descr->sl.use_idle        = !!(flags & 0x02);
++        descr->sl.timestamp_res   = avio_rb32(&d->pb);
++        avio_rb32(&d->pb);
++        R8_CHECK_CLIP_MAX(timestamp_len, 63);
++        R8_CHECK_CLIP_MAX(ocr_len,       63);
++        R8_CHECK_CLIP_MAX(au_len,        31);
++        descr->sl.inst_bitrate_len   = avio_r8(&d->pb);
++        lengths                      = avio_rb16(&d->pb);
++        descr->sl.degr_prior_len     = lengths >> 12;
++        descr->sl.au_seq_num_len     = (lengths >> 7) & 0x1f;
++        descr->sl.packet_seq_num_len = (lengths >> 2) & 0x1f;
++    } else if (!d->predefined_SLConfigDescriptor_seen){
++        avpriv_report_missing_feature(d->s, "Predefined SLConfigDescriptor");
++        d->predefined_SLConfigDescriptor_seen = 1;
++    }
++    return 0;
++}
++
++static int parse_mp4_descr(MP4DescrParseContext *d, int64_t off, int len,
++                           int target_tag)
++{
++    int tag;
++    int len1 = ff_mp4_read_descr(d->s, &d->pb, &tag);
++    int ret = 0;
++
++    update_offsets(&d->pb, &off, &len);
++    if (len < 0 || len1 > len || len1 <= 0) {
++        av_log(d->s, AV_LOG_ERROR,
++               "Tag %x length violation new length %d bytes remaining %d\n",
++               tag, len1, len);
++        return AVERROR_INVALIDDATA;
++    }
++
++    if (d->level++ >= MAX_LEVEL) {
++        av_log(d->s, AV_LOG_ERROR, "Maximum MP4 descriptor level exceeded\n");
++        ret = AVERROR_INVALIDDATA;
++        goto done;
++    }
++
++    if (target_tag && tag != target_tag) {
++        av_log(d->s, AV_LOG_ERROR, "Found tag %x expected %x\n", tag,
++               target_tag);
++        ret = AVERROR_INVALIDDATA;
++        goto done;
++    }
++
++    switch (tag) {
++    case MP4IODescrTag:
++        ret = parse_MP4IODescrTag(d, off, len1);
++        break;
++    case MP4ODescrTag:
++        ret = parse_MP4ODescrTag(d, off, len1);
++        break;
++    case MP4ESDescrTag:
++        ret = parse_MP4ESDescrTag(d, off, len1);
++        break;
++    case MP4DecConfigDescrTag:
++        ret = parse_MP4DecConfigDescrTag(d, off, len1);
++        break;
++    case MP4SLDescrTag:
++        ret = parse_MP4SLDescrTag(d, off, len1);
++        break;
++    }
++
++
++done:
++    d->level--;
++    avio_seek(&d->pb, off + len1, SEEK_SET);
++    return ret;
++}
++
++static int mp4_read_iods(AVFormatContext *s, const uint8_t *buf, unsigned size,
++                         Mp4Descr *descr, int *descr_count, int max_descr_count)
++{
++    MP4DescrParseContext d;
++    int ret;
++
++    ret = init_MP4DescrParseContext(&d, s, buf, size, descr, max_descr_count);
++    if (ret < 0)
++        return ret;
++
++    ret = parse_mp4_descr(&d, avio_tell(&d.pb), size, MP4IODescrTag);
++
++    *descr_count = d.descr_count;
++    return ret;
++}
++
++static int mp4_read_od(AVFormatContext *s, const uint8_t *buf, unsigned size,
++                       Mp4Descr *descr, int *descr_count, int max_descr_count)
++{
++    MP4DescrParseContext d;
++    int ret;
++
++    ret = init_MP4DescrParseContext(&d, s, buf, size, descr, max_descr_count);
++    if (ret < 0)
++        return ret;
++
++    ret = parse_mp4_descr_arr(&d, avio_tell(&d.pb), size);
++
++    *descr_count = d.descr_count;
++    return ret;
++}
++
++static void m4sl_cb(MpegTSFilter *filter, const uint8_t *section,
++                    int section_len)
++{
++    MpegTSContext *ts = filter->u.section_filter.opaque;
++    MpegTSSectionFilter *tssf = &filter->u.section_filter;
++    SectionHeader h;
++    const uint8_t *p, *p_end;
++    AVIOContext pb;
++    int mp4_descr_count = 0;
++    Mp4Descr mp4_descr[MAX_MP4_DESCR_COUNT] = { { 0 } };
++    int i, pid;
++    AVFormatContext *s = ts->stream;
++
++    p_end = section + section_len - 4;
++    p = section;
++    if (parse_section_header(&h, &p, p_end) < 0)
++        return;
++    if (h.tid != M4OD_TID)
++        return;
++    if (skip_identical(&h, tssf))
++        return;
++
++    mp4_read_od(s, p, (unsigned) (p_end - p), mp4_descr, &mp4_descr_count,
++                MAX_MP4_DESCR_COUNT);
++
++    for (pid = 0; pid < NB_PID_MAX; pid++) {
++        if (!ts->pids[pid])
++            continue;
++        for (i = 0; i < mp4_descr_count; i++) {
++            PESContext *pes;
++            AVStream *st;
++            if (ts->pids[pid]->es_id != mp4_descr[i].es_id)
++                continue;
++            if (ts->pids[pid]->type != MPEGTS_PES) {
++                av_log(s, AV_LOG_ERROR, "pid %x is not PES\n", pid);
++                continue;
++            }
++            pes = ts->pids[pid]->u.pes_filter.opaque;
++            st  = pes->st;
++            if (!st)
++                continue;
++
++            pes->sl = mp4_descr[i].sl;
++
++            ffio_init_context(&pb, mp4_descr[i].dec_config_descr,
++                              mp4_descr[i].dec_config_descr_len, 0,
++                              NULL, NULL, NULL, NULL);
++            ff_mp4_read_dec_config_descr(s, st, &pb);
++            if (st->codecpar->codec_id == AV_CODEC_ID_AAC &&
++                st->codecpar->extradata_size > 0)
++                st->need_parsing = 0;
++            if (st->codecpar->codec_id == AV_CODEC_ID_H264 &&
++                st->codecpar->extradata_size > 0)
++                st->need_parsing = 0;
++
++            st->codecpar->codec_type = avcodec_get_type(st->codecpar->codec_id);
++            st->internal->need_context_update = 1;
++        }
++    }
++    for (i = 0; i < mp4_descr_count; i++)
++        av_free(mp4_descr[i].dec_config_descr);
++}
++
++static void scte_data_cb(MpegTSFilter *filter, const uint8_t *section,
++                    int section_len)
++{
++    AVProgram *prg = NULL;
++    MpegTSContext *ts = filter->u.section_filter.opaque;
++
++    int idx = ff_find_stream_index(ts->stream, filter->pid);
++    if (idx < 0)
++        return;
++
++    /**
++     * In case we receive an SCTE-35 packet before mpegts context is fully
++     * initialized.
++     */
++    if (!ts->pkt)
++        return;
++
++    new_data_packet(section, section_len, ts->pkt);
++    ts->pkt->stream_index = idx;
++    prg = av_find_program_from_stream(ts->stream, NULL, idx);
++    if (prg && prg->pcr_pid != -1 && prg->discard != AVDISCARD_ALL) {
++        MpegTSFilter *f = ts->pids[prg->pcr_pid];
++        if (f && f->last_pcr != -1)
++            ts->pkt->pts = ts->pkt->dts = f->last_pcr/300;
++    }
++    ts->stop_parse = 1;
++
++}
++
++static const uint8_t opus_coupled_stream_cnt[9] = {
++    1, 0, 1, 1, 2, 2, 2, 3, 3
++};
++
++static const uint8_t opus_stream_cnt[9] = {
++    1, 1, 1, 2, 2, 3, 4, 4, 5,
++};
++
++static const uint8_t opus_channel_map[8][8] = {
++    { 0 },
++    { 0,1 },
++    { 0,2,1 },
++    { 0,1,2,3 },
++    { 0,4,1,2,3 },
++    { 0,4,1,2,3,5 },
++    { 0,4,1,2,3,5,6 },
++    { 0,6,1,2,3,4,5,7 },
++};
++
++int ff_parse_mpeg2_descriptor(AVFormatContext *fc, AVStream *st, int stream_type,
++                              const uint8_t **pp, const uint8_t *desc_list_end,
++                              Mp4Descr *mp4_descr, int mp4_descr_count, int pid,
++                              MpegTSContext *ts)
++{
++    const uint8_t *desc_end;
++    int desc_len, desc_tag, desc_es_id, ext_desc_tag, channels, channel_config_code;
++    char language[252];
++    int i;
++
++    desc_tag = get8(pp, desc_list_end);
++    if (desc_tag < 0)
++        return AVERROR_INVALIDDATA;
++    desc_len = get8(pp, desc_list_end);
++    if (desc_len < 0)
++        return AVERROR_INVALIDDATA;
++    desc_end = *pp + desc_len;
++    if (desc_end > desc_list_end)
++        return AVERROR_INVALIDDATA;
++
++    av_log(fc, AV_LOG_TRACE, "tag: 0x%02x len=%d\n", desc_tag, desc_len);
++
++    if ((st->codecpar->codec_id == AV_CODEC_ID_NONE || st->internal->request_probe > 0) &&
++        stream_type == STREAM_TYPE_PRIVATE_DATA)
++        mpegts_find_stream_type(st, desc_tag, DESC_types);
++
++    switch (desc_tag) {
++    case VIDEO_STREAM_DESCRIPTOR:
++        if (get8(pp, desc_end) & 0x1) {
++            st->disposition |= AV_DISPOSITION_STILL_IMAGE;
++        }
++        break;
++    case SL_DESCRIPTOR:
++        desc_es_id = get16(pp, desc_end);
++        if (desc_es_id < 0)
++            break;
++        if (ts && ts->pids[pid])
++            ts->pids[pid]->es_id = desc_es_id;
++        for (i = 0; i < mp4_descr_count; i++)
++            if (mp4_descr[i].dec_config_descr_len &&
++                mp4_descr[i].es_id == desc_es_id) {
++                AVIOContext pb;
++                ffio_init_context(&pb, mp4_descr[i].dec_config_descr,
++                                  mp4_descr[i].dec_config_descr_len, 0,
++                                  NULL, NULL, NULL, NULL);
++                ff_mp4_read_dec_config_descr(fc, st, &pb);
++                if (st->codecpar->codec_id == AV_CODEC_ID_AAC &&
++                    st->codecpar->extradata_size > 0) {
++                    st->need_parsing = 0;
++                    st->internal->need_context_update = 1;
++                }
++                if (st->codecpar->codec_id == AV_CODEC_ID_MPEG4SYSTEMS)
++                    mpegts_open_section_filter(ts, pid, m4sl_cb, ts, 1);
++            }
++        break;
++    case FMC_DESCRIPTOR:
++        if (get16(pp, desc_end) < 0)
++            break;
++        if (mp4_descr_count > 0 &&
++            (st->codecpar->codec_id == AV_CODEC_ID_AAC_LATM ||
++             (st->internal->request_probe == 0 && st->codecpar->codec_id == AV_CODEC_ID_NONE) ||
++             st->internal->request_probe > 0) &&
++            mp4_descr->dec_config_descr_len && mp4_descr->es_id == pid) {
++            AVIOContext pb;
++            ffio_init_context(&pb, mp4_descr->dec_config_descr,
++                              mp4_descr->dec_config_descr_len, 0,
++                              NULL, NULL, NULL, NULL);
++            ff_mp4_read_dec_config_descr(fc, st, &pb);
++            if (st->codecpar->codec_id == AV_CODEC_ID_AAC &&
++                st->codecpar->extradata_size > 0) {
++                st->internal->request_probe = st->need_parsing = 0;
++                st->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;
++                st->internal->need_context_update = 1;
++            }
++        }
++        break;
++    case 0x56: /* DVB teletext descriptor */
++        {
++            uint8_t *extradata = NULL;
++            int language_count = desc_len / 5, ret;
++
++            if (desc_len > 0 && desc_len % 5 != 0)
++                return AVERROR_INVALIDDATA;
++
++            if (language_count > 0) {
++                /* 4 bytes per language code (3 bytes) with comma or NUL byte should fit language buffer */
++                av_assert0(language_count <= sizeof(language) / 4);
++
++                if (st->codecpar->extradata == NULL) {
++                    ret = ff_alloc_extradata(st->codecpar, language_count * 2);
++                    if (ret < 0)
++                        return ret;
++                }
++
++                if (st->codecpar->extradata_size < language_count * 2)
++                    return AVERROR_INVALIDDATA;
++
++                extradata = st->codecpar->extradata;
++
++                for (i = 0; i < language_count; i++) {
++                    language[i * 4 + 0] = get8(pp, desc_end);
++                    language[i * 4 + 1] = get8(pp, desc_end);
++                    language[i * 4 + 2] = get8(pp, desc_end);
++                    language[i * 4 + 3] = ',';
++
++                    memcpy(extradata, *pp, 2);
++                    extradata += 2;
++
++                    *pp += 2;
++                }
++
++                language[i * 4 - 1] = 0;
++                av_dict_set(&st->metadata, "language", language, 0);
++                st->internal->need_context_update = 1;
++            }
++        }
++        break;
++    case 0x59: /* subtitling descriptor */
++        {
++            /* 8 bytes per DVB subtitle substream data:
++             * ISO_639_language_code (3 bytes),
++             * subtitling_type (1 byte),
++             * composition_page_id (2 bytes),
++             * ancillary_page_id (2 bytes) */
++            int language_count = desc_len / 8, ret;
++
++            if (desc_len > 0 && desc_len % 8 != 0)
++                return AVERROR_INVALIDDATA;
++
++            if (language_count > 1) {
++                avpriv_request_sample(fc, "DVB subtitles with multiple languages");
++            }
++
++            if (language_count > 0) {
++                uint8_t *extradata;
++
++                /* 4 bytes per language code (3 bytes) with comma or NUL byte should fit language buffer */
++                av_assert0(language_count <= sizeof(language) / 4);
++
++                if (st->codecpar->extradata == NULL) {
++                    ret = ff_alloc_extradata(st->codecpar, language_count * 5);
++                    if (ret < 0)
++                        return ret;
++                }
++
++                if (st->codecpar->extradata_size < language_count * 5)
++                    return AVERROR_INVALIDDATA;
++
++                extradata = st->codecpar->extradata;
++
++                for (i = 0; i < language_count; i++) {
++                    language[i * 4 + 0] = get8(pp, desc_end);
++                    language[i * 4 + 1] = get8(pp, desc_end);
++                    language[i * 4 + 2] = get8(pp, desc_end);
++                    language[i * 4 + 3] = ',';
++
++                    /* hearing impaired subtitles detection using subtitling_type */
++                    switch (*pp[0]) {
++                    case 0x20: /* DVB subtitles (for the hard of hearing) with no monitor aspect ratio criticality */
++                    case 0x21: /* DVB subtitles (for the hard of hearing) for display on 4:3 aspect ratio monitor */
++                    case 0x22: /* DVB subtitles (for the hard of hearing) for display on 16:9 aspect ratio monitor */
++                    case 0x23: /* DVB subtitles (for the hard of hearing) for display on 2.21:1 aspect ratio monitor */
++                    case 0x24: /* DVB subtitles (for the hard of hearing) for display on a high definition monitor */
++                    case 0x25: /* DVB subtitles (for the hard of hearing) with plano-stereoscopic disparity for display on a high definition monitor */
++                        st->disposition |= AV_DISPOSITION_HEARING_IMPAIRED;
++                        break;
++                    }
++
++                    extradata[4] = get8(pp, desc_end); /* subtitling_type */
++                    memcpy(extradata, *pp, 4); /* composition_page_id and ancillary_page_id */
++                    extradata += 5;
++
++                    *pp += 4;
++                }
++
++                language[i * 4 - 1] = 0;
++                av_dict_set(&st->metadata, "language", language, 0);
++                st->internal->need_context_update = 1;
++            }
++        }
++        break;
++    case ISO_639_LANGUAGE_DESCRIPTOR:
++        for (i = 0; i + 4 <= desc_len; i += 4) {
++            language[i + 0] = get8(pp, desc_end);
++            language[i + 1] = get8(pp, desc_end);
++            language[i + 2] = get8(pp, desc_end);
++            language[i + 3] = ',';
++            switch (get8(pp, desc_end)) {
++            case 0x01:
++                st->disposition |= AV_DISPOSITION_CLEAN_EFFECTS;
++                break;
++            case 0x02:
++                st->disposition |= AV_DISPOSITION_HEARING_IMPAIRED;
++                break;
++            case 0x03:
++                st->disposition |= AV_DISPOSITION_VISUAL_IMPAIRED;
++                st->disposition |= AV_DISPOSITION_DESCRIPTIONS;
++                break;
++            }
++        }
++        if (i && language[0]) {
++            language[i - 1] = 0;
++            /* don't overwrite language, as it may already have been set by
++             * another, more specific descriptor (e.g. supplementary audio) */
++            av_dict_set(&st->metadata, "language", language, AV_DICT_DONT_OVERWRITE);
++        }
++        break;
++    case REGISTRATION_DESCRIPTOR:
++        st->codecpar->codec_tag = bytestream_get_le32(pp);
++        av_log(fc, AV_LOG_TRACE, "reg_desc=%.4s\n", (char *)&st->codecpar->codec_tag);
++        if (st->codecpar->codec_id == AV_CODEC_ID_NONE || st->internal->request_probe > 0) {
++            mpegts_find_stream_type(st, st->codecpar->codec_tag, REGD_types);
++            if (st->codecpar->codec_tag == MKTAG('B', 'S', 'S', 'D'))
++                st->internal->request_probe = 50;
++        }
++        break;
++    case 0x52: /* stream identifier descriptor */
++        st->stream_identifier = 1 + get8(pp, desc_end);
++        break;
++    case METADATA_DESCRIPTOR:
++        if (get16(pp, desc_end) == 0xFFFF)
++            *pp += 4;
++        if (get8(pp, desc_end) == 0xFF) {
++            st->codecpar->codec_tag = bytestream_get_le32(pp);
++            if (st->codecpar->codec_id == AV_CODEC_ID_NONE)
++                mpegts_find_stream_type(st, st->codecpar->codec_tag, METADATA_types);
++        }
++        break;
++    case 0x7f: /* DVB extension descriptor */
++        ext_desc_tag = get8(pp, desc_end);
++        if (ext_desc_tag < 0)
++            return AVERROR_INVALIDDATA;
++        if (st->codecpar->codec_id == AV_CODEC_ID_OPUS &&
++            ext_desc_tag == 0x80) { /* User defined (provisional Opus) */
++            if (!st->codecpar->extradata) {
++                st->codecpar->extradata = av_mallocz(sizeof(opus_default_extradata) +
++                                                     AV_INPUT_BUFFER_PADDING_SIZE);
++                if (!st->codecpar->extradata)
++                    return AVERROR(ENOMEM);
++
++                st->codecpar->extradata_size = sizeof(opus_default_extradata);
++                memcpy(st->codecpar->extradata, opus_default_extradata, sizeof(opus_default_extradata));
++
++                channel_config_code = get8(pp, desc_end);
++                if (channel_config_code < 0)
++                    return AVERROR_INVALIDDATA;
++                if (channel_config_code <= 0x8) {
++                    st->codecpar->extradata[9]  = channels = channel_config_code ? channel_config_code : 2;
++                    AV_WL32(&st->codecpar->extradata[12], 48000);
++                    st->codecpar->extradata[18] = channel_config_code ? (channels > 2) : /* Dual Mono */ 255;
++                    st->codecpar->extradata[19] = opus_stream_cnt[channel_config_code];
++                    st->codecpar->extradata[20] = opus_coupled_stream_cnt[channel_config_code];
++                    memcpy(&st->codecpar->extradata[21], opus_channel_map[channels - 1], channels);
++                } else {
++                    avpriv_request_sample(fc, "Opus in MPEG-TS - channel_config_code > 0x8");
++                }
++                st->need_parsing = AVSTREAM_PARSE_FULL;
++                st->internal->need_context_update = 1;
++            }
++        }
++        if (ext_desc_tag == 0x06) { /* supplementary audio descriptor */
++            int flags;
++
++            if (desc_len < 1)
++                return AVERROR_INVALIDDATA;
++            flags = get8(pp, desc_end);
++
++            if ((flags & 0x80) == 0) /* mix_type */
++                st->disposition |= AV_DISPOSITION_DEPENDENT;
++
++            switch ((flags >> 2) & 0x1F) { /* editorial_classification */
++            case 0x01:
++                st->disposition |= AV_DISPOSITION_VISUAL_IMPAIRED;
++                st->disposition |= AV_DISPOSITION_DESCRIPTIONS;
++                break;
++            case 0x02:
++                st->disposition |= AV_DISPOSITION_HEARING_IMPAIRED;
++                break;
++            case 0x03:
++                st->disposition |= AV_DISPOSITION_VISUAL_IMPAIRED;
++                break;
++            }
++
++            if (flags & 0x01) { /* language_code_present */
++                if (desc_len < 4)
++                    return AVERROR_INVALIDDATA;
++                language[0] = get8(pp, desc_end);
++                language[1] = get8(pp, desc_end);
++                language[2] = get8(pp, desc_end);
++                language[3] = 0;
++
++                /* This language always has to override a possible
++                 * ISO 639 language descriptor language */
++                if (language[0])
++                    av_dict_set(&st->metadata, "language", language, 0);
++            }
++        }
++        break;
++    case 0x6a: /* ac-3_descriptor */
++        {
++            int component_type_flag = get8(pp, desc_end) & (1 << 7);
++            if (component_type_flag) {
++                int component_type = get8(pp, desc_end);
++                int service_type_mask = 0x38;  // 0b00111000
++                int service_type = ((component_type & service_type_mask) >> 3);
++                if (service_type == 0x02 /* 0b010 */) {
++                    st->disposition |= AV_DISPOSITION_DESCRIPTIONS;
++                    av_log(ts ? ts->stream : fc, AV_LOG_DEBUG, "New track disposition for id %u: %u\n", st->id, st->disposition);
++                }
++            }
++        }
++        break;
++    case 0x7a: /* enhanced_ac-3_descriptor */
++        {
++            int component_type_flag = get8(pp, desc_end) & (1 << 7);
++            if (component_type_flag) {
++                int component_type = get8(pp, desc_end);
++                int service_type_mask = 0x38;  // 0b00111000
++                int service_type = ((component_type & service_type_mask) >> 3);
++                if (service_type == 0x02 /* 0b010 */) {
++                    st->disposition |= AV_DISPOSITION_DESCRIPTIONS;
++                    av_log(ts ? ts->stream : fc, AV_LOG_DEBUG, "New track disposition for id %u: %u\n", st->id, st->disposition);
++                }
++            }
++        }
++        break;
++    case 0xfd: /* ARIB data coding type descriptor */
++        // STD-B24, fascicle 3, chapter 4 defines private_stream_1
++        // for captions
++        if (stream_type == STREAM_TYPE_PRIVATE_DATA) {
++            // This structure is defined in STD-B10, part 1, listing 5.4 and
++            // part 2, 6.2.20).
++            // Listing of data_component_ids is in STD-B10, part 2, Annex J.
++            // Component tag limits are documented in TR-B14, fascicle 2,
++            // Vol. 3, Section 2, 4.2.8.1
++            int actual_component_tag = st->stream_identifier - 1;
++            int picked_profile = FF_PROFILE_UNKNOWN;
++            int data_component_id = get16(pp, desc_end);
++            if (data_component_id < 0)
++                return AVERROR_INVALIDDATA;
++
++            switch (data_component_id) {
++            case 0x0008:
++                // [0x30..0x37] are component tags utilized for
++                // non-mobile captioning service ("profile A").
++                if (actual_component_tag >= 0x30 &&
++                    actual_component_tag <= 0x37) {
++                    picked_profile = FF_PROFILE_ARIB_PROFILE_A;
++                }
++                break;
++            case 0x0012:
++                // component tag 0x87 signifies a mobile/partial reception
++                // (1seg) captioning service ("profile C").
++                if (actual_component_tag == 0x87) {
++                    picked_profile = FF_PROFILE_ARIB_PROFILE_C;
++                }
++                break;
++            default:
++                break;
++            }
++
++            if (picked_profile == FF_PROFILE_UNKNOWN)
++                break;
++
++            st->codecpar->codec_type = AVMEDIA_TYPE_SUBTITLE;
++            st->codecpar->codec_id   = AV_CODEC_ID_ARIB_CAPTION;
++            st->codecpar->profile    = picked_profile;
++            st->internal->request_probe        = 0;
++        }
++        break;
++    case 0xb0: /* DOVI video stream descriptor */
++        {
++            uint32_t buf;
++            AVDOVIDecoderConfigurationRecord *dovi;
++            size_t dovi_size;
++            int ret;
++            if (desc_end - *pp < 4) // (8 + 8 + 7 + 6 + 1 + 1 + 1) / 8
++                return AVERROR_INVALIDDATA;
++
++            dovi = av_dovi_alloc(&dovi_size);
++            if (!dovi)
++                return AVERROR(ENOMEM);
++
++            dovi->dv_version_major = get8(pp, desc_end);
++            dovi->dv_version_minor = get8(pp, desc_end);
++            buf = get16(pp, desc_end);
++            dovi->dv_profile        = (buf >> 9) & 0x7f;    // 7 bits
++            dovi->dv_level          = (buf >> 3) & 0x3f;    // 6 bits
++            dovi->rpu_present_flag  = (buf >> 2) & 0x01;    // 1 bit
++            dovi->el_present_flag   = (buf >> 1) & 0x01;    // 1 bit
++            dovi->bl_present_flag   =  buf       & 0x01;    // 1 bit
++            if (desc_end - *pp >= 20) {  // 4 + 4 * 4
++                buf = get8(pp, desc_end);
++                dovi->dv_bl_signal_compatibility_id = (buf >> 4) & 0x0f; // 4 bits
++            } else {
++                // 0 stands for None
++                // Dolby Vision V1.2.93 profiles and levels
++                dovi->dv_bl_signal_compatibility_id = 0;
++            }
++
++            ret = av_stream_add_side_data(st, AV_PKT_DATA_DOVI_CONF,
++                                          (uint8_t *)dovi, dovi_size);
++            if (ret < 0) {
++                av_free(dovi);
++                return ret;
++            }
++
++            av_log(fc, AV_LOG_TRACE, "DOVI, version: %d.%d, profile: %d, level: %d, "
++                   "rpu flag: %d, el flag: %d, bl flag: %d, compatibility id: %d\n",
++                   dovi->dv_version_major, dovi->dv_version_minor,
++                   dovi->dv_profile, dovi->dv_level,
++                   dovi->rpu_present_flag,
++                   dovi->el_present_flag,
++                   dovi->bl_present_flag,
++                   dovi->dv_bl_signal_compatibility_id);
++        }
++        break;
++    default:
++        break;
++    }
++    *pp = desc_end;
++    return 0;
++}
++
++static AVStream *find_matching_stream(MpegTSContext *ts, int pid, unsigned int programid,
++                                      int stream_identifier, int pmt_stream_idx, struct Program *p)
++{
++    AVFormatContext *s = ts->stream;
++    int i;
++    AVStream *found = NULL;
++
++    if (stream_identifier) { /* match based on "stream identifier descriptor" if present */
++        for (i = 0; i < p->nb_streams; i++) {
++            if (p->streams[i].stream_identifier == stream_identifier)
++                if (!found || pmt_stream_idx == i) /* fallback to idx based guess if multiple streams have the same identifier */
++                    found = s->streams[p->streams[i].idx];
++        }
++    } else if (pmt_stream_idx < p->nb_streams) { /* match based on position within the PMT */
++        found = s->streams[p->streams[pmt_stream_idx].idx];
++    }
++
++    if (found) {
++        av_log(ts->stream, AV_LOG_VERBOSE,
++               "re-using existing %s stream %d (pid=0x%x) for new pid=0x%x\n",
++               av_get_media_type_string(found->codecpar->codec_type),
++               i, found->id, pid);
++    }
++
++    return found;
++}
++
++static int parse_stream_identifier_desc(const uint8_t *p, const uint8_t *p_end)
++{
++    const uint8_t **pp = &p;
++    const uint8_t *desc_list_end;
++    const uint8_t *desc_end;
++    int desc_list_len;
++    int desc_len, desc_tag;
++
++    desc_list_len = get16(pp, p_end);
++    if (desc_list_len < 0)
++        return -1;
++    desc_list_len &= 0xfff;
++    desc_list_end  = p + desc_list_len;
++    if (desc_list_end > p_end)
++        return -1;
++
++    while (1) {
++        desc_tag = get8(pp, desc_list_end);
++        if (desc_tag < 0)
++            return -1;
++        desc_len = get8(pp, desc_list_end);
++        if (desc_len < 0)
++            return -1;
++        desc_end = *pp + desc_len;
++        if (desc_end > desc_list_end)
++            return -1;
++
++        if (desc_tag == 0x52) {
++            return get8(pp, desc_end);
++        }
++        *pp = desc_end;
++    }
++
++    return -1;
++}
++
++static int is_pes_stream(int stream_type, uint32_t prog_reg_desc)
++{
++    return !(stream_type == 0x13 ||
++             (stream_type == 0x86 && prog_reg_desc == AV_RL32("CUEI")) );
++}
++
++static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len)
++{
++    MpegTSContext *ts = filter->u.section_filter.opaque;
++    MpegTSSectionFilter *tssf = &filter->u.section_filter;
++    struct Program old_program;
++    SectionHeader h1, *h = &h1;
++    PESContext *pes;
++    AVStream *st;
++    const uint8_t *p, *p_end, *desc_list_end;
++    int program_info_length, pcr_pid, pid, stream_type;
++    int desc_list_len;
++    uint32_t prog_reg_desc = 0; /* registration descriptor */
++    int stream_identifier = -1;
++    struct Program *prg;
++
++    int mp4_descr_count = 0;
++    Mp4Descr mp4_descr[MAX_MP4_DESCR_COUNT] = { { 0 } };
++    int i;
++
++    av_log(ts->stream, AV_LOG_TRACE, "PMT: len %i\n", section_len);
++    hex_dump_debug(ts->stream, section, section_len);
++
++    p_end = section + section_len - 4;
++    p = section;
++    if (parse_section_header(h, &p, p_end) < 0)
++        return;
++    if (h->tid != PMT_TID)
++        return;
++    if (skip_identical(h, tssf))
++        return;
++
++    av_log(ts->stream, AV_LOG_TRACE, "sid=0x%x sec_num=%d/%d version=%d tid=%d\n",
++            h->id, h->sec_num, h->last_sec_num, h->version, h->tid);
++
++    if (!ts->scan_all_pmts && ts->skip_changes)
++        return;
++
++    prg = get_program(ts, h->id);
++    if (prg)
++        old_program = *prg;
++    else
++        clear_program(&old_program);
++
++    if (ts->skip_unknown_pmt && !prg)
++        return;
++    if (prg && prg->nb_pids && prg->pids[0] != ts->current_pid)
++        return;
++    if (!ts->skip_clear)
++        clear_avprogram(ts, h->id);
++    clear_program(prg);
++    add_pid_to_program(prg, ts->current_pid);
++
++    pcr_pid = get16(&p, p_end);
++    if (pcr_pid < 0)
++        return;
++    pcr_pid &= 0x1fff;
++    add_pid_to_program(prg, pcr_pid);
++    update_av_program_info(ts->stream, h->id, pcr_pid, h->version);
++
++    av_log(ts->stream, AV_LOG_TRACE, "pcr_pid=0x%x\n", pcr_pid);
++
++    program_info_length = get16(&p, p_end);
++    if (program_info_length < 0)
++        return;
++    program_info_length &= 0xfff;
++    while (program_info_length >= 2) {
++        uint8_t tag, len;
++        tag = get8(&p, p_end);
++        len = get8(&p, p_end);
++
++        av_log(ts->stream, AV_LOG_TRACE, "program tag: 0x%02x len=%d\n", tag, len);
++
++        if (len > program_info_length - 2)
++            // something else is broken, exit the program_descriptors_loop
++            break;
++        program_info_length -= len + 2;
++        if (tag == IOD_DESCRIPTOR) {
++            get8(&p, p_end); // scope
++            get8(&p, p_end); // label
++            len -= 2;
++            mp4_read_iods(ts->stream, p, len, mp4_descr + mp4_descr_count,
++                          &mp4_descr_count, MAX_MP4_DESCR_COUNT);
++        } else if (tag == REGISTRATION_DESCRIPTOR && len >= 4) {
++            prog_reg_desc = bytestream_get_le32(&p);
++            len -= 4;
++        }
++        p += len;
++    }
++    p += program_info_length;
++    if (p >= p_end)
++        goto out;
++
++    // stop parsing after pmt, we found header
++    if (!ts->pkt)
++        ts->stop_parse = 2;
++
++    if (prg)
++        prg->pmt_found = 1;
++
++    for (i = 0; i < MAX_STREAMS_PER_PROGRAM; i++) {
++        st = 0;
++        pes = NULL;
++        stream_type = get8(&p, p_end);
++        if (stream_type < 0)
++            break;
++        pid = get16(&p, p_end);
++        if (pid < 0)
++            goto out;
++        pid &= 0x1fff;
++        if (pid == ts->current_pid)
++            goto out;
++
++        stream_identifier = parse_stream_identifier_desc(p, p_end) + 1;
++
++        /* now create stream */
++        if (ts->pids[pid] && ts->pids[pid]->type == MPEGTS_PES) {
++            pes = ts->pids[pid]->u.pes_filter.opaque;
++            if (ts->merge_pmt_versions && !pes->st) {
++                st = find_matching_stream(ts, pid, h->id, stream_identifier, i, &old_program);
++                if (st) {
++                    pes->st = st;
++                    pes->stream_type = stream_type;
++                    pes->merged_st = 1;
++                }
++            }
++            if (!pes->st) {
++                pes->st = avformat_new_stream(pes->stream, NULL);
++                if (!pes->st)
++                    goto out;
++                pes->st->id = pes->pid;
++            }
++            st = pes->st;
++        } else if (is_pes_stream(stream_type, prog_reg_desc)) {
++            if (ts->pids[pid])
++                mpegts_close_filter(ts, ts->pids[pid]); // wrongly added sdt filter probably
++            pes = add_pes_stream(ts, pid, pcr_pid);
++            if (ts->merge_pmt_versions && pes && !pes->st) {
++                st = find_matching_stream(ts, pid, h->id, stream_identifier, i, &old_program);
++                if (st) {
++                    pes->st = st;
++                    pes->stream_type = stream_type;
++                    pes->merged_st = 1;
++                }
++            }
++            if (pes && !pes->st) {
++                st = avformat_new_stream(pes->stream, NULL);
++                if (!st)
++                    goto out;
++                st->id = pes->pid;
++            }
++        } else {
++            int idx = ff_find_stream_index(ts->stream, pid);
++            if (idx >= 0) {
++                st = ts->stream->streams[idx];
++            }
++            if (ts->merge_pmt_versions && !st) {
++                st = find_matching_stream(ts, pid, h->id, stream_identifier, i, &old_program);
++            }
++            if (!st) {
++                st = avformat_new_stream(ts->stream, NULL);
++                if (!st)
++                    goto out;
++                st->id = pid;
++                st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
++                if (stream_type == 0x86 && prog_reg_desc == AV_RL32("CUEI")) {
++                    mpegts_find_stream_type(st, stream_type, SCTE_types);
++                    mpegts_open_section_filter(ts, pid, scte_data_cb, ts, 1);
++                }
++            }
++        }
++
++        if (!st)
++            goto out;
++
++        if (pes && !pes->stream_type)
++            mpegts_set_stream_info(st, pes, stream_type, prog_reg_desc);
++
++        add_pid_to_program(prg, pid);
++        if (prg) {
++            prg->streams[i].idx = st->index;
++            prg->streams[i].stream_identifier = stream_identifier;
++            prg->nb_streams++;
++        }
++
++        av_program_add_stream_index(ts->stream, h->id, st->index);
++
++        desc_list_len = get16(&p, p_end);
++        if (desc_list_len < 0)
++            goto out;
++        desc_list_len &= 0xfff;
++        desc_list_end  = p + desc_list_len;
++        if (desc_list_end > p_end)
++            goto out;
++        for (;;) {
++            if (ff_parse_mpeg2_descriptor(ts->stream, st, stream_type, &p,
++                                          desc_list_end, mp4_descr,
++                                          mp4_descr_count, pid, ts) < 0)
++                break;
++
++            if (pes && prog_reg_desc == AV_RL32("HDMV") &&
++                stream_type == 0x83 && pes->sub_st) {
++                av_program_add_stream_index(ts->stream, h->id,
++                                            pes->sub_st->index);
++                pes->sub_st->codecpar->codec_tag = st->codecpar->codec_tag;
++            }
++        }
++        p = desc_list_end;
++    }
++
++    if (!ts->pids[pcr_pid])
++        mpegts_open_pcr_filter(ts, pcr_pid);
++
++out:
++    for (i = 0; i < mp4_descr_count; i++)
++        av_free(mp4_descr[i].dec_config_descr);
++}
++
++static void pat_cb(MpegTSFilter *filter, const uint8_t *section, int section_len)
++{
++    MpegTSContext *ts = filter->u.section_filter.opaque;
++    MpegTSSectionFilter *tssf = &filter->u.section_filter;
++    SectionHeader h1, *h = &h1;
++    const uint8_t *p, *p_end;
++    int sid, pmt_pid;
++    int nb_prg = 0;
++    AVProgram *program;
++
++    av_log(ts->stream, AV_LOG_TRACE, "PAT:\n");
++    hex_dump_debug(ts->stream, section, section_len);
++
++    p_end = section + section_len - 4;
++    p     = section;
++    if (parse_section_header(h, &p, p_end) < 0)
++        return;
++    if (h->tid != PAT_TID)
++        return;
++    if (ts->skip_changes)
++        return;
++
++    if (skip_identical(h, tssf))
++        return;
++    ts->stream->ts_id = h->id;
++
++    for (;;) {
++        sid = get16(&p, p_end);
++        if (sid < 0)
++            break;
++        pmt_pid = get16(&p, p_end);
++        if (pmt_pid < 0)
++            break;
++        pmt_pid &= 0x1fff;
++
++        if (pmt_pid == ts->current_pid)
++            break;
++
++        av_log(ts->stream, AV_LOG_TRACE, "sid=0x%x pid=0x%x\n", sid, pmt_pid);
++
++        if (sid == 0x0000) {
++            /* NIT info */
++        } else {
++            MpegTSFilter *fil = ts->pids[pmt_pid];
++            struct Program *prg;
++            program = av_new_program(ts->stream, sid);
++            if (program) {
++                program->program_num = sid;
++                program->pmt_pid = pmt_pid;
++            }
++            if (fil)
++                if (   fil->type != MPEGTS_SECTION
++                    || fil->pid != pmt_pid
++                    || fil->u.section_filter.section_cb != pmt_cb)
++                    mpegts_close_filter(ts, ts->pids[pmt_pid]);
++
++            if (!ts->pids[pmt_pid])
++                mpegts_open_section_filter(ts, pmt_pid, pmt_cb, ts, 1);
++            prg = add_program(ts, sid);
++            if (prg) {
++                unsigned prg_idx = prg - ts->prg;
++                if (prg->nb_pids && prg->pids[0] != pmt_pid)
++                    clear_program(prg);
++                add_pid_to_program(prg, pmt_pid);
++                if (prg_idx > nb_prg)
++                    FFSWAP(struct Program, ts->prg[nb_prg], ts->prg[prg_idx]);
++                if (prg_idx >= nb_prg)
++                    nb_prg++;
++            }
++        }
++    }
++    ts->nb_prg = nb_prg;
++
++    if (sid < 0) {
++        int i,j;
++        for (j=0; j<ts->stream->nb_programs; j++) {
++            for (i = 0; i < ts->nb_prg; i++)
++                if (ts->prg[i].id == ts->stream->programs[j]->id)
++                    break;
++            if (i==ts->nb_prg && !ts->skip_clear)
++                clear_avprogram(ts, ts->stream->programs[j]->id);
++        }
++    }
++}
++
++static void eit_cb(MpegTSFilter *filter, const uint8_t *section, int section_len)
++{
++    MpegTSContext *ts = filter->u.section_filter.opaque;
++    const uint8_t *p, *p_end;
++    SectionHeader h1, *h = &h1;
++
++    /*
++     * Sometimes we receive EPG packets but SDT table do not have
++     * eit_pres_following or eit_sched turned on, so we open EPG
++     * stream directly here.
++     */
++    if (!ts->epg_stream) {
++        ts->epg_stream = avformat_new_stream(ts->stream, NULL);
++        if (!ts->epg_stream)
++            return;
++        ts->epg_stream->id = EIT_PID;
++        ts->epg_stream->codecpar->codec_type = AVMEDIA_TYPE_DATA;
++        ts->epg_stream->codecpar->codec_id = AV_CODEC_ID_EPG;
++    }
++
++    if (ts->epg_stream->discard == AVDISCARD_ALL)
++        return;
++
++    p_end = section + section_len - 4;
++    p     = section;
++
++    if (parse_section_header(h, &p, p_end) < 0)
++        return;
++    if (h->tid < EIT_TID || h->tid > OEITS_END_TID)
++        return;
++
++    av_log(ts->stream, AV_LOG_TRACE, "EIT: tid received = %.02x\n", h->tid);
++
++    /**
++     * Service_id 0xFFFF is reserved, it indicates that the current EIT table
++     * is scrambled.
++     */
++    if (h->id == 0xFFFF) {
++        av_log(ts->stream, AV_LOG_TRACE, "Scrambled EIT table received.\n");
++        return;
++    }
++
++    /**
++     * In case we receive an EPG packet before mpegts context is fully
++     * initialized.
++     */
++    if (!ts->pkt)
++        return;
++
++    new_data_packet(section, section_len, ts->pkt);
++    ts->pkt->stream_index = ts->epg_stream->index;
++    ts->stop_parse = 1;
++}
++
++static void sdt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len)
++{
++    MpegTSContext *ts = filter->u.section_filter.opaque;
++    MpegTSSectionFilter *tssf = &filter->u.section_filter;
++    SectionHeader h1, *h = &h1;
++    const uint8_t *p, *p_end, *desc_list_end, *desc_end;
++    int onid, val, sid, desc_list_len, desc_tag, desc_len, service_type;
++    char *name, *provider_name;
++
++    av_log(ts->stream, AV_LOG_TRACE, "SDT:\n");
++    hex_dump_debug(ts->stream, section, section_len);
++
++    p_end = section + section_len - 4;
++    p     = section;
++    if (parse_section_header(h, &p, p_end) < 0)
++        return;
++    if (h->tid != SDT_TID)
++        return;
++    if (ts->skip_changes)
++        return;
++    if (skip_identical(h, tssf))
++        return;
++
++    onid = get16(&p, p_end);
++    if (onid < 0)
++        return;
++    val = get8(&p, p_end);
++    if (val < 0)
++        return;
++    for (;;) {
++        sid = get16(&p, p_end);
++        if (sid < 0)
++            break;
++        val = get8(&p, p_end);
++        if (val < 0)
++            break;
++        desc_list_len = get16(&p, p_end);
++        if (desc_list_len < 0)
++            break;
++        desc_list_len &= 0xfff;
++        desc_list_end  = p + desc_list_len;
++        if (desc_list_end > p_end)
++            break;
++        for (;;) {
++            desc_tag = get8(&p, desc_list_end);
++            if (desc_tag < 0)
++                break;
++            desc_len = get8(&p, desc_list_end);
++            desc_end = p + desc_len;
++            if (desc_len < 0 || desc_end > desc_list_end)
++                break;
++
++            av_log(ts->stream, AV_LOG_TRACE, "tag: 0x%02x len=%d\n",
++                    desc_tag, desc_len);
++
++            switch (desc_tag) {
++            case 0x48:
++                service_type = get8(&p, p_end);
++                if (service_type < 0)
++                    break;
++                provider_name = getstr8(&p, p_end);
++                if (!provider_name)
++                    break;
++                name = getstr8(&p, p_end);
++                if (name) {
++                    AVProgram *program = av_new_program(ts->stream, sid);
++                    if (program) {
++                        av_dict_set(&program->metadata, "service_name", name, 0);
++                        av_dict_set(&program->metadata, "service_provider",
++                                    provider_name, 0);
++                    }
++                }
++                av_free(name);
++                av_free(provider_name);
++                break;
++            default:
++                break;
++            }
++            p = desc_end;
++        }
++        p = desc_list_end;
++    }
++}
++
++static int parse_pcr(int64_t *ppcr_high, int *ppcr_low,
++                     const uint8_t *packet);
++
++/* handle one TS packet */
++static int handle_packet(MpegTSContext *ts, const uint8_t *packet, int64_t pos)
++{
++    MpegTSFilter *tss;
++    int len, pid, cc, expected_cc, cc_ok, afc, is_start, is_discontinuity,
++        has_adaptation, has_payload;
++    const uint8_t *p, *p_end;
++
++    pid = AV_RB16(packet + 1) & 0x1fff;
++    is_start = packet[1] & 0x40;
++    tss = ts->pids[pid];
++    if (ts->auto_guess && !tss && is_start) {
++        add_pes_stream(ts, pid, -1);
++        tss = ts->pids[pid];
++    }
++    if (!tss)
++        return 0;
++    if (is_start)
++        tss->discard = discard_pid(ts, pid);
++    if (tss->discard)
++        return 0;
++    ts->current_pid = pid;
++
++    afc = (packet[3] >> 4) & 3;
++    if (afc == 0) /* reserved value */
++        return 0;
++    has_adaptation   = afc & 2;
++    has_payload      = afc & 1;
++    is_discontinuity = has_adaptation &&
++                       packet[4] != 0 && /* with length > 0 */
++                       (packet[5] & 0x80); /* and discontinuity indicated */
++
++    /* continuity check (currently not used) */
++    cc = (packet[3] & 0xf);
++    expected_cc = has_payload ? (tss->last_cc + 1) & 0x0f : tss->last_cc;
++    cc_ok = pid == 0x1FFF || // null packet PID
++            is_discontinuity ||
++            tss->last_cc < 0 ||
++            expected_cc == cc;
++
++    tss->last_cc = cc;
++    if (!cc_ok) {
++        av_log(ts->stream, AV_LOG_DEBUG,
++               "Continuity check failed for pid %d expected %d got %d\n",
++               pid, expected_cc, cc);
++        if (tss->type == MPEGTS_PES) {
++            PESContext *pc = tss->u.pes_filter.opaque;
++            pc->flags |= AV_PKT_FLAG_CORRUPT;
++        }
++    }
++
++    if (packet[1] & 0x80) {
++        av_log(ts->stream, AV_LOG_DEBUG, "Packet had TEI flag set; marking as corrupt\n");
++        if (tss->type == MPEGTS_PES) {
++            PESContext *pc = tss->u.pes_filter.opaque;
++            pc->flags |= AV_PKT_FLAG_CORRUPT;
++        }
++    }
++
++    p = packet + 4;
++    if (has_adaptation) {
++        int64_t pcr_h;
++        int pcr_l;
++        if (parse_pcr(&pcr_h, &pcr_l, packet) == 0)
++            tss->last_pcr = pcr_h * 300 + pcr_l;
++        /* skip adaptation field */
++        p += p[0] + 1;
++    }
++    /* if past the end of packet, ignore */
++    p_end = packet + TS_PACKET_SIZE;
++    if (p >= p_end || !has_payload)
++        return 0;
++
++    if (pos >= 0) {
++        av_assert0(pos >= TS_PACKET_SIZE);
++        ts->pos47_full = pos - TS_PACKET_SIZE;
++    }
++
++    if (tss->type == MPEGTS_SECTION) {
++        if (is_start) {
++            /* pointer field present */
++            len = *p++;
++            if (len > p_end - p)
++                return 0;
++            if (len && cc_ok) {
++                /* write remaining section bytes */
++                write_section_data(ts, tss,
++                                   p, len, 0);
++                /* check whether filter has been closed */
++                if (!ts->pids[pid])
++                    return 0;
++            }
++            p += len;
++            if (p < p_end) {
++                write_section_data(ts, tss,
++                                   p, p_end - p, 1);
++            }
++        } else {
++            if (cc_ok) {
++                write_section_data(ts, tss,
++                                   p, p_end - p, 0);
++            }
++        }
++
++        // stop find_stream_info from waiting for more streams
++        // when all programs have received a PMT
++        if (ts->stream->ctx_flags & AVFMTCTX_NOHEADER && ts->scan_all_pmts <= 0) {
++            int i;
++            for (i = 0; i < ts->nb_prg; i++) {
++                if (!ts->prg[i].pmt_found)
++                    break;
++            }
++            if (i == ts->nb_prg && ts->nb_prg > 0) {
++                int types = 0;
++                for (i = 0; i < ts->stream->nb_streams; i++) {
++                    AVStream *st = ts->stream->streams[i];
++                    if (st->codecpar->codec_type >= 0)
++                        types |= 1<<st->codecpar->codec_type;
++                }
++                if ((types & (1<<AVMEDIA_TYPE_AUDIO) && types & (1<<AVMEDIA_TYPE_VIDEO)) || pos > 100000) {
++                    av_log(ts->stream, AV_LOG_DEBUG, "All programs have pmt, headers found\n");
++                    ts->stream->ctx_flags &= ~AVFMTCTX_NOHEADER;
++                }
++            }
++        }
++
++    } else {
++        int ret;
++        // Note: The position here points actually behind the current packet.
++        if (tss->type == MPEGTS_PES) {
++            if ((ret = tss->u.pes_filter.pes_cb(tss, p, p_end - p, is_start,
++                                                pos - ts->raw_packet_size)) < 0)
++                return ret;
++        }
++    }
++
++    return 0;
++}
++
++static int mpegts_resync(AVFormatContext *s, int seekback, const uint8_t *current_packet)
++{
++    MpegTSContext *ts = s->priv_data;
++    AVIOContext *pb = s->pb;
++    int c, i;
++    uint64_t pos = avio_tell(pb);
++    int64_t back = FFMIN(seekback, pos);
++
++    //Special case for files like 01c56b0dc1.ts
++    if (current_packet[0] == 0x80 && current_packet[12] == 0x47 && pos >= TS_PACKET_SIZE) {
++        avio_seek(pb, 12 - TS_PACKET_SIZE, SEEK_CUR);
++        return 0;
++    }
++
++    avio_seek(pb, -back, SEEK_CUR);
++
++    for (i = 0; i < ts->resync_size; i++) {
++        c = avio_r8(pb);
++        if (avio_feof(pb))
++            return AVERROR_EOF;
++        if (c == 0x47) {
++            int new_packet_size, ret;
++            avio_seek(pb, -1, SEEK_CUR);
++            pos = avio_tell(pb);
++            ret = ffio_ensure_seekback(pb, PROBE_PACKET_MAX_BUF);
++            if (ret < 0)
++                return ret;
++            new_packet_size = get_packet_size(s);
++            if (new_packet_size > 0 && new_packet_size != ts->raw_packet_size) {
++                av_log(ts->stream, AV_LOG_WARNING, "changing packet size to %d\n", new_packet_size);
++                ts->raw_packet_size = new_packet_size;
++            }
++            avio_seek(pb, pos, SEEK_SET);
++            return 0;
++        }
++    }
++    av_log(s, AV_LOG_ERROR,
++           "max resync size reached, could not find sync byte\n");
++    /* no sync found */
++    return AVERROR_INVALIDDATA;
++}
++
++/* return AVERROR_something if error or EOF. Return 0 if OK. */
++static int read_packet(AVFormatContext *s, uint8_t *buf, int raw_packet_size,
++                       const uint8_t **data)
++{
++    AVIOContext *pb = s->pb;
++    int len;
++
++    for (;;) {
++        len = ffio_read_indirect(pb, buf, TS_PACKET_SIZE, data);
++        if (len != TS_PACKET_SIZE)
++            return len < 0 ? len : AVERROR_EOF;
++        /* check packet sync byte */
++        if ((*data)[0] != 0x47) {
++            /* find a new packet start */
++
++            if (mpegts_resync(s, raw_packet_size, *data) < 0)
++                return AVERROR(EAGAIN);
++            else
++                continue;
++        } else {
++            break;
++        }
++    }
++    return 0;
++}
++
++static void finished_reading_packet(AVFormatContext *s, int raw_packet_size)
++{
++    AVIOContext *pb = s->pb;
++    int skip = raw_packet_size - TS_PACKET_SIZE;
++    if (skip > 0)
++        avio_skip(pb, skip);
++}
++
++static int handle_packets(MpegTSContext *ts, int64_t nb_packets)
++{
++    AVFormatContext *s = ts->stream;
++    uint8_t packet[TS_PACKET_SIZE + AV_INPUT_BUFFER_PADDING_SIZE];
++    const uint8_t *data;
++    int64_t packet_num;
++    int ret = 0;
++
++    if (avio_tell(s->pb) != ts->last_pos) {
++        int i;
++        av_log(ts->stream, AV_LOG_TRACE, "Skipping after seek\n");
++        /* seek detected, flush pes buffer */
++        for (i = 0; i < NB_PID_MAX; i++) {
++            if (ts->pids[i]) {
++                if (ts->pids[i]->type == MPEGTS_PES) {
++                    PESContext *pes = ts->pids[i]->u.pes_filter.opaque;
++                    av_buffer_unref(&pes->buffer);
++                    pes->data_index = 0;
++                    pes->state = MPEGTS_SKIP; /* skip until pes header */
++                } else if (ts->pids[i]->type == MPEGTS_SECTION) {
++                    ts->pids[i]->u.section_filter.last_ver = -1;
++                }
++                ts->pids[i]->last_cc = -1;
++                ts->pids[i]->last_pcr = -1;
++            }
++        }
++    }
++
++    ts->stop_parse = 0;
++    packet_num = 0;
++    memset(packet + TS_PACKET_SIZE, 0, AV_INPUT_BUFFER_PADDING_SIZE);
++    for (;;) {
++        packet_num++;
++        if (nb_packets != 0 && packet_num >= nb_packets ||
++            ts->stop_parse > 1) {
++            ret = AVERROR(EAGAIN);
++            break;
++        }
++        if (ts->stop_parse > 0)
++            break;
++
++        ret = read_packet(s, packet, ts->raw_packet_size, &data);
++        if (ret != 0)
++            break;
++        ret = handle_packet(ts, data, avio_tell(s->pb));
++        finished_reading_packet(s, ts->raw_packet_size);
++        if (ret != 0)
++            break;
++    }
++    ts->last_pos = avio_tell(s->pb);
++    return ret;
++}
++
++static int mpegts_probe(const AVProbeData *p)
++{
++    const int size = p->buf_size;
++    int maxscore = 0;
++    int sumscore = 0;
++    int i;
++    int check_count = size / TS_FEC_PACKET_SIZE;
++#define CHECK_COUNT 10
++#define CHECK_BLOCK 100
++
++    if (!check_count)
++        return 0;
++
++    for (i = 0; i<check_count; i+=CHECK_BLOCK) {
++        int left = FFMIN(check_count - i, CHECK_BLOCK);
++        int score      = analyze(p->buf + TS_PACKET_SIZE     *i, TS_PACKET_SIZE     *left, TS_PACKET_SIZE     , 1);
++        int dvhs_score = analyze(p->buf + TS_DVHS_PACKET_SIZE*i, TS_DVHS_PACKET_SIZE*left, TS_DVHS_PACKET_SIZE, 1);
++        int fec_score  = analyze(p->buf + TS_FEC_PACKET_SIZE *i, TS_FEC_PACKET_SIZE *left, TS_FEC_PACKET_SIZE , 1);
++        score = FFMAX3(score, dvhs_score, fec_score);
++        sumscore += score;
++        maxscore = FFMAX(maxscore, score);
++    }
++
++    sumscore = sumscore * CHECK_COUNT / check_count;
++    maxscore = maxscore * CHECK_COUNT / CHECK_BLOCK;
++
++    ff_dlog(0, "TS score: %d %d\n", sumscore, maxscore);
++
++    if        (check_count > CHECK_COUNT && sumscore > 6) {
++        return AVPROBE_SCORE_MAX   + sumscore - CHECK_COUNT;
++    } else if (check_count >= CHECK_COUNT && sumscore > 6) {
++        return AVPROBE_SCORE_MAX/2 + sumscore - CHECK_COUNT;
++    } else if (check_count >= CHECK_COUNT && maxscore > 6) {
++        return AVPROBE_SCORE_MAX/2 + sumscore - CHECK_COUNT;
++    } else if (sumscore > 6) {
++        return 2;
++    } else {
++        return 0;
++    }
++}
++
++/* return the 90kHz PCR and the extension for the 27MHz PCR. return
++ * (-1) if not available */
++static int parse_pcr(int64_t *ppcr_high, int *ppcr_low, const uint8_t *packet)
++{
++    int afc, len, flags;
++    const uint8_t *p;
++    unsigned int v;
++
++    afc = (packet[3] >> 4) & 3;
++    if (afc <= 1)
++        return AVERROR_INVALIDDATA;
++    p   = packet + 4;
++    len = p[0];
++    p++;
++    if (len == 0)
++        return AVERROR_INVALIDDATA;
++    flags = *p++;
++    len--;
++    if (!(flags & 0x10))
++        return AVERROR_INVALIDDATA;
++    if (len < 6)
++        return AVERROR_INVALIDDATA;
++    v          = AV_RB32(p);
++    *ppcr_high = ((int64_t) v << 1) | (p[4] >> 7);
++    *ppcr_low  = ((p[4] & 1) << 8) | p[5];
++    return 0;
++}
++
++static void seek_back(AVFormatContext *s, AVIOContext *pb, int64_t pos) {
++
++    /* NOTE: We attempt to seek on non-seekable files as well, as the
++     * probe buffer usually is big enough. Only warn if the seek failed
++     * on files where the seek should work. */
++    if (avio_seek(pb, pos, SEEK_SET) < 0)
++        av_log(s, (pb->seekable & AVIO_SEEKABLE_NORMAL) ? AV_LOG_ERROR : AV_LOG_INFO, "Unable to seek back to the start\n");
++}
++
++static int mpegts_read_header(AVFormatContext *s)
++{
++    MpegTSContext *ts = s->priv_data;
++    AVIOContext *pb   = s->pb;
++    int64_t pos, probesize = s->probesize;
++    int64_t seekback = FFMAX(s->probesize, (int64_t)ts->resync_size + PROBE_PACKET_MAX_BUF);
++
++    s->internal->prefer_codec_framerate = 1;
++
++    if (ffio_ensure_seekback(pb, seekback) < 0)
++        av_log(s, AV_LOG_WARNING, "Failed to allocate buffers for seekback\n");
++
++    pos = avio_tell(pb);
++    ts->raw_packet_size = get_packet_size(s);
++    if (ts->raw_packet_size <= 0) {
++        av_log(s, AV_LOG_WARNING, "Could not detect TS packet size, defaulting to non-FEC/DVHS\n");
++        ts->raw_packet_size = TS_PACKET_SIZE;
++    }
++    ts->stream     = s;
++    ts->auto_guess = 0;
++
++    if (s->iformat == &ff_mpegts_demuxer) {
++        /* normal demux */
++
++        /* first do a scan to get all the services */
++        seek_back(s, pb, pos);
++
++        mpegts_open_section_filter(ts, SDT_PID, sdt_cb, ts, 1);
++        mpegts_open_section_filter(ts, PAT_PID, pat_cb, ts, 1);
++        mpegts_open_section_filter(ts, EIT_PID, eit_cb, ts, 1);
++
++        handle_packets(ts, probesize / ts->raw_packet_size);
++        /* if could not find service, enable auto_guess */
++
++        ts->auto_guess = 1;
++
++        av_log(ts->stream, AV_LOG_TRACE, "tuning done\n");
++
++        s->ctx_flags |= AVFMTCTX_NOHEADER;
++    } else {
++        AVStream *st;
++        int pcr_pid, pid, nb_packets, nb_pcrs, ret, pcr_l;
++        int64_t pcrs[2], pcr_h;
++        uint8_t packet[TS_PACKET_SIZE];
++        const uint8_t *data;
++
++        /* only read packets */
++
++        st = avformat_new_stream(s, NULL);
++        if (!st)
++            return AVERROR(ENOMEM);
++        avpriv_set_pts_info(st, 60, 1, 27000000);
++        st->codecpar->codec_type = AVMEDIA_TYPE_DATA;
++        st->codecpar->codec_id   = AV_CODEC_ID_MPEG2TS;
++
++        /* we iterate until we find two PCRs to estimate the bitrate */
++        pcr_pid    = -1;
++        nb_pcrs    = 0;
++        nb_packets = 0;
++        for (;;) {
++            ret = read_packet(s, packet, ts->raw_packet_size, &data);
++            if (ret < 0)
++                return ret;
++            pid = AV_RB16(data + 1) & 0x1fff;
++            if ((pcr_pid == -1 || pcr_pid == pid) &&
++                parse_pcr(&pcr_h, &pcr_l, data) == 0) {
++                finished_reading_packet(s, ts->raw_packet_size);
++                pcr_pid = pid;
++                pcrs[nb_pcrs] = pcr_h * 300 + pcr_l;
++                nb_pcrs++;
++                if (nb_pcrs >= 2) {
++                    if (pcrs[1] - pcrs[0] > 0) {
++                        /* the difference needs to be positive to make sense for bitrate computation */
++                        break;
++                    } else {
++                        av_log(ts->stream, AV_LOG_WARNING, "invalid pcr pair %"PRId64" >= %"PRId64"\n", pcrs[0], pcrs[1]);
++                        pcrs[0] = pcrs[1];
++                        nb_pcrs--;
++                    }
++                }
++            } else {
++                finished_reading_packet(s, ts->raw_packet_size);
++            }
++            nb_packets++;
++        }
++
++        /* NOTE1: the bitrate is computed without the FEC */
++        /* NOTE2: it is only the bitrate of the start of the stream */
++        ts->pcr_incr = pcrs[1] - pcrs[0];
++        ts->cur_pcr  = pcrs[0] - ts->pcr_incr * (nb_packets - 1);
++        s->bit_rate  = TS_PACKET_SIZE * 8 * 27000000LL / ts->pcr_incr;
++        st->codecpar->bit_rate = s->bit_rate;
++        st->start_time      = ts->cur_pcr;
++        av_log(ts->stream, AV_LOG_TRACE, "start=%0.3f pcr=%0.3f incr=%"PRId64"\n",
++                st->start_time / 1000000.0, pcrs[0] / 27e6, ts->pcr_incr);
++    }
++
++    seek_back(s, pb, pos);
++    return 0;
++}
++
++#define MAX_PACKET_READAHEAD ((128 * 1024) / 188)
++
++static int mpegts_raw_read_packet(AVFormatContext *s, AVPacket *pkt)
++{
++    MpegTSContext *ts = s->priv_data;
++    int ret, i;
++    int64_t pcr_h, next_pcr_h, pos;
++    int pcr_l, next_pcr_l;
++    uint8_t pcr_buf[12];
++    const uint8_t *data;
++
++    if ((ret = av_new_packet(pkt, TS_PACKET_SIZE)) < 0)
++        return ret;
++    ret = read_packet(s, pkt->data, ts->raw_packet_size, &data);
++    pkt->pos = avio_tell(s->pb);
++    if (ret < 0) {
++        return ret;
++    }
++    if (data != pkt->data)
++        memcpy(pkt->data, data, TS_PACKET_SIZE);
++    finished_reading_packet(s, ts->raw_packet_size);
++    if (ts->mpeg2ts_compute_pcr) {
++        /* compute exact PCR for each packet */
++        if (parse_pcr(&pcr_h, &pcr_l, pkt->data) == 0) {
++            /* we read the next PCR (XXX: optimize it by using a bigger buffer */
++            pos = avio_tell(s->pb);
++            for (i = 0; i < MAX_PACKET_READAHEAD; i++) {
++                avio_seek(s->pb, pos + i * ts->raw_packet_size, SEEK_SET);
++                avio_read(s->pb, pcr_buf, 12);
++                if (parse_pcr(&next_pcr_h, &next_pcr_l, pcr_buf) == 0) {
++                    /* XXX: not precise enough */
++                    ts->pcr_incr =
++                        ((next_pcr_h - pcr_h) * 300 + (next_pcr_l - pcr_l)) /
++                        (i + 1);
++                    break;
++                }
++            }
++            avio_seek(s->pb, pos, SEEK_SET);
++            /* no next PCR found: we use previous increment */
++            ts->cur_pcr = pcr_h * 300 + pcr_l;
++        }
++        pkt->pts      = ts->cur_pcr;
++        pkt->duration = ts->pcr_incr;
++        ts->cur_pcr  += ts->pcr_incr;
++    }
++    pkt->stream_index = 0;
++    return 0;
++}
++
++static int mpegts_read_packet(AVFormatContext *s, AVPacket *pkt)
++{
++    MpegTSContext *ts = s->priv_data;
++    int ret, i;
++
++    pkt->size = -1;
++    ts->pkt = pkt;
++    ret = handle_packets(ts, 0);
++    if (ret < 0) {
++        av_packet_unref(ts->pkt);
++        /* flush pes data left */
++        for (i = 0; i < NB_PID_MAX; i++)
++            if (ts->pids[i] && ts->pids[i]->type == MPEGTS_PES) {
++                PESContext *pes = ts->pids[i]->u.pes_filter.opaque;
++                if (pes->state == MPEGTS_PAYLOAD && pes->data_index > 0) {
++                    ret = new_pes_packet(pes, pkt);
++                    if (ret < 0)
++                        return ret;
++                    pes->state = MPEGTS_SKIP;
++                    ret = 0;
++                    break;
++                }
++            }
++    }
++
++    if (!ret && pkt->size < 0)
++        ret = AVERROR_INVALIDDATA;
++    return ret;
++}
++
++static void mpegts_free(MpegTSContext *ts)
++{
++    int i;
++
++    clear_programs(ts);
++
++    for (i = 0; i < FF_ARRAY_ELEMS(ts->pools); i++)
++        av_buffer_pool_uninit(&ts->pools[i]);
++
++    for (i = 0; i < NB_PID_MAX; i++)
++        if (ts->pids[i])
++            mpegts_close_filter(ts, ts->pids[i]);
++}
++
++static int mpegts_read_close(AVFormatContext *s)
++{
++    MpegTSContext *ts = s->priv_data;
++    mpegts_free(ts);
++    return 0;
++}
++
++static av_unused int64_t mpegts_get_pcr(AVFormatContext *s, int stream_index,
++                              int64_t *ppos, int64_t pos_limit)
++{
++    MpegTSContext *ts = s->priv_data;
++    int64_t pos, timestamp;
++    uint8_t buf[TS_PACKET_SIZE];
++    int pcr_l, pcr_pid =
++        ((PESContext *)s->streams[stream_index]->priv_data)->pcr_pid;
++    int pos47 = ts->pos47_full % ts->raw_packet_size;
++    pos =
++        ((*ppos + ts->raw_packet_size - 1 - pos47) / ts->raw_packet_size) *
++        ts->raw_packet_size + pos47;
++    while(pos < pos_limit) {
++        if (avio_seek(s->pb, pos, SEEK_SET) < 0)
++            return AV_NOPTS_VALUE;
++        if (avio_read(s->pb, buf, TS_PACKET_SIZE) != TS_PACKET_SIZE)
++            return AV_NOPTS_VALUE;
++        if (buf[0] != 0x47) {
++            if (mpegts_resync(s, TS_PACKET_SIZE, buf) < 0)
++                return AV_NOPTS_VALUE;
++            pos = avio_tell(s->pb);
++            continue;
++        }
++        if ((pcr_pid < 0 || (AV_RB16(buf + 1) & 0x1fff) == pcr_pid) &&
++            parse_pcr(&timestamp, &pcr_l, buf) == 0) {
++            *ppos = pos;
++            return timestamp;
++        }
++        pos += ts->raw_packet_size;
++    }
++
++    return AV_NOPTS_VALUE;
++}
++
++static int64_t mpegts_get_dts(AVFormatContext *s, int stream_index,
++                              int64_t *ppos, int64_t pos_limit)
++{
++    MpegTSContext *ts = s->priv_data;
++    AVPacket *pkt;
++    int64_t pos;
++    int pos47 = ts->pos47_full % ts->raw_packet_size;
++    pos = ((*ppos  + ts->raw_packet_size - 1 - pos47) / ts->raw_packet_size) * ts->raw_packet_size + pos47;
++    ff_read_frame_flush(s);
++    if (avio_seek(s->pb, pos, SEEK_SET) < 0)
++        return AV_NOPTS_VALUE;
++    pkt = av_packet_alloc();
++    if (!pkt)
++        return AV_NOPTS_VALUE;
++    while(pos < pos_limit) {
++        int ret = av_read_frame(s, pkt);
++        if (ret < 0) {
++            av_packet_free(&pkt);
++            return AV_NOPTS_VALUE;
++        }
++        if (pkt->dts != AV_NOPTS_VALUE && pkt->pos >= 0) {
++            ff_reduce_index(s, pkt->stream_index);
++            av_add_index_entry(s->streams[pkt->stream_index], pkt->pos, pkt->dts, 0, 0, AVINDEX_KEYFRAME /* FIXME keyframe? */);
++            if (pkt->stream_index == stream_index && pkt->pos >= *ppos) {
++                int64_t dts = pkt->dts;
++                *ppos = pkt->pos;
++                av_packet_free(&pkt);
++                return dts;
++            }
++        }
++        pos = pkt->pos;
++        av_packet_unref(pkt);
++    }
++
++    av_packet_free(&pkt);
++    return AV_NOPTS_VALUE;
++}
++
++/**************************************************************/
++/* parsing functions - called from other demuxers such as RTP */
++
++MpegTSContext *avpriv_mpegts_parse_open(AVFormatContext *s)
++{
++    MpegTSContext *ts;
++
++    ts = av_mallocz(sizeof(MpegTSContext));
++    if (!ts)
++        return NULL;
++    /* no stream case, currently used by RTP */
++    ts->raw_packet_size = TS_PACKET_SIZE;
++    ts->stream = s;
++    ts->auto_guess = 1;
++
++    mpegts_open_section_filter(ts, SDT_PID, sdt_cb, ts, 1);
++    mpegts_open_section_filter(ts, PAT_PID, pat_cb, ts, 1);
++    mpegts_open_section_filter(ts, EIT_PID, eit_cb, ts, 1);
++
++    return ts;
++}
++
++/* return the consumed length if a packet was output, or -1 if no
++ * packet is output */
++int avpriv_mpegts_parse_packet(MpegTSContext *ts, AVPacket *pkt,
++                               const uint8_t *buf, int len)
++{
++    int len1;
++
++    len1 = len;
++    ts->pkt = pkt;
++    for (;;) {
++        ts->stop_parse = 0;
++        if (len < TS_PACKET_SIZE)
++            return AVERROR_INVALIDDATA;
++        if (buf[0] != 0x47) {
++            buf++;
++            len--;
++        } else {
++            handle_packet(ts, buf, len1 - len + TS_PACKET_SIZE);
++            buf += TS_PACKET_SIZE;
++            len -= TS_PACKET_SIZE;
++            if (ts->stop_parse == 1)
++                break;
++        }
++    }
++    return len1 - len;
++}
++
++void avpriv_mpegts_parse_close(MpegTSContext *ts)
++{
++    mpegts_free(ts);
++    av_free(ts);
++}
++
++AVInputFormat ff_mpegts_demuxer = {
++    .name           = "mpegts",
++    .long_name      = NULL_IF_CONFIG_SMALL("MPEG-TS (MPEG-2 Transport Stream)"),
++    .priv_data_size = sizeof(MpegTSContext),
++    .read_probe     = mpegts_probe,
++    .read_header    = mpegts_read_header,
++    .read_packet    = mpegts_read_packet,
++    .read_close     = mpegts_read_close,
++    .read_timestamp = mpegts_get_dts,
++    .flags          = AVFMT_SHOW_IDS | AVFMT_TS_DISCONT,
++    .priv_class     = &mpegts_class,
++};
++
++AVInputFormat ff_mpegtsraw_demuxer = {
++    .name           = "mpegtsraw",
++    .long_name      = NULL_IF_CONFIG_SMALL("raw MPEG-TS (MPEG-2 Transport Stream)"),
++    .priv_data_size = sizeof(MpegTSContext),
++    .read_header    = mpegts_read_header,
++    .read_packet    = mpegts_raw_read_packet,
++    .read_close     = mpegts_read_close,
++    .read_timestamp = mpegts_get_dts,
++    .flags          = AVFMT_SHOW_IDS | AVFMT_TS_DISCONT,
++    .priv_class     = &mpegtsraw_class,
++};


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

I don't expect this to actually get accepted, but wanted to make it for tracking purposes.  This adds the AC4 codec patch that exists to the ffmpeg used by jellyfin so that ATSC 3.0 support can be achieved.  I've tested this with my local install and an ATSC 3.0 broadcast and it works very well.  

This could be used while awaiting official support in FFMpeg in a future version, and I've created an amd64 .deb that I'm placing as a release on my fork for anyone who needs it.
