### PR TITLE
Bump version to reflect the deb name has been changed

### DIFF
--- a/build-win64
+++ b/build-win64
@@ -10,7 +10,7 @@ done
 
 # Use the latest distro for toolchains
 distro="ubuntu:jammy"
-ffrevison="2"
+ffrevison="3"
 image_name="jellyfin-ffmpeg-build-windows-win64"
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "5.0.1-2"
+version: "5.0.1-3"
 packages:
   - buster-amd64
   - buster-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (5.0.1-3) unstable; urgency=medium
+
+  * Bump version to reflect the deb name has been changed to jellyfin-ffmpeg5.
+
+ -- nyanmisaka <nst799610810@gmail.com>  Fri, 6 May 2022 21:45:03 +0800
+
 jellyfin-ffmpeg (5.0.1-2) unstable; urgency=medium
 
   * Hotfix for shaderc loading issue on buster


### PR DESCRIPTION
**Changes**
- Bump version to reflect the deb name has been changed to jellyfin-ffmpeg5