### PR TITLE
Add HEVC DOVI sidedata to hlsenc

### DIFF
--- a/debian/patches/0034-add-hevc-dovi-sidedata-to-hlsenc.patch
+++ b/debian/patches/0034-add-hevc-dovi-sidedata-to-hlsenc.patch
@@ -1,0 +1,42 @@
+Index: jellyfin-ffmpeg/libavformat/hlsenc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/hlsenc.c
++++ jellyfin-ffmpeg/libavformat/hlsenc.c
+@@ -850,7 +850,7 @@ static int hls_mux_init(AVFormatContext
+     AVFormatContext *vtt_oc = NULL;
+     int byterange_mode = (hls->flags & HLS_SINGLE_FILE) || (hls->max_seg_size > 0);
+     int remaining_options;
+-    int i, ret;
++    int i, j, ret;
+ 
+     ret = avformat_alloc_output_context2(&vs->avf, vs->oformat, NULL, NULL);
+     if (ret < 0)
+@@ -897,6 +897,15 @@ static int hls_mux_init(AVFormatContext
+             st->codecpar->codec_tag = 0;
+         }
+ 
++        // copy side data
++        for (j = 0; j < vs->streams[i]->nb_side_data; j++) {
++            const AVPacketSideData *sd_src = &vs->streams[i]->side_data[j];
++            uint8_t *dst_data = av_stream_new_side_data(st, sd_src->type, sd_src->size);
++            if (!dst_data)
++                return AVERROR(ENOMEM);
++            memcpy(dst_data, sd_src->data, sd_src->size);
++        }
++
+         st->sample_aspect_ratio = vs->streams[i]->sample_aspect_ratio;
+         st->time_base = vs->streams[i]->time_base;
+         av_dict_copy(&st->metadata, vs->streams[i]->metadata, 0);
+Index: jellyfin-ffmpeg/libavformat/movenc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/movenc.c
++++ jellyfin-ffmpeg/libavformat/movenc.c
+@@ -7311,6 +7311,8 @@ static const AVCodecTag codec_mp4_tags[]
+     { AV_CODEC_ID_H264,            MKTAG('a', 'v', 'c', '3') },
+     { AV_CODEC_ID_HEVC,            MKTAG('h', 'e', 'v', '1') },
+     { AV_CODEC_ID_HEVC,            MKTAG('h', 'v', 'c', '1') },
++    { AV_CODEC_ID_HEVC,            MKTAG('d', 'v', 'h', '1') },
++    { AV_CODEC_ID_HEVC,            MKTAG('d', 'v', 'h', 'e') },
+     { AV_CODEC_ID_MPEG2VIDEO,      MKTAG('m', 'p', '4', 'v') },
+     { AV_CODEC_ID_MPEG1VIDEO,      MKTAG('m', 'p', '4', 'v') },
+     { AV_CODEC_ID_MJPEG,           MKTAG('m', 'p', '4', 'v') },

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -31,3 +31,4 @@
 0031-add-webp-support-for-id3v2.patch
 0032-remove-fdk-aac-from-nonfree.patch
 0033-add-fixes-for-vulkan-scale-and-overlay-filters.patch
+0034-add-hevc-dovi-sidedata-to-hlsenc.patch


### PR DESCRIPTION
**Changes**
- Add HEVC DOVI sidedata to hlsenc muxer
- Enable `dvh1` and `dvhe` tags in mov muxer