### PR TITLE
Disable the broken hevc packed header in Mesa

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -295,6 +295,13 @@ prepare_extra_amd64() {
         apt-get install -y llvm-11-dev
         pushd ${SOURCE_DIR}
         git clone -b mesa-22.0.3 --depth=1 https://gitlab.freedesktop.org/mesa/mesa.git
+        # disable the broken hevc packed header
+        MESA_VA_PIC=mesa/src/gallium/frontends/va/picture.c
+        MESA_VA_CONF=mesa/src/gallium/frontends/va/config.c
+        sed -i 's|handleVAEncPackedHeaderParameterBufferType(context, buf);||g' ${MESA_VA_PIC}
+        sed -i 's|handleVAEncPackedHeaderDataBufferType(context, buf);||g' ${MESA_VA_PIC}
+        sed -i 's|if (u_reduce_video_profile(ProfileToPipe(profile)) == PIPE_VIDEO_FORMAT_HEVC)||g' ${MESA_VA_CONF}
+        sed -i 's|value \|= VA_ENC_PACKED_HEADER_SEQUENCE;||g' ${MESA_VA_CONF}
         meson setup mesa mesa_build \
             --prefix=${TARGET_DIR} \
             --libdir=lib \


### PR DESCRIPTION
**Changes**
- Disable the broken hevc packed header in Mesa

**Issues**
Otherwise fmp4 stream produced by hevc_vaapi encoder on AMD VAAPI cannot be decoded by Safari.