### PR TITLE
Fix a double free core dump

### DIFF
--- a/debian/patches/0005-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0005-add-cuda-tonemap-impl.patch
@@ -1477,15 +1477,15 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
 +    }
 +
 +    if (s->dovi)
-+        av_free(s->dovi);
++        av_freep(&s->dovi);
 +    if (s->dovi_params)
-+        av_free(s->dovi_params);
++        av_freep(&s->dovi_params);
 +    if (s->dovi_pivots)
-+        av_free(s->dovi_pivots);
++        av_freep(&s->dovi_pivots);
 +    if (s->dovi_coeffs)
-+        av_free(s->dovi_coeffs);
++        av_freep(&s->dovi_coeffs);
 +    if (s->dovi_mmr)
-+        av_free(s->dovi_mmr);
++        av_freep(&s->dovi_mmr);
 +
 +    av_frame_free(&s->frame);
 +    av_buffer_unref(&s->frames_ctx);
@@ -2134,7 +2134,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
 +        if (ret < 0)
 +            goto fail;
 +
-+        av_free(s->dovi);
++        av_freep(&s->dovi);
 +    }
 +
 +    ret = do_tonemap(ctx, out, in);
@@ -2153,7 +2153,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
 +    return ff_filter_frame(outlink, out);
 +fail:
 +    if (s->dovi)
-+        av_free(s->dovi);
++        av_freep(&s->dovi);
 +    av_frame_free(&in);
 +    av_frame_free(&out);
 +    return ret;

--- a/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -1349,7 +1349,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 +    if (ctx->dovi) {
 +        cle = tonemap_opencl_update_dovi_params(avctx);
 +        CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to update dovi params: %d.\n", cle);
-+        av_free(ctx->dovi);
++        av_freep(&ctx->dovi);
      }
  
 +    err = launch_kernel(avctx, ctx->kernel, output, input, ctx->peak);
@@ -1399,7 +1399,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  fail:
      clFinish(ctx->command_queue);
 +    if (ctx->dovi)
-+        av_free(ctx->dovi);
++        av_freep(&ctx->dovi);
      av_frame_free(&input);
      av_frame_free(&output);
      return err;
@@ -1410,7 +1410,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 -    if (ctx->util_mem)
 -        clReleaseMemObject(ctx->util_mem);
 +    if (ctx->dovi)
-+        av_free(ctx->dovi);
++        av_freep(&ctx->dovi);
 +    if (ctx->dovi_params)
 +        clReleaseMemObject(ctx->dovi_params);
 +    if (ctx->dovi_pivots)


### PR DESCRIPTION
**Changes**
- Fix a double free core dump at uninit

**Issues**
Fixes "double free or corruption (!prev)" in 54ef9a1