### PR TITLE
Fix some issues and update dependencies

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -71,6 +71,8 @@ jobs:
           key: ${{ secrets.DEPLOY_KEY }}
           script_stop: true
           script: |-
+            set -o errexit
+            set -o xtrace
             tag="${{ github.event.release.tag_name }}"
             version="${tag#v}"
             basename="jellyfin-ffmpeg*_${version}-${{ matrix.arrays.codename }}"

--- a/build-win64
+++ b/build-win64
@@ -10,7 +10,7 @@ done
 
 # Use the latest distro for toolchains
 distro="ubuntu:jammy"
-ffrevison="5"
+ffrevison="6"
 image_name="jellyfin-ffmpeg-build-windows-win64"
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "5.0.1-5"
+version: "5.0.1-6"
 packages:
   - buster-amd64
   - buster-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+jellyfin-ffmpeg (5.0.1-6) unstable; urgency=medium
+
+  * Fix using hwupload with hwmap on d3d11va.
+  * Fix the unsupported subscripted access on nvidia.
+  * Update dependencies.
+
+ -- nyanmisaka <nst799610810@gmail.com>  Thu, 13 Jun 2022 22:50:13 +0800
+
 jellyfin-ffmpeg (5.0.1-5) unstable; urgency=medium
 
   * Enable chromaprint.

--- a/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -469,7 +469,7 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
  
      // Rescale the variables in order to bring it into a representation where
      // 1.0 represents the dst_peak. This is because all of the tone mapping
-@@ -178,95 +114,231 @@ float3 map_one_pixel_rgb(float3 rgb, flo
+@@ -178,95 +114,232 @@ float3 map_one_pixel_rgb(float3 rgb, flo
  
      float sig_old = sig;
  
@@ -555,7 +555,9 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
 +{
 +    int i;
 +    float s;
-+    float3 sig;
++    float3 sig = clamp(yuv.xyz, 0.0f, 1.0f);
++    float sig_arr[3] = {sig.x, sig.y, sig.z};
++    float yuv_arr[3];
 +    float4 coeffs;
 +    float dovi_num_pivots, dovi_has_mmr, dovi_has_poly;
 +    float dovi_mmr_single, dovi_min_order, dovi_max_order;
@@ -564,7 +566,6 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
 +    __global float *dovi_pivots;
 +    __global float4 *dovi_coeffs, *dovi_mmr;
 +
-+    sig = clamp(yuv.xyz, 0.0f, 1.0f);
 +#pragma unroll
 +    for (i = 0; i < 3; i++) {
 +        dovi_params = src_dovi_params + i*8;
@@ -580,7 +581,7 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
 +        dovi_lo = dovi_params[6];
 +        dovi_hi = dovi_params[7];
 +
-+        s = sig[i];
++        s = sig_arr[i];
 +        if (dovi_num_pivots > 2) {
 +            coeffs = mix(mix(mix(dovi_coeffs[0], dovi_coeffs[1], (float4)(s >= dovi_pivots[0])),
 +                             mix(dovi_coeffs[2], dovi_coeffs[3], (float4)(s >= dovi_pivots[2])),
@@ -604,10 +605,10 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/tonemap.cl
 +        } else {
 +            RESHAPE_MMR_FUNC
 +        }
-+        yuv[i] = clamp(s, dovi_lo, dovi_hi);
++        yuv_arr[i] = clamp(s, dovi_lo, dovi_hi);
 +    }
 +
-+    return yuv;
++    return (float3)(yuv_arr[0], yuv_arr[1], yuv_arr[2]);
 +}
 +#undef RESHAPE_POLY_FUNC
 +#undef RESHAPE_MMR_FUNC

--- a/debian/patches/0011-add-a-hack-for-opencl-reverse-mapping.patch
+++ b/debian/patches/0011-add-a-hack-for-opencl-reverse-mapping.patch
@@ -117,3 +117,31 @@ Index: jellyfin-ffmpeg/libavutil/hwcontext_d3d11va.c
      if (hwctx->texture) {
          D3D11_TEXTURE2D_DESC texDesc2;
          ID3D11Texture2D_GetDesc(hwctx->texture, &texDesc2);
+Index: jellyfin-ffmpeg/libavfilter/vf_hwupload.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/vf_hwupload.c
++++ jellyfin-ffmpeg/libavfilter/vf_hwupload.c
+@@ -23,6 +23,10 @@
+ #include "libavutil/pixdesc.h"
+ #include "libavutil/opt.h"
+ 
++#if HAVE_OPENCL_D3D11
++#include "libavutil/hwcontext_d3d11va.h"
++#endif
++
+ #include "avfilter.h"
+ #include "formats.h"
+ #include "internal.h"
+@@ -151,6 +155,12 @@ static int hwupload_config_output(AVFilt
+     if (avctx->extra_hw_frames >= 0)
+         ctx->hwframes->initial_pool_size = 2 + avctx->extra_hw_frames;
+ 
++#if HAVE_OPENCL_D3D11
++    D3D11_TEXTURE2D_DESC texDesc = { .BindFlags = D3D11_BIND_DECODER, };
++    if (ctx->hwframes->format == AV_PIX_FMT_D3D11)
++        ctx->hwframes->user_opaque = &texDesc;
++#endif
++
+     err = av_hwframe_ctx_init(ctx->hwframes_ref);
+     if (err < 0)
+         goto fail;

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -359,6 +359,8 @@ prepare_extra_amd64() {
         sed -i 's|handleVAEncPackedHeaderDataBufferType(context, buf);||g' ${MESA_VA_PIC}
         sed -i 's|if (u_reduce_video_profile(ProfileToPipe(profile)) == PIPE_VIDEO_FORMAT_HEVC)||g' ${MESA_VA_CONF}
         sed -i 's|value \|= VA_ENC_PACKED_HEADER_SEQUENCE;||g' ${MESA_VA_CONF}
+        # Force reporting packed headers are supported
+        sed -i 's|value = VA_ENC_PACKED_HEADER_NONE;|value = 1;|g' ${MESA_VA_CONF}
         meson setup mesa-${mesa_ver} mesa_build \
             --prefix=${TARGET_DIR} \
             --libdir=lib \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -151,19 +151,25 @@ prepare_extra_amd64() {
 
     # LIBDRM
     pushd ${SOURCE_DIR}
-    git clone -b libdrm-2.4.110 --depth=1 https://gitlab.freedesktop.org/mesa/drm.git
-    meson setup drm drm_build \
+    mkdir libdrm
+    pushd libdrm
+    libdrm_ver="2.4.111"
+    libdrm_link="https://dri.freedesktop.org/libdrm/libdrm-${libdrm_ver}.tar.xz"
+    wget ${libdrm_link} -O libdrm.tar.xz
+    tar xaf libdrm.tar.xz
+    meson setup libdrm-${libdrm_ver} drm_build \
         --prefix=${TARGET_DIR} \
         --libdir=lib \
         --buildtype=release \
         -D{amdgpu,radeon,intel,udev}=true \
-        -D{libkms,valgrind,freedreno,vc4,vmwgfx,nouveau,man-pages}=false
+        -D{valgrind,freedreno,vc4,vmwgfx,nouveau,man-pages}=false
     meson configure drm_build
     ninja -C drm_build install
-    cp ${TARGET_DIR}/lib/libdrm*.so* ${SOURCE_DIR}/drm
-    cp ${TARGET_DIR}/share/libdrm/*.ids ${SOURCE_DIR}/drm
-    echo "drm/libdrm*.so* usr/lib/jellyfin-ffmpeg/lib" >> ${DPKG_INSTALL_LIST}
-    echo "drm/*.ids usr/lib/jellyfin-ffmpeg/share/libdrm" >> ${DPKG_INSTALL_LIST}
+    cp ${TARGET_DIR}/lib/libdrm*.so* ${SOURCE_DIR}/libdrm
+    cp ${TARGET_DIR}/share/libdrm/*.ids ${SOURCE_DIR}/libdrm
+    echo "libdrm/libdrm*.so* usr/lib/jellyfin-ffmpeg/lib" >> ${DPKG_INSTALL_LIST}
+    echo "libdrm/*.ids usr/lib/jellyfin-ffmpeg/share/libdrm" >> ${DPKG_INSTALL_LIST}
+    popd
     popd
 
     # LIBVA
@@ -224,7 +230,7 @@ prepare_extra_amd64() {
     # Provides MSDK runtime (libmfxhw64.so.1) for 11th Gen Rocket Lake and older
     # Provides MFX dispatcher (libmfx.so.1) for FFmpeg
     pushd ${SOURCE_DIR}
-    git clone -b intel-mediasdk-22.4.2 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
+    git clone -b intel-mediasdk-22.4.3 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
     pushd MediaSDK
     sed -i 's|MFX_PLUGINS_CONF_DIR "/plugins.cfg"|"/usr/lib/jellyfin-ffmpeg/lib/mfx/plugins.cfg"|g' api/mfx_dispatch/linux/mfxloader.cpp
     mkdir build && pushd build
@@ -244,7 +250,7 @@ prepare_extra_amd64() {
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     # Both MSDK and VPL runtime can be loaded by MFX dispatcher (libmfx.so.1)
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-22.4.2 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu
+    git clone -b intel-onevpl-22.4.3 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu
     pushd oneVPL-intel-gpu
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -258,7 +264,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-22.4.2 --depth=1 https://github.com/intel/media-driver
+    git clone -b intel-media-22.4.3 --depth=1 https://github.com/intel/media-driver
     pushd media-driver
     sed -i 's|find_package(X11)||g' media_softlet/media_top_cmake.cmake media_driver/media_top_cmake.cmake
     mkdir build && pushd build
@@ -278,7 +284,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.215 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers
+    git clone -b v1.3.216 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -291,7 +297,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.215 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader
+    git clone -b v1.3.216 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \
@@ -340,15 +346,20 @@ prepare_extra_amd64() {
         # llvm >= 11
         apt-get install -y llvm-11-dev
         pushd ${SOURCE_DIR}
-        git clone -b mesa-22.0.4 --depth=1 https://gitlab.freedesktop.org/mesa/mesa.git
+        mkdir mesa
+        pushd mesa
+        mesa_ver="22.0.5"
+        mesa_link="https://mesa.freedesktop.org/archive/mesa-${mesa_ver}.tar.xz"
+        wget ${mesa_link} -O mesa.tar.xz
+        tar xaf mesa.tar.xz
         # disable the broken hevc packed header
-        MESA_VA_PIC=mesa/src/gallium/frontends/va/picture.c
-        MESA_VA_CONF=mesa/src/gallium/frontends/va/config.c
+        MESA_VA_PIC="mesa-${mesa_ver}/src/gallium/frontends/va/picture.c"
+        MESA_VA_CONF="mesa-${mesa_ver}/src/gallium/frontends/va/config.c"
         sed -i 's|handleVAEncPackedHeaderParameterBufferType(context, buf);||g' ${MESA_VA_PIC}
         sed -i 's|handleVAEncPackedHeaderDataBufferType(context, buf);||g' ${MESA_VA_PIC}
         sed -i 's|if (u_reduce_video_profile(ProfileToPipe(profile)) == PIPE_VIDEO_FORMAT_HEVC)||g' ${MESA_VA_CONF}
         sed -i 's|value \|= VA_ENC_PACKED_HEADER_SEQUENCE;||g' ${MESA_VA_CONF}
-        meson setup mesa mesa_build \
+        meson setup mesa-${mesa_ver} mesa_build \
             --prefix=${TARGET_DIR} \
             --libdir=lib \
             --buildtype=release \


### PR DESCRIPTION
**Changes**
- Fix the unsupported subscripted access on nVidia (we don't use opencl on nVidia though)
- Fix using hwupload with hwmap on d3d11va
- Update dependencies
- Bump version to 5.0.1-6
- Add params to trace the symlink err on publishing
- Force reporting packed headers are supported on AMD VAAPI (it's a hack to workaround something like https://github.com/jellyfin/jellyfin/issues/7642)