### PR TITLE
Try to fix amd packed header

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -357,10 +357,10 @@ prepare_extra_amd64() {
         MESA_VA_CONF="mesa-${mesa_ver}/src/gallium/frontends/va/config.c"
         sed -i 's|handleVAEncPackedHeaderParameterBufferType(context, buf);||g' ${MESA_VA_PIC}
         sed -i 's|handleVAEncPackedHeaderDataBufferType(context, buf);||g' ${MESA_VA_PIC}
-        sed -i 's|if (u_reduce_video_profile(ProfileToPipe(profile)) == PIPE_VIDEO_FORMAT_HEVC)||g' ${MESA_VA_CONF}
-        sed -i 's|value \|= VA_ENC_PACKED_HEADER_SEQUENCE;||g' ${MESA_VA_CONF}
-        # Force reporting packed headers are supported
-        sed -i 's|value = VA_ENC_PACKED_HEADER_NONE;|value = 1;|g' ${MESA_VA_CONF}
+        sed -i 's|if (u_reduce_video_profile(ProfileToPipe(profile)) == PIPE_VIDEO_FORMAT_HEVC)|if (0)|g' ${MESA_VA_CONF}
+        # force reporting all packed headers are supported
+        sed -i 's|value = VA_ENC_PACKED_HEADER_NONE;|value = 0x0000001f;|g' ${MESA_VA_CONF}
+        sed -i 's|if (attrib_list\[i\].type == VAConfigAttribEncPackedHeaders)|if (0)|g' ${MESA_VA_CONF}
         meson setup mesa-${mesa_ver} mesa_build \
             --prefix=${TARGET_DIR} \
             --libdir=lib \


### PR DESCRIPTION
**Changes**
- Fix AMD VAAPI encoder packed header

These flags are force enabled to satisfy Mkv container, but they are not fully supported by AMD VAAPI driver.
```
VA_ENC_PACKED_HEADER_SEQUENCE |
VA_ENC_PACKED_HEADER_PICTURE |
VA_ENC_PACKED_HEADER_SLICE |
VA_ENC_PACKED_HEADER_MISC |
VA_ENC_PACKED_HEADER_RAW_DATA
```