### PR TITLE
Try to fix the windows build publish issue

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,7 +84,8 @@ jobs:
               find /srv/repository/releases/server/${{ matrix.arrays.distro }}/ -type l -name "${basename}_*" -exec rm {} \;
               reprepro -b /srv/repository/${{ matrix.arrays.distro }} deleteunreferenced
               reprepro -b /srv/repository/${{ matrix.arrays.distro }} export
-            else
+            fi
+            if [ "${{ matrix.arrays.distro }}" == "windows" ]; then
               ln -fs /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}/${basename}_*.zip /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}/jellyfin-ffmpeg.zip
             fi
             rm -f /srv/repository/releases/server/${{ matrix.arrays.distro }}/ffmpeg


### PR DESCRIPTION
**Changes**
- Try to fix the windows build publish issue

As per the error log, it seems that the `ln -fs` command after `else` was never executed.
```
err: + '[' windows '!=' windows ']'
err: + DRONE_SSH_PREV_COMMAND_EXIT_CODE=1
2022/06/15 09:34:35 Process exited with status 1
err: + '[' 1 -ne 0 ']'
err: + exit 1
```

For reference, the linux build shows:
```
err: + '[' ubuntu '!=' windows ']'
err: + DRONE_SSH_PREV_COMMAND_EXIT_CODE=0
err: + '[' 0 -ne 0 ']'
err: + find /srv/repository/releases/server/ubuntu/versions/jellyfin-ffmpeg/5.0.1-6 -type f -name 'jellyfin-ffmpeg*_5.0.1-6-impish_*.deb'
err: + read file
err: + DRONE_SSH_PREV_COMMAND_EXIT_CODE=0
err: + '[' 0 -ne 0 ']'
```