### PR TITLE
Switch to single precision fftw, enable neon for arm

### DIFF
--- a/build-win64
+++ b/build-win64
@@ -10,7 +10,7 @@ done
 
 # Use the latest distro for toolchains
 distro="ubuntu:jammy"
-ffrevison="6"
+ffrevison="7"
 image_name="jellyfin-ffmpeg-build-windows-win64"
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "5.0.1-6"
+version: "5.0.1-7"
 packages:
   - buster-amd64
   - buster-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (5.0.1-7) unstable; urgency=medium
+
+  * Switch to single precision fftw, enable neon for arm.
+
+ -- nyanmisaka <nst799610810@gmail.com>  Thu, 23 Jun 2022 19:19:17 +0800
+
 jellyfin-ffmpeg (5.0.1-6) unstable; urgency=medium
 
   * Fix using hwupload with hwmap on d3d11va.

--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,7 @@ PACKAGEVERSION := "$(ORIG_VERSION)-$(VERSION_SUFFIX)"
 
 CONFIG := --prefix=${TARGET_DIR} \
 	--target-os=linux \
-	--extra-libs='-lfftw3' \
+	--extra-libs='-lfftw3f' \
 	--extra-version=Jellyfin \
 	--disable-doc \
 	--disable-ffplay \

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -133,7 +133,7 @@ pushd fftw-${fftw3_ver}
     --prefix=${FF_DEPS_PREFIX} \
     --host=${FF_TOOLCHAIN} \
     --disable-{shared,doc} \
-    --enable-{static,threads,fortran} \
+    --enable-{static,single,threads,fortran} \
     --enable-{sse2,avx,avx-128-fma,avx2,avx512} \
     --with-our-malloc \
     --with-combined-threads \
@@ -154,11 +154,11 @@ cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DBUILD_SHARED_LIBS=OFF \
     -DBUILD_{TOOLS,TESTS}=OFF \
-    -DFFT_LIB=fftw3 \
+    -DFFT_LIB=fftw3f \
     ..
 make -j$(nproc)
 make install
-FF_EXTRA_LIBS="-lfftw3 -lstdc++${FF_EXTRA_LIBS}"
+FF_EXTRA_LIBS="-lfftw3f -lstdc++${FF_EXTRA_LIBS}"
 FF_EXTRA_CFLAGS="-DCHROMAPRINT_NODLL${FF_EXTRA_CFLAGS}"
 popd
 popd

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -40,19 +40,19 @@ prepare_extra_common() {
     if [ "${ARCH}" = "amd64" ]; then
         fftw3_optimizations="--enable-sse2 --enable-avx --enable-avx-128-fma --enable-avx2 --enable-avx512"
     else
-        fftw3_optimizations=""
+        fftw3_optimizations="--enable-neon"
     fi
     ./configure \
         ${CROSS_OPT} \
         --prefix=${TARGET_DIR} \
         --disable-{static,doc} \
-        --enable-{shared,threads,fortran} \
+        --enable-{shared,single,threads,fortran} \
         $fftw3_optimizations \
         --with-our-malloc \
         --with-combined-threads \
         --with-incoming-stack-boundary=2
     make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/fftw3
-    echo "fftw3${TARGET_DIR}/lib/libfftw3.so* usr/lib/jellyfin-ffmpeg/lib" >> ${DPKG_INSTALL_LIST}
+    echo "fftw3${TARGET_DIR}/lib/libfftw3f.so* usr/lib/jellyfin-ffmpeg/lib" >> ${DPKG_INSTALL_LIST}
     popd
     popd
     popd
@@ -69,7 +69,7 @@ prepare_extra_common() {
         -DCMAKE_BUILD_TYPE=Release \
         -DBUILD_SHARED_LIBS=ON \
         -DBUILD_{TOOLS,TESTS}=OFF \
-        -DFFT_LIB=fftw3 \
+        -DFFT_LIB=fftw3f \
         ..
     make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/chromaprint
     echo "chromaprint${TARGET_DIR}/lib/libchromaprint.so* usr/lib/jellyfin-ffmpeg/lib" >> ${DPKG_INSTALL_LIST}


### PR DESCRIPTION
**Changes**
- Switch to single precision fftw
- Enable NEON SIMD for Arm fftw
- Bump version to 5.0.1-7

Intro-skipper (chromaprint) should be faster on x86 and Arm.