### PR TITLE
Fix the incorrect full to limit color range on DoVi tonemap.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 jellyfin-ffmpeg (5.0.1-7) unstable; urgency=medium
 
   * Switch to single precision fftw, enable neon for arm.
+  * Fix the incorrect full to limit color range on DoVi tonemap.
 
  -- nyanmisaka <nst799610810@gmail.com>  Thu, 23 Jun 2022 19:19:17 +0800
 

--- a/debian/patches/0005-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0005-add-cuda-tonemap-impl.patch
@@ -456,7 +456,7 @@ Index: jellyfin-ffmpeg/libavfilter/cuda/colorspace_common.h
 +    float r = linearize(c.x);
 +    float g = linearize(c.y);
 +    float b = linearize(c.z);
-+    return make_float3(r, g, b);
++    return lrgb2lrgb(make_float3(r, g, b));
 +}
 +
 +static __inline__ __device__ float3 ycc2rgb(float y, float cb, float cr) {

--- a/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -165,24 +165,12 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/colorspace_common.cl
 +float inverse_eotf_st2084(float x) {
 +    x *= REF_WHITE / ST2084_MAX_LUMINANCE;
 +    return inverse_eotf_st2084_common(x);
- }
- 
--float inverse_eotf_bt1886(float c) {
--    return c < 0.0f ? 0.0f : powr(c, 1.0f / 2.4f);
++}
++
 +float ootf_1_2(float x) {
 +    return x > 0.0f ? native_powr(x, 1.2f) : x;
- }
- 
--float oetf_bt709(float c) {
--    c = c < 0.0f ? 0.0f : c;
--    float r1 = 4.5f * c;
--    float r2 = 1.099f * powr(c, 0.45f) - 0.099f;
--    return c < 0.018f ? r1 : r2;
--}
--float inverse_oetf_bt709(float c) {
--    float r1 = c / 4.5f;
--    float r2 = powr((c + 0.099f) / 1.099f, 1.0f / 0.45f);
--    return c < 0.081f ? r1 : r2;
++}
++
 +float inverse_ootf_1_2(float x) {
 +    return x > 0.0f ? native_powr(x, 1.0f / 1.2f) : x;
 +}
@@ -204,13 +192,25 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/colorspace_common.cl
 +// linearizer for HLG/ARIB-B67
 +float eotf_arib_b67(float x) {
 +    return ootf_1_2(inverse_oetf_arib_b67(x));
-+}
-+
+ }
+ 
+-float inverse_eotf_bt1886(float c) {
+-    return c < 0.0f ? 0.0f : powr(c, 1.0f / 2.4f);
 +// delinearizer for HLG/ARIB-B67
 +float inverse_eotf_arib_b67(float x) {
 +    return oetf_arib_b67(inverse_ootf_1_2(x));
-+}
-+
+ }
+ 
+-float oetf_bt709(float c) {
+-    c = c < 0.0f ? 0.0f : c;
+-    float r1 = 4.5f * c;
+-    float r2 = 1.099f * powr(c, 0.45f) - 0.099f;
+-    return c < 0.018f ? r1 : r2;
+-}
+-float inverse_oetf_bt709(float c) {
+-    float r1 = c / 4.5f;
+-    float r2 = powr((c + 0.099f) / 1.099f, 1.0f / 0.45f);
+-    return c < 0.081f ? r1 : r2;
 +// delinearizer for BT709, BT2020-10
 +float inverse_eotf_bt1886(float x) {
 +    return x > 0.0f ? native_powr(x, 1.0f / 2.4f) : 0.0f;
@@ -224,14 +224,16 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/colorspace_common.cl
 -float3 ootf(float3 c, float peak) {
 -#ifdef ootf_impl
 -    return ootf_impl(c, peak);
+-#else
+-    return c;
 +float3 rgb2lrgb(float3 c) {
 +#ifdef linearize
 +    float r = linearize(c.x);
 +    float g = linearize(c.y);
 +    float b = linearize(c.z);
-+    return (float3)(r, g, b);
- #else
-     return c;
++    return lrgb2lrgb((float3)(r, g, b));
++#else
++    return lrgb2lrgb((float3)(c.x, c.y, c.z))
  #endif
  }
  


### PR DESCRIPTION
**Changes**
- Fix the incorrect full to limit color range on DoVi tonemap.

I forgot about this. This will avoid desaturation on full->limit range transitions.