### PR TITLE
Add fixes for VAAPI render node enumeration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["jammy", "focal", "bionic"]'
+      codenames: '["kinetic", "jammy", "focal", "bionic"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["jammy", "focal", "bionic"]'
+      codenames: '["kinetic", "jammy", "focal", "bionic"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: true
     secrets:
@@ -56,6 +56,7 @@ jobs:
         arrays: [
           {distro: 'debian', codename: 'buster'},
           {distro: 'debian', codename: 'bullseye'},
+          {distro: 'ubuntu', codename: 'kinetic'},
           {distro: 'ubuntu', codename: 'jammy'},
           {distro: 'ubuntu', codename: 'focal'},
           {distro: 'ubuntu', codename: 'bionic'},

--- a/build
+++ b/build
@@ -9,6 +9,7 @@ usage() {
     echo -e " * bionic           * arm64"
     echo -e " * focal"
     echo -e " * jammy"
+    echo -e " * kinetic"
 }
 
 if [[ -z ${1} ]]; then
@@ -37,6 +38,10 @@ case ${cli_release} in
     'jammy')
         release="ubuntu:jammy"
         gcc_version="11"
+    ;;
+    'kinetic')
+        release="ubuntu:kinetic"
+        gcc_version="12"
     ;;
     *)
         echo "Invalid release."

--- a/build-win64
+++ b/build-win64
@@ -10,7 +10,7 @@ done
 
 # Use the latest distro for toolchains
 distro="ubuntu:jammy"
-ffrevison="1"
+ffrevison="2"
 image_name="jellyfin-ffmpeg-build-windows-win64"
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "5.1.1-1"
+version: "5.1.1-2"
 packages:
   - buster-amd64
   - buster-armhf

--- a/build.yaml
+++ b/build.yaml
@@ -18,3 +18,6 @@ packages:
   - jammy-amd64
   - jammy-armhf
   - jammy-arm64
+  - kinetic-amd64
+  - kinetic-armhf
+  - kinetic-arm64

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+jellyfin-ffmpeg (5.1.1-2) unstable; urgency=medium
+
+  * Add fixes for VAAPI render node enumeration
+  * Pin libva to release and update dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Sun, 25 Sep 2022 13:41:31 +0800
+
 jellyfin-ffmpeg (5.1.1-1) unstable; urgency=medium
 
   * New upstream version 5.1.1

--- a/debian/patches/0037-add-fixes-for-vaapi-rendernode-enumeration.patch
+++ b/debian/patches/0037-add-fixes-for-vaapi-rendernode-enumeration.patch
@@ -1,0 +1,13 @@
+Index: jellyfin-ffmpeg/libavutil/hwcontext_vaapi.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_vaapi.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_vaapi.c
+@@ -1692,7 +1692,7 @@ static int vaapi_device_create(AVHWDevic
+                 if (priv->drm_fd < 0) {
+                     av_log(ctx, AV_LOG_VERBOSE, "Cannot open "
+                            "DRM render node for device %d.\n", n);
+-                    break;
++                    continue;
+                 }
+ #if CONFIG_LIBDRM
+                 if (kernel_driver) {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -34,3 +34,4 @@
 0034-add-hevc-dovi-sidedata-to-hlsenc.patch
 0035-add-pause-support-for-ffmpeg.patch
 0036-enable-gcc-vectorization-and-lto-auto.patch
+0037-add-fixes-for-vaapi-rendernode-enumeration.patch

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -482,7 +482,7 @@ mv * ${FF_DEPS_PREFIX}/include/CL
 popd
 
 # OpenCL ICD loader
-git clone -b v2022.05.18 --depth=1 https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
+git clone -b v2022.09.23 --depth=1 https://github.com/KhronosGroup/OpenCL-ICD-Loader.git
 pushd OpenCL-ICD-Loader
 mkdir build
 pushd build

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -175,7 +175,7 @@ prepare_extra_amd64() {
 
     # LIBVA
     pushd ${SOURCE_DIR}
-    git clone --depth=1 https://github.com/intel/libva
+    git clone -b 2.15.0 --depth=1 https://github.com/intel/libva
     pushd libva
     sed -i 's|getenv("LIBVA_DRIVERS_PATH")|"/usr/lib/jellyfin-ffmpeg/lib/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/dri:/usr/local/lib/dri"|g' va/va.c
     sed -i 's|getenv("LIBVA_DRIVER_NAME")|getenv("LIBVA_DRIVER_NAME_JELLYFIN")|g' va/va.c
@@ -192,7 +192,7 @@ prepare_extra_amd64() {
 
     # LIBVA-UTILS
     pushd ${SOURCE_DIR}
-    git clone --depth=1 https://github.com/intel/libva-utils
+    git clone -b 2.15.0 --depth=1 https://github.com/intel/libva-utils
     pushd libva-utils
     ./autogen.sh
     ./configure --prefix=${TARGET_DIR}
@@ -216,7 +216,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.1.7 --depth=1 https://github.com/intel/gmmlib
+    git clone -b intel-gmmlib-22.2.0 --depth=1 https://github.com/intel/gmmlib
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -285,7 +285,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.226 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers
+    git clone -b v1.3.229 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -298,7 +298,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.226 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader
+    git clone -b v1.3.229 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \
@@ -413,14 +413,14 @@ prepare_extra_amd64() {
     # LIBPLACEBO
     pushd ${SOURCE_DIR}
     git clone --recursive --depth=1 https://github.com/haasn/libplacebo
-    sed -i 's|env: python_env,||g' libplacebo/src/meson.build
+    sed -i 's|env: python_env,||g' libplacebo/src/vulkan/meson.build
     meson setup libplacebo placebo_build \
         --prefix=${TARGET_DIR} \
         --libdir=lib \
         --buildtype=release \
         --default-library=shared \
         -Dvulkan=enabled \
-        -Dvulkan-link=false \
+        -Dvk-proc-addr=enabled \
         -Dvulkan-registry=${TARGET_DIR}/share/vulkan/registry/vk.xml \
         -Dshaderc=enabled \
         -Dglslang=disabled \


### PR DESCRIPTION
**Changes**
[VAAPI hwcontext](https://github.com/FFmpeg/FFmpeg/blob/1bad30dbe34f2d100b43e8f773d3fe0b5eb23523/libavutil/hwcontext_vaapi.c#L1679-L1683) should use `continue` instead of `break` in case of the first render node isn't renderD128.

- Add fixes for VAAPI render node enumeration
- Pin libva to release and update dependencies
- Bump version to 5.1.1-2
- Add support for the upcoming Ubuntu Kinetic 22.10

**Issues**
https://github.com/jellyfin/jellyfin/pull/8443