### PR TITLE
Add fixes for the invalid modifier on AMD APU

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -21,11 +21,12 @@ ENV CFLAGS="-I${TARGET_DIR}/include $CFLAGS"
 
 # Prepare Debian build environment
 RUN apt-get update \
+ && apt-get upgrade -y \
  && yes | apt-get install -y apt-transport-https curl ninja-build debhelper gnupg wget devscripts mmv equivs git nasm pkg-config subversion dh-autoreconf libpciaccess-dev libwayland-dev libx11-dev libx11-xcb-dev libxcb-dri2-0-dev libxcb-dri3-dev libxcb-present-dev libxcb-shm0-dev libxcb-sync-dev libxshmfence-dev libxext-dev libxfixes-dev libxcb1-dev libxrandr-dev libzstd-dev libelf-dev python3-pip zip unzip tar flex bison
 
 # Install newer tools from pip3
 RUN pip3 install --upgrade pip \
- && pip3 install meson cmake mako
+ && pip3 install meson cmake mako jinja2
 # Avoids timeouts when using git and disable the detachedHead advice
 RUN git config --global http.postbuffer 524288000 \
  && git config --global advice.detachedHead false

--- a/build-win64
+++ b/build-win64
@@ -10,7 +10,7 @@ done
 
 # Use the latest distro for toolchains
 distro="ubuntu:kinetic"
-ffrevison="1"
+ffrevison="2"
 image_name="jellyfin-ffmpeg-build-windows-win64"
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "5.1.2-1"
+version: "5.1.2-2"
 packages:
   - buster-amd64
   - buster-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+jellyfin-ffmpeg (5.1.2-2) unstable; urgency=medium
+
+  * Add fixes for the invalid modifier on AMD APU
+  * Update dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Sun, 16 Oct 2022 22:36:31 +0800
+
 jellyfin-ffmpeg (5.1.2-1) unstable; urgency=medium
 
   * New upstream version 5.1.2

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -201,7 +201,7 @@ prepare_extra_amd64() {
 
     # LIBVA
     pushd ${SOURCE_DIR}
-    git clone -b 2.15.0 --depth=1 https://github.com/intel/libva
+    git clone -b 2.16.0 --depth=1 https://github.com/intel/libva
     pushd libva
     sed -i 's|getenv("LIBVA_DRIVERS_PATH")|"/usr/lib/jellyfin-ffmpeg/lib/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/dri:/usr/local/lib/dri"|g' va/va.c
     sed -i 's|getenv("LIBVA_DRIVER_NAME")|getenv("LIBVA_DRIVER_NAME_JELLYFIN")|g' va/va.c
@@ -218,7 +218,7 @@ prepare_extra_amd64() {
 
     # LIBVA-UTILS
     pushd ${SOURCE_DIR}
-    git clone -b 2.15.0 --depth=1 https://github.com/intel/libva-utils
+    git clone -b 2.16.0 --depth=1 https://github.com/intel/libva-utils
     pushd libva-utils
     ./autogen.sh
     ./configure --prefix=${TARGET_DIR}
@@ -242,7 +242,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.2.0 --depth=1 https://github.com/intel/gmmlib
+    git clone -b intel-gmmlib-22.2.1 --depth=1 https://github.com/intel/gmmlib
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -310,7 +310,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.230 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers
+    git clone -b v1.3.231 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -323,7 +323,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.230 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader
+    git clone -b v1.3.231 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \
@@ -344,7 +344,7 @@ prepare_extra_amd64() {
 
     # SHADERC
     pushd ${SOURCE_DIR}
-    git clone -b v2022.2 --depth=1 https://github.com/google/shaderc
+    git clone -b v2022.3 --depth=1 https://github.com/google/shaderc
     pushd shaderc
     ./utils/git-sync-deps
     mkdir build && pushd build
@@ -378,6 +378,9 @@ prepare_extra_amd64() {
         mesa_link="https://mesa.freedesktop.org/archive/mesa-${mesa_ver}.tar.xz"
         wget ${mesa_link} -O mesa.tar.xz
         tar xaf mesa.tar.xz
+        # fix the invalid modifier issue on amd apu
+        MESA_SI_TEX="mesa-${mesa_ver}/src/gallium/drivers/radeonsi/si_texture.c"
+	sed -i 's|(struct si_texture \*)screen->resource_create(screen, \&templ)|(struct si_texture\*)((tex->surface.modifier==DRM_FORMAT_MOD_INVALID\|\|!screen->resource_create_with_modifiers)?screen->resource_create(screen,\&templ):screen->resource_create_with_modifiers(screen,\&templ,\&tex->surface.modifier,1))|g' ${MESA_SI_TEX}
         # disable the broken hevc packed header
         MESA_VA_PIC="mesa-${mesa_ver}/src/gallium/frontends/va/picture.c"
         MESA_VA_CONF="mesa-${mesa_ver}/src/gallium/frontends/va/config.c"


### PR DESCRIPTION
**Changes**
- Add fixes for the invalid modifier on AMD APU
- Update dependencies
- Bump version to 5.1.2-2

**Issues**
- Fixes "Cannot map DRM frame to Vulkan: VK_ERROR_FORMAT_NOT_SUPPORTED" in [AMD Vulkan PR](https://github.com/jellyfin/jellyfin/pull/7708).