### PR TITLE
Status of Intel Arc support

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -297,6 +297,7 @@ prepare_extra_amd64() {
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
           -DENABLE_KERNELS=ON \
           -DENABLE_NONFREE_KERNELS=ON \
+          -DENABLE_PRODUCTION_KMD=ON \
           LIBVA_DRIVERS_PATH=${TARGET_DIR}/lib/dri \
           ..
     make -j$(nproc) && make install && make install DESTDIR=${SOURCE_DIR}/intel


### PR DESCRIPTION
As of Linux 6.0 release, media features on Intel Arc GPU have not been finished in upsteam i915 driver.

To use Intel Arc GPU on Linux, you need:
- Ubuntu OEM kernel from 20.04 or 22.04
- [Intel's special DKMS](https://dgpu-docs.intel.com/installation-guides/index.html#intel-arc-gpus)
- Special `jellyfin-ffmpeg5` deb from this action artifacts

**DO NOT MERGE, THIS WON'T WORK WITHOUT SPECIAL DKMS INSTALLED!**

---

Status of QSV on Intel Arc A380 with the latest Jellyfin release:
- hw decoding & encoding
- hw scaling
- hw deinterlacing
- hw HDR/DV tonemapping
- hw subtitle burn-in

![arc](https://user-images.githubusercontent.com/14953024/197138122-c7470dc6-cbbc-4e2c-bc2d-4c3d8afdae67.png)
