### PR TITLE
Some QSV and D3D11VA fixes for Intel

### DIFF
--- a/Dockerfile.make
+++ b/Dockerfile.make
@@ -1,6 +1,7 @@
 #!/usr/bin/make
 DISTRO=bullseye
 GCC_VER=10
+LLVM_VER=13
 ARCH=amd64
 .PHONY: Dockerfile
 Dockerfile: Dockerfile.in

--- a/build
+++ b/build
@@ -22,26 +22,32 @@ case ${cli_release} in
     'buster')
         release="debian:buster"
         gcc_version="8"
+        llvm_version="13"
     ;;
     'bullseye')
         release="debian:bullseye"
         gcc_version="10"
+        llvm_version="13"
     ;;
     'bionic')
         release="ubuntu:bionic"
         gcc_version="7"
+        llvm_version="10"
     ;;
     'focal')
         release="ubuntu:focal"
         gcc_version="9"
+        llvm_version="12"
     ;;
     'jammy')
         release="ubuntu:jammy"
         gcc_version="11"
+        llvm_version="14"
     ;;
     'kinetic')
         release="ubuntu:kinetic"
         gcc_version="12"
+        llvm_version="15"
     ;;
     *)
         echo "Invalid release."
@@ -90,7 +96,7 @@ cleanup() {
 trap cleanup EXIT INT
 
 # Generate Dockerfile
-make -f Dockerfile.make DISTRO=${release} GCC_VER=${gcc_version} ARCH=${arch}
+make -f Dockerfile.make DISTRO=${release} GCC_VER=${gcc_version} LLVM_VER=${llvm_version} ARCH=${arch}
 # Set up the build environment docker image
 docker build . -t "${image_name}"
 # Build the APKs and copy out to ${package_temporary_dir}

--- a/build-win64
+++ b/build-win64
@@ -10,7 +10,7 @@ done
 
 # Use the latest distro for toolchains
 distro="ubuntu:kinetic"
-ffrevison="2"
+ffrevison="3"
 image_name="jellyfin-ffmpeg-build-windows-win64"
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "5.1.2-2"
+version: "5.1.2-3"
 packages:
   - buster-amd64
   - buster-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+jellyfin-ffmpeg (5.1.2-3) unstable; urgency=medium
+
+  * Add tier option for the QSV HEVC encoder
+  * Add fixes for some quirks on DG2 on Windows
+  * Update dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Tue, 26 Oct 2022 20:44:03 +0800
+
 jellyfin-ffmpeg (5.1.2-2) unstable; urgency=medium
 
   * Add fixes for the invalid modifier on AMD APU

--- a/debian/patches/0038-add-tier-option-for-qsv-hevc-encoder.patch
+++ b/debian/patches/0038-add-tier-option-for-qsv-hevc-encoder.patch
@@ -1,0 +1,43 @@
+Index: jellyfin-ffmpeg/libavcodec/qsvenc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/qsvenc.c
++++ jellyfin-ffmpeg/libavcodec/qsvenc.c
+@@ -612,8 +612,11 @@ static int init_video_param(AVCodecConte
+         return AVERROR_BUG;
+     q->param.mfx.CodecId = ret;
+ 
+-    if (avctx->level > 0)
++    if (avctx->level > 0) {
+         q->param.mfx.CodecLevel = avctx->level;
++        if (avctx->codec_id == AV_CODEC_ID_HEVC && avctx->level >= MFX_LEVEL_HEVC_4)
++            q->param.mfx.CodecLevel |= q->tier;
++    }
+ 
+     if (avctx->compression_level == FF_COMPRESSION_DEFAULT) {
+         avctx->compression_level = q->preset;
+Index: jellyfin-ffmpeg/libavcodec/qsvenc.h
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/qsvenc.h
++++ jellyfin-ffmpeg/libavcodec/qsvenc.h
+@@ -160,6 +160,7 @@ typedef struct QSVEncContext {
+     int async_depth;
+     int idr_interval;
+     int profile;
++    int tier;
+     int preset;
+     int avbr_accuracy;
+     int avbr_convergence;
+Index: jellyfin-ffmpeg/libavcodec/qsvenc_hevc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/qsvenc_hevc.c
++++ jellyfin-ffmpeg/libavcodec/qsvenc_hevc.c
+@@ -257,6 +257,9 @@ static const AVOption options[] = {
+ #if QSV_VERSION_ATLEAST(1, 32)
+     { "scc",     NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_HEVC_SCC     }, INT_MIN, INT_MAX,     VE, "profile" },
+ #endif
++    { "tier",    "Set the encoding tier (only level >= 4 can support high tier)", OFFSET(qsv.tier), AV_OPT_TYPE_INT, { .i64 = MFX_TIER_HEVC_HIGH }, MFX_TIER_HEVC_MAIN, MFX_TIER_HEVC_HIGH, VE, "tier" },
++    { "main",    NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_TIER_HEVC_MAIN       }, INT_MIN, INT_MAX,     VE, "tier" },
++    { "high",    NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_TIER_HEVC_HIGH       }, INT_MIN, INT_MAX,     VE, "tier" },
+ 
+     { "gpb", "1: GPB (generalized P/B frame); 0: regular P frame", OFFSET(qsv.gpb), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE},
+ 

--- a/debian/patches/0039-add-fixes-for-some-quirks-on-dg2-on-windows.patch
+++ b/debian/patches/0039-add-fixes-for-some-quirks-on-dg2-on-windows.patch
@@ -1,0 +1,105 @@
+Index: jellyfin-ffmpeg/libavcodec/dxva2.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/dxva2.c
++++ jellyfin-ffmpeg/libavcodec/dxva2.c
+@@ -615,6 +615,16 @@ int ff_dxva2_common_frame_params(AVCodec
+     else
+         surface_alignment = 16;
+ 
++    /* align surfaces to 32 on Intel to keep in line with the MSDK impl,
++    which avoids the unnecessary resizing when mapping to QSV */
++    if (device_ctx->type == AV_HWDEVICE_TYPE_D3D11VA) {
++        AVD3D11VADeviceContext *device_hwctx = device_ctx->hwctx;
++        if (device_hwctx->device_desc.VendorId == 0x8086) {
++            av_log(avctx, AV_LOG_DEBUG, "Intel d3d11va found, alignment changed!\n");
++            surface_alignment = 32;
++        }
++    }
++
+     /* 1 base work surface */
+     num_surfaces = 1;
+ 
+Index: jellyfin-ffmpeg/libavutil/hwcontext_d3d11va.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_d3d11va.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_d3d11va.c
+@@ -558,6 +558,35 @@ static void d3d11va_device_uninit(AVHWDe
+     }
+ }
+ 
++static int d3d11va_check_uma_support(AVHWDeviceContext *ctx)
++{
++    AVD3D11VADeviceContext *device_hwctx = ctx->hwctx;
++    D3D11_FEATURE_DATA_D3D11_OPTIONS2 data = {};
++    HRESULT hr = ID3D11Device_CheckFeatureSupport(device_hwctx->device,
++                                                  D3D11_FEATURE_D3D11_OPTIONS2,
++                                                  &data, sizeof(data));
++    return SUCCEEDED(hr) && data.UnifiedMemoryArchitecture;
++}
++
++static void d3d11va_query_device_desc(AVHWDeviceContext *ctx,
++                                      DXGI_ADAPTER_DESC *desc)
++{
++    AVD3D11VADeviceContext *device_hwctx = ctx->hwctx;
++    IDXGIDevice *pDXGIDevice = NULL;
++    IDXGIAdapter *pDXGIAdapter = NULL;
++    HRESULT hr = ID3D11Device_QueryInterface(device_hwctx->device, &IID_IDXGIDevice,
++                                             (void **)&pDXGIDevice);
++    if (SUCCEEDED(hr) && pDXGIDevice) {
++        hr = IDXGIDevice_GetParent(pDXGIDevice, &IID_IDXGIAdapter,
++                                   (void **)&pDXGIAdapter);
++        if (SUCCEEDED(hr) && pDXGIAdapter) {
++            IDXGIAdapter_GetDesc(pDXGIAdapter, desc);
++            IDXGIAdapter_Release(pDXGIAdapter);
++        }
++        IDXGIDevice_Release(pDXGIDevice);
++    }
++}
++
+ static int d3d11va_device_create(AVHWDeviceContext *ctx, const char *device,
+                                  AVDictionary *opts, int flags)
+ {
+@@ -656,6 +685,9 @@ static int d3d11va_device_create(AVHWDev
+         ID3D10Multithread_Release(pMultithread);
+     }
+ 
++    device_hwctx->is_uma = d3d11va_check_uma_support(ctx);
++    d3d11va_query_device_desc(ctx, &device_hwctx->device_desc);
++
+ #if !HAVE_UWP && HAVE_DXGIDEBUG_H
+     if (is_debug) {
+         HANDLE dxgidebug_dll = LoadLibrary("dxgidebug.dll");
+Index: jellyfin-ffmpeg/libavutil/hwcontext_d3d11va.h
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_d3d11va.h
++++ jellyfin-ffmpeg/libavutil/hwcontext_d3d11va.h
+@@ -94,6 +94,16 @@ typedef struct AVD3D11VADeviceContext {
+     void (*lock)(void *lock_ctx);
+     void (*unlock)(void *lock_ctx);
+     void *lock_ctx;
++
++    /**
++     * DXGI adapter description of the device.
++     */
++    DXGI_ADAPTER_DESC device_desc;
++
++    /**
++     * Whether the device is an UMA device.
++     */
++    int is_uma;
+ } AVD3D11VADeviceContext;
+ 
+ /**
+Index: jellyfin-ffmpeg/libavutil/hwcontext_opencl.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_opencl.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_opencl.c
+@@ -1380,7 +1380,7 @@ static int opencl_device_derive(AVHWDevi
+                 CL_CONTEXT_D3D11_DEVICE_KHR,
+                 (intptr_t)src_hwctx->device,
+                 CL_CONTEXT_INTEROP_USER_SYNC,
+-                CL_TRUE,
++                (!src_hwctx->device_desc.VendorId == 0x8086 || src_hwctx->is_uma),
+                 0,
+             };
+             OpenCLDeviceSelector selector = {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -35,3 +35,4 @@
 0035-add-pause-support-for-ffmpeg.patch
 0036-enable-gcc-vectorization-and-lto-auto.patch
 0037-add-fixes-for-vaapi-rendernode-enumeration.patch
+0038-add-tier-option-for-qsv-hevc-encoder.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -36,3 +36,4 @@
 0036-enable-gcc-vectorization-and-lto-auto.patch
 0037-add-fixes-for-vaapi-rendernode-enumeration.patch
 0038-add-tier-option-for-qsv-hevc-encoder.patch
+0039-add-fixes-for-some-quirks-on-dg2-on-windows.patch

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -442,7 +442,7 @@ popd
 popd
 
 # SVT-AV1
-git clone -b v1.2.1 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v1.3.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 pushd SVT-AV1
 mkdir build
 pushd build

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -141,7 +141,7 @@ prepare_extra_amd64() {
         NASM_PATH=/usr/lib/nasm-mozilla/bin/nasm
     fi
     pushd ${SOURCE_DIR}
-    git clone -b v1.2.1 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+    git clone -b v1.3.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
     pushd SVT-AV1
     mkdir build
     pushd build
@@ -242,7 +242,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.2.1 --depth=1 https://github.com/intel/gmmlib
+    git clone -b intel-gmmlib-22.3.0 --depth=1 https://github.com/intel/gmmlib
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -368,13 +368,12 @@ prepare_extra_amd64() {
 
     # MESA
     # Minimal libs for AMD VAAPI, AMD RADV and Intel ANV
-    if [[ $( lsb_release -c -s ) != "bionic" ]]; then
-        # llvm >= 11
-        apt-get install -y llvm-11-dev libudev-dev
+    if [[ ${LLVM_VER} -ge 11 ]]; then
+        apt-get install -y llvm-${LLVM_VER}-dev libudev-dev
         pushd ${SOURCE_DIR}
         mkdir mesa
         pushd mesa
-        mesa_ver="22.0.5"
+        mesa_ver="22.2.2"
         mesa_link="https://mesa.freedesktop.org/archive/mesa-${mesa_ver}.tar.xz"
         wget ${mesa_link} -O mesa.tar.xz
         tar xaf mesa.tar.xz
@@ -407,6 +406,7 @@ prepare_extra_amd64() {
             -Dgallium-{extra-hud,nine}=false \
             -Dgallium-{omx,vdpau,xa,xvmc,opencl}=disabled \
             -Dgallium-va=enabled \
+            -Dvideo-codecs=vc1dec,h264dec,h264enc,h265dec,h265enc \
             -Dgbm=disabled \
             -Dgles1=disabled \
             -Dgles2=disabled \


### PR DESCRIPTION
**Changes**
- Add tier option for the QSV HEVC encoder => fixes some blocky video issues
- Add fixes for some quirks on DG2 on Windows => avoids unnecessary resizing and fixes some multithread issues
- Update dependencies
- Bump version to 5.1.2-3

