### PR TITLE
Improve the robustness of DV tonemap

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ jellyfin-ffmpeg (5.1.2-3) unstable; urgency=medium
 
   * Add tier option for the QSV HEVC encoder
   * Add fixes for some quirks on DG2 on Windows
+  * Improve the robustness of DV tonemap
   * Update dependencies
 
  -- nyanmisaka <nst799610810@gmail.com>  Tue, 26 Oct 2022 20:44:03 +0800

--- a/debian/patches/0005-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0005-add-cuda-tonemap-impl.patch
@@ -1518,7 +1518,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
 ===================================================================
 --- /dev/null
 +++ jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
-@@ -0,0 +1,1036 @@
+@@ -0,0 +1,1039 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -1990,7 +1990,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
 +        // dovi_pivots
 +        if (comp->num_pivots > 2) {
 +            // Skip the (irrelevant) lower and upper bounds
-+            float pivots_data[7];
++            float pivots_data[7] = {0};
 +            memcpy(pivots_data, comp->pivots + 1,
 +                   (comp->num_pivots - 2) * sizeof(pivots_data[0]));
 +            // Fill the remainder with a quasi-infinite sentinel pivot
@@ -2417,6 +2417,9 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
 +        s->out_pri        = s->pri;
 +        s->out_range      = s->range;
 +        s->out_chroma_loc = s->in_chroma_loc;
++
++        if (!s->dovi)
++            s->apply_dovi = 0;
 +
 +        if ((ret = compile(link)) < 0)
 +            goto fail;

--- a/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -1023,7 +1023,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  static int get_rgb2rgb_matrix(enum AVColorPrimaries in, enum AVColorPrimaries out,
                                double rgb2rgb[3][3]) {
      double rgb2xyz[3][3], xyz2rgb[3][3];
-@@ -108,23 +197,141 @@ static int get_rgb2rgb_matrix(enum AVCol
+@@ -108,23 +197,140 @@ static int get_rgb2rgb_matrix(enum AVCol
      return 0;
  }
  
@@ -1034,8 +1034,8 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 +static int tonemap_opencl_update_dovi_params(AVFilterContext *avctx)
 +{
 +    TonemapOpenCLContext *ctx = avctx->priv;
-+    float coeffs_data[8][4];
-+    float mmr_packed_data[8*6][4];
++    float coeffs_data[8][4] = {0};
++    float mmr_packed_data[8*6][4] = {0};
 +    int c, i, j, k, err;
 +    cl_int cle;
 +
@@ -1102,7 +1102,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 +        // dovi_pivots
 +        if (comp->num_pivots > 2) {
 +            // Skip the (irrelevant) lower and upper bounds
-+            float pivots_data[7];
++            float pivots_data[7] = {0};
 +            memcpy(pivots_data, comp->pivots + 1,
 +                   (comp->num_pivots - 2) * sizeof(pivots_data[0]));
 +            // Fill the remainder with a quasi-infinite sentinel pivot
@@ -1118,10 +1118,9 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 +                                        dovi_coeffs_size, &coeffs_data[0], NULL);
 +
 +        // dovi_mmr
-+        if (has_mmr) {
++        if (has_mmr)
 +            CL_BLOCKING_WRITE_BUFFER_OFFSET(ctx->command_queue, ctx->dovi_mmr, c*dovi_mmr_size,
 +                                            dovi_mmr_size, &mmr_packed_data[0], NULL);
-+        }
 +    }
 +
 +fail:
@@ -1174,7 +1173,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  
      switch(ctx->tonemap) {
      case TONEMAP_GAMMA:
-@@ -144,48 +351,108 @@ static int tonemap_opencl_init(AVFilterC
+@@ -144,48 +350,108 @@ static int tonemap_opencl_init(AVFilterC
      if (isnan(ctx->param))
          ctx->param = 1.0f;
  
@@ -1298,7 +1297,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      if (ctx->range_in == AVCOL_RANGE_JPEG)
          av_bprintf(&header, "#define FULL_RANGE_IN\n");
  
-@@ -199,19 +466,38 @@ static int tonemap_opencl_init(AVFilterC
+@@ -199,19 +465,38 @@ static int tonemap_opencl_init(AVFilterC
      else
          ff_opencl_print_const_matrix_3x3(&header, "rgb2rgb", rgb2rgb);
  
@@ -1345,7 +1344,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
                 ctx->colorspace_out, av_color_space_name(ctx->colorspace_out));
          goto fail;
      }
-@@ -219,24 +505,24 @@ static int tonemap_opencl_init(AVFilterC
+@@ -219,24 +504,24 @@ static int tonemap_opencl_init(AVFilterC
      ff_fill_rgb2yuv_table(luma_dst, rgb2yuv);
      ff_opencl_print_const_matrix_3x3(&header, "yuv_matrix", rgb2yuv);
  
@@ -1386,7 +1385,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
      opencl_sources[0] = header.str;
-@@ -254,46 +540,131 @@ static int tonemap_opencl_init(AVFilterC
+@@ -254,46 +539,131 @@ static int tonemap_opencl_init(AVFilterC
      CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create OpenCL "
                       "command queue %d.\n", cle);
  
@@ -1537,7 +1536,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      ret = ff_opencl_filter_config_output(outlink);
      if (ret < 0)
          return ret;
-@@ -308,13 +679,46 @@ static int launch_kernel(AVFilterContext
+@@ -308,13 +678,46 @@ static int launch_kernel(AVFilterContext
      size_t global_work[2];
      size_t local_work[2];
      cl_int cle;
@@ -1586,7 +1585,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  
      local_work[0]  = 16;
      local_work[1]  = 16;
-@@ -338,13 +742,10 @@ static int tonemap_opencl_filter_frame(A
+@@ -338,13 +741,10 @@ static int tonemap_opencl_filter_frame(A
      AVFilterContext    *avctx = inlink->dst;
      AVFilterLink     *outlink = avctx->outputs[0];
      TonemapOpenCLContext *ctx = avctx->priv;
@@ -1601,7 +1600,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(input->format),
-@@ -363,9 +764,6 @@ static int tonemap_opencl_filter_frame(A
+@@ -363,9 +763,6 @@ static int tonemap_opencl_filter_frame(A
      if (err < 0)
          goto fail;
  
@@ -1611,7 +1610,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      if (ctx->trc != -1)
          output->color_trc = ctx->trc;
      if (ctx->primaries != -1)
-@@ -385,72 +783,84 @@ static int tonemap_opencl_filter_frame(A
+@@ -385,72 +782,87 @@ static int tonemap_opencl_filter_frame(A
      ctx->range_out = output->color_range;
      ctx->chroma_loc = output->chroma_location;
  
@@ -1644,10 +1643,10 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 +            ctx->peak = ff_determine_dovi_signal_peak(metadata);
 +        } else {
 +            ctx->peak = ff_determine_signal_peak(input);
-         }
++        }
 +        av_log(ctx, AV_LOG_DEBUG, "Computed signal peak: %f\n", ctx->peak);
 +    }
- 
++
 +    if (dovi_sd) {
 +        const AVDOVIMetadata *metadata = (AVDOVIMetadata *) dovi_sd->data;
 +        const AVDOVIRpuDataHeader *rpu = av_dovi_get_header(metadata);
@@ -1662,10 +1661,13 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 +            ctx->trc_in = AVCOL_TRC_SMPTE2084;
 +            ctx->colorspace_in = AVCOL_SPC_UNSPECIFIED;
 +            ctx->primaries_in = AVCOL_PRI_BT2020;
-+        }
+         }
 +    }
 +
 +    if (!ctx->initialised) {
++        if (!ctx->dovi)
++            ctx->apply_dovi = 0;
+ 
          err = tonemap_opencl_init(avctx);
          if (err < 0)
              goto fail;
@@ -1736,7 +1738,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      av_frame_free(&input);
      av_frame_free(&output);
      return err;
-@@ -461,8 +871,22 @@ static av_cold void tonemap_opencl_unini
+@@ -461,8 +873,22 @@ static av_cold void tonemap_opencl_unini
      TonemapOpenCLContext *ctx = avctx->priv;
      cl_int cle;
  
@@ -1761,7 +1763,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      if (ctx->kernel) {
          cle = clReleaseKernel(ctx->kernel);
          if (cle != CL_SUCCESS)
-@@ -470,6 +894,13 @@ static av_cold void tonemap_opencl_unini
+@@ -470,6 +896,13 @@ static av_cold void tonemap_opencl_unini
                     "kernel: %d.\n", cle);
      }
  
@@ -1775,7 +1777,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      if (ctx->command_queue) {
          cle = clReleaseCommandQueue(ctx->command_queue);
          if (cle != CL_SUCCESS)
-@@ -483,37 +914,44 @@ static av_cold void tonemap_opencl_unini
+@@ -483,37 +916,44 @@ static av_cold void tonemap_opencl_unini
  #define OFFSET(x) offsetof(TonemapOpenCLContext, x)
  #define FLAGS (AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_VIDEO_PARAM)
  static const AVOption tonemap_opencl_options[] = {


### PR DESCRIPTION
**Changes**
- Improve the robustness of DV tonemap

**Issues**
```
[Parsed_tonemap_opencl_4 @ 000002009b2cbc80] Failed to write buffer to device: -38.
[Parsed_tonemap_opencl_4 @ 000002009b2cbc80] Failed to update dovi params: -38.
```