### PR TITLE
Do not hardcode pkg version for windows build

### DIFF
--- a/Dockerfile.win64.in
+++ b/Dockerfile.win64.in
@@ -8,7 +8,6 @@ ARG ARTIFACT_DIR=/dist
 ENV DEBIAN_FRONTEND=noninteractive \
     SOURCE_DIR=/ffmpeg \
     ARTIFACT_DIR=/dist \
-    FF_REV=FFMPEG_REV \
     FF_PREFIX=/opt/ffmpeg \
     FF_DEPS_PREFIX=/opt/ffdeps \
     FF_TOOLCHAIN=x86_64-w64-mingw32 \

--- a/Dockerfile.win64.make
+++ b/Dockerfile.win64.make
@@ -1,8 +1,7 @@
 #!/usr/bin/make
 DISTRO=ubuntu:hirsute
-FF_REV=1
 .PHONY: Dockerfile
 Dockerfile: Dockerfile.win64.in
-	sed 's/DISTRO/$(DISTRO)/; s/FFMPEG_REV/$(FF_REV)/' $< > $@ || rm -f $@
+	sed 's/DISTRO/$(DISTRO)/' $< > $@ || rm -f $@
 clean:
 	rm -f Dockerfile

--- a/build-win64
+++ b/build-win64
@@ -10,7 +10,6 @@ done
 
 # Use the latest distro for toolchains
 distro="ubuntu:kinetic"
-ffrevison="3"
 image_name="jellyfin-ffmpeg-build-windows-win64"
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"
@@ -25,7 +24,7 @@ cleanup() {
 trap cleanup EXIT INT
 
 # Generate Dockerfile
-make -f Dockerfile.win64.make DISTRO=${distro} FF_REV=${ffrevison}
+make -f Dockerfile.win64.make DISTRO=${distro}
 # Set up the build environment docker image
 docker build . -t "${image_name}"
 # Build the APKs and copy out to ${package_temporary_dir}

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -558,7 +558,7 @@ popd
 
 # Jellyfin-FFmpeg
 pushd ${SOURCE_DIR}
-ffversion="$(cat RELEASE)-${FF_REV}"
+ffversion="$(dpkg-parsechangelog --show-field Version)"
 if [[ -f "patches/series" ]]; then
     quilt push -a
 fi


### PR DESCRIPTION
**Changes**
- Do not hardcode pkg version for windows build
 (use `dpkg-parsechangelog --show-field Version` instead)