### PR TITLE
Update dependencies to support Arc DG2 with upstream kernel

### DIFF
--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/mirror/mingw-w64.git"
-SCRIPT_COMMIT="7dcf65a7f26071c6aa26d5a5a8689089ae9a6740"
+SCRIPT_COMMIT="92eac6fea3c2c5142f6974a35530e23cbe9f9bbe"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/builder/scripts.d/20-libxml2.sh
+++ b/builder/scripts.d/20-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="66f781cf385bf690892b48c181257841841d3d41"
+SCRIPT_COMMIT="85c6cacd67371045b1d4c9f167606f64ed0d18c7"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-freetype.sh
+++ b/builder/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
-SCRIPT_COMMIT="109179c70ee8c9f101dd49700acbd9df124f9b1c"
+SCRIPT_COMMIT="b405fc5c1dbbe8163bf199b921ccfc5f902eaa4f"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-gmp.sh
+++ b/builder/scripts.d/25-gmp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gmplib.org/repo/gmp/"
-SCRIPT_HGREV="3ac5afa36be5"
+SCRIPT_HGREV="614a1cd8bb1d"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/35-fontconfig.sh
+++ b/builder/scripts.d/35-fontconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
-SCRIPT_COMMIT="eb0a199e0658d3ba64ff19072cb2ae39c5ca7c4c"
+SCRIPT_COMMIT="ddea974d3cc5d013bdc1c69a090529745cd987b1"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="630f09c8b6022184f7a414bb5e07c01898fae60c"
+SCRIPT_COMMIT="35233d2514cc202e9e2f8f94b3102cb620a0d403"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-opencl.sh
+++ b/builder/scripts.d/45-opencl.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/OpenCL-Headers.git"
-SCRIPT_COMMIT="b590a6bfe034ea3a418b7b523e3490956bcb367a"
+SCRIPT_COMMIT="8f33fba7c14b926c6551bf86b5b255e3e0f47f86"
 
 SCRIPT_REPO2="https://github.com/KhronosGroup/OpenCL-ICD-Loader.git"
-SCRIPT_COMMIT2="e009e321701fc851e157cadd969bfa5e675cef9c"
+SCRIPT_COMMIT2="9a3e962f16f5097d2054233ad8b6dad51b6f41b7"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-x11/20-libxau.sh
+++ b/builder/scripts.d/45-x11/20-libxau.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxau.git"
-SCRIPT_COMMIT="4fbefa02d6c842401ff79065d364edd7087a12a6"
+SCRIPT_COMMIT="14fdf25db9f21c8f3ad37f0d32a5b8e726efdc0d"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/30-libxcb.sh
+++ b/builder/scripts.d/45-x11/30-libxcb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcb.git"
-SCRIPT_COMMIT="33f3dbe3699a92e8ca18f470adac456e0b935e75"
+SCRIPT_COMMIT="cb8c70f5a65b4bd68b449dcaa637c3c4753e2f81"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/40-libx11.sh
+++ b/builder/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="b4f24b272c6ef888b6fcfcf80670c196b2e8f755"
+SCRIPT_COMMIT="7f7bcd7b6f569e9f70e3ddd134924f178e2596b1"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxfixes.sh
+++ b/builder/scripts.d/45-x11/50-libxfixes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxfixes.git"
-SCRIPT_COMMIT="d10ec36c81a6b488d1f700a28c5bff4714287b78"
+SCRIPT_COMMIT="332394278b7110a774b5277bb3cfc58c42cd888c"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxscrnsaver.sh
+++ b/builder/scripts.d/45-x11/50-libxscrnsaver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxscrnsaver.git"
-SCRIPT_COMMIT="d39f92be6b513c28546ebb0baf335f32ab154a89"
+SCRIPT_COMMIT="34f3f72b88c0a0a10d618e9dfbc88474ae5ce880"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libglvnd.sh
+++ b/builder/scripts.d/45-x11/60-libglvnd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/glvnd/libglvnd.git"
-SCRIPT_COMMIT="58d49d7f1db39aa2ffb018de478bef30e2e855f6"
+SCRIPT_COMMIT="b05bbcdaeb9b700cf7877e6d66f8fc3ac952295b"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libxrandr.sh
+++ b/builder/scripts.d/45-x11/60-libxrandr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxrandr.git"
-SCRIPT_COMMIT="7181160b2c32b1bb804792990783fa25c1122bae"
+SCRIPT_COMMIT="3387129532899eaeee3477a2d92fa662d7292a84"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libxv.sh
+++ b/builder/scripts.d/45-x11/60-libxv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxv.git"
-SCRIPT_COMMIT="9744d1f77b092eb4982c60e4750136fb19683545"
+SCRIPT_COMMIT="d419928942dbf1897c9627475aa4a2828a81240f"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-amf.sh
+++ b/builder/scripts.d/50-amf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git"
-SCRIPT_COMMIT="9f558757af85029541110139586c35f8d4c6b2ad"
+SCRIPT_COMMIT="734a9ae3ab446cbedb70028469bd323be45700f2"
 
 ffbuild_enabled() {
     [[ $TARGET == *arm64 ]] && return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="4b9f5b704e299543afcea87f375a308b90ef6c70"
+SCRIPT_COMMIT="c56e352b95960d8dd243f6a14c7f1d7a431ceced"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libass.sh
+++ b/builder/scripts.d/50-libass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libass/libass.git"
-SCRIPT_COMMIT="44beae2ae57790ba592b8f0d20c0b51006f6b7c7"
+SCRIPT_COMMIT="062d4ec598b4fd06f75c0cd6a0f43f5d0939a764"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libbluray.sh
+++ b/builder/scripts.d/50-libbluray.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/libbluray.git"
-SCRIPT_COMMIT="c923cc09c274934452f795aa06d3a5aadb31d6fb"
+SCRIPT_COMMIT="bb5bc108ec695889855f06df338958004ff289ef"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xiph/opus.git"
-SCRIPT_COMMIT="bce1f392353d72d77d543bb2069a044ae1045e9d"
+SCRIPT_COMMIT="757c53f775a0b651b0512a1992d67f4b2159a378"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="fb2d1616f657f6617a6d3ea1cf6e06100f92cddd"
+SCRIPT_COMMIT="1450ec46e273b32234b036d7803aaae09423dd08"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="3f73e8f7ac83e97a26346886b529b61809a839f5"
+SCRIPT_COMMIT="e5fe2cfc1bea149106d94ef5233c488ed1287b68"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="e082f30aa5d6346105be5333fc861e486f94a38d"
+SCRIPT_COMMIT="38b4211dfc6da072e21ee9472e03acc1f6e1d09a"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-svtav1.sh
+++ b/builder/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="2f879beaa62dfb86983db8a6ab63fa9bcf6cd766"
+SCRIPT_COMMIT="b4c89396fa22791570c3992f9c56a6a65bdaca48"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/builder/scripts.d/50-vaapi/40-libdrm.sh
+++ b/builder/scripts.d/50-vaapi/40-libdrm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/mesa/drm.git"
-SCRIPT_COMMIT="0a8fad5f5c2197c7585daa04e414fd9c67042e10"
+SCRIPT_COMMIT="874af994636a534236a747a88aec086b9b35b001"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vaapi/50-libva.sh
+++ b/builder/scripts.d/50-vaapi/50-libva.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libva.git"
-SCRIPT_COMMIT="391ef4021a0a7f2a011d674fb07c02d922445c0d"
+SCRIPT_COMMIT="aeb704af762e3b5010908a544f5b2b1adeb27896"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/45-vulkan.sh
+++ b/builder/scripts.d/50-vulkan/45-vulkan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/Vulkan-Headers.git"
-SCRIPT_COMMIT="v1.3.234"
+SCRIPT_COMMIT="v1.3.237"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-vulkan/50-shaderc.sh
+++ b/builder/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
-SCRIPT_COMMIT="dc9d28ae95594edaef725012acd9de15a7342048"
+SCRIPT_COMMIT="9806490ff5908aec0012f89df342c1a8985b1263"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="edd66a2fc9e932ad0d3dce78f2627eeae91c2660"
+SCRIPT_COMMIT="c77b09b57c27837dc2d41aa371ed3d236ce9ce47"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-vulkan/60-libplacebo.sh
+++ b/builder/scripts.d/50-vulkan/60-libplacebo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/libplacebo.git"
-SCRIPT_COMMIT="c0373263e665248b856625a71ff9a17d86218eef"
+SCRIPT_COMMIT="7ead30db8aa75db28236eee40899f0ff6e3c9688"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-x264.sh
+++ b/builder/scripts.d/50-x264.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/mirror/x264.git"
-SCRIPT_COMMIT="b093bbe7d9bc642c8f24067cbdcc73bb43562eab"
+SCRIPT_COMMIT="416e3eb2b52abb0a67e57599aba4f8be3003b36d"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/builder/scripts.d/50-x265.sh
+++ b/builder/scripts.d/50-x265.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
-SCRIPT_COMMIT="40e37bce9a357fb18f70ff0852015983cf90a6d3"
+SCRIPT_COMMIT="4da1198a94028026ce96ba1781d3c7842e74e173"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ jellyfin-ffmpeg (5.1.2-5) unstable; urgency=medium
   * Add HDR metadata support for QSV/NVENC HEVC encoder
   * Add 10bit overlay support for QSV/CUDA/OpenCL
   * Add DOVI to HDR support for CUDA/OpenCL
+  * Add D3D11VA/DXVA2 HEVC 422 444 8-12 bits decoding on Intel
   * Update dependencies
 
  -- nyanmisaka <nst799610810@gmail.com>  Mon, 07 Oct 2022 21:31:17 +0800

--- a/debian/patches/0043-add-d3d11va-dxva2-hevc-422-444-decoding.patch
+++ b/debian/patches/0043-add-d3d11va-dxva2-hevc-422-444-decoding.patch
@@ -1,0 +1,349 @@
+Index: jellyfin-ffmpeg/libavcodec/dxva2.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/dxva2.c
++++ jellyfin-ffmpeg/libavcodec/dxva2.c
+@@ -43,6 +43,12 @@ DEFINE_GUID(ff_DXVA2_ModeVC1_D,
+ DEFINE_GUID(ff_DXVA2_ModeVC1_D2010,      0x1b81beA4, 0xa0c7,0x11d3,0xb9,0x84,0x00,0xc0,0x4f,0x2e,0x73,0xc5);
+ DEFINE_GUID(ff_DXVA2_ModeHEVC_VLD_Main,  0x5b11d51b, 0x2f4c,0x4452,0xbc,0xc3,0x09,0xf2,0xa1,0x16,0x0c,0xc0);
+ DEFINE_GUID(ff_DXVA2_ModeHEVC_VLD_Main10,0x107af0e0, 0xef1a,0x4d19,0xab,0xa8,0x67,0xa1,0x63,0x07,0x3d,0x13);
++DEFINE_GUID(ff_DXVA2_ModeHEVC_VLD_Main12_Intel,     0x8ff8a3aa, 0xc456,0x4132,0xb6,0xef,0x69,0xd9,0xdd,0x72,0x57,0x1d);
++DEFINE_GUID(ff_DXVA2_ModeHEVC_VLD_Main422_10_Intel, 0xe484dcb8, 0xcac9,0x4859,0x99,0xf5,0x5c,0x0d,0x45,0x06,0x90,0x89);
++DEFINE_GUID(ff_DXVA2_ModeHEVC_VLD_Main422_12_Intel, 0xc23dd857, 0x874b,0x423c,0xb6,0xe0,0x82,0xce,0xaa,0x9b,0x11,0x8a);
++DEFINE_GUID(ff_DXVA2_ModeHEVC_VLD_Main444_Intel,    0x41a5af96, 0xe415,0x4b0c,0x9d,0x03,0x90,0x78,0x58,0xe2,0x3e,0x78);
++DEFINE_GUID(ff_DXVA2_ModeHEVC_VLD_Main444_10_Intel, 0x6a6a81ba, 0x912a,0x485d,0xb5,0x7f,0xcc,0xd2,0xd3,0x7b,0x8d,0x94);
++DEFINE_GUID(ff_DXVA2_ModeHEVC_VLD_Main444_12_Intel, 0x5b08e35d, 0x0c66,0x4c51,0xa6,0xf1,0x89,0xd0,0x0c,0xb2,0xc1,0x97);
+ DEFINE_GUID(ff_DXVA2_ModeVP9_VLD_Profile0,0x463707f8,0xa1d0,0x4585,0x87,0x6d,0x83,0xaa,0x6d,0x60,0xb8,0x9e);
+ DEFINE_GUID(ff_DXVA2_ModeVP9_VLD_10bit_Profile2,0xa4c749ef,0x6ecf,0x48aa,0x84,0x48,0x50,0xa7,0xa1,0x16,0x5f,0xf7);
+ DEFINE_GUID(ff_DXVA2_ModeAV1_VLD_Profile0,0xb8be4ccb,0xcf53,0x46ba,0x8d,0x59,0xd6,0xb8,0xa6,0xda,0x5d,0x2a);
+@@ -69,6 +75,8 @@ static const int prof_hevc_main[]    = {
+                                         FF_PROFILE_UNKNOWN};
+ static const int prof_hevc_main10[]  = {FF_PROFILE_HEVC_MAIN_10,
+                                         FF_PROFILE_UNKNOWN};
++static const int prof_hevc_main_rext[] = {FF_PROFILE_HEVC_REXT,
++                                          FF_PROFILE_UNKNOWN};
+ static const int prof_vp9_profile0[] = {FF_PROFILE_VP9_0,
+                                         FF_PROFILE_UNKNOWN};
+ static const int prof_vp9_profile2[] = {FF_PROFILE_VP9_2,
+@@ -97,6 +105,14 @@ static const dxva_mode dxva_modes[] = {
+     { &ff_DXVA2_ModeHEVC_VLD_Main10, AV_CODEC_ID_HEVC, prof_hevc_main10 },
+     { &ff_DXVA2_ModeHEVC_VLD_Main,   AV_CODEC_ID_HEVC, prof_hevc_main },
+ 
++    /* Intel specific HEVC/H.265 Main Rext mode */
++    { &ff_DXVA2_ModeHEVC_VLD_Main12_Intel,     AV_CODEC_ID_HEVC, prof_hevc_main_rext },
++    { &ff_DXVA2_ModeHEVC_VLD_Main422_10_Intel, AV_CODEC_ID_HEVC, prof_hevc_main_rext },
++    { &ff_DXVA2_ModeHEVC_VLD_Main422_12_Intel, AV_CODEC_ID_HEVC, prof_hevc_main_rext },
++    { &ff_DXVA2_ModeHEVC_VLD_Main444_Intel,    AV_CODEC_ID_HEVC, prof_hevc_main_rext },
++    { &ff_DXVA2_ModeHEVC_VLD_Main444_10_Intel, AV_CODEC_ID_HEVC, prof_hevc_main_rext },
++    { &ff_DXVA2_ModeHEVC_VLD_Main444_12_Intel, AV_CODEC_ID_HEVC, prof_hevc_main_rext },
++
+     /* VP8/9 */
+     { &ff_DXVA2_ModeVP9_VLD_Profile0,       AV_CODEC_ID_VP9, prof_vp9_profile0 },
+     { &ff_DXVA2_ModeVP9_VLD_10bit_Profile2, AV_CODEC_ID_VP9, prof_vp9_profile2 },
+@@ -107,6 +123,22 @@ static const dxva_mode dxva_modes[] = {
+     { NULL,                          0 },
+ };
+ 
++static enum AVPixelFormat dxva_map_sw_to_sw_format(enum AVPixelFormat pix_fmt)
++{
++    switch (pix_fmt) {
++    case AV_PIX_FMT_YUV420P:   return AV_PIX_FMT_NV12;
++    case AV_PIX_FMT_YUV420P10: return AV_PIX_FMT_P010;
++    case AV_PIX_FMT_YUV420P12: return AV_PIX_FMT_P012;
++    case AV_PIX_FMT_YUV422P:   return AV_PIX_FMT_YUYV422;
++    case AV_PIX_FMT_YUV422P10: return AV_PIX_FMT_Y210;
++    case AV_PIX_FMT_YUV422P12: return AV_PIX_FMT_Y212;
++    case AV_PIX_FMT_YUV444P:   return AV_PIX_FMT_0YUV;
++    case AV_PIX_FMT_YUV444P10: return AV_PIX_FMT_Y410;
++    case AV_PIX_FMT_YUV444P12: return AV_PIX_FMT_Y412;
++    default:                   return AV_PIX_FMT_NV12;
++    }
++}
++
+ static int dxva_get_decoder_configuration(AVCodecContext *avctx,
+                                           const void *cfg_list,
+                                           unsigned cfg_count)
+@@ -245,7 +277,14 @@ static void dxva_list_guids_debug(AVCode
+ #if CONFIG_DXVA2
+         if (sctx->pix_fmt == AV_PIX_FMT_DXVA2_VLD) {
+             const D3DFORMAT formats[] = {MKTAG('N', 'V', '1', '2'),
+-                                         MKTAG('P', '0', '1', '0')};
++                                         MKTAG('P', '0', '1', '0'),
++                                         MKTAG('P', '0', '1', '6'),
++                                         MKTAG('Y', 'U', 'Y', '2'),
++                                         MKTAG('Y', '2', '1', '0'),
++                                         MKTAG('Y', '2', '1', '6'),
++                                         MKTAG('A', 'Y', 'U', 'V'),
++                                         MKTAG('Y', '4', '1', '0'),
++                                         MKTAG('Y', '4', '1', '6')};
+             int i;
+             for (i = 0; i < FF_ARRAY_ELEMS(formats); i++) {
+                 if (dxva2_validate_output(service, *guid, &formats[i]))
+@@ -339,14 +378,28 @@ static int dxva2_get_decoder_configurati
+     return ret;
+ }
+ 
++static D3DFORMAT dxva2_map_sw_to_hw_format(enum AVPixelFormat pix_fmt)
++{
++    switch (pix_fmt) {
++    case AV_PIX_FMT_NV12:    return MKTAG('N', 'V', '1', '2');
++    case AV_PIX_FMT_P010:    return MKTAG('P', '0', '1', '0');
++    case AV_PIX_FMT_P012:    return MKTAG('P', '0', '1', '6');
++    case AV_PIX_FMT_YUYV422: return MKTAG('Y', 'U', 'Y', '2');
++    case AV_PIX_FMT_Y210:    return MKTAG('Y', '2', '1', '0');
++    case AV_PIX_FMT_Y212:    return MKTAG('Y', '2', '1', '6');
++    case AV_PIX_FMT_0YUV:    return MKTAG('A', 'Y', 'U', 'V');
++    case AV_PIX_FMT_Y410:    return MKTAG('Y', '4', '1', '0');
++    case AV_PIX_FMT_Y412:    return MKTAG('Y', '4', '1', '6');
++    default:                 return D3DFMT_UNKNOWN;
++    }
++}
++
+ static int dxva2_create_decoder(AVCodecContext *avctx)
+ {
+     FFDXVASharedContext *sctx = DXVA_SHARED_CONTEXT(avctx);
+     GUID *guid_list;
+     unsigned guid_count;
+     GUID device_guid;
+-    D3DFORMAT surface_format = avctx->sw_pix_fmt == AV_PIX_FMT_YUV420P10 ?
+-                               MKTAG('P', '0', '1', '0') : MKTAG('N', 'V', '1', '2');
+     DXVA2_VideoDesc desc = { 0 };
+     DXVA2_ConfigPictureDecode config;
+     HRESULT hr;
+@@ -355,6 +408,7 @@ static int dxva2_create_decoder(AVCodecC
+     AVHWFramesContext *frames_ctx = (AVHWFramesContext*)avctx->hw_frames_ctx->data;
+     AVDXVA2FramesContext *frames_hwctx = frames_ctx->hwctx;
+     AVDXVA2DeviceContext *device_hwctx = frames_ctx->device_ctx->hwctx;
++    D3DFORMAT surface_format = dxva2_map_sw_to_hw_format(frames_ctx->sw_format);
+ 
+     hr = IDirect3DDeviceManager9_OpenDeviceHandle(device_hwctx->devmgr,
+                                                   &device_handle);
+@@ -455,10 +509,17 @@ static int d3d11va_get_decoder_configura
+ static DXGI_FORMAT d3d11va_map_sw_to_hw_format(enum AVPixelFormat pix_fmt)
+ {
+     switch (pix_fmt) {
+-    case AV_PIX_FMT_NV12:       return DXGI_FORMAT_NV12;
+-    case AV_PIX_FMT_P010:       return DXGI_FORMAT_P010;
+-    case AV_PIX_FMT_YUV420P:    return DXGI_FORMAT_420_OPAQUE;
+-    default:                    return DXGI_FORMAT_UNKNOWN;
++    case AV_PIX_FMT_NV12:    return DXGI_FORMAT_NV12;
++    case AV_PIX_FMT_P010:    return DXGI_FORMAT_P010;
++    case AV_PIX_FMT_P012:    return DXGI_FORMAT_P016;
++    case AV_PIX_FMT_YUYV422: return DXGI_FORMAT_YUY2;
++    case AV_PIX_FMT_Y210:    return DXGI_FORMAT_Y210;
++    case AV_PIX_FMT_Y212:    return DXGI_FORMAT_Y216;
++    case AV_PIX_FMT_0YUV:    return DXGI_FORMAT_AYUV;
++    case AV_PIX_FMT_Y410:    return DXGI_FORMAT_Y410;
++    case AV_PIX_FMT_Y412:    return DXGI_FORMAT_Y416;
++    case AV_PIX_FMT_YUV420P: return DXGI_FORMAT_420_OPAQUE;
++    default:                 return DXGI_FORMAT_UNKNOWN;
+     }
+ }
+ 
+@@ -636,8 +697,7 @@ int ff_dxva2_common_frame_params(AVCodec
+     else
+         num_surfaces += 2;
+ 
+-    frames_ctx->sw_format = avctx->sw_pix_fmt == AV_PIX_FMT_YUV420P10 ?
+-                            AV_PIX_FMT_P010 : AV_PIX_FMT_NV12;
++    frames_ctx->sw_format = dxva_map_sw_to_sw_format(avctx->sw_pix_fmt);
+     frames_ctx->width = FFALIGN(avctx->coded_width, surface_alignment);
+     frames_ctx->height = FFALIGN(avctx->coded_height, surface_alignment);
+     frames_ctx->initial_pool_size = num_surfaces;
+Index: jellyfin-ffmpeg/libavcodec/dxva2_hevc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/dxva2_hevc.c
++++ jellyfin-ffmpeg/libavcodec/dxva2_hevc.c
+@@ -28,10 +28,60 @@
+ #include "hevc_data.h"
+ #include "hevcdec.h"
+ 
++/**
++ * Picture Parameters DXVA buffer struct for Rext is not specified in DXVA
++ * spec. The below structures come from Intel platform DDI definition, so they
++ * are currently Intel specific.
++ *
++ * For Nvidia and AMD platforms supporting HEVC Rext, it is expected
++ * the picture param information included in below structures is sufficient
++ * for underlying drivers supporting range extension.
++ */
++#pragma pack(push, 1)
++typedef struct
++{
++    DXVA_PicParams_HEVC main;
++
++    // HEVC Range Extension. Fields are named the same as in HEVC spec.
++    __C89_NAMELESS union {
++        __C89_NAMELESS struct {
++            UINT32 transform_skip_rotation_enabled_flag : 1;
++            UINT32 transform_skip_context_enabled_flag : 1;
++            UINT32 implicit_rdpcm_enabled_flag : 1;
++            UINT32 explicit_rdpcm_enabled_flag : 1;
++            UINT32 extended_precision_processing_flag : 1;
++            UINT32 intra_smoothing_disabled_flag : 1;
++            UINT32 high_precision_offsets_enabled_flag : 1;
++            UINT32 persistent_rice_adaptation_enabled_flag : 1;
++            UINT32 cabac_bypass_alignment_enabled_flag : 1;
++            UINT32 cross_component_prediction_enabled_flag : 1;
++            UINT32 chroma_qp_offset_list_enabled_flag : 1;
++            // Indicates if luma bit depth equals to 16. If its value is 1, the
++            // corresponding bit_depth_luma_minus8 must be set to 0.
++            UINT32 BitDepthLuma16 : 1;
++            // Indicates if chroma bit depth equals to 16. If its value is 1, the
++            // corresponding bit_depth_chroma_minus8 must be set to 0.
++            UINT32 BitDepthChroma16 : 1;
++            UINT32 ReservedBits8 : 19;
++        };
++        UINT32 dwRangeExtensionFlags;
++    };
++
++    UCHAR diff_cu_chroma_qp_offset_depth;    // [0..3]
++    UCHAR chroma_qp_offset_list_len_minus1;  // [0..5]
++    UCHAR log2_sao_offset_scale_luma;        // [0..6]
++    UCHAR log2_sao_offset_scale_chroma;      // [0..6]
++    UCHAR log2_max_transform_skip_block_size_minus2;
++    CHAR cb_qp_offset_list[6];  // [-12..12]
++    CHAR cr_qp_offset_list[6];  // [-12..12]
++
++} DXVA_PicParams_HEVC_Rext;
++#pragma pack(pop)
++
+ #define MAX_SLICES 256
+ 
+ struct hevc_dxva2_picture_context {
+-    DXVA_PicParams_HEVC   pp;
++    DXVA_PicParams_HEVC_Rext pp;
+     DXVA_Qmatrix_HEVC     qm;
+     unsigned              slice_count;
+     DXVA_Slice_HEVC_Short slice_short[MAX_SLICES];
+@@ -57,18 +107,48 @@ static int get_refpic_index(const DXVA_P
+ }
+ 
+ static void fill_picture_parameters(const AVCodecContext *avctx, AVDXVAContext *ctx, const HEVCContext *h,
+-                                    DXVA_PicParams_HEVC *pp)
++                                    DXVA_PicParams_HEVC_Rext *ppext)
+ {
+     const HEVCFrame *current_picture = h->ref;
+     const HEVCSPS *sps = h->ps.sps;
+     const HEVCPPS *pps = h->ps.pps;
+     int i, j;
++    DXVA_PicParams_HEVC *pp = &ppext->main;
+ 
+-    memset(pp, 0, sizeof(*pp));
++    memset(ppext, 0, sizeof(*ppext));
+ 
+     pp->PicWidthInMinCbsY  = sps->min_cb_width;
+     pp->PicHeightInMinCbsY = sps->min_cb_height;
+ 
++    if (sps->sps_range_extension_flag) {
++        ppext->dwRangeExtensionFlags |= (sps->transform_skip_rotation_enabled_flag     <<  0) |
++                                        (sps->transform_skip_context_enabled_flag      <<  1) |
++                                        (sps->implicit_rdpcm_enabled_flag              <<  2) |
++                                        (sps->explicit_rdpcm_enabled_flag              <<  3) |
++                                        (sps->extended_precision_processing_flag       <<  4) |
++                                        (sps->intra_smoothing_disabled_flag            <<  5) |
++                                        (sps->high_precision_offsets_enabled_flag      <<  5) |
++                                        (sps->persistent_rice_adaptation_enabled_flag  <<  7) |
++                                        (sps->cabac_bypass_alignment_enabled_flag      <<  8);
++    }
++    if (pps->pps_range_extensions_flag) {
++        ppext->dwRangeExtensionFlags |= (pps->cross_component_prediction_enabled_flag  <<  9) |
++                                        (pps->chroma_qp_offset_list_enabled_flag       << 10);
++        if (pps->chroma_qp_offset_list_enabled_flag) {
++            ppext->diff_cu_chroma_qp_offset_depth   = pps->diff_cu_chroma_qp_offset_depth;
++            ppext->chroma_qp_offset_list_len_minus1 = pps->chroma_qp_offset_list_len_minus1;
++            for (i = 0; i <= pps->chroma_qp_offset_list_len_minus1; i++) {
++                ppext->cb_qp_offset_list[i] = pps->cb_qp_offset_list[i];
++                ppext->cr_qp_offset_list[i] = pps->cr_qp_offset_list[i];
++            }
++        }
++        ppext->log2_sao_offset_scale_luma   = pps->log2_sao_offset_scale_luma;
++        ppext->log2_sao_offset_scale_chroma = pps->log2_sao_offset_scale_chroma;
++        if (pps->transform_skip_enabled_flag) {
++            ppext->log2_max_transform_skip_block_size_minus2 = pps->log2_max_transform_skip_block_size - 2;
++        }
++    }
++
+     pp->wFormatAndSequenceInfoFlags = (sps->chroma_format_idc             <<  0) |
+                                       (sps->separate_colour_plane_flag    <<  2) |
+                                       ((sps->bit_depth - 8)               <<  3) |
+@@ -404,16 +484,18 @@ static int dxva2_hevc_decode_slice(AVCod
+ 
+ static int dxva2_hevc_end_frame(AVCodecContext *avctx)
+ {
++    AVDXVAContext *ctx = DXVA_CONTEXT(avctx);
+     HEVCContext *h = avctx->priv_data;
+     struct hevc_dxva2_picture_context *ctx_pic = h->ref->hwaccel_picture_private;
+-    int scale = ctx_pic->pp.dwCodingParamToolFlags & 1;
++    int scale = ctx_pic->pp.main.dwCodingParamToolFlags & 1;
++    int rext = avctx->profile == FF_PROFILE_HEVC_REXT;
+     int ret;
+ 
+     if (ctx_pic->slice_count <= 0 || ctx_pic->bitstream_size <= 0)
+         return -1;
+ 
+     ret = ff_dxva2_common_end_frame(avctx, h->ref->frame,
+-                                    &ctx_pic->pp, sizeof(ctx_pic->pp),
++                                    &ctx_pic->pp, rext ? sizeof(ctx_pic->pp) : sizeof(ctx_pic->pp.main),
+                                     scale ? &ctx_pic->qm : NULL, scale ? sizeof(ctx_pic->qm) : 0,
+                                     commit_bitstream_and_slice_buffer);
+     return ret;
+Index: jellyfin-ffmpeg/libavcodec/hevcdec.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/hevcdec.c
++++ jellyfin-ffmpeg/libavcodec/hevcdec.c
+@@ -452,6 +452,13 @@ static enum AVPixelFormat get_format(HEV
+ #endif
+         break;
+     case AV_PIX_FMT_YUV444P:
++#if CONFIG_HEVC_DXVA2_HWACCEL
++        *fmt++ = AV_PIX_FMT_DXVA2_VLD;
++#endif
++#if CONFIG_HEVC_D3D11VA_HWACCEL
++        *fmt++ = AV_PIX_FMT_D3D11VA_VLD;
++        *fmt++ = AV_PIX_FMT_D3D11;
++#endif
+ #if CONFIG_HEVC_VAAPI_HWACCEL
+         *fmt++ = AV_PIX_FMT_VAAPI;
+ #endif
+@@ -467,6 +474,13 @@ static enum AVPixelFormat get_format(HEV
+         break;
+     case AV_PIX_FMT_YUV422P:
+     case AV_PIX_FMT_YUV422P10LE:
++#if CONFIG_HEVC_DXVA2_HWACCEL
++        *fmt++ = AV_PIX_FMT_DXVA2_VLD;
++#endif
++#if CONFIG_HEVC_D3D11VA_HWACCEL
++        *fmt++ = AV_PIX_FMT_D3D11VA_VLD;
++        *fmt++ = AV_PIX_FMT_D3D11;
++#endif
+ #if CONFIG_HEVC_VAAPI_HWACCEL
+        *fmt++ = AV_PIX_FMT_VAAPI;
+ #endif
+@@ -475,6 +489,13 @@ static enum AVPixelFormat get_format(HEV
+ #endif
+         break;
+     case AV_PIX_FMT_YUV422P12LE:
++#if CONFIG_HEVC_DXVA2_HWACCEL
++        *fmt++ = AV_PIX_FMT_DXVA2_VLD;
++#endif
++#if CONFIG_HEVC_D3D11VA_HWACCEL
++        *fmt++ = AV_PIX_FMT_D3D11VA_VLD;
++        *fmt++ = AV_PIX_FMT_D3D11;
++#endif
+ #if CONFIG_HEVC_VAAPI_HWACCEL
+         *fmt++ = AV_PIX_FMT_VAAPI;
+ #endif
+@@ -485,6 +506,13 @@ static enum AVPixelFormat get_format(HEV
+ #endif
+     case AV_PIX_FMT_YUV420P12:
+     case AV_PIX_FMT_YUV444P12:
++#if CONFIG_HEVC_DXVA2_HWACCEL
++        *fmt++ = AV_PIX_FMT_DXVA2_VLD;
++#endif
++#if CONFIG_HEVC_D3D11VA_HWACCEL
++        *fmt++ = AV_PIX_FMT_D3D11VA_VLD;
++        *fmt++ = AV_PIX_FMT_D3D11;
++#endif
+ #if CONFIG_HEVC_VAAPI_HWACCEL
+         *fmt++ = AV_PIX_FMT_VAAPI;
+ #endif

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -40,3 +40,4 @@
 0040-add-10bit-support-for-cuda-overlay.patch
 0041-add-hdr-metadata-for-qsv-hevc-encoder.patch
 0042-add-hdr-metadata-for-nvenc-hevc-encoder.patch
+0043-add-d3d11va-dxva2-hevc-422-444-decoding.patch

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -166,7 +166,7 @@ popd
 # LZMA
 mkdir xz
 pushd xz
-xz_ver="5.2.7"
+xz_ver="5.2.9"
 xz_link="https://sourceforge.net/projects/lzmautils/files/xz-${xz_ver}.tar.xz/download"
 wget ${xz_link} -O xz.tar.xz
 tar xaf xz.tar.xz

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -242,7 +242,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.3.0 --depth=1 https://github.com/intel/gmmlib
+    git clone -b intel-gmmlib-22.3.1 --depth=1 https://github.com/intel/gmmlib
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -256,7 +256,7 @@ prepare_extra_amd64() {
     # Provides MSDK runtime (libmfxhw64.so.1) for 11th Gen Rocket Lake and older
     # Provides MFX dispatcher (libmfx.so.1) for FFmpeg
     pushd ${SOURCE_DIR}
-    git clone -b intel-mediasdk-22.6.2 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
+    git clone -b intel-mediasdk-22.6.4 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
     pushd MediaSDK
     sed -i 's|MFX_PLUGINS_CONF_DIR "/plugins.cfg"|"/usr/lib/jellyfin-ffmpeg/lib/mfx/plugins.cfg"|g' api/mfx_dispatch/linux/mfxloader.cpp
     mkdir build && pushd build
@@ -276,7 +276,7 @@ prepare_extra_amd64() {
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     # Both MSDK and VPL runtime can be loaded by MFX dispatcher (libmfx.so.1)
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-22.6.2 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu
+    git clone -b intel-onevpl-22.6.4 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu
     pushd oneVPL-intel-gpu
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -290,8 +290,9 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-22.6.2 --depth=1 https://github.com/intel/media-driver
+    git clone -b intel-media-22.6.4 --depth=1 https://github.com/intel/media-driver
     pushd media-driver
+    sed -i 's|#include <va/va_dricommon.h>||g' media_softlet/linux/common/vp/ddi/ddi_vp_functions.cpp
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
           -DENABLE_KERNELS=ON \
@@ -309,7 +310,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.234 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers
+    git clone -b v1.3.236 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -322,7 +323,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.234 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader
+    git clone -b v1.3.236 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \
@@ -343,7 +344,7 @@ prepare_extra_amd64() {
 
     # SHADERC
     pushd ${SOURCE_DIR}
-    git clone -b v2022.3 --depth=1 https://github.com/google/shaderc
+    git clone -b v2022.4 --depth=1 https://github.com/google/shaderc
     pushd shaderc
     ./utils/git-sync-deps
     mkdir build && pushd build
@@ -372,7 +373,7 @@ prepare_extra_amd64() {
         pushd ${SOURCE_DIR}
         mkdir mesa
         pushd mesa
-        mesa_ver="22.2.3"
+        mesa_ver="22.2.4"
         mesa_link="https://mesa.freedesktop.org/archive/mesa-${mesa_ver}.tar.xz"
         wget ${mesa_link} -O mesa.tar.xz
         tar xaf mesa.tar.xz


### PR DESCRIPTION
**Changes**
- Update dependencies to support Arc DG2 with upstream kernel
 ([verified](https://github.com/jellyfin/jellyfin-ffmpeg/files/10188394/log.txt) with `6.1.0-rc8-1-drm-tip-git-gf5d2f00fe4da` and the latest linux-firmware)

- Add D3D11VA/DXVA2 HEVC 422 444 8-12 bits decoding on Intel

