### PR TITLE
Bump version to 5.1.2-9

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'debian'
-      codenames: '["buster", "bullseye"]'
+      codenames: '["buster", "bullseye", "bookworm"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: false
 
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["kinetic", "jammy", "focal", "bionic"]'
+      codenames: '["bionic", "focal", "jammy", "kinetic", "lunar"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'debian'
-      codenames: '["buster", "bullseye"]'
+      codenames: '["buster", "bullseye", "bookworm"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: true
     secrets:
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["kinetic", "jammy", "focal", "bionic"]'
+      codenames: '["bionic", "focal", "jammy", "kinetic", "lunar"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: true
     secrets:
@@ -65,10 +65,12 @@ jobs:
         arrays: [
           {distro: 'debian', codename: 'buster'},
           {distro: 'debian', codename: 'bullseye'},
-          {distro: 'ubuntu', codename: 'kinetic'},
-          {distro: 'ubuntu', codename: 'jammy'},
-          {distro: 'ubuntu', codename: 'focal'},
+          {distro: 'debian', codename: 'bookworm'},
           {distro: 'ubuntu', codename: 'bionic'}
+          {distro: 'ubuntu', codename: 'focal'},
+          {distro: 'ubuntu', codename: 'jammy'},
+          {distro: 'ubuntu', codename: 'kinetic'},
+          {distro: 'ubuntu', codename: 'lunar'},
         ]
     steps:
       - name: Sync mirrors and update symlinks

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -26,11 +26,13 @@ RUN apt-get update \
  && yes | apt-get install -y apt-transport-https curl ninja-build debhelper gnupg wget devscripts mmv equivs git nasm pkg-config subversion dh-autoreconf libpciaccess-dev libwayland-dev libx11-dev libx11-xcb-dev libxcb-dri2-0-dev libxcb-dri3-dev libxcb-present-dev libxcb-shm0-dev libxcb-sync-dev libxshmfence-dev libxext-dev libxfixes-dev libxcb1-dev libxrandr-dev libzstd-dev libelf-dev python3-pip zip unzip tar flex bison
 
 # Install newer tools from pip3
-RUN pip3 install --upgrade pip \
- && pip3 install meson cmake mako jinja2
+RUN pip3 install $(pip3 help install | grep -o "\-\-break-system-packages") --upgrade pip \
+ && pip3 install $(pip3 help install | grep -o "\-\-break-system-packages") meson cmake mako jinja2
+
 # Avoids timeouts when using git and disable the detachedHead advice
 RUN git config --global http.postbuffer 524288000 \
  && git config --global advice.detachedHead false
+
 # Link to docker-build script
 RUN ln -sf ${SOURCE_DIR}/docker-build.sh /docker-build.sh
 

--- a/build.yaml
+++ b/build.yaml
@@ -9,6 +9,9 @@ packages:
   - bullseye-amd64
   - bullseye-armhf
   - bullseye-arm64
+  - bookworm-amd64
+  - bookworm-armhf
+  - bookworm-arm64
   - bionic-amd64
   - bionic-armhf
   - bionic-arm64
@@ -21,3 +24,6 @@ packages:
   - kinetic-amd64
   - kinetic-armhf
   - kinetic-arm64
+  - lunar-amd64
+  - lunar-armhf
+  - lunar-arm64

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "5.1.2-8"
+version: "5.1.2-9"
 packages:
   - buster-amd64
   - buster-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+jellyfin-ffmpeg (5.1.2-9) unstable; urgency=medium
+
+  * Fix a typo in the patch
+  * Update dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Fri, 3 Mar 2023 19:15:27 +0800
+
 jellyfin-ffmpeg (5.1.2-8) unstable; urgency=medium
 
   * Remove the changed vulkan video extensions

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ jellyfin-ffmpeg (5.1.2-9) unstable; urgency=medium
 
   * Fix a typo in the patch
   * Update dependencies
+  * Enable Debian bookworm and Ubuntu lunar
 
  -- nyanmisaka <nst799610810@gmail.com>  Fri, 3 Mar 2023 19:15:27 +0800
 

--- a/debian/jellyfin-ffmpeg5.install
+++ b/debian/jellyfin-ffmpeg5.install
@@ -1,2 +1,10 @@
 ffmpeg usr/lib/jellyfin-ffmpeg
 ffprobe usr/lib/jellyfin-ffmpeg
+libavcodec/libavcodec.so* usr/lib/jellyfin-ffmpeg/lib
+libavdevice/libavdevice.so* usr/lib/jellyfin-ffmpeg/lib
+libavfilter/libavfilter.so* usr/lib/jellyfin-ffmpeg/lib
+libavformat/libavformat.so* usr/lib/jellyfin-ffmpeg/lib
+libavutil/libavutil.so* usr/lib/jellyfin-ffmpeg/lib
+libpostproc/libpostproc.so* usr/lib/jellyfin-ffmpeg/lib
+libswresample/libswresample.so* usr/lib/jellyfin-ffmpeg/lib
+libswscale/libswscale.so* usr/lib/jellyfin-ffmpeg/lib

--- a/debian/patches/0039-add-fixes-for-some-quirks-on-dg2-on-windows.patch
+++ b/debian/patches/0039-add-fixes-for-some-quirks-on-dg2-on-windows.patch
@@ -99,7 +99,7 @@ Index: jellyfin-ffmpeg/libavutil/hwcontext_opencl.c
                  (intptr_t)src_hwctx->device,
                  CL_CONTEXT_INTEROP_USER_SYNC,
 -                CL_TRUE,
-+                (!src_hwctx->device_desc.VendorId == 0x8086 || src_hwctx->is_uma),
++                (src_hwctx->device_desc.VendorId != 0x8086 || src_hwctx->is_uma),
                  0,
              };
              OpenCLDeviceSelector selector = {

--- a/debian/rules
+++ b/debian/rules
@@ -17,14 +17,14 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--disable-doc \
 	--disable-ffplay \
 	--disable-ptx-compression \
-	--disable-shared \
+	--disable-static \
 	--disable-libxcb \
 	--disable-sdl2 \
 	--disable-xlib \
 	--enable-lto \
 	--enable-gpl \
 	--enable-version3 \
-	--enable-static \
+	--enable-shared \
 	--enable-gmp \
 	--enable-gnutls \
 	--enable-chromaprint \
@@ -105,7 +105,6 @@ override_dh_auto_clean:
 	dh_auto_clean || true
 
 override_dh_auto_install:
-	make -j1 install-data DESTDIR=/srv/build/ffmpeg/jellyfin-ffmpeg/debian/jellyfin-ffmpeg AM_UPDATE_INFO_DIR=no 
 
 override_dh_usrlocal:
 

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -67,13 +67,9 @@ make install
 popd
 
 # FREETYPE
-mkdir freetype
+git clone --depth=1 https://gitlab.freedesktop.org/freetype/freetype.git
 pushd freetype
-ft_ver="2.13.0"
-ft_link="https://download.savannah.gnu.org/releases/freetype/freetype-${ft_ver}.tar.gz"
-wget ${ft_link} -O ft.tar.gz
-tar xaf ft.tar.gz
-pushd freetype-${ft_ver}
+./autogen.sh
 ./configure \
     --prefix=${FF_DEPS_PREFIX} \
     --host=${FF_TOOLCHAIN} \
@@ -81,7 +77,6 @@ pushd freetype-${ft_ver}
     --enable-static
 make -j$(nproc)
 make install
-popd
 popd
 
 # FRIBIDI
@@ -488,7 +483,7 @@ make install
 popd
 
 # OpenCL headers
-git clone --depth=1 https://github.com/KhronosGroup/OpenCL-Headers
+git clone --depth=1 https://github.com/KhronosGroup/OpenCL-Headers.git
 pushd OpenCL-Headers/CL
 mkdir -p ${FF_DEPS_PREFIX}/include/CL
 mv * ${FF_DEPS_PREFIX}/include/CL
@@ -532,7 +527,7 @@ make PREFIX=${FF_DEPS_PREFIX} install
 popd
 
 # AMF
-git clone --depth=1 https://github.com/GPUOpen-LibrariesAndSDKs/AMF
+git clone --depth=1 https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git
 pushd AMF/amf/public/include
 mkdir -p ${FF_DEPS_PREFIX}/include/AMF
 mv * ${FF_DEPS_PREFIX}/include/AMF

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -80,7 +80,7 @@ prepare_extra_common() {
 
     # ZIMG
     pushd ${SOURCE_DIR}
-    git clone --recursive --depth=1 https://github.com/sekrit-twc/zimg
+    git clone --recursive --depth=1 https://github.com/sekrit-twc/zimg.git
     pushd zimg
     ./autogen.sh
     ./configure --prefix=${TARGET_DIR} ${CROSS_OPT}
@@ -160,7 +160,7 @@ prepare_extra_amd64() {
 
     # FFNVCODEC
     pushd ${SOURCE_DIR}
-    git clone -b n11.1.5.2 --depth=1 https://github.com/FFmpeg/nv-codec-headers
+    git clone -b n11.1.5.2 --depth=1 https://github.com/FFmpeg/nv-codec-headers.git
     pushd nv-codec-headers
     make
     make install
@@ -169,7 +169,7 @@ prepare_extra_amd64() {
 
     # AMF
     # https://www.ffmpeg.org/general.html#AMD-AMF_002fVCE
-    git clone --depth=1 https://github.com/GPUOpen-LibrariesAndSDKs/AMF
+    git clone --depth=1 https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git
     pushd AMF/amf/public/include
     mkdir -p /usr/include/AMF
     mv * /usr/include/AMF
@@ -201,7 +201,7 @@ prepare_extra_amd64() {
 
     # LIBVA
     pushd ${SOURCE_DIR}
-    git clone -b 2.17.0 --depth=1 https://github.com/intel/libva
+    git clone -b 2.17.0 --depth=1 https://github.com/intel/libva.git
     pushd libva
     sed -i 's|getenv("LIBVA_DRIVERS_PATH")|"/usr/lib/jellyfin-ffmpeg/lib/dri:/usr/lib/x86_64-linux-gnu/dri:/usr/lib/dri:/usr/local/lib/dri"|g' va/va.c
     sed -i 's|getenv("LIBVA_DRIVER_NAME")|getenv("LIBVA_DRIVER_NAME_JELLYFIN")|g' va/va.c
@@ -218,7 +218,7 @@ prepare_extra_amd64() {
 
     # LIBVA-UTILS
     pushd ${SOURCE_DIR}
-    git clone -b 2.17.1 --depth=1 https://github.com/intel/libva-utils
+    git clone -b 2.17.1 --depth=1 https://github.com/intel/libva-utils.git
     pushd libva-utils
     ./autogen.sh
     ./configure --prefix=${TARGET_DIR}
@@ -229,7 +229,7 @@ prepare_extra_amd64() {
 
     # INTEL-VAAPI-DRIVER
     pushd ${SOURCE_DIR}
-    git clone --depth=1 https://github.com/intel/intel-vaapi-driver
+    git clone --depth=1 https://github.com/intel/intel-vaapi-driver.git
     pushd intel-vaapi-driver
     ./autogen.sh
     ./configure LIBVA_DRIVERS_PATH=${TARGET_DIR}/lib/dri
@@ -242,7 +242,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.3.3 --depth=1 https://github.com/intel/gmmlib
+    git clone -b intel-gmmlib-22.3.4 --depth=1 https://github.com/intel/gmmlib.git
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -256,7 +256,7 @@ prepare_extra_amd64() {
     # Provides MSDK runtime (libmfxhw64.so.1) for 11th Gen Rocket Lake and older
     # Provides MFX dispatcher (libmfx.so.1) for FFmpeg
     pushd ${SOURCE_DIR}
-    git clone -b intel-mediasdk-23.1.1 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK
+    git clone -b intel-mediasdk-23.1.2 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK.git
     pushd MediaSDK
     sed -i 's|MFX_PLUGINS_CONF_DIR "/plugins.cfg"|"/usr/lib/jellyfin-ffmpeg/lib/mfx/plugins.cfg"|g' api/mfx_dispatch/linux/mfxloader.cpp
     mkdir build && pushd build
@@ -276,7 +276,7 @@ prepare_extra_amd64() {
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     # Both MSDK and VPL runtime can be loaded by MFX dispatcher (libmfx.so.1)
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-23.1.1 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu
+    git clone -b intel-onevpl-23.1.2 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu.git
     pushd oneVPL-intel-gpu
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -290,10 +290,10 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-23.1.1 --depth=1 https://github.com/intel/media-driver
+    git clone -b intel-media-23.1.2 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
     # Possible fix for TGLx timeout caused by 'HCP Scalability Decode' under heavy load
-    wget -q -O - https://github.com/intel/media-driver/commit/284750bf2619112627dd8c60bd5c8032c7780606.patch | git apply
+    wget -q -O - https://github.com/intel/media-driver/commit/284750bf.patch | git apply
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
           -DENABLE_KERNELS=ON \
@@ -311,7 +311,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.240 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers
+    git clone -b v1.3.240 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -324,7 +324,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.240 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader
+    git clone -b v1.3.240 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \
@@ -345,7 +345,7 @@ prepare_extra_amd64() {
 
     # SHADERC
     pushd ${SOURCE_DIR}
-    git clone -b v2023.2 --depth=1 https://github.com/google/shaderc
+    git clone -b v2023.2 --depth=1 https://github.com/google/shaderc.git
     pushd shaderc
     ./utils/git-sync-deps
     mkdir build && pushd build
@@ -372,25 +372,22 @@ prepare_extra_amd64() {
     if [[ ${LLVM_VER} -ge 11 ]]; then
         apt-get install -y llvm-${LLVM_VER}-dev libudev-dev
         pushd ${SOURCE_DIR}
-        mkdir mesa
+        git clone https://gitlab.freedesktop.org/mesa/mesa.git
         pushd mesa
-        mesa_ver="22.3.5"
-        mesa_link="https://mesa.freedesktop.org/archive/mesa-${mesa_ver}.tar.xz"
-        wget ${mesa_link} -O mesa.tar.xz
-        tar xaf mesa.tar.xz
-        # reduce encode overhead with optimized buffer types
-        wget -O - https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/20376.patch | git apply
-        wget -O - https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/20989.patch | git apply
+        git reset --hard "a19a37e8"
+        # fix av1 main nv12 decoding
+        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/39c6f1f5.patch | git apply
+        popd
         # disable the broken hevc packed header
-        MESA_VA_PIC="mesa-${mesa_ver}/src/gallium/frontends/va/picture.c"
-        MESA_VA_CONF="mesa-${mesa_ver}/src/gallium/frontends/va/config.c"
+        MESA_VA_PIC="mesa/src/gallium/frontends/va/picture.c"
+        MESA_VA_CONF="mesa/src/gallium/frontends/va/config.c"
         sed -i 's|handleVAEncPackedHeaderParameterBufferType(context, buf);||g' ${MESA_VA_PIC}
         sed -i 's|handleVAEncPackedHeaderDataBufferType(context, buf);||g' ${MESA_VA_PIC}
         sed -i 's|if (u_reduce_video_profile(ProfileToPipe(profile)) == PIPE_VIDEO_FORMAT_HEVC)|if (0)|g' ${MESA_VA_CONF}
         # force reporting all packed headers are supported
         sed -i 's|value = VA_ENC_PACKED_HEADER_NONE;|value = 0x0000001f;|g' ${MESA_VA_CONF}
         sed -i 's|if (attrib_list\[i\].type == VAConfigAttribEncPackedHeaders)|if (0)|g' ${MESA_VA_CONF}
-        meson setup mesa-${mesa_ver} mesa_build \
+        meson setup mesa mesa_build \
             --prefix=${TARGET_DIR} \
             --libdir=lib \
             --buildtype=release \
@@ -398,7 +395,6 @@ prepare_extra_amd64() {
             -Db_ndebug=true \
             -Db_lto=false \
             -Dplatforms=x11 \
-            -Ddri-drivers=[] \
             -Dgallium-drivers=radeonsi \
             -Dvulkan-drivers=amd,intel \
             -Dvulkan-layers=device-select,overlay \
@@ -441,7 +437,7 @@ prepare_extra_amd64() {
 
     # LIBPLACEBO
     pushd ${SOURCE_DIR}
-    git clone -b v5.229.2 --recursive --depth=1 https://github.com/haasn/libplacebo
+    git clone -b v5.229.2 --recursive --depth=1 https://github.com/haasn/libplacebo.git
     sed -i 's|env: python_env,||g' libplacebo/src/vulkan/meson.build
     meson setup libplacebo placebo_build \
         --prefix=${TARGET_DIR} \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -493,7 +493,7 @@ EOF
     # Install dependencies
     pushd cross-gcc-packages-amd64/cross-gcc-${GCC_VER}-armhf
     ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime
-    yes | apt-get install -y -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-arm-linux-gnueabihf g++-${GCC_VER}-arm-linux-gnueabihf libstdc++6-armhf-cross binutils-arm-linux-gnueabihf bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf libstdc++6:armhf
+    yes | apt-get install -y -o Dpkg::Options::="--force-overwrite" -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-arm-linux-gnueabihf g++-${GCC_VER}-arm-linux-gnueabihf libstdc++6-armhf-cross binutils-arm-linux-gnueabihf bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:armhf linux-libc-dev:armhf libgcc1:armhf libcurl4-openssl-dev:armhf libfontconfig1-dev:armhf libfreetype6-dev:armhf libstdc++6:armhf
     popd
 }
 prepare_crossbuild_env_arm64() {
@@ -531,7 +531,7 @@ EOF
     # Install dependencies
     pushd cross-gcc-packages-amd64/cross-gcc-${GCC_VER}-arm64
     ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime
-    yes | apt-get install -y -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-aarch64-linux-gnu g++-${GCC_VER}-aarch64-linux-gnu libstdc++6-arm64-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 libfreetype6-dev:arm64 libstdc++6:arm64
+    yes | apt-get install -y -o Dpkg::Options::="--force-overwrite" -o APT::Immediate-Configure=0 gcc-${GCC_VER}-source gcc-${GCC_VER}-aarch64-linux-gnu g++-${GCC_VER}-aarch64-linux-gnu libstdc++6-arm64-cross binutils-aarch64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev libgmp-dev systemtap-sdt-dev autogen expect chrpath zlib1g-dev zip libc6-dev:arm64 linux-libc-dev:arm64 libgcc1:arm64 libcurl4-openssl-dev:arm64 libfontconfig1-dev:arm64 libfreetype6-dev:arm64 libstdc++6:arm64
     popd
 }
 


### PR DESCRIPTION
Also enable shared `libav*` for smaller package size. Done in the 6.0 branch too.

**Changes**
  - Fix a typo in the patch
  - Update dependencies
  - Enable Debian bookworm and Ubuntu lunar