### PR TITLE
[6.0] Fix the empty output in webvtt transcoding

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -89,15 +89,8 @@ jobs:
             find /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} -type f -name "${basename}_*.deb" | while read file; do
               reprepro -b /srv/repository/${{ matrix.arrays.distro }} --export=never --keepunreferencedfiles includedeb ${{ matrix.arrays.codename }} ${file}
             done
-            find /srv/repository/releases/server/${{ matrix.arrays.distro }}/ -type l -name "${basename}_*" -exec rm {} \;
             reprepro -b /srv/repository/${{ matrix.arrays.distro }} deleteunreferenced
             reprepro -b /srv/repository/${{ matrix.arrays.distro }} export
-            rm -f /srv/repository/releases/server/${{ matrix.arrays.distro }}/ffmpeg
-            rm -f /srv/repository/releases/server/${{ matrix.arrays.distro }}/{stable,stable-pre,unstable}/ffmpeg
-            ln -fs /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/ffmpeg
-            ln -fs /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/stable/ffmpeg
-            ln -fs /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/stable-pre/ffmpeg
-            ln -fs /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/unstable/ffmpeg
 
   maintain_repository_portable:
     name: Maintain Repository (Portable)
@@ -124,16 +117,8 @@ jobs:
             set -o xtrace
             tag="${{ github.event.release.tag_name }}"
             version="${tag#v}"
-            find /srv/repository/releases/server/${{ matrix.arrays.distro }}/ -type l -name "jellyfin-ffmpeg*_*" -exec rm {} \;
             if [ "${{ matrix.arrays.distro }}" == "windows" ]; then
               mkdir -p /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}
-              ln -fs /srv/repository/releases/ffmpeg/${version}/*.zip /srv/repository/releases/ffmpeg/${version}/jellyfin-ffmpeg-portable_win64.zip
               ln -fs /srv/repository/releases/ffmpeg/${version}/*.zip /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}/
               ln -fs /srv/repository/releases/ffmpeg/${version}/*.zip.sha265sum /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}/
             fi
-            rm -f /srv/repository/releases/server/${{ matrix.arrays.distro }}/ffmpeg
-            rm -f /srv/repository/releases/server/${{ matrix.arrays.distro }}/{stable,stable-pre,unstable}/ffmpeg
-            ln -fs /srv/repository/releases/ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/ffmpeg
-            ln -fs /srv/repository/releases/ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/stable/ffmpeg
-            ln -fs /srv/repository/releases/ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/stable-pre/ffmpeg
-            ln -fs /srv/repository/releases/ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/unstable/ffmpeg

--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/mirror/mingw-w64.git"
-SCRIPT_COMMIT="166b83cc85eb515a49764480600dca10862b6d55"
+SCRIPT_COMMIT="0f2264e7b8fedbe225921367e82aeb97ddfed46b"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/builder/scripts.d/20-libxml2.sh
+++ b/builder/scripts.d/20-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="f560065f4d6bd970be3bab81477abaa75cdd36fa"
+SCRIPT_COMMIT="b1319c902f6e44d08f8cb33f1fc28847f2bc8aeb"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-fftw3f.sh
+++ b/builder/scripts.d/25-fftw3f.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/FFTW/fftw3.git"
-SCRIPT_COMMIT="9426cd59106ffddde1f55131c07fa9c562fa2f8e"
+SCRIPT_COMMIT="c277d55689eef1616fa622b3bf6794af3a58e960"
 
 ffbuild_enabled() {
     # Dependency of GPL-Only librubberband

--- a/builder/scripts.d/25-freetype.sh
+++ b/builder/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
-SCRIPT_COMMIT="e8931f8c56104786479de38adbe2c8bb7f49c822"
+SCRIPT_COMMIT="4f0a55d15ed1c9af267ed8223cc2f04307a3d656"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/35-fontconfig.sh
+++ b/builder/scripts.d/35-fontconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
-SCRIPT_COMMIT="a6a169572204dd86f4ab462ef505d98fdfd82d76"
+SCRIPT_COMMIT="04546f18768e1ce57c24743035118b3eabbd4181"
 
 ffbuild_enabled() {
     return 0
@@ -22,7 +22,13 @@ ffbuild_dockerbuild() {
         --enable-static
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == linux* ]]; then
+        myconf+=(
+            --sysconfdir=/etc
+            --localstatedir=/var
+            --host="$FFBUILD_TOOLCHAIN"
+        )
+    elif [[ $TARGET == win* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="e8f94f9e1249fd1374fa282685ae93aba3b8fcdd"
+SCRIPT_COMMIT="79233a149209e3da199bb4e2f74271668502c574"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-opencl.sh
+++ b/builder/scripts.d/45-opencl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/OpenCL-Headers.git"
-SCRIPT_COMMIT="1080743ea047d6467bc609f979a21f00e06ac928"
+SCRIPT_COMMIT="e3e85862d6905eba9f4b5ed02c52effe673721d3"
 
 SCRIPT_REPO2="https://github.com/KhronosGroup/OpenCL-ICD-Loader.git"
 SCRIPT_COMMIT2="ece91448a958099b9c277f050fca9df96a2ea718"

--- a/builder/scripts.d/45-x11/10-xproto.sh
+++ b/builder/scripts.d/45-x11/10-xproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xorgproto.git"
-SCRIPT_COMMIT="423098656f145afeb72cbf21aaa0b3a3f9bc36bb"
+SCRIPT_COMMIT="cf35a91fe57d4721a173d2bc428dd07dcc4674f9"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/10-xtrans.sh
+++ b/builder/scripts.d/45-x11/10-xtrans.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxtrans.git"
-SCRIPT_COMMIT="c761c6505d49e8381a3eae94f2e5e118cbdf6487"
+SCRIPT_COMMIT="9d77996f9f972da63c06099fd8c0f0529159b98f"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/30-libxcb.sh
+++ b/builder/scripts.d/45-x11/30-libxcb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcb.git"
-SCRIPT_COMMIT="fd04ab24a5e99d53874789439d3ffb0eb82574f7"
+SCRIPT_COMMIT="18e109d755c5ce18157fdabb6de8ee6845b348ff"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/40-libx11.sh
+++ b/builder/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="53bf8584e8d7d5d4a4a8114bff26a6f631c7fac1"
+SCRIPT_COMMIT="ca99e338a9b8aad300933b1336f9e3c091392213"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxext.sh
+++ b/builder/scripts.d/45-x11/50-libxext.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxext.git"
-SCRIPT_COMMIT="50cac0209f96469d3a332a59a9c8d6d658edaf5f"
+SCRIPT_COMMIT="de2ebd62c1eb8fe16c11aceac4a6981bda124cf4"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxi.sh
+++ b/builder/scripts.d/45-x11/50-libxi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxi.git"
-SCRIPT_COMMIT="08431d0684f9a1edf199f6c6060d2bef1ac78399"
+SCRIPT_COMMIT="826215af0cc46b19555063b8894de6781d4c5993"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxinerama.sh
+++ b/builder/scripts.d/45-x11/50-libxinerama.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxinerama.git"
-SCRIPT_COMMIT="71dfee64feb84f907016940263b235a61c9e8960"
+SCRIPT_COMMIT="51c28095951676a5896437c4c3aa40fb1972bad2"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxrender.sh
+++ b/builder/scripts.d/45-x11/50-libxrender.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxrender.git"
-SCRIPT_COMMIT="e5e23272394c90731debd7e18dd167e8c25b5c15"
+SCRIPT_COMMIT="07efd80468f6b595e6432edd28b8560ca7695ba0"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxscrnsaver.sh
+++ b/builder/scripts.d/45-x11/50-libxscrnsaver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxscrnsaver.git"
-SCRIPT_COMMIT="34f3f72b88c0a0a10d618e9dfbc88474ae5ce880"
+SCRIPT_COMMIT="9b4e000c6c4ae213a3e52345751d885543f17929"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxxf86vm.sh
+++ b/builder/scripts.d/45-x11/50-libxxf86vm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxxf86vm.git"
-SCRIPT_COMMIT="7fe2d41f164d3015216c1079cc7fbce1eea90c98"
+SCRIPT_COMMIT="cfda59347e3a04415340a99f925a9cd85c0531b2"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libglvnd.sh
+++ b/builder/scripts.d/45-x11/60-libglvnd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/glvnd/libglvnd.git"
-SCRIPT_COMMIT="dba80d0158b587de91640fae5c0b420c23599d1e"
+SCRIPT_COMMIT="056feac0780220822e71a2fd38a83353102e5b36"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libxcursor.sh
+++ b/builder/scripts.d/45-x11/60-libxcursor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcursor.git"
-SCRIPT_COMMIT="87a30b1758b7757dd74d0a70e871d7af1cac3a44"
+SCRIPT_COMMIT="81dc4a481b64499ab7c355ee43c91e4fe0767545"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libxrandr.sh
+++ b/builder/scripts.d/45-x11/60-libxrandr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxrandr.git"
-SCRIPT_COMMIT="3387129532899eaeee3477a2d92fa662d7292a84"
+SCRIPT_COMMIT="5b96863cf2a34ee9e72ffc4ec6415bc59b6121fc"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libxv.sh
+++ b/builder/scripts.d/45-x11/60-libxv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxv.git"
-SCRIPT_COMMIT="d419928942dbf1897c9627475aa4a2828a81240f"
+SCRIPT_COMMIT="b022c9cf7004fe6f794c4c00dd519a2e4c74eca0"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="d426d1c91075b9c552b12dd052af1cd0368f05a2"
+SCRIPT_COMMIT="16c943484e63da7ed8a8a8d85af88995369f23cd"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="0e7804ca30c367eefb17594a0c5096f2f26de732"
+SCRIPT_COMMIT="6788c75055899796c13787ed44cc6f1cc45e09d7"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="d64e6d7d9d1e91d99e07de5e17afa0134d87f4ab"
+SCRIPT_COMMIT="0825faa4c10d622f2747c5b2752e7b6a6848bf3f"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-onevpl.sh
+++ b/builder/scripts.d/50-onevpl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/oneapi-src/oneVPL.git"
-SCRIPT_COMMIT="6ca7a09c4b5b2c1ae6b52d73bc44c334ab66adbc"
+SCRIPT_COMMIT="4cdf44ccaa605460499c52f39eff5517da2fc3c8"
 
 ffbuild_enabled() {
     [[ $TARGET == *arm64 ]] && return -1

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="1cffd2f2abad1782d1218f2c2b893f26bf4bbfce"
+SCRIPT_COMMIT="39822840c506d72cef5a742d28f32ea28e144345"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-svtav1.sh
+++ b/builder/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="f2b4b2d8729d0f9afabaf85ff0dd9741e24b57fd"
+SCRIPT_COMMIT="72fd3d479b315fbf6bd1d7e80dec7afe42037819"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/builder/scripts.d/50-vaapi/40-libdrm.sh
+++ b/builder/scripts.d/50-vaapi/40-libdrm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/mesa/drm.git"
-SCRIPT_COMMIT="332809f3ee19f07abc03b62d5892fae51b9d9902"
+SCRIPT_COMMIT="d1681af05471176215ad3d437249c38768dc959f"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vaapi/50-libva.sh
+++ b/builder/scripts.d/50-vaapi/50-libva.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libva.git"
-SCRIPT_COMMIT="97cbc87c94351c62a47d87e776488a9317ad398b"
+SCRIPT_COMMIT="0fa448dd00c509f08cf53b9a95a55922ff09d5cf"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/50-shaderc.sh
+++ b/builder/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
-SCRIPT_COMMIT="dde14deee743b1ae4ec8ad541f3cd268941051bb"
+SCRIPT_COMMIT="f1268e6d36cfdcd647d5c7032a6c61a0aad8487b"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="7512345f61e5f9b543ebb87df678f3fe7735587b"
+SCRIPT_COMMIT="d26c233e1c2629fec1ae1b6fdf538958e5d52bff"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-zimg.sh
+++ b/builder/scripts.d/50-zimg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/sekrit-twc/zimg.git"
-SCRIPT_COMMIT="5a5397c2b149fc9e5cb898973121de6edea77c70"
+SCRIPT_COMMIT="71394bd10d833ac48faa255f085c3e702a42921d"
 
 ffbuild_enabled() {
     return 0

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ jellyfin-ffmpeg (6.0-1) unstable; urgency=medium
   * Update build scripts and dependencies
   * Drop the EOL Ubuntu bionic
   * Enable Debian bookworm and Ubuntu lunar
+  * Fix the empty output in webvtt transcoding
 
  -- nyanmisaka <nst799610810@gmail.com>  Tue, 28 Feb 2023 19:50:24 +0800
 

--- a/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -7,7 +7,7 @@ Index: jellyfin-ffmpeg/libavfilter/opencl.c
  
      cle = clBuildProgram(ctx->program, 1, &ctx->hwctx->device_id,
 -                         NULL, NULL, NULL);
-+                         "-cl-fast-relaxed-math -cl-mad-enable", NULL, NULL);
++                         "-cl-finite-math-only -cl-unsafe-math-optimizations", NULL, NULL);
      if (cle != CL_SUCCESS) {
          av_log(avctx, AV_LOG_ERROR, "Failed to build program: %d.\n", cle);
  

--- a/debian/patches/0021-add-code-polishing-to-qsv-filters.patch
+++ b/debian/patches/0021-add-code-polishing-to-qsv-filters.patch
@@ -32,128 +32,6 @@ Index: jellyfin-ffmpeg/libavfilter/qsvvpp.c
          out_frame->queued++;
          aframe = (QSVAsyncFrame){ sync, out_frame };
          av_fifo_write(s->async_fifo, &aframe, 1);
-Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
-===================================================================
---- jellyfin-ffmpeg.orig/libavfilter/vf_vpp_qsv.c
-+++ jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
-@@ -344,6 +344,30 @@ static mfxStatus get_mfx_version(const A
-     return MFXQueryVersion(device_hwctx->session, mfx_version);
- }
- 
-+static mfxStatus get_mfx_platform(const AVFilterContext *ctx, mfxPlatform *mfx_platform)
-+{
-+    const AVFilterLink *inlink = ctx->inputs[0];
-+    AVBufferRef *device_ref;
-+    AVHWDeviceContext *device_ctx;
-+    AVQSVDeviceContext *device_hwctx;
-+
-+    if (inlink->hw_frames_ctx) {
-+        AVHWFramesContext *frames_ctx = (AVHWFramesContext *)inlink->hw_frames_ctx->data;
-+        device_ref = frames_ctx->device_ref;
-+    } else if (ctx->hw_device_ctx) {
-+        device_ref = ctx->hw_device_ctx;
-+    } else {
-+        mfx_platform->CodeName = 0;
-+        mfx_platform->DeviceId = 0;
-+        return MFX_ERR_NONE;
-+    }
-+
-+    device_ctx   = (AVHWDeviceContext *)device_ref->data;
-+    device_hwctx = device_ctx->hwctx;
-+
-+    return MFXVideoCORE_QueryPlatform(device_hwctx->session, mfx_platform);
-+}
-+
- static int config_output(AVFilterLink *outlink)
- {
-     AVFilterContext *ctx = outlink->src;
-@@ -504,12 +528,21 @@ static int config_output(AVFilterLink *o
- 
-     if (inlink->w != outlink->w || inlink->h != outlink->h || in_format != vpp->out_format) {
-         if (QSV_RUNTIME_VERSION_ATLEAST(mfx_version, 1, 19)) {
-+            mfxPlatform mfx_platform;
-+            int compute = 0;
-             int mode = vpp->scale_mode;
-+            int vpl = QSV_RUNTIME_VERSION_ATLEAST(mfx_version, 1, 255);
- 
--#if QSV_ONEVPL
--            if (mode > 2)
--                mode = MFX_SCALING_MODE_VENDOR + mode - 2;
--#endif
-+            /* Compute mode is only available on DG2+ platforms */
-+            if (vpl && get_mfx_platform(ctx, &mfx_platform) == MFX_ERR_NONE) {
-+                int code_name = mfx_platform.CodeName;
-+                compute = code_name >= 45 && code_name != 55 && code_name != 50;
-+            }
-+
-+            if (mode == -1)
-+                mode = (vpl && compute) ? 1001 : MFX_SCALING_MODE_DEFAULT;
-+            else if (mode > 2)
-+                mode = vpl ? (1000 + mode - 2) : MFX_SCALING_MODE_DEFAULT;
- 
-             INIT_MFX_EXTBUF(scale_conf, MFX_EXTBUFF_VPP_SCALING);
-             SET_MFX_PARAM_FIELD(scale_conf, ScalingMode, mode);
-@@ -685,20 +718,14 @@ static const AVOption vpp_options[] = {
-     { "h",      "Output video height(0=input video height, -1=keep input video aspect)", OFFSET(oh), AV_OPT_TYPE_STRING, { .str="w*ch/cw" }, 0, 255, .flags = FLAGS },
-     { "height", "Output video height(0=input video height, -1=keep input video aspect)", OFFSET(oh), AV_OPT_TYPE_STRING, { .str="w*ch/cw" }, 0, 255, .flags = FLAGS },
-     { "format", "Output pixel format", OFFSET(output_format_str), AV_OPT_TYPE_STRING, { .str = "same" }, .flags = FLAGS },
--    { "async_depth", "Internal parallelization depth, the higher the value the higher the latency.", OFFSET(qsv.async_depth), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, .flags = FLAGS },
--#if QSV_ONEVPL
--    { "scale_mode", "scaling & format conversion mode (mode compute(3), vd(4) and ve(5) are only available on some platforms)", OFFSET(scale_mode), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 5, .flags = FLAGS, "scale mode" },
--#else
--    { "scale_mode", "scaling & format conversion mode", OFFSET(scale_mode), AV_OPT_TYPE_INT, { .i64 = MFX_SCALING_MODE_DEFAULT }, MFX_SCALING_MODE_DEFAULT, MFX_SCALING_MODE_QUALITY, .flags = FLAGS, "scale mode" },
--#endif
-+    { "async_depth", "Internal parallelization depth, the higher the value the higher the latency.", OFFSET(qsv.async_depth), AV_OPT_TYPE_INT, { .i64 = 4 }, 0, INT_MAX, .flags = FLAGS },
-+    { "scale_mode", "scaling & format conversion mode (mode compute(3), vd(4) and ve(5) are only available on some platforms)", OFFSET(scale_mode), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 5, .flags = FLAGS, "scale mode" },
-     { "auto",      "auto mode",             0,    AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_DEFAULT},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
-     { "low_power", "low power mode",        0,    AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_LOWPOWER}, INT_MIN, INT_MAX, FLAGS, "scale mode"},
-     { "hq",        "high quality mode",     0,    AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_QUALITY},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
--#if QSV_ONEVPL
-     { "compute",   "compute",               0,    AV_OPT_TYPE_CONST,  { .i64 = 3},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
-     { "vd",        "vd",                    0,    AV_OPT_TYPE_CONST,  { .i64 = 4},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
-     { "ve",        "ve",                    0,    AV_OPT_TYPE_CONST,  { .i64 = 5},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
--#endif
- 
-     { "rate", "Generate output at frame rate or field rate, available only for deinterlace mode",
-       OFFSET(field_rate), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, FLAGS, "rate" },
-@@ -707,6 +734,7 @@ static const AVOption vpp_options[] = {
-     { "field", "Output at field rate (one frame of output for each field)",
-       0, AV_OPT_TYPE_CONST, { .i64 = 1 }, 0, 0, FLAGS, "rate" },
- 
-+    { "passthrough", "Apply pass through mode if possible.", OFFSET(has_passthrough), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, .flags = FLAGS },
-     { NULL }
- };
- 
-@@ -751,19 +779,14 @@ static const AVOption qsvscale_options[]
-     { "h",      "Output video height(0=input video height, -1=keep input video aspect)", OFFSET(oh), AV_OPT_TYPE_STRING, { .str = "ih"   }, .flags = FLAGS },
-     { "format", "Output pixel format", OFFSET(output_format_str), AV_OPT_TYPE_STRING, { .str = "same" }, .flags = FLAGS },
- 
--#if QSV_ONEVPL
--    { "mode",      "scaling & format conversion mode (mode compute(3), vd(4) and ve(5) are only available on some platforms)",    OFFSET(scale_mode),    AV_OPT_TYPE_INT,    { .i64 = 0}, 0, 5, FLAGS, "mode"},
--#else
--    { "mode",      "scaling & format conversion mode",    OFFSET(scale_mode),    AV_OPT_TYPE_INT,    { .i64 = MFX_SCALING_MODE_DEFAULT}, MFX_SCALING_MODE_DEFAULT, MFX_SCALING_MODE_QUALITY, FLAGS, "mode"},
--#endif
-+    { "mode",      "scaling & format conversion mode (mode compute(3), vd(4) and ve(5) are only available on some platforms)",    OFFSET(scale_mode),    AV_OPT_TYPE_INT,    { .i64 = -1}, -1, 5, FLAGS, "mode"},
-     { "low_power", "low power mode",        0,             AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_LOWPOWER}, INT_MIN, INT_MAX, FLAGS, "mode"},
-     { "hq",        "high quality mode",     0,             AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_QUALITY},  INT_MIN, INT_MAX, FLAGS, "mode"},
--#if QSV_ONEVPL
-     { "compute",   "compute",               0,             AV_OPT_TYPE_CONST,  { .i64 = 3},  INT_MIN, INT_MAX, FLAGS, "mode"},
-     { "vd",        "vd",                    0,             AV_OPT_TYPE_CONST,  { .i64 = 4},  INT_MIN, INT_MAX, FLAGS, "mode"},
-     { "ve",        "ve",                    0,             AV_OPT_TYPE_CONST,  { .i64 = 5},  INT_MIN, INT_MAX, FLAGS, "mode"},
--#endif
- 
-+    { "async_depth", "Internal parallelization depth, the higher the value the higher the latency.", OFFSET(qsv.async_depth), AV_OPT_TYPE_INT, { .i64 = 4 }, 0, INT_MAX, .flags = FLAGS },
-     { NULL },
- };
- 
-@@ -788,6 +811,7 @@ static const AVOption qsvdeint_options[]
-     { "bob",   "bob algorithm",                  0, AV_OPT_TYPE_CONST,      {.i64 = MFX_DEINTERLACING_BOB}, MFX_DEINTERLACING_BOB, MFX_DEINTERLACING_ADVANCED, FLAGS, "mode"},
-     { "advanced", "Motion adaptive algorithm",   0, AV_OPT_TYPE_CONST, {.i64 = MFX_DEINTERLACING_ADVANCED}, MFX_DEINTERLACING_BOB, MFX_DEINTERLACING_ADVANCED, FLAGS, "mode"},
- 
-+    { "async_depth", "Internal parallelization depth, the higher the value the higher the latency.", OFFSET(qsv.async_depth), AV_OPT_TYPE_INT, { .i64 = 4 }, 0, INT_MAX, .flags = FLAGS },
-     { NULL },
- };
- 
 Index: jellyfin-ffmpeg/libavfilter/vf_overlay_qsv.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavfilter/vf_overlay_qsv.c
@@ -264,3 +142,133 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_qsv.c
          AV_PIX_FMT_QSV,
          AV_PIX_FMT_NONE
      };
+Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/vf_vpp_qsv.c
++++ jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
+@@ -344,6 +344,30 @@ static mfxStatus get_mfx_version(const A
+     return MFXQueryVersion(device_hwctx->session, mfx_version);
+ }
+ 
++static mfxStatus get_mfx_platform(const AVFilterContext *ctx, mfxPlatform *mfx_platform)
++{
++    const AVFilterLink *inlink = ctx->inputs[0];
++    AVBufferRef *device_ref;
++    AVHWDeviceContext *device_ctx;
++    AVQSVDeviceContext *device_hwctx;
++
++    if (inlink->hw_frames_ctx) {
++        AVHWFramesContext *frames_ctx = (AVHWFramesContext *)inlink->hw_frames_ctx->data;
++        device_ref = frames_ctx->device_ref;
++    } else if (ctx->hw_device_ctx) {
++        device_ref = ctx->hw_device_ctx;
++    } else {
++        mfx_platform->CodeName = 0;
++        mfx_platform->DeviceId = 0;
++        return MFX_ERR_NONE;
++    }
++
++    device_ctx   = (AVHWDeviceContext *)device_ref->data;
++    device_hwctx = device_ctx->hwctx;
++
++    return MFXVideoCORE_QueryPlatform(device_hwctx->session, mfx_platform);
++}
++
+ static int config_output(AVFilterLink *outlink)
+ {
+     AVFilterContext *ctx = outlink->src;
+@@ -504,12 +528,21 @@ static int config_output(AVFilterLink *o
+ 
+     if (inlink->w != outlink->w || inlink->h != outlink->h || in_format != vpp->out_format) {
+         if (QSV_RUNTIME_VERSION_ATLEAST(mfx_version, 1, 19)) {
++            mfxPlatform mfx_platform;
++            int compute = 0;
+             int mode = vpp->scale_mode;
++            int vpl = QSV_RUNTIME_VERSION_ATLEAST(mfx_version, 1, 255);
+ 
+-#if QSV_ONEVPL
+-            if (mode > 2)
+-                mode = MFX_SCALING_MODE_VENDOR + mode - 2;
+-#endif
++            /* Compute mode is only available on DG2+ platforms */
++            if (vpl && get_mfx_platform(ctx, &mfx_platform) == MFX_ERR_NONE) {
++                int code_name = mfx_platform.CodeName;
++                compute = code_name >= 45 && code_name != 55 && code_name != 50;
++            }
++
++            if (mode == -1)
++                mode = (vpl && compute) ? 1001 : MFX_SCALING_MODE_DEFAULT;
++            else if (mode > 2)
++                mode = vpl ? (1000 + mode - 2) : MFX_SCALING_MODE_DEFAULT;
+ 
+             INIT_MFX_EXTBUF(scale_conf, MFX_EXTBUFF_VPP_SCALING);
+             SET_MFX_PARAM_FIELD(scale_conf, ScalingMode, mode);
+@@ -602,6 +635,7 @@ not_ready:
+     return FFERROR_NOT_READY;
+ 
+ eof:
++    pts = av_rescale_q(pts, inlink->time_base, outlink->time_base);
+     ff_outlink_set_status(outlink, status, pts);
+     return 0;
+ }
+@@ -685,20 +719,14 @@ static const AVOption vpp_options[] = {
+     { "h",      "Output video height(0=input video height, -1=keep input video aspect)", OFFSET(oh), AV_OPT_TYPE_STRING, { .str="w*ch/cw" }, 0, 255, .flags = FLAGS },
+     { "height", "Output video height(0=input video height, -1=keep input video aspect)", OFFSET(oh), AV_OPT_TYPE_STRING, { .str="w*ch/cw" }, 0, 255, .flags = FLAGS },
+     { "format", "Output pixel format", OFFSET(output_format_str), AV_OPT_TYPE_STRING, { .str = "same" }, .flags = FLAGS },
+-    { "async_depth", "Internal parallelization depth, the higher the value the higher the latency.", OFFSET(qsv.async_depth), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, .flags = FLAGS },
+-#if QSV_ONEVPL
+-    { "scale_mode", "scaling & format conversion mode (mode compute(3), vd(4) and ve(5) are only available on some platforms)", OFFSET(scale_mode), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 5, .flags = FLAGS, "scale mode" },
+-#else
+-    { "scale_mode", "scaling & format conversion mode", OFFSET(scale_mode), AV_OPT_TYPE_INT, { .i64 = MFX_SCALING_MODE_DEFAULT }, MFX_SCALING_MODE_DEFAULT, MFX_SCALING_MODE_QUALITY, .flags = FLAGS, "scale mode" },
+-#endif
++    { "async_depth", "Internal parallelization depth, the higher the value the higher the latency.", OFFSET(qsv.async_depth), AV_OPT_TYPE_INT, { .i64 = 4 }, 0, INT_MAX, .flags = FLAGS },
++    { "scale_mode", "scaling & format conversion mode (mode compute(3), vd(4) and ve(5) are only available on some platforms)", OFFSET(scale_mode), AV_OPT_TYPE_INT, { .i64 = -1 }, -1, 5, .flags = FLAGS, "scale mode" },
+     { "auto",      "auto mode",             0,    AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_DEFAULT},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
+     { "low_power", "low power mode",        0,    AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_LOWPOWER}, INT_MIN, INT_MAX, FLAGS, "scale mode"},
+     { "hq",        "high quality mode",     0,    AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_QUALITY},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
+-#if QSV_ONEVPL
+     { "compute",   "compute",               0,    AV_OPT_TYPE_CONST,  { .i64 = 3},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
+     { "vd",        "vd",                    0,    AV_OPT_TYPE_CONST,  { .i64 = 4},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
+     { "ve",        "ve",                    0,    AV_OPT_TYPE_CONST,  { .i64 = 5},  INT_MIN, INT_MAX, FLAGS, "scale mode"},
+-#endif
+ 
+     { "rate", "Generate output at frame rate or field rate, available only for deinterlace mode",
+       OFFSET(field_rate), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, FLAGS, "rate" },
+@@ -707,6 +735,7 @@ static const AVOption vpp_options[] = {
+     { "field", "Output at field rate (one frame of output for each field)",
+       0, AV_OPT_TYPE_CONST, { .i64 = 1 }, 0, 0, FLAGS, "rate" },
+ 
++    { "passthrough", "Apply pass through mode if possible.", OFFSET(has_passthrough), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, .flags = FLAGS },
+     { NULL }
+ };
+ 
+@@ -751,19 +780,14 @@ static const AVOption qsvscale_options[]
+     { "h",      "Output video height(0=input video height, -1=keep input video aspect)", OFFSET(oh), AV_OPT_TYPE_STRING, { .str = "ih"   }, .flags = FLAGS },
+     { "format", "Output pixel format", OFFSET(output_format_str), AV_OPT_TYPE_STRING, { .str = "same" }, .flags = FLAGS },
+ 
+-#if QSV_ONEVPL
+-    { "mode",      "scaling & format conversion mode (mode compute(3), vd(4) and ve(5) are only available on some platforms)",    OFFSET(scale_mode),    AV_OPT_TYPE_INT,    { .i64 = 0}, 0, 5, FLAGS, "mode"},
+-#else
+-    { "mode",      "scaling & format conversion mode",    OFFSET(scale_mode),    AV_OPT_TYPE_INT,    { .i64 = MFX_SCALING_MODE_DEFAULT}, MFX_SCALING_MODE_DEFAULT, MFX_SCALING_MODE_QUALITY, FLAGS, "mode"},
+-#endif
++    { "mode",      "scaling & format conversion mode (mode compute(3), vd(4) and ve(5) are only available on some platforms)",    OFFSET(scale_mode),    AV_OPT_TYPE_INT,    { .i64 = -1}, -1, 5, FLAGS, "mode"},
+     { "low_power", "low power mode",        0,             AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_LOWPOWER}, INT_MIN, INT_MAX, FLAGS, "mode"},
+     { "hq",        "high quality mode",     0,             AV_OPT_TYPE_CONST,  { .i64 = MFX_SCALING_MODE_QUALITY},  INT_MIN, INT_MAX, FLAGS, "mode"},
+-#if QSV_ONEVPL
+     { "compute",   "compute",               0,             AV_OPT_TYPE_CONST,  { .i64 = 3},  INT_MIN, INT_MAX, FLAGS, "mode"},
+     { "vd",        "vd",                    0,             AV_OPT_TYPE_CONST,  { .i64 = 4},  INT_MIN, INT_MAX, FLAGS, "mode"},
+     { "ve",        "ve",                    0,             AV_OPT_TYPE_CONST,  { .i64 = 5},  INT_MIN, INT_MAX, FLAGS, "mode"},
+-#endif
+ 
++    { "async_depth", "Internal parallelization depth, the higher the value the higher the latency.", OFFSET(qsv.async_depth), AV_OPT_TYPE_INT, { .i64 = 4 }, 0, INT_MAX, .flags = FLAGS },
+     { NULL },
+ };
+ 
+@@ -788,6 +812,7 @@ static const AVOption qsvdeint_options[]
+     { "bob",   "bob algorithm",                  0, AV_OPT_TYPE_CONST,      {.i64 = MFX_DEINTERLACING_BOB}, MFX_DEINTERLACING_BOB, MFX_DEINTERLACING_ADVANCED, FLAGS, "mode"},
+     { "advanced", "Motion adaptive algorithm",   0, AV_OPT_TYPE_CONST, {.i64 = MFX_DEINTERLACING_ADVANCED}, MFX_DEINTERLACING_BOB, MFX_DEINTERLACING_ADVANCED, FLAGS, "mode"},
+ 
++    { "async_depth", "Internal parallelization depth, the higher the value the higher the latency.", OFFSET(qsv.async_depth), AV_OPT_TYPE_INT, { .i64 = 4 }, 0, INT_MAX, .flags = FLAGS },
+     { NULL },
+ };
+ 

--- a/debian/patches/0050-fix-nvenc-b-ref-mode-cap-check.patch
+++ b/debian/patches/0050-fix-nvenc-b-ref-mode-cap-check.patch
@@ -2,18 +2,34 @@ Index: jellyfin-ffmpeg/libavcodec/nvenc.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavcodec/nvenc.c
 +++ jellyfin-ffmpeg/libavcodec/nvenc.c
-@@ -546,12 +546,12 @@ static int nvenc_check_capabilities(AVCo
-     if (ctx->b_ref_mode == NV_ENC_BFRAME_REF_MODE_EACH && ret != 1 && ret != 3) {
+@@ -461,7 +461,7 @@ static int nvenc_check_cap(AVCodecContex
+ static int nvenc_check_capabilities(AVCodecContext *avctx)
+ {
+     NvencContext *ctx = avctx->priv_data;
+-    int ret;
++    int tmp, ret;
+ 
+     ret = nvenc_check_codec_support(avctx);
+     if (ret < 0) {
+@@ -542,16 +542,18 @@ static int nvenc_check_capabilities(AVCo
+     }
+ 
+ #ifdef NVENC_HAVE_BFRAME_REF_MODE
++    tmp = (ctx->b_ref_mode >= 0) ? ctx->b_ref_mode : NV_ENC_BFRAME_REF_MODE_DISABLED;
+     ret = nvenc_check_cap(avctx, NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE);
+-    if (ctx->b_ref_mode == NV_ENC_BFRAME_REF_MODE_EACH && ret != 1 && ret != 3) {
++    if (tmp == NV_ENC_BFRAME_REF_MODE_EACH && ret != 1 && ret != 3) {
          av_log(avctx, AV_LOG_WARNING, "Each B frame as reference is not supported\n");
          return AVERROR(ENOSYS);
 -    } else if (ctx->b_ref_mode != NV_ENC_BFRAME_REF_MODE_DISABLED && ret == 0) {
-+    } else if (ctx->b_ref_mode > 0 && ret == 0) {
++    } else if (tmp != NV_ENC_BFRAME_REF_MODE_DISABLED && ret == 0) {
          av_log(avctx, AV_LOG_WARNING, "B frames as references are not supported\n");
          return AVERROR(ENOSYS);
      }
  #else
 -    if (ctx->b_ref_mode != 0) {
-+    if (ctx->b_ref_mode > 0) {
++    tmp = (ctx->b_ref_mode >= 0) ? ctx->b_ref_mode : 0;
++    if (tmp > 0) {
          av_log(avctx, AV_LOG_WARNING, "B frames as references need SDK 8.1 at build time\n");
          return AVERROR(ENOSYS);
      }

--- a/debian/patches/0051-fix-the-empty-output-in-webvtt-transcoding.patch
+++ b/debian/patches/0051-fix-the-empty-output-in-webvtt-transcoding.patch
@@ -1,0 +1,80 @@
+Index: jellyfin-ffmpeg/libavformat/webvttdec.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/webvttdec.c
++++ jellyfin-ffmpeg/libavformat/webvttdec.c
+@@ -60,7 +60,7 @@ static int64_t read_ts(const char *s)
+ static int webvtt_read_header(AVFormatContext *s)
+ {
+     WebVTTContext *webvtt = s->priv_data;
+-    AVBPrint cue;
++    AVBPrint cue, header;
+     int res = 0;
+     AVStream *st = avformat_new_stream(s, NULL);
+ 
+@@ -72,6 +72,7 @@ static int webvtt_read_header(AVFormatCo
+     st->disposition |= webvtt->kind;
+ 
+     av_bprint_init(&cue,    0, AV_BPRINT_SIZE_UNLIMITED);
++    av_bprint_init(&header, 0, AV_BPRINT_SIZE_UNLIMITED);
+ 
+     for (;;) {
+         int i;
+@@ -89,12 +90,18 @@ static int webvtt_read_header(AVFormatCo
+         p = identifier = cue.str;
+         pos = avio_tell(s->pb);
+ 
+-        /* ignore header chunk */
++        /* ignore the magic word and any comments */
+         if (!strncmp(p, "\xEF\xBB\xBFWEBVTT", 9) ||
+             !strncmp(p, "WEBVTT", 6) ||
+             !strncmp(p, "NOTE", 4))
+             continue;
+ 
++        /* store the style and region blocks from the header */
++        if (!strncmp(p, "STYLE", 5) || !strncmp(p, "REGION", 6)) {
++            av_bprintf(&header, "%s%s", header.len ? "\n\n" : "", p);
++            continue;
++        }
++
+         /* optional cue identifier (can be a number like in SRT or some kind of
+          * chaptering id) */
+         for (i = 0; p[i] && p[i] != '\n' && p[i] != '\r'; i++) {
+@@ -161,10 +168,15 @@ static int webvtt_read_header(AVFormatCo
+         SET_SIDE_DATA(settings,   AV_PKT_DATA_WEBVTT_SETTINGS);
+     }
+ 
++    res = ff_bprint_to_codecpar_extradata(st->codecpar, &header);
++    if (res < 0)
++        goto end;
++
+     ff_subtitles_queue_finalize(s, &webvtt->q);
+ 
+ end:
+     av_bprint_finalize(&cue,    NULL);
++    av_bprint_finalize(&header, NULL);
+     return res;
+ }
+ 
+Index: jellyfin-ffmpeg/libavformat/webvttenc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/webvttenc.c
++++ jellyfin-ffmpeg/libavformat/webvttenc.c
+@@ -59,6 +59,18 @@ static int webvtt_write_header(AVFormatC
+ 
+     avio_printf(pb, "WEBVTT\n");
+ 
++    if (par->extradata_size > 0) {
++        size_t header_size = par->extradata_size;
++
++        if (par->extradata[0] != '\n')
++            avio_printf(pb, "\n");
++
++        avio_write(pb, par->extradata, header_size);
++
++        if (par->extradata[header_size - 1] != '\n')
++            avio_printf(pb, "\n");
++    }
++
+     return 0;
+ }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -48,3 +48,4 @@
 0048-fix-nvenc-potential-null-pointer-dereference.patch
 0049-fix-filter_at_id_syntax_from_upstream.patch
 0050-fix-nvenc-b-ref-mode-cap-check.patch
+0051-fix-the-empty-output-in-webvtt-transcoding.patch

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -521,9 +521,8 @@ EOF
 popd
 
 # FFNVCODEC
-git clone --depth=1 https://github.com/FFmpeg/nv-codec-headers.git
+git clone -b n12.0.16.0 --depth=1 https://github.com/FFmpeg/nv-codec-headers.git
 pushd nv-codec-headers
-git reset --hard "c5e4af7"
 make PREFIX=${FF_DEPS_PREFIX} install
 popd
 
@@ -535,7 +534,7 @@ mv * ${FF_DEPS_PREFIX}/include/AMF
 popd
 
 # VPL
-git clone -b v2023.1.2 --depth=1 https://github.com/oneapi-src/oneVPL.git
+git clone -b v2023.1.3 --depth=1 https://github.com/oneapi-src/oneVPL.git
 pushd oneVPL
 mkdir build && pushd build
 cmake \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -156,9 +156,8 @@ prepare_extra_amd64() {
 
     # FFNVCODEC
     pushd ${SOURCE_DIR}
-    git clone --depth=1 https://github.com/FFmpeg/nv-codec-headers.git
+    git clone -b n12.0.16.0 --depth=1 https://github.com/FFmpeg/nv-codec-headers.git
     pushd nv-codec-headers
-    git reset --hard "c5e4af7"
     make && make install
     popd
     popd
@@ -252,7 +251,7 @@ prepare_extra_amd64() {
     # Provides MSDK runtime (libmfxhw64.so.1) for 11th Gen Rocket Lake and older
     # Provides MFX dispatcher (libmfx.so.1) for FFmpeg
     pushd ${SOURCE_DIR}
-    git clone -b intel-mediasdk-23.1.2 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK.git
+    git clone -b intel-mediasdk-23.1.3 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK.git
     pushd MediaSDK
     sed -i 's|MFX_PLUGINS_CONF_DIR "/plugins.cfg"|"/usr/lib/jellyfin-ffmpeg/lib/mfx/plugins.cfg"|g' api/mfx_dispatch/linux/mfxloader.cpp
     mkdir build && pushd build
@@ -269,7 +268,7 @@ prepare_extra_amd64() {
 
     # ONEVPL (dispatcher + header)
     pushd ${SOURCE_DIR}
-    git clone -b v2023.1.2 --depth=1 https://github.com/oneapi-src/oneVPL.git
+    git clone -b v2023.1.3 --depth=1 https://github.com/oneapi-src/oneVPL.git
     pushd oneVPL
     sed -i 's|ParseEnvSearchPaths(ONEVPL_PRIORITY_PATH_VAR, searchDirList)|searchDirList.push_back("/usr/lib/jellyfin-ffmpeg/lib")|g' dispatcher/vpl/mfx_dispatcher_vpl_loader.cpp
     mkdir build && pushd build
@@ -293,7 +292,7 @@ prepare_extra_amd64() {
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     # Both MSDK and VPL runtime can be loaded by MFX dispatcher (libmfx.so.1)
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-23.1.2 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu.git
+    git clone -b intel-onevpl-23.1.3 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu.git
     pushd oneVPL-intel-gpu
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -307,7 +306,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-23.1.2 --depth=1 https://github.com/intel/media-driver.git
+    git clone -b intel-media-23.1.3 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
     # Possible fix for TGLx timeout caused by 'HCP Scalability Decode' under heavy load
     wget -q -O - https://github.com/intel/media-driver/commit/284750bf.patch | git apply
@@ -362,7 +361,7 @@ prepare_extra_amd64() {
 
     # SHADERC
     pushd ${SOURCE_DIR}
-    git clone -b v2023.2 --depth=1 https://github.com/google/shaderc.git
+    git clone -b v2023.3 --depth=1 https://github.com/google/shaderc.git
     pushd shaderc
     ./utils/git-sync-deps
     mkdir build && pushd build
@@ -391,9 +390,10 @@ prepare_extra_amd64() {
         pushd ${SOURCE_DIR}
         git clone -b main https://gitlab.freedesktop.org/mesa/mesa.git
         pushd mesa
-        git reset --hard "a19a37e8"
-        # fix av1 main nv12 decoding
-        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/39c6f1f5.patch | git apply
+        git reset --hard "10622ccc"
+        # fix building with python 3.8
+        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/044db56a.patch | git apply
+        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/40f89860.patch | git apply
         popd
         # disable the broken hevc packed header
         MESA_VA_PIC="mesa/src/gallium/frontends/va/picture.c"


### PR DESCRIPTION
**Changes**
- Fix an upstream vpp_qsv timestamp issue
- Update patch for the nvenc b_ref cap issue
- Tune cl compiler options for Intel on Linux
- Fix the empty output in webvtt transcoding
- Fix the font config dirs in portable build
- Update dependencies

**Issues**
Fixes #207 