### PR TITLE
[5.1] Fix the empty output in webvtt transcoding

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,8 +90,15 @@ jobs:
             find /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} -type f -name "${basename}_*.deb" | while read file; do
               reprepro -b /srv/repository/${{ matrix.arrays.distro }} --export=never --keepunreferencedfiles includedeb ${{ matrix.arrays.codename }} ${file}
             done
+            find /srv/repository/releases/server/${{ matrix.arrays.distro }}/ -type l -name "${basename}_*" -exec rm {} \;
             reprepro -b /srv/repository/${{ matrix.arrays.distro }} deleteunreferenced
             reprepro -b /srv/repository/${{ matrix.arrays.distro }} export
+            rm -f /srv/repository/releases/server/${{ matrix.arrays.distro }}/ffmpeg
+            rm -f /srv/repository/releases/server/${{ matrix.arrays.distro }}/{stable,stable-pre,unstable}/ffmpeg
+            ln -fs /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/ffmpeg
+            ln -fs /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/stable/ffmpeg
+            ln -fs /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/stable-pre/ffmpeg
+            ln -fs /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/unstable/ffmpeg
 
   maintain_repository_portable:
     name: Maintain Repository (Portable)
@@ -118,8 +125,16 @@ jobs:
             set -o xtrace
             tag="${{ github.event.release.tag_name }}"
             version="${tag#v}"
+            find /srv/repository/releases/server/${{ matrix.arrays.distro }}/ -type l -name "jellyfin-ffmpeg*_*" -exec rm {} \;
             if [ "${{ matrix.arrays.distro }}" == "windows" ]; then
               mkdir -p /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}
+              ln -fs /srv/repository/releases/ffmpeg/${version}/*.zip /srv/repository/releases/ffmpeg/${version}/jellyfin-ffmpeg-portable_win64.zip
               ln -fs /srv/repository/releases/ffmpeg/${version}/*.zip /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}/
               ln -fs /srv/repository/releases/ffmpeg/${version}/*.zip.sha265sum /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}/
             fi
+            rm -f /srv/repository/releases/server/${{ matrix.arrays.distro }}/ffmpeg
+            rm -f /srv/repository/releases/server/${{ matrix.arrays.distro }}/{stable,stable-pre,unstable}/ffmpeg
+            ln -fs /srv/repository/releases/ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/ffmpeg
+            ln -fs /srv/repository/releases/ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/stable/ffmpeg
+            ln -fs /srv/repository/releases/ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/stable-pre/ffmpeg
+            ln -fs /srv/repository/releases/ffmpeg/${version} /srv/repository/releases/server/${{ matrix.arrays.distro }}/unstable/ffmpeg

--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/mirror/mingw-w64.git"
-SCRIPT_COMMIT="e4bde579f050f5686ec5eefb4ad3128444797929"
+SCRIPT_COMMIT="0f2264e7b8fedbe225921367e82aeb97ddfed46b"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/builder/scripts.d/20-libxml2.sh
+++ b/builder/scripts.d/20-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="e20f4d7a656e47553f9da9d594e299e2fa2dbe41"
+SCRIPT_COMMIT="b1319c902f6e44d08f8cb33f1fc28847f2bc8aeb"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-fftw3f.sh
+++ b/builder/scripts.d/25-fftw3f.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/FFTW/fftw3.git"
-SCRIPT_COMMIT="9426cd59106ffddde1f55131c07fa9c562fa2f8e"
+SCRIPT_COMMIT="c277d55689eef1616fa622b3bf6794af3a58e960"
 
 ffbuild_enabled() {
     # Dependency of GPL-Only librubberband

--- a/builder/scripts.d/25-freetype.sh
+++ b/builder/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
-SCRIPT_COMMIT="dacbb55433079fb3539163862958a6b9466a0661"
+SCRIPT_COMMIT="4f0a55d15ed1c9af267ed8223cc2f04307a3d656"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/35-fontconfig.sh
+++ b/builder/scripts.d/35-fontconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
-SCRIPT_COMMIT="2ef790a0dbbab24235d1b8c0325ab4414de5f0a9"
+SCRIPT_COMMIT="04546f18768e1ce57c24743035118b3eabbd4181"
 
 ffbuild_enabled() {
     return 0
@@ -22,7 +22,13 @@ ffbuild_dockerbuild() {
         --enable-static
     )
 
-    if [[ $TARGET == win* || $TARGET == linux* ]]; then
+    if [[ $TARGET == linux* ]]; then
+        myconf+=(
+            --sysconfdir=/etc
+            --localstatedir=/var
+            --host="$FFBUILD_TOOLCHAIN"
+        )
+    elif [[ $TARGET == win* ]]; then
         myconf+=(
             --host="$FFBUILD_TOOLCHAIN"
         )

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="b41efb6c4da9b1180b5178a55ceb31c68791dfdc"
+SCRIPT_COMMIT="79233a149209e3da199bb4e2f74271668502c574"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-opencl.sh
+++ b/builder/scripts.d/45-opencl.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/OpenCL-Headers.git"
-SCRIPT_COMMIT="4c82e9cfaaad18c340f48af3cf5d09ff33e8c1b7"
+SCRIPT_COMMIT="e3e85862d6905eba9f4b5ed02c52effe673721d3"
 
 SCRIPT_REPO2="https://github.com/KhronosGroup/OpenCL-ICD-Loader.git"
-SCRIPT_COMMIT2="2cde5d09953a041786d1cfdcb1c08704a82cb904"
+SCRIPT_COMMIT2="ece91448a958099b9c277f050fca9df96a2ea718"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-x11/10-xcbproto.sh
+++ b/builder/scripts.d/45-x11/10-xcbproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xcbproto.git"
-SCRIPT_COMMIT="842d91316243eb1f2e208231acc1512c2cf43a1f"
+SCRIPT_COMMIT="15d140d7867e8e654ce917b8d6d1dbd45b3de3b8"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/10-xproto.sh
+++ b/builder/scripts.d/45-x11/10-xproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xorgproto.git"
-SCRIPT_COMMIT="1b6e63b2c38a0cf6cd1c70bfc5483cac0d1710e1"
+SCRIPT_COMMIT="cf35a91fe57d4721a173d2bc428dd07dcc4674f9"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/10-xtrans.sh
+++ b/builder/scripts.d/45-x11/10-xtrans.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxtrans.git"
-SCRIPT_COMMIT="c761c6505d49e8381a3eae94f2e5e118cbdf6487"
+SCRIPT_COMMIT="9d77996f9f972da63c06099fd8c0f0529159b98f"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/30-libxcb.sh
+++ b/builder/scripts.d/45-x11/30-libxcb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcb.git"
-SCRIPT_COMMIT="4d1a578dd5348909ade2a853d806272326d228d7"
+SCRIPT_COMMIT="18e109d755c5ce18157fdabb6de8ee6845b348ff"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/40-libx11.sh
+++ b/builder/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="53bf8584e8d7d5d4a4a8114bff26a6f631c7fac1"
+SCRIPT_COMMIT="ca99e338a9b8aad300933b1336f9e3c091392213"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxext.sh
+++ b/builder/scripts.d/45-x11/50-libxext.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxext.git"
-SCRIPT_COMMIT="e8556ab06e03b59e9a512eb02955247efd4c4054"
+SCRIPT_COMMIT="de2ebd62c1eb8fe16c11aceac4a6981bda124cf4"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxfixes.sh
+++ b/builder/scripts.d/45-x11/50-libxfixes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxfixes.git"
-SCRIPT_COMMIT="332394278b7110a774b5277bb3cfc58c42cd888c"
+SCRIPT_COMMIT="ad22c5ade8789cdb606b244336106a713473318c"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxi.sh
+++ b/builder/scripts.d/45-x11/50-libxi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxi.git"
-SCRIPT_COMMIT="08431d0684f9a1edf199f6c6060d2bef1ac78399"
+SCRIPT_COMMIT="826215af0cc46b19555063b8894de6781d4c5993"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxinerama.sh
+++ b/builder/scripts.d/45-x11/50-libxinerama.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxinerama.git"
-SCRIPT_COMMIT="71dfee64feb84f907016940263b235a61c9e8960"
+SCRIPT_COMMIT="51c28095951676a5896437c4c3aa40fb1972bad2"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxrender.sh
+++ b/builder/scripts.d/45-x11/50-libxrender.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxrender.git"
-SCRIPT_COMMIT="e5e23272394c90731debd7e18dd167e8c25b5c15"
+SCRIPT_COMMIT="07efd80468f6b595e6432edd28b8560ca7695ba0"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxscrnsaver.sh
+++ b/builder/scripts.d/45-x11/50-libxscrnsaver.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxscrnsaver.git"
-SCRIPT_COMMIT="34f3f72b88c0a0a10d618e9dfbc88474ae5ce880"
+SCRIPT_COMMIT="9b4e000c6c4ae213a3e52345751d885543f17929"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxxf86vm.sh
+++ b/builder/scripts.d/45-x11/50-libxxf86vm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxxf86vm.git"
-SCRIPT_COMMIT="7fe2d41f164d3015216c1079cc7fbce1eea90c98"
+SCRIPT_COMMIT="cfda59347e3a04415340a99f925a9cd85c0531b2"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libglvnd.sh
+++ b/builder/scripts.d/45-x11/60-libglvnd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/glvnd/libglvnd.git"
-SCRIPT_COMMIT="dba80d0158b587de91640fae5c0b420c23599d1e"
+SCRIPT_COMMIT="056feac0780220822e71a2fd38a83353102e5b36"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libxcursor.sh
+++ b/builder/scripts.d/45-x11/60-libxcursor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcursor.git"
-SCRIPT_COMMIT="87a30b1758b7757dd74d0a70e871d7af1cac3a44"
+SCRIPT_COMMIT="81dc4a481b64499ab7c355ee43c91e4fe0767545"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libxrandr.sh
+++ b/builder/scripts.d/45-x11/60-libxrandr.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxrandr.git"
-SCRIPT_COMMIT="3387129532899eaeee3477a2d92fa662d7292a84"
+SCRIPT_COMMIT="5b96863cf2a34ee9e72ffc4ec6415bc59b6121fc"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libxv.sh
+++ b/builder/scripts.d/45-x11/60-libxv.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxv.git"
-SCRIPT_COMMIT="d419928942dbf1897c9627475aa4a2828a81240f"
+SCRIPT_COMMIT="b022c9cf7004fe6f794c4c00dd519a2e4c74eca0"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-amf.sh
+++ b/builder/scripts.d/50-amf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git"
-SCRIPT_COMMIT="37452e9e60940f04fc235a923ffcc31c407240fa"
+SCRIPT_COMMIT="4bfa819fc3d6aa4714ad28f8dab46d0fa95177ad"
 
 ffbuild_enabled() {
     [[ $TARGET == *arm64 ]] && return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="9593e625b75d498d1edea544da21ea764b98d507"
+SCRIPT_COMMIT="16c943484e63da7ed8a8a8d85af88995369f23cd"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libass.sh
+++ b/builder/scripts.d/50-libass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libass/libass.git"
-SCRIPT_COMMIT="077328ca6715e2e2826881003946640f56cb763c"
+SCRIPT_COMMIT="218dacece7d24b45e4637ced4dc56564de29919d"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="660031ccf380e6a37beecc67e78154b7b6ea78d8"
+SCRIPT_COMMIT="6788c75055899796c13787ed44cc6f1cc45e09d7"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="1347a32d82276ecf4daba12f6e9142cc4e1f2401"
+SCRIPT_COMMIT="0825faa4c10d622f2747c5b2752e7b6a6848bf3f"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-onevpl.sh
+++ b/builder/scripts.d/50-onevpl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/oneapi-src/oneVPL.git"
-SCRIPT_COMMIT="6ca7a09c4b5b2c1ae6b52d73bc44c334ab66adbc"
+SCRIPT_COMMIT="4cdf44ccaa605460499c52f39eff5517da2fc3c8"
 
 ffbuild_enabled() {
     [[ $TARGET == *arm64 ]] && return -1

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="e8d0533176ef53bfb2b95442f125ec9c878cf791"
+SCRIPT_COMMIT="39822840c506d72cef5a742d28f32ea28e144345"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-svtav1.sh
+++ b/builder/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="71a1e23d87eeda36c28feec80f229576c9d83314"
+SCRIPT_COMMIT="72fd3d479b315fbf6bd1d7e80dec7afe42037819"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/builder/scripts.d/50-vaapi/40-libdrm.sh
+++ b/builder/scripts.d/50-vaapi/40-libdrm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/mesa/drm.git"
-SCRIPT_COMMIT="c6d6dce99fb3e7e681fbba9e198345fdbd10e49e"
+SCRIPT_COMMIT="d1681af05471176215ad3d437249c38768dc959f"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vaapi/50-libva.sh
+++ b/builder/scripts.d/50-vaapi/50-libva.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libva.git"
-SCRIPT_COMMIT="29ac033a2998eb012b2a98fea46fc43dcdec35e4"
+SCRIPT_COMMIT="0fa448dd00c509f08cf53b9a95a55922ff09d5cf"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/50-shaderc.sh
+++ b/builder/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
-SCRIPT_COMMIT="dde14deee743b1ae4ec8ad541f3cd268941051bb"
+SCRIPT_COMMIT="f1268e6d36cfdcd647d5c7032a6c61a0aad8487b"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="4e2fdb25671c742a9fbe93a6034eb1542244c7e1"
+SCRIPT_COMMIT="d26c233e1c2629fec1ae1b6fdf538958e5d52bff"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-x265.sh
+++ b/builder/scripts.d/50-x265.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
-SCRIPT_COMMIT="6da609e41ca5ae1d661a1b5c4805ed7a3f4117cc"
+SCRIPT_COMMIT="38cf1c379b5af08856bb2fdd65f65a1f99384886"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/builder/scripts.d/50-zimg.sh
+++ b/builder/scripts.d/50-zimg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/sekrit-twc/zimg.git"
-SCRIPT_COMMIT="5a5397c2b149fc9e5cb898973121de6edea77c70"
+SCRIPT_COMMIT="71394bd10d833ac48faa255f085c3e702a42921d"
 
 ffbuild_enabled() {
     return 0

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ jellyfin-ffmpeg (5.1.2-9) unstable; urgency=medium
   * Fix a typo in the patch
   * Update dependencies
   * Enable Debian bookworm and Ubuntu lunar
+  * Fix the empty output in webvtt transcoding
 
  -- nyanmisaka <nst799610810@gmail.com>  Fri, 3 Mar 2023 19:15:27 +0800
 

--- a/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -7,7 +7,7 @@ Index: jellyfin-ffmpeg/libavfilter/opencl.c
  
      cle = clBuildProgram(ctx->program, 1, &ctx->hwctx->device_id,
 -                         NULL, NULL, NULL);
-+                         "-cl-fast-relaxed-math -cl-mad-enable", NULL, NULL);
++                         "-cl-finite-math-only -cl-unsafe-math-optimizations", NULL, NULL);
      if (cle != CL_SUCCESS) {
          av_log(avctx, AV_LOG_ERROR, "Failed to build program: %d.\n", cle);
  

--- a/debian/patches/0022-add-code-polishing-to-qsv-filters.patch
+++ b/debian/patches/0022-add-code-polishing-to-qsv-filters.patch
@@ -150,13 +150,14 @@ Index: jellyfin-ffmpeg/libavfilter/qsvvpp.c
  
      while (s->eof && av_fifo_read(s->async_fifo, &aframe, 1) >= 0) {
          if (MFXVideoCORE_SyncOperation(s->session, aframe.sync, 1000) < 0)
-@@ -842,8 +845,32 @@ int ff_qsvvpp_filter_frame(QSVVPPContext
+@@ -842,8 +845,33 @@ int ff_qsvvpp_filter_frame(QSVVPPContext
                  return AVERROR(EAGAIN);
              break;
          }
 -        out_frame->frame->pts = av_rescale_q(out_frame->surface.Data.TimeStamp,
 -                                             default_tb, outlink->time_base);
 +
++        /* Copy the color side data */
 +        if (in_frame->frame->color_primaries != -1)
 +            out_frame->frame->color_primaries = in_frame->frame->color_primaries;
 +        if (in_frame->frame->color_trc != -1)
@@ -185,7 +186,7 @@ Index: jellyfin-ffmpeg/libavfilter/qsvvpp.c
  
          out_frame->queued++;
          aframe = (QSVAsyncFrame){ sync, out_frame };
-@@ -853,8 +880,13 @@ int ff_qsvvpp_filter_frame(QSVVPPContext
+@@ -853,8 +881,13 @@ int ff_qsvvpp_filter_frame(QSVVPPContext
              av_fifo_read(s->async_fifo, &aframe, 1);
  
              do {
@@ -201,7 +202,7 @@ Index: jellyfin-ffmpeg/libavfilter/qsvvpp.c
  
              filter_ret = s->filter_frame(outlink, aframe.frame->frame);
              if (filter_ret < 0) {
-@@ -868,6 +900,8 @@ int ff_qsvvpp_filter_frame(QSVVPPContext
+@@ -868,6 +901,8 @@ int ff_qsvvpp_filter_frame(QSVVPPContext
          }
      } while(ret == MFX_ERR_MORE_SURFACE);
  
@@ -1631,7 +1632,12 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
          goto eof;
  
      FF_FILTER_FORWARD_WANTED(outlink, inlink);
-@@ -589,7 +635,96 @@ eof:
+@@ -585,11 +631,101 @@ not_ready:
+     return FFERROR_NOT_READY;
+ 
+ eof:
++    pts = av_rescale_q(pts, inlink->time_base, outlink->time_base);
+     ff_outlink_set_status(outlink, status, pts);
      return 0;
  }
  
@@ -1729,7 +1735,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
  {
      int ret;
      static const enum AVPixelFormat in_pix_fmts[] = {
-@@ -615,46 +750,79 @@ static int query_formats(AVFilterContext
+@@ -615,46 +751,79 @@ static int query_formats(AVFilterContext
                            &ctx->outputs[0]->incfg.formats);
  }
  

--- a/debian/patches/0051-fix-the-empty-output-in-webvtt-transcoding.patch
+++ b/debian/patches/0051-fix-the-empty-output-in-webvtt-transcoding.patch
@@ -1,0 +1,80 @@
+Index: jellyfin-ffmpeg/libavformat/webvttdec.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/webvttdec.c
++++ jellyfin-ffmpeg/libavformat/webvttdec.c
+@@ -60,7 +60,7 @@ static int64_t read_ts(const char *s)
+ static int webvtt_read_header(AVFormatContext *s)
+ {
+     WebVTTContext *webvtt = s->priv_data;
+-    AVBPrint cue;
++    AVBPrint cue, header;
+     int res = 0;
+     AVStream *st = avformat_new_stream(s, NULL);
+ 
+@@ -72,6 +72,7 @@ static int webvtt_read_header(AVFormatCo
+     st->disposition |= webvtt->kind;
+ 
+     av_bprint_init(&cue,    0, AV_BPRINT_SIZE_UNLIMITED);
++    av_bprint_init(&header, 0, AV_BPRINT_SIZE_UNLIMITED);
+ 
+     for (;;) {
+         int i;
+@@ -89,12 +90,18 @@ static int webvtt_read_header(AVFormatCo
+         p = identifier = cue.str;
+         pos = avio_tell(s->pb);
+ 
+-        /* ignore header chunk */
++        /* ignore the magic word and any comments */
+         if (!strncmp(p, "\xEF\xBB\xBFWEBVTT", 9) ||
+             !strncmp(p, "WEBVTT", 6) ||
+             !strncmp(p, "NOTE", 4))
+             continue;
+ 
++        /* store the style and region blocks from the header */
++        if (!strncmp(p, "STYLE", 5) || !strncmp(p, "REGION", 6)) {
++            av_bprintf(&header, "%s%s", header.len ? "\n\n" : "", p);
++            continue;
++        }
++
+         /* optional cue identifier (can be a number like in SRT or some kind of
+          * chaptering id) */
+         for (i = 0; p[i] && p[i] != '\n' && p[i] != '\r'; i++) {
+@@ -161,10 +168,15 @@ static int webvtt_read_header(AVFormatCo
+         SET_SIDE_DATA(settings,   AV_PKT_DATA_WEBVTT_SETTINGS);
+     }
+ 
++    res = ff_bprint_to_codecpar_extradata(st->codecpar, &header);
++    if (res < 0)
++        goto end;
++
+     ff_subtitles_queue_finalize(s, &webvtt->q);
+ 
+ end:
+     av_bprint_finalize(&cue,    NULL);
++    av_bprint_finalize(&header, NULL);
+     return res;
+ }
+ 
+Index: jellyfin-ffmpeg/libavformat/webvttenc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/webvttenc.c
++++ jellyfin-ffmpeg/libavformat/webvttenc.c
+@@ -59,6 +59,18 @@ static int webvtt_write_header(AVFormatC
+ 
+     avio_printf(pb, "WEBVTT\n");
+ 
++    if (par->extradata_size > 0) {
++        size_t header_size = par->extradata_size;
++
++        if (par->extradata[0] != '\n')
++            avio_printf(pb, "\n");
++
++        avio_write(pb, par->extradata, header_size);
++
++        if (par->extradata[header_size - 1] != '\n')
++            avio_printf(pb, "\n");
++    }
++
+     return 0;
+ }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -48,3 +48,4 @@
 0048-add-fixes-for-vaapi-drm-vulkan-tearing.patch
 0049-add-fixes-for-the-incorrect-null-terminator-in-assenc.patch
 0050-skip-loading-plugins-on-vpl-runtime.patch
+0051-fix-the-empty-output-in-webvtt-transcoding.patch

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -256,7 +256,7 @@ prepare_extra_amd64() {
     # Provides MSDK runtime (libmfxhw64.so.1) for 11th Gen Rocket Lake and older
     # Provides MFX dispatcher (libmfx.so.1) for FFmpeg
     pushd ${SOURCE_DIR}
-    git clone -b intel-mediasdk-23.1.2 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK.git
+    git clone -b intel-mediasdk-23.1.3 --depth=1 https://github.com/Intel-Media-SDK/MediaSDK.git
     pushd MediaSDK
     sed -i 's|MFX_PLUGINS_CONF_DIR "/plugins.cfg"|"/usr/lib/jellyfin-ffmpeg/lib/mfx/plugins.cfg"|g' api/mfx_dispatch/linux/mfxloader.cpp
     mkdir build && pushd build
@@ -276,7 +276,7 @@ prepare_extra_amd64() {
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     # Both MSDK and VPL runtime can be loaded by MFX dispatcher (libmfx.so.1)
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-23.1.2 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu.git
+    git clone -b intel-onevpl-23.1.3 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu.git
     pushd oneVPL-intel-gpu
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -290,7 +290,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-23.1.2 --depth=1 https://github.com/intel/media-driver.git
+    git clone -b intel-media-23.1.3 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
     # Possible fix for TGLx timeout caused by 'HCP Scalability Decode' under heavy load
     wget -q -O - https://github.com/intel/media-driver/commit/284750bf.patch | git apply
@@ -345,7 +345,7 @@ prepare_extra_amd64() {
 
     # SHADERC
     pushd ${SOURCE_DIR}
-    git clone -b v2023.2 --depth=1 https://github.com/google/shaderc.git
+    git clone -b v2023.3 --depth=1 https://github.com/google/shaderc.git
     pushd shaderc
     ./utils/git-sync-deps
     mkdir build && pushd build
@@ -374,9 +374,10 @@ prepare_extra_amd64() {
         pushd ${SOURCE_DIR}
         git clone https://gitlab.freedesktop.org/mesa/mesa.git
         pushd mesa
-        git reset --hard "a19a37e8"
-        # fix av1 main nv12 decoding
-        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/39c6f1f5.patch | git apply
+        git reset --hard "10622ccc"
+        # fix building with python 3.8
+        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/044db56a.patch | git apply
+        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/40f89860.patch | git apply
         popd
         # disable the broken hevc packed header
         MESA_VA_PIC="mesa/src/gallium/frontends/va/picture.c"


### PR DESCRIPTION
**Changes**
- Fix an upstream vpp_qsv timestamp issue
- Tune cl compiler options for Intel on Linux
- Fix the empty output in webvtt transcoding
- Fix the font config dirs in portable build
- Update dependencies

**Issues**
Fixes #207 