### PR TITLE
Enable ffplay generation in the ffmpeg build

### DIFF
--- a/debian/jellyfin-ffmpeg6.install
+++ b/debian/jellyfin-ffmpeg6.install
@@ -1,4 +1,5 @@
 ffmpeg usr/lib/jellyfin-ffmpeg
+ffplay usr/lib/jellyfin-ffplay
 ffprobe usr/lib/jellyfin-ffmpeg
 libavcodec/libavcodec.so* usr/lib/jellyfin-ffmpeg/lib
 libavdevice/libavdevice.so* usr/lib/jellyfin-ffmpeg/lib

--- a/debian/rules
+++ b/debian/rules
@@ -10,7 +10,6 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--target-os=linux \
 	--extra-version=Jellyfin \
 	--disable-doc \
-	--disable-ffplay \
 	--disable-ptx-compression \
 	--disable-static \
 	--disable-libxcb \


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
Adds back the `ffplay` generation in the `ffmpeg` build, which was previously disabled. This allows comparison testing of the `jellyfin-ffplay` binary with system `ffplay` builds.
