### PR TITLE
Bump version to 6.0-4

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "6.0-3"
+version: "6.0-4"
 packages:
   - buster-amd64
   - buster-armhf

--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/mingw-w64/mingw-w64.git"
-SCRIPT_COMMIT="d78ef3552df8cdbfd1a275296921787975573d54"
+SCRIPT_COMMIT="d7877cbd2e080ffb77070cc08033efde9e034f13"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/builder/scripts.d/20-libxml2.sh
+++ b/builder/scripts.d/20-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="6273df6c6d84b6be8a62a62abf1d9b79cc2035f8"
+SCRIPT_COMMIT="884474477284474e0151280aaa275a18e3d7a036"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-freetype.sh
+++ b/builder/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
-SCRIPT_COMMIT="7bed7a02f4bfbfe2a47efb4d06b9c02fdb83b758"
+SCRIPT_COMMIT="e4586d960f339cf75e2e0b34aee30a0ed8353c0d"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-gmp.sh
+++ b/builder/scripts.d/25-gmp.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 
-SCRIPT_REPO="https://gmplib.org/repo/gmp/"
-SCRIPT_HGREV="614a1cd8bb1d"
+SCRIPT_VERSION="6.2.1"
+SCRIPT_SHA512="c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84"
+SCRIPT_URL="https://ftp.gnu.org/gnu/gmp/gmp-${SCRIPT_VERSION}.tar.xz"
 
 ffbuild_enabled() {
     return 0
 }
 
 ffbuild_dockerbuild() {
-    retry-tool sh -c "rm -rf gmp && hg clone -r '$SCRIPT_HGREV' -u '$SCRIPT_HGREV' '$SCRIPT_REPO' gmp"
-    cd gmp
+    retry-tool check-wget "gmp.tar.xz" "$SCRIPT_URL" "$SCRIPT_SHA512"
 
-    ./.bootstrap
+    tar xaf "gmp.tar.xz"
+    cd "gmp-$SCRIPT_VERSION"
 
     local myconf=(
         --prefix="$FFBUILD_PREFIX"

--- a/builder/scripts.d/25-xz.sh
+++ b/builder/scripts.d/25-xz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xz-mirror/xz.git"
-SCRIPT_COMMIT="1dbe12b90cff79bb51923733ac0840747b4b4131"
+SCRIPT_COMMIT="dbb3a536ed9873ffa0870321f6873e564c6a9da8"
 
 ffbuild_enabled() {
     return 0
@@ -11,7 +11,7 @@ ffbuild_dockerbuild() {
     git-mini-clone "$SCRIPT_REPO" "$SCRIPT_COMMIT" xz
     cd xz
 
-    ./autogen.sh --no-po4a
+    ./autogen.sh --no-po4a --no-doxygen
 
     local myconf=(
         --prefix="$FFBUILD_PREFIX"

--- a/builder/scripts.d/35-fontconfig.sh
+++ b/builder/scripts.d/35-fontconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
-SCRIPT_COMMIT="ff037052bc27ae1c0e97879fd7333d3afdf2566e"
+SCRIPT_COMMIT="7e2a1b2577e8d90ea5be3f14091e809ac7742438"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="efefec13ccedc1461867544e2066e2042e86c66f"
+SCRIPT_COMMIT="d4bbe3f48663944385f25f608438e1eb678fc4b7"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-x11/10-xproto.sh
+++ b/builder/scripts.d/45-x11/10-xproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xorgproto.git"
-SCRIPT_COMMIT="6b1012c29c2eee95c6ea2ef63b0e5dc628a6cb7f"
+SCRIPT_COMMIT="766967322209f2dcb72e6a8edea0c651f586201d"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/40-libx11.sh
+++ b/builder/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="71b08b8af20474bb704a11affaa8ea39b06d5ddf"
+SCRIPT_COMMIT="ab0442d3fa835ce16559b29532ac7f674f8557f4"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="8b419c16bf1e37bc98044089da58f06824462cb9"
+SCRIPT_COMMIT="2373fda303d46489c1ec269dc66369a31663cb25"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xiph/opus.git"
-SCRIPT_COMMIT="5023249b5c935545fb02dbfe845cae996ecfc8bb"
+SCRIPT_COMMIT="9fc8fc4cf432640f284113ba502ee027268b0d9f"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="575bd73f6118a88c5a0cf1d27a8ec9b5bda8c278"
+SCRIPT_COMMIT="14e52008edbf2e91386423fdd53310fe49654991"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="46bc4fc9d981b1760def26dd64b9c80ccbad9f6f"
+SCRIPT_COMMIT="08d60d60066eb30ab8e0e3ccfa0cd0b68f8cccc6"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-openmpt.sh
+++ b/builder/scripts.d/50-openmpt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://source.openmpt.org/svn/openmpt/trunk/OpenMPT"
-SCRIPT_REV="19366"
+SCRIPT_REV="19439"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="3cefedefe91fca543083d260d1ed32efd2e7cba5"
+SCRIPT_COMMIT="9448e26fcd7602098b4bf9cd7fe535136e89e10b"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-svtav1.sh
+++ b/builder/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="6f3651c76d30c7564f9cbd2db8523a5bbaf2cee1"
+SCRIPT_COMMIT="08c18ba0768ed3dbbff0903adc326fb3a7549bd9"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/builder/scripts.d/50-vaapi/50-libva.sh
+++ b/builder/scripts.d/50-vaapi/50-libva.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libva.git"
-SCRIPT_COMMIT="f4c4c0370df2b756bd201f25b1ed7942475d44e0"
+SCRIPT_COMMIT="1c58941b93ba5013c68e8370a408efd630275c9c"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/50-shaderc.sh
+++ b/builder/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
-SCRIPT_COMMIT="4dc596ddc2702092c670e828745dc3e0338d83c1"
+SCRIPT_COMMIT="e31c4c2e41544d63d90be28c46e4a4793a624240"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="12542fc6fc05000e04742daf93892a0b10edbe80"
+SCRIPT_COMMIT="2d3a152081ca6e6bea7093940d0f81088fe4d01c"
 
 ffbuild_enabled() {
     return 0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+jellyfin-ffmpeg (6.0-4) unstable; urgency=medium
+
+  * Allow VA-API import DRM prime2 planar formats
+  * Fix the slow VPP tone-mapping on ADL-S and ADL-N
+  * Fix a potential memory leak in QSV
+  * Refine VA-API AV1 encoder
+  * Update queued fixes from upstream
+  * Update dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Thu, 15 Jun 2023 23:10:39 +0800
+
 jellyfin-ffmpeg (6.0-3) unstable; urgency=medium
 
   * Add AV1 VA-API encoder from upstream intel

--- a/debian/patches/0049-add-queued-key-fixes-from-upstream.patch
+++ b/debian/patches/0049-add-queued-key-fixes-from-upstream.patch
@@ -1,90 +1,16 @@
-Index: jellyfin-ffmpeg/libavcodec/nvenc.c
+Index: jellyfin-ffmpeg/fftools/ffmpeg_mux_init.c
 ===================================================================
---- jellyfin-ffmpeg.orig/libavcodec/nvenc.c
-+++ jellyfin-ffmpeg/libavcodec/nvenc.c
-@@ -178,6 +178,8 @@ static void reorder_queue_flush(AVFifo *
- {
-     FrameData fd;
+--- jellyfin-ffmpeg.orig/fftools/ffmpeg_mux_init.c
++++ jellyfin-ffmpeg/fftools/ffmpeg_mux_init.c
+@@ -2063,7 +2063,7 @@ static void parse_forced_key_frames(Keyf
+         if (next)
+             *next++ = 0;
  
-+    av_assert0(queue);
-+
-     while (av_fifo_read(queue, &fd, 1) >= 0)
-         av_buffer_unref(&fd.frame_opaque_ref);
- }
-@@ -1853,8 +1855,11 @@ av_cold int ff_nvenc_encode_close(AVCode
-         p_nvenc->nvEncEncodePicture(ctx->nvencoder, &params);
-     }
- 
--    reorder_queue_flush(ctx->reorder_queue);
--    av_fifo_freep2(&ctx->reorder_queue);
-+    if (ctx->reorder_queue) {
-+        reorder_queue_flush(ctx->reorder_queue);
-+        av_fifo_freep2(&ctx->reorder_queue);
-+    }
-+
-     av_fifo_freep2(&ctx->output_surface_ready_queue);
-     av_fifo_freep2(&ctx->output_surface_queue);
-     av_fifo_freep2(&ctx->unused_surface_queue);
-Index: jellyfin-ffmpeg/libavfilter/graphparser.c
-===================================================================
---- jellyfin-ffmpeg.orig/libavfilter/graphparser.c
-+++ jellyfin-ffmpeg/libavfilter/graphparser.c
-@@ -532,8 +532,7 @@ int avfilter_graph_segment_create_filter
-         for (size_t j = 0; j < ch->nb_filters; j++) {
-             AVFilterParams *p = ch->filters[j];
-             const AVFilter *f = avfilter_get_by_name(p->filter_name);
--            char inst_name[30], *name = p->instance_name ? p->instance_name :
--                                                           inst_name;
-+            char name[64];
- 
-             // skip already processed filters
-             if (p->filter || !p->filter_name)
-@@ -546,7 +545,9 @@ int avfilter_graph_segment_create_filter
-             }
- 
-             if (!p->instance_name)
--                snprintf(inst_name, sizeof(inst_name), "Parsed_%s_%zu", f->name, idx);
-+                snprintf(name, sizeof(name), "Parsed_%s_%zu", f->name, idx);
-+            else
-+                snprintf(name, sizeof(name), "%s@%s", f->name, p->instance_name);
- 
-             p->filter = avfilter_graph_alloc_filter(seg->graph, f, name);
-             if (!p->filter)
-Index: jellyfin-ffmpeg/libavcodec/nvenc.c
-===================================================================
---- jellyfin-ffmpeg.orig/libavcodec/nvenc.c
-+++ jellyfin-ffmpeg/libavcodec/nvenc.c
-@@ -461,7 +461,7 @@ static int nvenc_check_cap(AVCodecContex
- static int nvenc_check_capabilities(AVCodecContext *avctx)
- {
-     NvencContext *ctx = avctx->priv_data;
--    int ret;
-+    int tmp, ret;
- 
-     ret = nvenc_check_codec_support(avctx);
-     if (ret < 0) {
-@@ -542,16 +542,18 @@ static int nvenc_check_capabilities(AVCo
-     }
- 
- #ifdef NVENC_HAVE_BFRAME_REF_MODE
-+    tmp = (ctx->b_ref_mode >= 0) ? ctx->b_ref_mode : NV_ENC_BFRAME_REF_MODE_DISABLED;
-     ret = nvenc_check_cap(avctx, NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE);
--    if (ctx->b_ref_mode == NV_ENC_BFRAME_REF_MODE_EACH && ret != 1 && ret != 3) {
-+    if (tmp == NV_ENC_BFRAME_REF_MODE_EACH && ret != 1 && ret != 3) {
-         av_log(avctx, AV_LOG_WARNING, "Each B frame as reference is not supported\n");
-         return AVERROR(ENOSYS);
--    } else if (ctx->b_ref_mode != NV_ENC_BFRAME_REF_MODE_DISABLED && ret == 0) {
-+    } else if (tmp != NV_ENC_BFRAME_REF_MODE_DISABLED && ret == 0) {
-         av_log(avctx, AV_LOG_WARNING, "B frames as references are not supported\n");
-         return AVERROR(ENOSYS);
-     }
- #else
--    if (ctx->b_ref_mode != 0) {
-+    tmp = (ctx->b_ref_mode >= 0) ? ctx->b_ref_mode : 0;
-+    if (tmp > 0) {
-         av_log(avctx, AV_LOG_WARNING, "B frames as references need SDK 8.1 at build time\n");
-         return AVERROR(ENOSYS);
-     }
+-        if (!memcmp(p, "chapters", 8)) {
++        if (strstr(p, "chapters") == p) {
+             AVChapter * const *ch = mux->fc->chapters;
+             unsigned int    nb_ch = mux->fc->nb_chapters;
+             int j;
 Index: jellyfin-ffmpeg/libavcodec/decode.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavcodec/decode.c
@@ -116,16 +42,456 @@ Index: jellyfin-ffmpeg/libavcodec/decode.c
      }
  #if FF_API_REORDERED_OPAQUE
  FF_DISABLE_DEPRECATION_WARNINGS
-Index: jellyfin-ffmpeg/fftools/ffmpeg_mux_init.c
+Index: jellyfin-ffmpeg/libavcodec/nvdec_mpeg12.c
 ===================================================================
---- jellyfin-ffmpeg.orig/fftools/ffmpeg_mux_init.c
-+++ jellyfin-ffmpeg/fftools/ffmpeg_mux_init.c
-@@ -2063,7 +2063,7 @@ static void parse_forced_key_frames(Keyf
-         if (next)
-             *next++ = 0;
+--- jellyfin-ffmpeg.orig/libavcodec/nvdec_mpeg12.c
++++ jellyfin-ffmpeg/libavcodec/nvdec_mpeg12.c
+@@ -83,8 +83,9 @@ static int nvdec_mpeg12_start_frame(AVCo
+     };
  
--        if (!memcmp(p, "chapters", 8)) {
-+        if (strstr(p, "chapters") == p) {
-             AVChapter * const *ch = mux->fc->chapters;
-             unsigned int    nb_ch = mux->fc->nb_chapters;
-             int j;
+     for (i = 0; i < 64; ++i) {
+-        ppc->QuantMatrixIntra[i] = s->intra_matrix[i];
+-        ppc->QuantMatrixInter[i] = s->inter_matrix[i];
++        int n = s->idsp.idct_permutation[i];
++        ppc->QuantMatrixIntra[i] = s->intra_matrix[n];
++        ppc->QuantMatrixInter[i] = s->inter_matrix[n];
+     }
+ 
+     return 0;
+Index: jellyfin-ffmpeg/libavcodec/nvdec_mpeg4.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/nvdec_mpeg4.c
++++ jellyfin-ffmpeg/libavcodec/nvdec_mpeg4.c
+@@ -88,8 +88,9 @@ static int nvdec_mpeg4_start_frame(AVCod
+     };
+ 
+     for (i = 0; i < 64; ++i) {
+-        ppc->QuantMatrixIntra[i] = s->intra_matrix[i];
+-        ppc->QuantMatrixInter[i] = s->inter_matrix[i];
++        int n = s->idsp.idct_permutation[i];
++        ppc->QuantMatrixIntra[i] = s->intra_matrix[n];
++        ppc->QuantMatrixInter[i] = s->inter_matrix[n];
+     }
+ 
+     // We need to pass the full frame buffer and not just the slice
+Index: jellyfin-ffmpeg/libavcodec/nvenc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/nvenc.c
++++ jellyfin-ffmpeg/libavcodec/nvenc.c
+@@ -29,7 +29,6 @@
+ #include "av1.h"
+ #endif
+ 
+-#include "libavutil/buffer.h"
+ #include "libavutil/hwcontext_cuda.h"
+ #include "libavutil/hwcontext.h"
+ #include "libavutil/cuda_check.h"
+@@ -165,25 +164,6 @@ static int nvenc_print_error(AVCodecCont
+     return ret;
+ }
+ 
+-typedef struct FrameData {
+-    int64_t pts;
+-    int64_t duration;
+-#if FF_API_REORDERED_OPAQUE
+-    int64_t reordered_opaque;
+-#endif
+-
+-    void        *frame_opaque;
+-    AVBufferRef *frame_opaque_ref;
+-} FrameData;
+-
+-static void reorder_queue_flush(AVFifo *queue)
+-{
+-    FrameData fd;
+-
+-    while (av_fifo_read(queue, &fd, 1) >= 0)
+-        av_buffer_unref(&fd.frame_opaque_ref);
+-}
+-
+ typedef struct GUIDTuple {
+     const GUID guid;
+     int flags;
+@@ -459,7 +439,7 @@ static int nvenc_check_cap(AVCodecContex
+ static int nvenc_check_capabilities(AVCodecContext *avctx)
+ {
+     NvencContext *ctx = avctx->priv_data;
+-    int ret;
++    int tmp, ret;
+ 
+     ret = nvenc_check_codec_support(avctx);
+     if (ret < 0) {
+@@ -540,16 +520,18 @@ static int nvenc_check_capabilities(AVCo
+     }
+ 
+ #ifdef NVENC_HAVE_BFRAME_REF_MODE
++    tmp = (ctx->b_ref_mode >= 0) ? ctx->b_ref_mode : NV_ENC_BFRAME_REF_MODE_DISABLED;
+     ret = nvenc_check_cap(avctx, NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE);
+-    if (ctx->b_ref_mode == NV_ENC_BFRAME_REF_MODE_EACH && ret != 1 && ret != 3) {
++    if (tmp == NV_ENC_BFRAME_REF_MODE_EACH && ret != 1 && ret != 3) {
+         av_log(avctx, AV_LOG_WARNING, "Each B frame as reference is not supported\n");
+         return AVERROR(ENOSYS);
+-    } else if (ctx->b_ref_mode != NV_ENC_BFRAME_REF_MODE_DISABLED && ret == 0) {
++    } else if (tmp != NV_ENC_BFRAME_REF_MODE_DISABLED && ret == 0) {
+         av_log(avctx, AV_LOG_WARNING, "B frames as references are not supported\n");
+         return AVERROR(ENOSYS);
+     }
+ #else
+-    if (ctx->b_ref_mode != 0) {
++    tmp = (ctx->b_ref_mode >= 0) ? ctx->b_ref_mode : 0;
++    if (tmp > 0) {
+         av_log(avctx, AV_LOG_WARNING, "B frames as references need SDK 8.1 at build time\n");
+         return AVERROR(ENOSYS);
+     }
+@@ -982,6 +964,10 @@ static av_cold int nvenc_recalc_surfaces
+     ctx->nb_surfaces = FFMAX(1, FFMIN(MAX_REGISTERED_FRAMES, ctx->nb_surfaces));
+     ctx->async_depth = FFMIN(ctx->async_depth, ctx->nb_surfaces - 1);
+ 
++    // Output in the worst case will only start when the surface buffer is completely full.
++    // Hence we need to keep at least the max amount of surfaces plus the max reorder delay around.
++    ctx->frame_data_array_nb = ctx->nb_surfaces + ctx->encode_config.frameIntervalP - 1;
++
+     return 0;
+ }
+ 
+@@ -1770,8 +1756,12 @@ static av_cold int nvenc_setup_surfaces(
+     if (!ctx->surfaces)
+         return AVERROR(ENOMEM);
+ 
+-    ctx->reorder_queue = av_fifo_alloc2(ctx->nb_surfaces, sizeof(FrameData), 0);
+-    if (!ctx->reorder_queue)
++    ctx->frame_data_array = av_calloc(ctx->frame_data_array_nb, sizeof(*ctx->frame_data_array));
++    if (!ctx->frame_data_array)
++        return AVERROR(ENOMEM);
++
++    ctx->timestamp_list = av_fifo_alloc2(ctx->nb_surfaces, sizeof(int64_t), 0);
++    if (!ctx->timestamp_list)
+         return AVERROR(ENOMEM);
+ 
+     ctx->unused_surface_queue = av_fifo_alloc2(ctx->nb_surfaces, sizeof(NvencSurface*), 0);
+@@ -1855,12 +1845,17 @@ av_cold int ff_nvenc_encode_close(AVCode
+         p_nvenc->nvEncEncodePicture(ctx->nvencoder, &params);
+     }
+ 
+-    reorder_queue_flush(ctx->reorder_queue);
+-    av_fifo_freep2(&ctx->reorder_queue);
++    av_fifo_freep2(&ctx->timestamp_list);
+     av_fifo_freep2(&ctx->output_surface_ready_queue);
+     av_fifo_freep2(&ctx->output_surface_queue);
+     av_fifo_freep2(&ctx->unused_surface_queue);
+ 
++    if (ctx->frame_data_array) {
++        for (i = 0; i < ctx->nb_surfaces; i++)
++            av_buffer_unref(&ctx->frame_data_array[i].frame_opaque_ref);
++        av_freep(&ctx->frame_data_array);
++    }
++
+     if (ctx->surfaces && (avctx->pix_fmt == AV_PIX_FMT_CUDA || avctx->pix_fmt == AV_PIX_FMT_D3D11)) {
+         for (i = 0; i < ctx->nb_registered_frames; i++) {
+             if (ctx->registered_frames[i].mapped)
+@@ -2200,73 +2195,95 @@ static void nvenc_codec_specific_pic_par
+     }
+ }
+ 
+-static void reorder_queue_enqueue(AVFifo *queue, const AVCodecContext *avctx,
+-                                  const AVFrame *frame, AVBufferRef **opaque_ref)
++static inline void timestamp_queue_enqueue(AVFifo *queue, int64_t timestamp)
+ {
+-    FrameData fd;
++    av_fifo_write(queue, &timestamp, 1);
++}
+ 
+-    fd.pts              = frame->pts;
+-    fd.duration         = frame->duration;
+-#if FF_API_REORDERED_OPAQUE
+-FF_DISABLE_DEPRECATION_WARNINGS
+-    fd.reordered_opaque = frame->reordered_opaque;
+-FF_ENABLE_DEPRECATION_WARNINGS
+-#endif
+-    fd.frame_opaque     = frame->opaque;
+-    fd.frame_opaque_ref = *opaque_ref;
++static inline int64_t timestamp_queue_dequeue(AVFifo *queue)
++{
++    int64_t timestamp = AV_NOPTS_VALUE;
++    // The following call might fail if the queue is empty.
++    av_fifo_read(queue, &timestamp, 1);
+ 
+-    *opaque_ref = NULL;
++    return timestamp;
++}
++
++static int nvenc_set_timestamp(AVCodecContext *avctx,
++                               NV_ENC_LOCK_BITSTREAM *params,
++                               AVPacket *pkt)
++{
++    NvencContext *ctx = avctx->priv_data;
++
++    pkt->pts = params->outputTimeStamp;
++
++    if (avctx->codec_descriptor->props & AV_CODEC_PROP_REORDER) {
++        pkt->dts = timestamp_queue_dequeue(ctx->timestamp_list) -
++            FFMAX(ctx->encode_config.frameIntervalP - 1, 0) * FFMAX(avctx->ticks_per_frame, 1);
++    } else {
++        pkt->dts = pkt->pts;
++    }
+ 
+-    av_fifo_write(queue, &fd, 1);
++    return 0;
+ }
+ 
+-static int64_t reorder_queue_dequeue(AVFifo *queue, AVCodecContext *avctx,
+-                                     AVPacket *pkt)
++static int nvenc_store_frame_data(AVCodecContext *avctx, NV_ENC_PIC_PARAMS *pic_params, const AVFrame *frame)
+ {
+-    FrameData fd;
++    NvencContext *ctx = avctx->priv_data;
++    int res = 0;
+ 
+-    // The following call might fail if the queue is empty.
+-    if (av_fifo_read(queue, &fd, 1) < 0)
+-        return AV_NOPTS_VALUE;
++    int idx = ctx->frame_data_array_pos;
++    NvencFrameData *frame_data = &ctx->frame_data_array[idx];
++
++    // in case the encoder got reconfigured, there might be leftovers
++    av_buffer_unref(&frame_data->frame_opaque_ref);
++
++    if (frame && frame->opaque_ref && avctx->flags & AV_CODEC_FLAG_COPY_OPAQUE) {
++        frame_data->frame_opaque_ref = av_buffer_ref(frame->opaque_ref);
++        if (!frame_data->frame_opaque_ref)
++            return AVERROR(ENOMEM);
++    }
++
++    frame_data->duration = frame->duration;
++    frame_data->frame_opaque = frame->opaque;
+ 
+-    if (pkt) {
+ #if FF_API_REORDERED_OPAQUE
+ FF_DISABLE_DEPRECATION_WARNINGS
+-        avctx->reordered_opaque = fd.reordered_opaque;
++    frame_data->reordered_opaque = frame->reordered_opaque;
+ FF_ENABLE_DEPRECATION_WARNINGS
+ #endif
+-        pkt->duration           = fd.duration;
+ 
+-        if (avctx->flags & AV_CODEC_FLAG_COPY_OPAQUE) {
+-            pkt->opaque             = fd.frame_opaque;
+-            pkt->opaque_ref         = fd.frame_opaque_ref;
+-            fd.frame_opaque_ref     = NULL;
+-        }
+-    }
++    ctx->frame_data_array_pos = (ctx->frame_data_array_pos + 1) % ctx->frame_data_array_nb;
++    pic_params->inputDuration = idx;
+ 
+-    av_buffer_unref(&fd.frame_opaque_ref);
+-
+-    return fd.pts;
++    return res;
+ }
+ 
+-static int nvenc_set_timestamp(AVCodecContext *avctx,
+-                               NV_ENC_LOCK_BITSTREAM *params,
+-                               AVPacket *pkt)
++static int nvenc_retrieve_frame_data(AVCodecContext *avctx, NV_ENC_LOCK_BITSTREAM *lock_params, AVPacket *pkt)
+ {
+     NvencContext *ctx = avctx->priv_data;
+-    int64_t dts;
++    int res = 0;
+ 
+-    pkt->pts = params->outputTimeStamp;
++    int idx = lock_params->outputDuration;
++    NvencFrameData *frame_data = &ctx->frame_data_array[idx];
+ 
+-    dts = reorder_queue_dequeue(ctx->reorder_queue, avctx, pkt);
++    pkt->duration = frame_data->duration;
+ 
+-    if (avctx->codec_descriptor->props & AV_CODEC_PROP_REORDER) {
+-        pkt->dts = dts - FFMAX(ctx->encode_config.frameIntervalP - 1, 0) * FFMAX(avctx->ticks_per_frame, 1);
+-    } else {
+-        pkt->dts = pkt->pts;
++#if FF_API_REORDERED_OPAQUE
++FF_DISABLE_DEPRECATION_WARNINGS
++    avctx->reordered_opaque = frame_data->reordered_opaque;
++FF_ENABLE_DEPRECATION_WARNINGS
++#endif
++
++    if (avctx->flags & AV_CODEC_FLAG_COPY_OPAQUE) {
++        pkt->opaque = frame_data->frame_opaque;
++        pkt->opaque_ref = frame_data->frame_opaque_ref;
++        frame_data->frame_opaque_ref = NULL;
+     }
+ 
+-    return 0;
++    av_buffer_unref(&frame_data->frame_opaque_ref);
++
++    return res;
+ }
+ 
+ static int process_output_surface(AVCodecContext *avctx, AVPacket *pkt, NvencSurface *tmpoutsurf)
+@@ -2355,10 +2372,14 @@ static int process_output_surface(AVCode
+     if (res < 0)
+         goto error2;
+ 
++    res = nvenc_retrieve_frame_data(avctx, &lock_params, pkt);
++    if (res < 0)
++        goto error2;
++
+     return 0;
+ 
+ error:
+-    reorder_queue_dequeue(ctx->reorder_queue, avctx, NULL);
++    timestamp_queue_dequeue(ctx->timestamp_list);
+ 
+ error2:
+     return res;
+@@ -2662,8 +2683,6 @@ static int nvenc_send_frame(AVCodecConte
+     int sei_count = 0;
+     int i;
+ 
+-    AVBufferRef *opaque_ref = NULL;
+-
+     NvencContext *ctx = avctx->priv_data;
+     NvencDynLoadFunctions *dl_fn = &ctx->nvenc_dload_funcs;
+     NV_ENCODE_API_FUNCTION_LIST *p_nvenc = &dl_fn->nvenc_funcs;
+@@ -2726,22 +2745,18 @@ static int nvenc_send_frame(AVCodecConte
+             sei_count = res;
+         }
+ 
++        res = nvenc_store_frame_data(avctx, &pic_params, frame);
++        if (res < 0)
++            return res;
++
+         nvenc_codec_specific_pic_params(avctx, &pic_params, ctx->sei_data, sei_count);
+     } else {
+         pic_params.encodePicFlags = NV_ENC_PIC_FLAG_EOS;
+     }
+ 
+-    // make a reference for enqueing in the reorder queue here,
+-    // so that reorder_queue_enqueue() cannot fail
+-    if (frame && frame->opaque_ref && avctx->flags & AV_CODEC_FLAG_COPY_OPAQUE) {
+-        opaque_ref = av_buffer_ref(frame->opaque_ref);
+-        if (!opaque_ref)
+-            return AVERROR(ENOMEM);
+-    }
+-
+     res = nvenc_push_context(avctx);
+     if (res < 0)
+-        goto opaque_ref_fail;
++        return res;
+ 
+     nv_status = p_nvenc->nvEncEncodePicture(ctx->nvencoder, &pic_params);
+ 
+@@ -2750,17 +2765,17 @@ static int nvenc_send_frame(AVCodecConte
+ 
+     res = nvenc_pop_context(avctx);
+     if (res < 0)
+-        goto opaque_ref_fail;
++        return res;
+ 
+     if (nv_status != NV_ENC_SUCCESS &&
+-        nv_status != NV_ENC_ERR_NEED_MORE_INPUT) {
+-        res = nvenc_print_error(avctx, nv_status, "EncodePicture failed!");
+-        goto opaque_ref_fail;
+-    }
++        nv_status != NV_ENC_ERR_NEED_MORE_INPUT)
++        return nvenc_print_error(avctx, nv_status, "EncodePicture failed!");
+ 
+     if (frame && frame->buf[0]) {
+         av_fifo_write(ctx->output_surface_queue, &in_surf, 1);
+-        reorder_queue_enqueue(ctx->reorder_queue, avctx, frame, &opaque_ref);
++
++        if (avctx->codec_descriptor->props & AV_CODEC_PROP_REORDER)
++            timestamp_queue_enqueue(ctx->timestamp_list, frame->pts);
+     }
+ 
+     /* all the pending buffers are now ready for output */
+@@ -2770,10 +2785,6 @@ static int nvenc_send_frame(AVCodecConte
+     }
+ 
+     return 0;
+-
+-opaque_ref_fail:
+-    av_buffer_unref(&opaque_ref);
+-    return res;
+ }
+ 
+ int ff_nvenc_receive_packet(AVCodecContext *avctx, AVPacket *pkt)
+@@ -2832,5 +2843,5 @@ av_cold void ff_nvenc_encode_flush(AVCod
+     NvencContext *ctx = avctx->priv_data;
+ 
+     nvenc_send_frame(avctx, NULL);
+-    reorder_queue_flush(ctx->reorder_queue);
++    av_fifo_reset2(ctx->timestamp_list);
+ }
+Index: jellyfin-ffmpeg/libavcodec/nvenc.h
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/nvenc.h
++++ jellyfin-ffmpeg/libavcodec/nvenc.h
+@@ -31,6 +31,7 @@ typedef void ID3D11Device;
+ #include <ffnvcodec/nvEncodeAPI.h>
+ 
+ #include "compat/cuda/dynlink_loader.h"
++#include "libavutil/buffer.h"
+ #include "libavutil/fifo.h"
+ #include "libavutil/opt.h"
+ #include "hwconfig.h"
+@@ -90,6 +91,18 @@ typedef struct NvencSurface
+     NV_ENC_BUFFER_FORMAT format;
+ } NvencSurface;
+ 
++typedef struct NvencFrameData
++{
++    int64_t duration;
++
++#if FF_API_REORDERED_OPAQUE
++    int64_t reordered_opaque;
++#endif
++
++    void        *frame_opaque;
++    AVBufferRef *frame_opaque_ref;
++} NvencFrameData;
++
+ typedef struct NvencDynLoadFunctions
+ {
+     CudaFunctions *cuda_dl;
+@@ -168,10 +181,14 @@ typedef struct NvencContext
+     int nb_surfaces;
+     NvencSurface *surfaces;
+ 
++    NvencFrameData *frame_data_array;
++    int frame_data_array_nb;
++    int frame_data_array_pos;
++
+     AVFifo *unused_surface_queue;
+     AVFifo *output_surface_queue;
+     AVFifo *output_surface_ready_queue;
+-    AVFifo *reorder_queue;
++    AVFifo *timestamp_list;
+ 
+     NV_ENC_SEI_PAYLOAD *sei_data;
+     int sei_data_size;
+Index: jellyfin-ffmpeg/libavfilter/graphparser.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/graphparser.c
++++ jellyfin-ffmpeg/libavfilter/graphparser.c
+@@ -532,8 +532,7 @@ int avfilter_graph_segment_create_filter
+         for (size_t j = 0; j < ch->nb_filters; j++) {
+             AVFilterParams *p = ch->filters[j];
+             const AVFilter *f = avfilter_get_by_name(p->filter_name);
+-            char inst_name[30], *name = p->instance_name ? p->instance_name :
+-                                                           inst_name;
++            char name[64];
+ 
+             // skip already processed filters
+             if (p->filter || !p->filter_name)
+@@ -546,7 +545,9 @@ int avfilter_graph_segment_create_filter
+             }
+ 
+             if (!p->instance_name)
+-                snprintf(inst_name, sizeof(inst_name), "Parsed_%s_%zu", f->name, idx);
++                snprintf(name, sizeof(name), "Parsed_%s_%zu", f->name, idx);
++            else
++                snprintf(name, sizeof(name), "%s@%s", f->name, p->instance_name);
+ 
+             p->filter = avfilter_graph_alloc_filter(seg->graph, f, name);
+             if (!p->filter)

--- a/debian/patches/0051-add-av1-vaapi-encoder-from-upstream-intel.patch
+++ b/debian/patches/0051-add-av1-vaapi-encoder-from-upstream-intel.patch
@@ -300,7 +300,9 @@ Index: jellyfin-ffmpeg/libavcodec/vaapi_encode.c
 +            if (err < 0)
 +                goto fail_mapped;
 +            ptr = pkt->data;
-+
+ 
+-    if (err < 0)
+-        goto fail_mapped;
 +            if (ctx->header_data_size) {
 +                memcpy(ptr, ctx->header_data, ctx->header_data_size);
 +                ptr += ctx->header_data_size;
@@ -320,9 +322,7 @@ Index: jellyfin-ffmpeg/libavcodec/vaapi_encode.c
 +                    err = AVERROR(AVERROR_BUG);
 +                    goto fail_mapped;
 +                }
- 
--    if (err < 0)
--        goto fail_mapped;
++
 +                err = ff_get_encode_buffer(avctx, ctx->tail_pkt, pic->tail_size, 0);
 +                if (err < 0)
 +                    goto fail_mapped;
@@ -454,18 +454,20 @@ Index: jellyfin-ffmpeg/libavcodec/vaapi_encode.c
  static av_cold void vaapi_encode_add_global_param(AVCodecContext *avctx, int type,
                                                    void *buffer, size_t size)
  {
-@@ -2597,6 +2671,10 @@ av_cold int ff_vaapi_encode_init(AVCodec
+@@ -2597,6 +2671,12 @@ av_cold int ff_vaapi_encode_init(AVCodec
      ctx->device = (AVHWDeviceContext*)ctx->device_ref->data;
      ctx->hwctx = ctx->device->hwctx;
  
 +    ctx->tail_pkt = av_packet_alloc();
-+    if (!ctx->tail_pkt)
++    if (!ctx->tail_pkt) {
++        err = AVERROR(ENOMEM);
 +        goto fail;
++    }
 +
      err = vaapi_encode_profile_entrypoint(avctx);
      if (err < 0)
          goto fail;
-@@ -2789,9 +2867,11 @@ av_cold int ff_vaapi_encode_close(AVCode
+@@ -2789,9 +2869,11 @@ av_cold int ff_vaapi_encode_close(AVCode
      }
  
      av_frame_free(&ctx->frame);

--- a/debian/patches/0052-backport-upstream-qsvenc-fixes.patch
+++ b/debian/patches/0052-backport-upstream-qsvenc-fixes.patch
@@ -139,3 +139,116 @@ Index: jellyfin-ffmpeg/libavcodec/qsvenc.c
                  if (ret < 0)
                      return ret;
              }
+Index: jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_qsv.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+@@ -663,6 +663,7 @@ static mfxStatus frame_get_hdl(mfxHDL pt
+ 
+ static int qsv_d3d11_update_config(void *ctx, mfxHDL handle, mfxConfig cfg)
+ {
++    int ret = AVERROR_UNKNOWN;
+ #if CONFIG_D3D11VA
+     mfxStatus sts;
+     IDXGIAdapter *pDXGIAdapter;
+@@ -677,7 +678,8 @@ static int qsv_d3d11_update_config(void
+         hr = IDXGIDevice_GetAdapter(pDXGIDevice, &pDXGIAdapter);
+         if (FAILED(hr)) {
+             av_log(ctx, AV_LOG_ERROR, "Error IDXGIDevice_GetAdapter %d\n", hr);
+-            goto fail;
++            IDXGIDevice_Release(pDXGIDevice);
++            return ret;
+         }
+ 
+         hr = IDXGIAdapter_GetDesc(pDXGIAdapter, &adapterDesc);
+@@ -687,7 +689,7 @@ static int qsv_d3d11_update_config(void
+         }
+     } else {
+         av_log(ctx, AV_LOG_ERROR, "Error ID3D11Device_QueryInterface %d\n", hr);
+-        goto fail;
++        return ret;
+     }
+ 
+     impl_value.Type = MFX_VARIANT_TYPE_U16;
+@@ -720,11 +722,13 @@ static int qsv_d3d11_update_config(void
+         goto fail;
+     }
+ 
+-    return 0;
++    ret = 0;
+ 
+ fail:
++    IDXGIAdapter_Release(pDXGIAdapter);
++    IDXGIDevice_Release(pDXGIDevice);
+ #endif
+-    return AVERROR_UNKNOWN;
++    return ret;
+ }
+ 
+ static int qsv_d3d9_update_config(void *ctx, mfxHDL handle, mfxConfig cfg)
+@@ -750,25 +754,28 @@ static int qsv_d3d9_update_config(void *
+     hr = IDirect3DDeviceManager9_LockDevice(devmgr, device_handle, &device, TRUE);
+     if (FAILED(hr)) {
+         av_log(ctx, AV_LOG_ERROR, "Error LockDevice %d\n", hr);
++        IDirect3DDeviceManager9_CloseDeviceHandle(devmgr, device_handle);
+         goto fail;
+     }
+ 
+     hr = IDirect3DDevice9Ex_GetCreationParameters(device, &params);
+     if (FAILED(hr)) {
+         av_log(ctx, AV_LOG_ERROR, "Error IDirect3DDevice9_GetCreationParameters %d\n", hr);
++        IDirect3DDevice9Ex_Release(device);
+         goto unlock;
+     }
+ 
+     hr = IDirect3DDevice9Ex_GetDirect3D(device, &d3d9ex);
+     if (FAILED(hr)) {
+         av_log(ctx, AV_LOG_ERROR, "Error IDirect3DDevice9Ex_GetAdapterLUID %d\n", hr);
++        IDirect3DDevice9Ex_Release(device);
+         goto unlock;
+     }
+ 
+     hr = IDirect3D9Ex_GetAdapterLUID(d3d9ex, params.AdapterOrdinal, &luid);
+     if (FAILED(hr)) {
+         av_log(ctx, AV_LOG_ERROR, "Error IDirect3DDevice9Ex_GetAdapterLUID %d\n", hr);
+-        goto unlock;
++        goto release;
+     }
+ 
+     impl_value.Type = MFX_VARIANT_TYPE_PTR;
+@@ -778,13 +785,18 @@ static int qsv_d3d9_update_config(void *
+     if (sts != MFX_ERR_NONE) {
+         av_log(ctx, AV_LOG_ERROR, "Error adding a MFX configuration"
+                "DeviceLUID property: %d.\n", sts);
+-        goto unlock;
++        goto release;
+     }
+ 
+     ret = 0;
+ 
++release:
++    IDirect3D9Ex_Release(d3d9ex);
++    IDirect3DDevice9Ex_Release(device);
++
+ unlock:
+     IDirect3DDeviceManager9_UnlockDevice(devmgr, device_handle, FALSE);
++    IDirect3DDeviceManager9_CloseDeviceHandle(devmgr, device_handle);
+ fail:
+ #endif
+     return ret;
+@@ -2187,6 +2199,15 @@ static int qsv_device_derive(AVHWDeviceC
+                              AVDictionary *opts, int flags)
+ {
+     mfxIMPL impl;
++    QSVDevicePriv *priv;
++
++    priv = av_mallocz(sizeof(*priv));
++    if (!priv)
++        return AVERROR(ENOMEM);
++
++    ctx->user_opaque = priv;
++    ctx->free = qsv_device_free;
++
+     impl = choose_implementation("hw_any", child_device_ctx->type);
+     return qsv_device_derive_from_child(ctx, impl,
+                                         child_device_ctx, flags);

--- a/debian/patches/0053-allow-vaapi-import-drm-prime2-planar-formats.patch
+++ b/debian/patches/0053-allow-vaapi-import-drm-prime2-planar-formats.patch
@@ -1,0 +1,55 @@
+Index: jellyfin-ffmpeg/libavutil/hwcontext_vaapi.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_vaapi.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_vaapi.c
+@@ -1021,9 +1021,11 @@ static const struct {
+     DRM_MAP(NV12, 1, DRM_FORMAT_NV12),
+ #if defined(VA_FOURCC_P010) && defined(DRM_FORMAT_R16)
+     DRM_MAP(P010, 2, DRM_FORMAT_R16, DRM_FORMAT_RG1616),
++    DRM_MAP(P010, 2, DRM_FORMAT_R16, DRM_FORMAT_GR1616),
+ #endif
+ #if defined(VA_FOURCC_P012) && defined(DRM_FORMAT_R16)
+     DRM_MAP(P012, 2, DRM_FORMAT_R16, DRM_FORMAT_RG1616),
++    DRM_MAP(P012, 2, DRM_FORMAT_R16, DRM_FORMAT_GR1616),
+ #endif
+     DRM_MAP(BGRA, 1, DRM_FORMAT_ARGB8888),
+     DRM_MAP(BGRX, 1, DRM_FORMAT_XRGB8888),
+@@ -1099,12 +1101,6 @@ static int vaapi_map_from_drm(AVHWFrames
+ 
+     desc = (AVDRMFrameDescriptor*)src->data[0];
+ 
+-    if (desc->nb_objects != 1) {
+-        av_log(dst_fc, AV_LOG_ERROR, "VAAPI can only map frames "
+-               "made from a single DRM object.\n");
+-        return AVERROR(EINVAL);
+-    }
+-
+     va_fourcc = 0;
+     for (i = 0; i < FF_ARRAY_ELEMS(vaapi_drm_format_map); i++) {
+         if (desc->nb_layers != vaapi_drm_format_map[i].nb_layer_formats)
+@@ -1213,6 +1209,12 @@ static int vaapi_map_from_drm(AVHWFrames
+             }
+         };
+ 
++        if (desc->nb_objects != 1) {
++            av_log(dst_fc, AV_LOG_ERROR, "VAAPI can only map frames "
++                   "made from a single DRM object.\n");
++            return AVERROR(EINVAL);
++        }
++
+         buffer_handle = desc->objects[0].fd;
+         buffer_desc.pixel_format = va_fourcc;
+         buffer_desc.width        = src_fc->width;
+@@ -1244,6 +1246,12 @@ static int vaapi_map_from_drm(AVHWFrames
+                                buffer_attrs, FF_ARRAY_ELEMS(buffer_attrs));
+     }
+ #else
++    if (desc->nb_objects != 1) {
++        av_log(dst_fc, AV_LOG_ERROR, "VAAPI can only map frames "
++               "made from a single DRM object.\n");
++        return AVERROR(EINVAL);
++    }
++
+     buffer_handle = desc->objects[0].fd;
+     buffer_desc.pixel_format = va_fourcc;
+     buffer_desc.width        = src_fc->width;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -50,3 +50,4 @@
 0050-revert-libplacebo-to-ad-hoc-mode.patch
 0051-add-av1-vaapi-encoder-from-upstream-intel.patch
 0052-backport-upstream-qsvenc-fixes.patch
+0053-allow-vaapi-import-drm-prime2-planar-formats.patch

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -159,9 +159,9 @@ popd
 popd
 
 # LZMA
-git clone -b v5.4.1 --depth=1 https://github.com/xz-mirror/xz.git
+git clone -b v5.4.3 --depth=1 https://github.com/xz-mirror/xz.git
 pushd xz
-./autogen.sh --no-po4a
+./autogen.sh --no-po4a --no-doxygen
 ./configure \
     --prefix=${FF_DEPS_PREFIX} \
     --host=${FF_TOOLCHAIN} \
@@ -322,7 +322,7 @@ popd
 # OPENMPT
 mkdir mpt
 pushd mpt
-mpt_ver="0.7.1"
+mpt_ver="0.7.2"
 mpt_link="https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${mpt_ver}+release.autotools.tar.gz"
 wget ${mpt_link} -O mpt.tar.gz
 tar xaf mpt.tar.gz
@@ -456,7 +456,7 @@ popd
 popd
 
 # SVT-AV1
-git clone -b v1.5.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v1.6.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 pushd SVT-AV1
 mkdir build
 pushd build

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -138,7 +138,7 @@ prepare_extra_amd64() {
     # SVT-AV1
     # nasm >= 2.14
     pushd ${SOURCE_DIR}
-    git clone -b v1.5.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+    git clone -b v1.6.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
     pushd SVT-AV1
     mkdir build
     pushd build
@@ -237,7 +237,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.3.5 --depth=1 https://github.com/intel/gmmlib.git
+    git clone -b intel-gmmlib-22.3.7 --depth=1 https://github.com/intel/gmmlib.git
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -292,7 +292,7 @@ prepare_extra_amd64() {
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     # Both MSDK and VPL runtime can be loaded by MFX dispatcher (libmfx.so.1)
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-23.2.2 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu.git
+    git clone -b intel-onevpl-23.2.3 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu.git
     pushd oneVPL-intel-gpu
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
@@ -318,6 +318,8 @@ prepare_extra_amd64() {
     wget -q -O - https://github.com/intel/media-driver/commit/cbbd676f.patch | git apply
     # Correct AV1 supported tx mode caps for the AV1 VA-API encoder
     wget -q -O - https://github.com/intel/media-driver/commit/89201eaa.patch | git apply
+    # Fix the slow VPP tone-mapping on ADL-S and ADL-N
+    wget -q -O - https://github.com/intel/media-driver/commit/1097e39b.patch | git apply
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
           -DENABLE_KERNELS=ON \
@@ -396,19 +398,7 @@ prepare_extra_amd64() {
     if [[ ${LLVM_VER} -ge 11 ]]; then
         apt-get install -y llvm-${LLVM_VER}-dev libudev-dev
         pushd ${SOURCE_DIR}
-        git clone -b main https://gitlab.freedesktop.org/mesa/mesa.git
-        pushd mesa
-        git reset --hard "cf323446"
-        popd
-        # disable the broken hevc packed header
-        MESA_VA_PIC="mesa/src/gallium/frontends/va/picture.c"
-        MESA_VA_CONF="mesa/src/gallium/frontends/va/config.c"
-        sed -i 's|handleVAEncPackedHeaderParameterBufferType(context, buf);||g' ${MESA_VA_PIC}
-        sed -i 's|handleVAEncPackedHeaderDataBufferType(context, buf);||g' ${MESA_VA_PIC}
-        sed -i 's|if (u_reduce_video_profile(ProfileToPipe(profile)) == PIPE_VIDEO_FORMAT_HEVC)|if (0)|g' ${MESA_VA_CONF}
-        # force reporting all packed headers are supported
-        sed -i 's|value = VA_ENC_PACKED_HEADER_NONE;|value = 0x0000001f;|g' ${MESA_VA_CONF}
-        sed -i 's|if (attrib_list\[i\].type == VAConfigAttribEncPackedHeaders)|if (0)|g' ${MESA_VA_CONF}
+        git clone -b llvm11 --depth=1 https://gitlab.freedesktop.org/nyanmisaka/mesa.git
         meson setup mesa mesa_build \
             --prefix=${TARGET_DIR} \
             --libdir=lib \


### PR DESCRIPTION
**Changes**
- Allow VA-API import DRM prime2 planar formats
- Refine VA-API AV1 encoder patches
- Update queued fixes from upstream
- Bump version to 6.0-4

**Issues**
- Fix the slow VPP tone-mapping on ADL-S and ADL-N
- Fix the packed header in VA-API HEVC encoder on AMD
- Fix a potential memory leak in QSV