### PR TITLE
Bump version to 5.1.3-3

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "5.1.3-2"
+version: "5.1.3-3"
 packages:
   - buster-amd64
   - buster-armhf

--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/mingw-w64/mingw-w64.git"
-SCRIPT_COMMIT="d78ef3552df8cdbfd1a275296921787975573d54"
+SCRIPT_COMMIT="d7877cbd2e080ffb77070cc08033efde9e034f13"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/builder/scripts.d/20-libxml2.sh
+++ b/builder/scripts.d/20-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="6273df6c6d84b6be8a62a62abf1d9b79cc2035f8"
+SCRIPT_COMMIT="884474477284474e0151280aaa275a18e3d7a036"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-freetype.sh
+++ b/builder/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
-SCRIPT_COMMIT="7bed7a02f4bfbfe2a47efb4d06b9c02fdb83b758"
+SCRIPT_COMMIT="e4586d960f339cf75e2e0b34aee30a0ed8353c0d"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-gmp.sh
+++ b/builder/scripts.d/25-gmp.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 
-SCRIPT_REPO="https://gmplib.org/repo/gmp/"
-SCRIPT_HGREV="614a1cd8bb1d"
+SCRIPT_VERSION="6.2.1"
+SCRIPT_SHA512="c99be0950a1d05a0297d65641dd35b75b74466f7bf03c9e8a99895a3b2f9a0856cd17887738fa51cf7499781b65c049769271cbcb77d057d2e9f1ec52e07dd84"
+SCRIPT_URL="https://ftp.gnu.org/gnu/gmp/gmp-${SCRIPT_VERSION}.tar.xz"
 
 ffbuild_enabled() {
     return 0
 }
 
 ffbuild_dockerbuild() {
-    retry-tool sh -c "rm -rf gmp && hg clone -r '$SCRIPT_HGREV' -u '$SCRIPT_HGREV' '$SCRIPT_REPO' gmp"
-    cd gmp
+    retry-tool check-wget "gmp.tar.xz" "$SCRIPT_URL" "$SCRIPT_SHA512"
 
-    ./.bootstrap
+    tar xaf "gmp.tar.xz"
+    cd "gmp-$SCRIPT_VERSION"
 
     local myconf=(
         --prefix="$FFBUILD_PREFIX"

--- a/builder/scripts.d/25-xz.sh
+++ b/builder/scripts.d/25-xz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xz-mirror/xz.git"
-SCRIPT_COMMIT="1dbe12b90cff79bb51923733ac0840747b4b4131"
+SCRIPT_COMMIT="dbb3a536ed9873ffa0870321f6873e564c6a9da8"
 
 ffbuild_enabled() {
     return 0
@@ -11,7 +11,7 @@ ffbuild_dockerbuild() {
     git-mini-clone "$SCRIPT_REPO" "$SCRIPT_COMMIT" xz
     cd xz
 
-    ./autogen.sh --no-po4a
+    ./autogen.sh --no-po4a --no-doxygen
 
     local myconf=(
         --prefix="$FFBUILD_PREFIX"

--- a/builder/scripts.d/35-fontconfig.sh
+++ b/builder/scripts.d/35-fontconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
-SCRIPT_COMMIT="ff037052bc27ae1c0e97879fd7333d3afdf2566e"
+SCRIPT_COMMIT="7e2a1b2577e8d90ea5be3f14091e809ac7742438"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="efefec13ccedc1461867544e2066e2042e86c66f"
+SCRIPT_COMMIT="d4bbe3f48663944385f25f608438e1eb678fc4b7"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-x11/10-xproto.sh
+++ b/builder/scripts.d/45-x11/10-xproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xorgproto.git"
-SCRIPT_COMMIT="6b1012c29c2eee95c6ea2ef63b0e5dc628a6cb7f"
+SCRIPT_COMMIT="766967322209f2dcb72e6a8edea0c651f586201d"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/40-libx11.sh
+++ b/builder/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="71b08b8af20474bb704a11affaa8ea39b06d5ddf"
+SCRIPT_COMMIT="ab0442d3fa835ce16559b29532ac7f674f8557f4"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="8b419c16bf1e37bc98044089da58f06824462cb9"
+SCRIPT_COMMIT="2373fda303d46489c1ec269dc66369a31663cb25"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xiph/opus.git"
-SCRIPT_COMMIT="5023249b5c935545fb02dbfe845cae996ecfc8bb"
+SCRIPT_COMMIT="9fc8fc4cf432640f284113ba502ee027268b0d9f"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="575bd73f6118a88c5a0cf1d27a8ec9b5bda8c278"
+SCRIPT_COMMIT="14e52008edbf2e91386423fdd53310fe49654991"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="46bc4fc9d981b1760def26dd64b9c80ccbad9f6f"
+SCRIPT_COMMIT="08d60d60066eb30ab8e0e3ccfa0cd0b68f8cccc6"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-openmpt.sh
+++ b/builder/scripts.d/50-openmpt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://source.openmpt.org/svn/openmpt/trunk/OpenMPT"
-SCRIPT_REV="19366"
+SCRIPT_REV="19439"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="3cefedefe91fca543083d260d1ed32efd2e7cba5"
+SCRIPT_COMMIT="9448e26fcd7602098b4bf9cd7fe535136e89e10b"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-svtav1.sh
+++ b/builder/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="6f3651c76d30c7564f9cbd2db8523a5bbaf2cee1"
+SCRIPT_COMMIT="08c18ba0768ed3dbbff0903adc326fb3a7549bd9"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/builder/scripts.d/50-vaapi/50-libva.sh
+++ b/builder/scripts.d/50-vaapi/50-libva.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libva.git"
-SCRIPT_COMMIT="f4c4c0370df2b756bd201f25b1ed7942475d44e0"
+SCRIPT_COMMIT="1c58941b93ba5013c68e8370a408efd630275c9c"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/50-shaderc.sh
+++ b/builder/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
-SCRIPT_COMMIT="4dc596ddc2702092c670e828745dc3e0338d83c1"
+SCRIPT_COMMIT="e31c4c2e41544d63d90be28c46e4a4793a624240"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="12542fc6fc05000e04742daf93892a0b10edbe80"
+SCRIPT_COMMIT="2d3a152081ca6e6bea7093940d0f81088fe4d01c"
 
 ffbuild_enabled() {
     return 0

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+jellyfin-ffmpeg (5.1.3-3) unstable; urgency=medium
+
+  * Allow VA-API import DRM prime2 planar formats
+  * Fix the slow VPP tone-mapping on ADL-S and ADL-N
+  * Fix a potential memory leak in QSV
+  * Update dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Thu, 15 Jun 2023 23:12:48 +0800
+
 jellyfin-ffmpeg (5.1.3-2) unstable; urgency=medium
 
   * Update deprecated params for SVT-AV1 encoder

--- a/debian/patches/0052-backport-upstream-qsvenc-fixes.patch
+++ b/debian/patches/0052-backport-upstream-qsvenc-fixes.patch
@@ -183,3 +183,23 @@ Index: jellyfin-ffmpeg/libavcodec/qsvenc.c
      }
  
      if ((avctx->codec_id == AV_CODEC_ID_H264 ||
+Index: jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_qsv.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+@@ -1689,6 +1689,15 @@ static int qsv_device_derive(AVHWDeviceC
+                              AVDictionary *opts, int flags)
+ {
+     mfxIMPL impl;
++    QSVDevicePriv *priv;
++
++    priv = av_mallocz(sizeof(*priv));
++    if (!priv)
++        return AVERROR(ENOMEM);
++
++    ctx->user_opaque = priv;
++    ctx->free = qsv_device_free;
++    
+     impl = choose_implementation("hw_any", child_device_ctx->type);
+     return qsv_device_derive_from_child(ctx, impl,
+                                         child_device_ctx, flags);

--- a/debian/patches/0053-allow-vaapi-import-drm-prime2-planar-formats.patch
+++ b/debian/patches/0053-allow-vaapi-import-drm-prime2-planar-formats.patch
@@ -1,0 +1,51 @@
+Index: jellyfin-ffmpeg/libavutil/hwcontext_vaapi.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_vaapi.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_vaapi.c
+@@ -1015,6 +1015,7 @@ static const struct {
+     DRM_MAP(NV12, 1, DRM_FORMAT_NV12),
+ #if defined(VA_FOURCC_P010) && defined(DRM_FORMAT_R16)
+     DRM_MAP(P010, 2, DRM_FORMAT_R16, DRM_FORMAT_RG1616),
++    DRM_MAP(P010, 2, DRM_FORMAT_R16, DRM_FORMAT_GR1616),
+ #endif
+     DRM_MAP(BGRA, 1, DRM_FORMAT_ARGB8888),
+     DRM_MAP(BGRX, 1, DRM_FORMAT_XRGB8888),
+@@ -1081,12 +1082,6 @@ static int vaapi_map_from_drm(AVHWFrames
+ 
+     desc = (AVDRMFrameDescriptor*)src->data[0];
+ 
+-    if (desc->nb_objects != 1) {
+-        av_log(dst_fc, AV_LOG_ERROR, "VAAPI can only map frames "
+-               "made from a single DRM object.\n");
+-        return AVERROR(EINVAL);
+-    }
+-
+     va_fourcc = 0;
+     for (i = 0; i < FF_ARRAY_ELEMS(vaapi_drm_format_map); i++) {
+         if (desc->nb_layers != vaapi_drm_format_map[i].nb_layer_formats)
+@@ -1195,6 +1190,12 @@ static int vaapi_map_from_drm(AVHWFrames
+             }
+         };
+ 
++        if (desc->nb_objects != 1) {
++            av_log(dst_fc, AV_LOG_ERROR, "VAAPI can only map frames "
++                   "made from a single DRM object.\n");
++            return AVERROR(EINVAL);
++        }
++
+         buffer_handle = desc->objects[0].fd;
+         buffer_desc.pixel_format = va_fourcc;
+         buffer_desc.width        = src_fc->width;
+@@ -1226,6 +1227,12 @@ static int vaapi_map_from_drm(AVHWFrames
+                                buffer_attrs, FF_ARRAY_ELEMS(buffer_attrs));
+     }
+ #else
++    if (desc->nb_objects != 1) {
++        av_log(dst_fc, AV_LOG_ERROR, "VAAPI can only map frames "
++               "made from a single DRM object.\n");
++        return AVERROR(EINVAL);
++    }
++
+     buffer_handle = desc->objects[0].fd;
+     buffer_desc.pixel_format = va_fourcc;
+     buffer_desc.width        = src_fc->width;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -50,3 +50,4 @@
 0050-fix-the-empty-output-in-webvtt-transcoding.patch
 0051-update-deprecated-params-for-svt-av1-encoder.patch
 0052-backport-upstream-qsvenc-fixes.patch
+0053-allow-vaapi-import-drm-prime2-planar-formats.patch

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -159,9 +159,9 @@ popd
 popd
 
 # LZMA
-git clone -b v5.4.1 --depth=1 https://github.com/xz-mirror/xz.git
+git clone -b v5.4.3 --depth=1 https://github.com/xz-mirror/xz.git
 pushd xz
-./autogen.sh --no-po4a
+./autogen.sh --no-po4a --no-doxygen
 ./configure \
     --prefix=${FF_DEPS_PREFIX} \
     --host=${FF_TOOLCHAIN} \
@@ -322,7 +322,7 @@ popd
 # OPENMPT
 mkdir mpt
 pushd mpt
-mpt_ver="0.7.1"
+mpt_ver="0.7.2"
 mpt_link="https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${mpt_ver}+release.autotools.tar.gz"
 wget ${mpt_link} -O mpt.tar.gz
 tar xaf mpt.tar.gz
@@ -456,7 +456,7 @@ popd
 popd
 
 # SVT-AV1
-git clone -b v1.5.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v1.6.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 pushd SVT-AV1
 mkdir build
 pushd build


### PR DESCRIPTION
**Changes**
- Allow VA-API import DRM prime2 planar formats
- Bump version to 5.1.3-3

**Issues**
- Fix the slow VPP tone-mapping on ADL-S and ADL-N
- Fix the packed header in VA-API HEVC encoder on AMD
- Fix a potential memory leak in QSV