### PR TITLE
[6.0] Fix mingw-w64 header version

### DIFF
--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/mingw-w64/mingw-w64.git"
-SCRIPT_COMMIT="d7877cbd2e080ffb77070cc08033efde9e034f13"
+SCRIPT_COMMIT="c3e587c067a00a561899d49d3e63a659e38802ec"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Update mingw-w64 headers
-git clone --depth=1 https://git.code.sf.net/p/mingw-w64/mingw-w64.git
+git clone -b v11.0.1 --depth=1 https://git.code.sf.net/p/mingw-w64/mingw-w64.git
 pushd mingw-w64/mingw-w64-headers
 ./configure \
     --prefix=/usr/${FF_TOOLCHAIN} \


### PR DESCRIPTION
**Changes**
- Fixed fontconfig build in win64 portable

```
/usr/bin/x86_64-w64-mingw32-ld: /opt/ffdeps/lib/libfreetype.a(sfnt.o):sfnt.c:(.text+0xa4b5): undefined reference to `__intrinsic_setjmpex'
/usr/bin/x86_64-w64-mingw32-ld: /opt/ffdeps/lib/libfreetype.a(smooth.o):smooth.c:(.text+0x1b3): undefined reference to `__intrinsic_setjmpex'
```