### PR TITLE
[6.0] Add VUI info to the seq header of HEVC VA-API encoder

### DIFF
--- a/debian/patches/0054-add-vui-info-to-the-seq-header-of-hevc-vaapi-encoder.patch
+++ b/debian/patches/0054-add-vui-info-to-the-seq-header-of-hevc-vaapi-encoder.patch
@@ -1,0 +1,31 @@
+Index: jellyfin-ffmpeg/libavcodec/vaapi_encode_h265.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/vaapi_encode_h265.c
++++ jellyfin-ffmpeg/libavcodec/vaapi_encode_h265.c
+@@ -691,7 +691,25 @@ static int vaapi_encode_h265_init_sequen
+             sps->log2_min_pcm_luma_coding_block_size_minus3 +
+             sps->log2_diff_max_min_pcm_luma_coding_block_size,
+ 
+-        .vui_parameters_present_flag = 0,
++        .vui_parameters_present_flag = sps->vui_parameters_present_flag,
++        .vui_fields.bits = {
++            .aspect_ratio_info_present_flag = vui->aspect_ratio_info_present_flag,
++            .vui_timing_info_present_flag = vui->vui_timing_info_present_flag,
++            .bitstream_restriction_flag = vui->bitstream_restriction_flag,
++            .motion_vectors_over_pic_boundaries_flag =
++                vui->motion_vectors_over_pic_boundaries_flag,
++            .restricted_ref_pic_lists_flag = vui->restricted_ref_pic_lists_flag,
++            .log2_max_mv_length_horizontal = vui->log2_max_mv_length_horizontal,
++            .log2_max_mv_length_vertical = vui->log2_max_mv_length_vertical,
++        },
++
++        .aspect_ratio_idc = vui->aspect_ratio_idc,
++        .sar_width = vui->sar_width,
++        .sar_height = vui->sar_height,
++        .vui_num_units_in_tick = vui->vui_num_units_in_tick,
++        .vui_time_scale = vui->vui_time_scale,
++        .max_bytes_per_pic_denom = vui->max_bytes_per_pic_denom,
++        .max_bits_per_min_cu_denom = vui->max_bits_per_min_cu_denom,
+     };
+ 
+     *vpic = (VAEncPictureParameterBufferHEVC) {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -51,3 +51,4 @@
 0051-add-av1-vaapi-encoder-from-upstream-intel.patch
 0052-backport-upstream-qsvenc-fixes.patch
 0053-allow-vaapi-import-drm-prime2-planar-formats.patch
+0054-add-vui-info-to-the-seq-header-of-hevc-vaapi-encoder.patch


### PR DESCRIPTION
**Changes**
- Add VUI info to the seq header of HEVC VA-API encoder

**Issues**
- Fixes the missing SAR and DAR of the AMD HEVC VA-API encoder

(You know, ffmpeg VA-API is maintained by intel. But they are not affected by this...)