### PR TITLE
[6.0] Sync intel D3D11VA textures before mapping to OpenCL

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "6.0-5"
+version: "6.0-6"
 packages:
   - buster-amd64
   - buster-armhf

--- a/builder/scripts.d/20-libxml2.sh
+++ b/builder/scripts.d/20-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="58de9d31da4d0e8cb6bcf7f5e99714f9df2c4411"
+SCRIPT_COMMIT="d39f78069dff496ec865c73aa44d7110e429bce9"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/20-zlib.sh
+++ b/builder/scripts.d/20-zlib.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/madler/zlib.git"
-SCRIPT_COMMIT="04f42ceca40f73e2978b50e93806c2a18c1281fc"
+SCRIPT_COMMIT="79a0e447a0dfa32979420cb21cfb96d684b2c9d5"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-fftw3f.sh
+++ b/builder/scripts.d/25-fftw3f.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/FFTW/fftw3.git"
-SCRIPT_COMMIT="69f6c1a6ebd7ac5af33e7074134fb79fbc729c3d"
+SCRIPT_COMMIT="38ea230e25e69e7a3f35b957b815bac4f9aa22b0"
 
 ffbuild_enabled() {
     # Dependency of GPL-Only librubberband

--- a/builder/scripts.d/25-freetype.sh
+++ b/builder/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
-SCRIPT_COMMIT="95a872085e5a79cf710acf6389dbd55b6e728aac"
+SCRIPT_COMMIT="d42679b93d5e77fe769591cd1d04522225940556"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/35-fontconfig.sh
+++ b/builder/scripts.d/35-fontconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
-SCRIPT_COMMIT="2fb3419a92156569bc1ec707401258c922cd0d99"
+SCRIPT_COMMIT="e0eb855462791cbe217adc368d156733b2b2c13a"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="1d665c2b521512cdd56964138fc601debd1f1177"
+SCRIPT_COMMIT="f380a32825a1b2c51bbe21dc7acb9b3cc0921f69"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-x11/10-xcbproto.sh
+++ b/builder/scripts.d/45-x11/10-xcbproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xcbproto.git"
-SCRIPT_COMMIT="b016df100111b56d7c1a2c63ea6791b2287a83e4"
+SCRIPT_COMMIT="98eeebfc2d7db5377b85437418fb942ea30ffc0d"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/20-libxau.sh
+++ b/builder/scripts.d/45-x11/20-libxau.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxau.git"
-SCRIPT_COMMIT="68e74d37b99f56bbd1a5f2fb8cb4ad6116f27bd3"
+SCRIPT_COMMIT="aec9d7266777e0b9243ef0f112fe0e07256bd446"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/30-libxcb.sh
+++ b/builder/scripts.d/45-x11/30-libxcb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcb.git"
-SCRIPT_COMMIT="038636786ad1914f3daf3503ae9611f40dffbb8f"
+SCRIPT_COMMIT="453115f7eeb694de9f41ea842a29bbb31b90c8dd"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/40-libx11.sh
+++ b/builder/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="b2c3fb7b4dd4c4c7b9d28c7af7776cccc8e0a98b"
+SCRIPT_COMMIT="44f908d9283710ffc75b22d2ae7a8948119b3e61"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxi.sh
+++ b/builder/scripts.d/45-x11/50-libxi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxi.git"
-SCRIPT_COMMIT="3a7503ec7703f10de17c622ea22b7bff736cea74"
+SCRIPT_COMMIT="09f3eb570fe79bfc0c430b6059d7b4acaf371c24"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-amf.sh
+++ b/builder/scripts.d/50-amf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git"
-SCRIPT_COMMIT="68f2396f1a55a5b12767f5433411bb4093ea65ed"
+SCRIPT_COMMIT="2f326350e849894a929296854f5290e66197c97c"
 
 ffbuild_enabled() {
     [[ $TARGET == *arm64 ]] && return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="e58afe4dd9057591882a01c31382c203e8a61c92"
+SCRIPT_COMMIT="97becd73726c3d4c4bb8793d2215f846da8795af"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libass.sh
+++ b/builder/scripts.d/50-libass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libass/libass.git"
-SCRIPT_COMMIT="91422bdb9497e8484b3248f5ae7eb50d41e2555d"
+SCRIPT_COMMIT="5c15c883a4783641f7e71a6a1f440209965eb64f"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="5556ebd894a9a9b07908c3c7fd0a7a87732a7635"
+SCRIPT_COMMIT="e052ada7801c458f9fc0c2818f1be814f86e94a4"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="dd7364c3cefe0f5c0b3c18c3b1887d353f90fc1f"
+SCRIPT_COMMIT="943b932a7ec6ac71737e1ea0af907c5439ca6ef0"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-openmpt.sh
+++ b/builder/scripts.d/50-openmpt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://source.openmpt.org/svn/openmpt/trunk/OpenMPT"
-SCRIPT_REV="19561"
+SCRIPT_REV="19588"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="88ca9ccca4984dbf61a5e1a06ac551b4dead5304"
+SCRIPT_COMMIT="51e3d0d50ba281ce985a1712785b5cb34f447b92"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-svtav1.sh
+++ b/builder/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="903ff3add82744d586295c37ec1241dc51dab16e"
+SCRIPT_COMMIT="6d5f2b4e1f04db677cdd4ab2b0d6831ab06a849c"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/builder/scripts.d/50-vaapi/40-libdrm.sh
+++ b/builder/scripts.d/50-vaapi/40-libdrm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/mesa/drm.git"
-SCRIPT_COMMIT="c6013245ce9ce287bb86d327f9b6420a320a08e6"
+SCRIPT_COMMIT="7bdb135f0c8e6ae2c0ed6d4bd6a8423eb1df5c26"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vaapi/50-libva.sh
+++ b/builder/scripts.d/50-vaapi/50-libva.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libva.git"
-SCRIPT_COMMIT="7d6c7d482b9d2330b1f3a8bac13a6a3205f33382"
+SCRIPT_COMMIT="b4870fdfe2d41b579036dae280dfc7a5e732127f"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/45-vulkan.sh
+++ b/builder/scripts.d/50-vulkan/45-vulkan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/Vulkan-Headers.git"
-SCRIPT_COMMIT="v1.3.260"
+SCRIPT_COMMIT="v1.3.261"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-vulkan/50-shaderc.sh
+++ b/builder/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
-SCRIPT_COMMIT="4d98dac61ee4857ea0691a2b9a48aee44eb409db"
+SCRIPT_COMMIT="5b892551dd02bbf8704adbc3fcde2fd645f333b2"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="bccaa94db814af33d8ef05c153e7c34d8bd4d685"
+SCRIPT_COMMIT="acf51c1b9f9f872b741ab369cb047898c9cc300b"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-x265.sh
+++ b/builder/scripts.d/50-x265.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
-SCRIPT_COMMIT="8f18e3ad32684eee95e885e718655f93951128c3"
+SCRIPT_COMMIT="59ff5e7b4840b3aac91fbc514a4c86a8722ce5e1"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+jellyfin-ffmpeg (6.0-6) unstable; urgency=medium
+
+  * Sync intel D3D11VA textures before mapping to OpenCL
+  * Tune the default param of QSV AV1e
+  * Backport upstream QSV fixes
+  * Update dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Sat, 26 Aug 2023 01:19:34 +0800
+
 jellyfin-ffmpeg (6.0-5) unstable; urgency=medium
 
   * Add VUI info to the seq header of HEVC VA-API encoder

--- a/debian/patches/0021-add-code-polishing-to-qsv-filters.patch
+++ b/debian/patches/0021-add-code-polishing-to-qsv-filters.patch
@@ -177,7 +177,19 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
  static int config_output(AVFilterLink *outlink)
  {
      AVFilterContext *ctx = outlink->src;
-@@ -504,12 +528,21 @@ static int config_output(AVFilterLink *o
+@@ -358,7 +382,10 @@ static int config_output(AVFilterLink *o
+     outlink->w          = vpp->out_width;
+     outlink->h          = vpp->out_height;
+     outlink->frame_rate = vpp->framerate;
+-    outlink->time_base  = av_inv_q(vpp->framerate);
++    if (vpp->framerate.num == 0 || vpp->framerate.den == 0)
++        outlink->time_base = inlink->time_base;
++    else
++        outlink->time_base = av_inv_q(vpp->framerate);
+ 
+     param.filter_frame  = NULL;
+     param.num_ext_buf   = 0;
+@@ -504,12 +531,21 @@ static int config_output(AVFilterLink *o
  
      if (inlink->w != outlink->w || inlink->h != outlink->h || in_format != vpp->out_format) {
          if (QSV_RUNTIME_VERSION_ATLEAST(mfx_version, 1, 19)) {
@@ -203,7 +215,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
  
              INIT_MFX_EXTBUF(scale_conf, MFX_EXTBUFF_VPP_SCALING);
              SET_MFX_PARAM_FIELD(scale_conf, ScalingMode, mode);
-@@ -582,6 +615,11 @@ static int activate(AVFilterContext *ctx
+@@ -582,6 +618,11 @@ static int activate(AVFilterContext *ctx
              if (in->pts != AV_NOPTS_VALUE)
                  in->pts = av_rescale_q(in->pts, inlink->time_base, outlink->time_base);
  
@@ -215,7 +227,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
              ret = ff_filter_frame(outlink, in);
              if (ret < 0)
                  return ret;
-@@ -602,6 +640,7 @@ not_ready:
+@@ -602,6 +643,7 @@ not_ready:
      return FFERROR_NOT_READY;
  
  eof:
@@ -223,7 +235,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
      ff_outlink_set_status(outlink, status, pts);
      return 0;
  }
-@@ -685,20 +724,14 @@ static const AVOption vpp_options[] = {
+@@ -685,20 +727,14 @@ static const AVOption vpp_options[] = {
      { "h",      "Output video height(0=input video height, -1=keep input video aspect)", OFFSET(oh), AV_OPT_TYPE_STRING, { .str="w*ch/cw" }, 0, 255, .flags = FLAGS },
      { "height", "Output video height(0=input video height, -1=keep input video aspect)", OFFSET(oh), AV_OPT_TYPE_STRING, { .str="w*ch/cw" }, 0, 255, .flags = FLAGS },
      { "format", "Output pixel format", OFFSET(output_format_str), AV_OPT_TYPE_STRING, { .str = "same" }, .flags = FLAGS },
@@ -246,7 +258,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
  
      { "rate", "Generate output at frame rate or field rate, available only for deinterlace mode",
        OFFSET(field_rate), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, 1, FLAGS, "rate" },
-@@ -707,6 +740,7 @@ static const AVOption vpp_options[] = {
+@@ -707,6 +743,7 @@ static const AVOption vpp_options[] = {
      { "field", "Output at field rate (one frame of output for each field)",
        0, AV_OPT_TYPE_CONST, { .i64 = 1 }, 0, 0, FLAGS, "rate" },
  
@@ -254,7 +266,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
      { NULL }
  };
  
-@@ -751,19 +785,14 @@ static const AVOption qsvscale_options[]
+@@ -751,19 +788,14 @@ static const AVOption qsvscale_options[]
      { "h",      "Output video height(0=input video height, -1=keep input video aspect)", OFFSET(oh), AV_OPT_TYPE_STRING, { .str = "ih"   }, .flags = FLAGS },
      { "format", "Output pixel format", OFFSET(output_format_str), AV_OPT_TYPE_STRING, { .str = "same" }, .flags = FLAGS },
  
@@ -276,7 +288,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_qsv.c
      { NULL },
  };
  
-@@ -788,6 +817,7 @@ static const AVOption qsvdeint_options[]
+@@ -788,6 +820,7 @@ static const AVOption qsvdeint_options[]
      { "bob",   "bob algorithm",                  0, AV_OPT_TYPE_CONST,      {.i64 = MFX_DEINTERLACING_BOB}, MFX_DEINTERLACING_BOB, MFX_DEINTERLACING_ADVANCED, FLAGS, "mode"},
      { "advanced", "Motion adaptive algorithm",   0, AV_OPT_TYPE_CONST, {.i64 = MFX_DEINTERLACING_ADVANCED}, MFX_DEINTERLACING_BOB, MFX_DEINTERLACING_ADVANCED, FLAGS, "mode"},
  

--- a/debian/patches/0037-add-fixes-for-some-quirks-on-dg2-on-windows.patch
+++ b/debian/patches/0037-add-fixes-for-some-quirks-on-dg2-on-windows.patch
@@ -90,16 +90,3 @@ Index: jellyfin-ffmpeg/libavutil/hwcontext_d3d11va.h
  } AVD3D11VADeviceContext;
  
  /**
-Index: jellyfin-ffmpeg/libavutil/hwcontext_opencl.c
-===================================================================
---- jellyfin-ffmpeg.orig/libavutil/hwcontext_opencl.c
-+++ jellyfin-ffmpeg/libavutil/hwcontext_opencl.c
-@@ -1371,7 +1371,7 @@ static int opencl_device_derive(AVHWDevi
-                 CL_CONTEXT_D3D11_DEVICE_KHR,
-                 (intptr_t)src_hwctx->device,
-                 CL_CONTEXT_INTEROP_USER_SYNC,
--                CL_TRUE,
-+                (src_hwctx->device_desc.VendorId != 0x8086 || src_hwctx->is_uma),
-                 0,
-             };
-             OpenCLDeviceSelector selector = {

--- a/debian/patches/0047-update-the-default-params-of-qsv-encoders.patch
+++ b/debian/patches/0047-update-the-default-params-of-qsv-encoders.patch
@@ -2,15 +2,17 @@ Index: jellyfin-ffmpeg/libavcodec/qsvenc_av1.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavcodec/qsvenc_av1.c
 +++ jellyfin-ffmpeg/libavcodec/qsvenc_av1.c
-@@ -130,7 +130,7 @@ static const AVClass class = {
+@@ -130,8 +130,8 @@ static const AVClass class = {
  
  static const FFCodecDefault qsv_enc_defaults[] = {
      { "b",         "1M"   },
 -    { "g",         "-1"   },
+-    { "bf",        "-1"   },
 +    { "g",         "250"  },
-     { "bf",        "-1"   },
++    { "bf",        "3"    },
      { "refs",      "0"    },
      { NULL },
+ };
 Index: jellyfin-ffmpeg/libavcodec/qsvenc_h264.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavcodec/qsvenc_h264.c

--- a/debian/patches/0052-backport-upstream-qsvenc-fixes.patch
+++ b/debian/patches/0052-backport-upstream-qsvenc-fixes.patch
@@ -139,6 +139,15 @@ Index: jellyfin-ffmpeg/libavcodec/qsvenc.c
                  if (ret < 0)
                      return ret;
              }
+@@ -2579,7 +2638,7 @@ int ff_qsv_encode(AVCodecContext *avctx,
+             pict_type = AV_PICTURE_TYPE_P;
+         else if (qpkt.bs->FrameType & MFX_FRAMETYPE_B || qpkt.bs->FrameType & MFX_FRAMETYPE_xB)
+             pict_type = AV_PICTURE_TYPE_B;
+-        else if (qpkt.bs->FrameType == MFX_FRAMETYPE_UNKNOWN) {
++        else if (qpkt.bs->FrameType == MFX_FRAMETYPE_UNKNOWN && qpkt.bs->DataLength) {
+             pict_type = AV_PICTURE_TYPE_NONE;
+             av_log(avctx, AV_LOG_WARNING, "Unknown FrameType, set pict_type to AV_PICTURE_TYPE_NONE.\n");
+         } else {
 Index: jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavutil/hwcontext_qsv.c

--- a/debian/patches/0058-sync-intel-d3d11va-textures-before-mapping-to-opencl.patch
+++ b/debian/patches/0058-sync-intel-d3d11va-textures-before-mapping-to-opencl.patch
@@ -1,0 +1,309 @@
+Index: jellyfin-ffmpeg/libavcodec/dxva2.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/dxva2.c
++++ jellyfin-ffmpeg/libavcodec/dxva2.c
+@@ -714,8 +714,10 @@ int ff_dxva2_common_frame_params(AVCodec
+ #if CONFIG_D3D11VA
+     if (frames_ctx->format == AV_PIX_FMT_D3D11) {
+         AVD3D11VAFramesContext *frames_hwctx = frames_ctx->hwctx;
++        AVD3D11VADeviceContext *device_hwctx = device_ctx->hwctx;
+ 
+         frames_hwctx->BindFlags |= D3D11_BIND_DECODER;
++        frames_hwctx->require_sync = device_hwctx->device_desc.VendorId == 0x8086;
+     }
+ #endif
+ 
+Index: jellyfin-ffmpeg/libavfilter/qsvvpp.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/qsvvpp.c
++++ jellyfin-ffmpeg/libavfilter/qsvvpp.c
+@@ -598,6 +598,9 @@ static int init_vpp_session(AVFilterCont
+             out_frames_ctx->initial_pool_size += avctx->extra_hw_frames;
+         out_frames_hwctx->frame_type      = s->out_mem_mode;
+ 
++        if (in_frames_hwctx)
++            out_frames_hwctx->require_sync = in_frames_hwctx->require_sync;
++
+         ret = av_hwframe_ctx_init(out_frames_ref);
+         if (ret < 0) {
+             av_buffer_unref(&out_frames_ref);
+Index: jellyfin-ffmpeg/libavutil/hwcontext_d3d11va.h
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_d3d11va.h
++++ jellyfin-ffmpeg/libavutil/hwcontext_d3d11va.h
+@@ -183,6 +183,11 @@ typedef struct AVD3D11VAFramesContext {
+      * This field is ignored/invalid if a user-allocated texture is provided.
+     */
+     AVD3D11FrameDescriptor *texture_infos;
++
++    /**
++     * Whether the frames require extra sync when exporting as external memory.
++     */
++    int require_sync;
+ } AVD3D11VAFramesContext;
+ 
+ #endif /* AVUTIL_HWCONTEXT_D3D11VA_H */
+Index: jellyfin-ffmpeg/libavutil/hwcontext_opencl.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_opencl.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_opencl.c
+@@ -167,6 +167,10 @@ typedef struct OpenCLFramesContext {
+     int                   nb_mapped_frames;
+     AVOpenCLFrameDescriptor *mapped_frames;
+ #endif
++#if HAVE_OPENCL_D3D11
++    ID3D11Asynchronous      *sync_point;
++    ID3D11Texture2D         *sync_tex_2x2;
++#endif
+ } OpenCLFramesContext;
+ 
+ static void CL_CALLBACK opencl_error_callback(const char *errinfo,
+@@ -1788,7 +1792,12 @@ static void opencl_frames_uninit(AVHWFra
+         av_freep(&priv->mapped_frames);
+     }
+ #endif
+-
++#if HAVE_OPENCL_D3D11
++    if (priv->sync_point)
++        ID3D11Asynchronous_Release(priv->sync_point);
++    if (priv->sync_tex_2x2)
++        ID3D11Texture2D_Release(priv->sync_tex_2x2);
++#endif
+     if (priv->command_queue) {
+         cle = clReleaseCommandQueue(priv->command_queue);
+         if (cle != CL_SUCCESS) {
+@@ -2563,6 +2572,82 @@ fail:
+ 
+ #if HAVE_OPENCL_D3D11
+ 
++static int opencl_init_d3d11_sync_point(OpenCLFramesContext    *priv,
++                                        AVD3D11VADeviceContext *device_hwctx,
++                                        ID3D11Texture2D        *src_texture,
++                                        void                   *logctx)
++{
++    HRESULT hr;
++    D3D11_QUERY_DESC query = { D3D11_QUERY_EVENT, 0 };
++    D3D11_TEXTURE2D_DESC src_desc = { 0 };
++    D3D11_TEXTURE2D_DESC dst_desc = {
++        .Width          = 2,
++        .Height         = 2,
++        .MipLevels      = 1,
++        .SampleDesc     = { .Count = 1 },
++        .ArraySize      = 1,
++        .Usage          = D3D11_USAGE_DEFAULT,
++    };
++
++    if (!priv || !device_hwctx || !src_texture)
++        return AVERROR(EINVAL);
++
++    hr = ID3D11Device_CreateQuery(device_hwctx->device, &query,
++                                  (ID3D11Query **)&priv->sync_point);
++    if (FAILED(hr)) {
++        av_log(logctx, AV_LOG_ERROR, "Could not create the sync point (%lx)\n", (long)hr);
++        goto fail;
++    }
++
++    ID3D11Texture2D_GetDesc(src_texture, &src_desc);
++    dst_desc.Format = src_desc.Format;
++    hr = ID3D11Device_CreateTexture2D(device_hwctx->device,
++                                      &dst_desc, NULL, &priv->sync_tex_2x2);
++    if (FAILED(hr)) {
++        av_log(logctx, AV_LOG_ERROR, "Could not create the sync texture (%lx)\n", (long)hr);
++        goto fail;
++    }
++
++    return 0;
++fail:
++    if (priv->sync_point)
++        ID3D11Asynchronous_Release(priv->sync_point);
++    if (priv->sync_tex_2x2)
++        ID3D11Texture2D_Release(priv->sync_tex_2x2);
++    return AVERROR_UNKNOWN;
++}
++
++static void opencl_sync_d3d11_texture(OpenCLFramesContext    *priv,
++                                      AVD3D11VADeviceContext *device_hwctx,
++                                      ID3D11Texture2D        *texture,
++                                      unsigned                subresource,
++                                      void                   *logctx)
++{
++    const D3D11_BOX box_2x2 = { 0, 0, 0, 2, 2, 1 };
++    BOOL data = FALSE;
++
++    if (!priv || !device_hwctx || !texture)
++        return;
++
++    av_log(logctx, AV_LOG_DEBUG, "Sync D3D11 texture %d\n", subresource);
++
++    device_hwctx->lock(device_hwctx->lock_ctx);
++    ID3D11DeviceContext_Begin(device_hwctx->device_context, priv->sync_point);
++
++    /* Force DX to wait for DXVA DEC/VP by copying 2x2 pixels, which can act as a sync point */
++    ID3D11DeviceContext_CopySubresourceRegion(device_hwctx->device_context,
++                                              (ID3D11Resource *)priv->sync_tex_2x2, 0, 0, 0, 0,
++                                              (ID3D11Resource *)texture, subresource, &box_2x2);
++    ID3D11DeviceContext_Flush(device_hwctx->device_context);
++    ID3D11DeviceContext_End(device_hwctx->device_context, priv->sync_point);
++
++    while ((S_OK != ID3D11DeviceContext_GetData(device_hwctx->device_context,
++                                                priv->sync_point,
++                                                &data,
++                                                sizeof(data), 0)) || (data != TRUE)) { /* do nothing */ }
++    device_hwctx->unlock(device_hwctx->lock_ctx);
++}
++
+ #if CONFIG_LIBMFX
+ 
+ static void opencl_unmap_from_d3d11_qsv(AVHWFramesContext *dst_fc,
+@@ -2603,6 +2688,13 @@ static void opencl_unmap_from_d3d11_qsv(
+ static int opencl_map_from_d3d11_qsv(AVHWFramesContext *dst_fc, AVFrame *dst,
+                                      const AVFrame *src, int flags)
+ {
++    AVHWFramesContext *src_fc =
++        (AVHWFramesContext*)src->hw_frames_ctx->data;
++    AVHWDeviceContext *src_dev = src_fc->device_ctx;
++    AVHWDeviceContext *src_subdev =
++        (AVHWDeviceContext*)src_dev->internal->source_device->data;
++    AVD3D11VADeviceContext *device_hwctx = src_subdev->hwctx;
++    AVQSVFramesContext     *src_hwctx = src_fc->hwctx;
+     AVOpenCLDeviceContext    *dst_dev = dst_fc->device_ctx->hwctx;
+     OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->internal->priv;
+     OpenCLFramesContext  *frames_priv = dst_fc->internal->priv;
+@@ -2630,6 +2722,14 @@ static int opencl_map_from_d3d11_qsv(AVH
+         return AVERROR(EINVAL);
+     }
+ 
++    if (src_hwctx->require_sync &&
++        frames_priv->sync_point && frames_priv->sync_tex_2x2) {
++        opencl_sync_d3d11_texture(frames_priv,
++                                  device_hwctx,
++                                  tex, (decoder_target ? index : 0),
++                                  dst_fc);
++    }
++
+     if (decoder_target) {
+         desc = &frames_priv->mapped_frames[index];
+     } else {
+@@ -2701,6 +2801,10 @@ fail2:
+ static int opencl_frames_derive_from_d3d11_qsv(AVHWFramesContext *dst_fc,
+                                                AVHWFramesContext *src_fc, int flags)
+ {
++    AVHWDeviceContext *src_dev = src_fc->device_ctx;
++    AVHWDeviceContext *src_subdev =
++        (AVHWDeviceContext*)src_dev->internal->source_device->data;
++    AVD3D11VADeviceContext *device_hwctx = src_subdev->hwctx;
+     AVOpenCLDeviceContext    *dst_dev = dst_fc->device_ctx->hwctx;
+     AVQSVFramesContext     *src_hwctx = src_fc->hwctx;
+     OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->internal->priv;
+@@ -2709,8 +2813,8 @@ static int opencl_frames_derive_from_d3d
+     cl_int cle;
+     int err, i, p, nb_planes = 2;
+ 
+-    mfxHDLPair *pair = (mfxHDLPair*)src_hwctx->surfaces[i].Data.MemId;
+-    ID3D11Texture2D *tex = (ID3D11Texture2D*)pair->first;
++    mfxHDLPair *pair = (mfxHDLPair *)src_hwctx->surfaces[0].Data.MemId;
++    ID3D11Texture2D *tex = (ID3D11Texture2D *)pair->first;
+ 
+     if (src_fc->sw_format != AV_PIX_FMT_NV12 &&
+         src_fc->sw_format != AV_PIX_FMT_P010) {
+@@ -2725,6 +2829,14 @@ static int opencl_frames_derive_from_d3d
+         return AVERROR(EINVAL);
+     }
+ 
++    if (src_hwctx->require_sync) {
++        err = opencl_init_d3d11_sync_point(frames_priv,
++                                           device_hwctx,
++                                           tex, dst_fc);
++        if (err < 0)
++            return err;
++    }
++
+     if (!(src_hwctx->frame_type & MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET) ||
+         (src_hwctx->frame_type & MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET) ||
+         (src_hwctx->frame_type & MFX_MEMTYPE_FROM_VPPOUT)) {
+@@ -2748,6 +2860,8 @@ static int opencl_frames_derive_from_d3d
+     for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
+         AVOpenCLFrameDescriptor *desc = &frames_priv->mapped_frames[i];
+         desc->nb_planes = nb_planes;
++        pair = (mfxHDLPair *)src_hwctx->surfaces[i].Data.MemId;
++        tex = (ID3D11Texture2D *)pair->first;
+ 
+         for (p = 0; p < nb_planes; p++) {
+             UINT subresource = 2 * i + p;
+@@ -2806,6 +2920,10 @@ static void opencl_unmap_from_d3d11(AVHW
+ static int opencl_map_from_d3d11(AVHWFramesContext *dst_fc, AVFrame *dst,
+                                  const AVFrame *src, int flags)
+ {
++    AVHWFramesContext *src_fc =
++        (AVHWFramesContext*)src->hw_frames_ctx->data;
++    AVD3D11VAFramesContext *src_hwctx = src_fc->hwctx;
++    AVD3D11VADeviceContext *device_hwctx = src_fc->device_ctx->hwctx;
+     OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->internal->priv;
+     OpenCLFramesContext  *frames_priv = dst_fc->internal->priv;
+     AVOpenCLFrameDescriptor *desc;
+@@ -2828,6 +2946,14 @@ static int opencl_map_from_d3d11(AVHWFra
+     nb_planes = device_priv->d3d11_map_amd ? (desc->nb_planes - 1)
+                                            : desc->nb_planes;
+ 
++    if (src_hwctx->require_sync &&
++        frames_priv->sync_point && frames_priv->sync_tex_2x2) {
++        opencl_sync_d3d11_texture(frames_priv,
++                                  device_hwctx,
++                                  src->data[0], index,
++                                  dst_fc);
++    }
++
+     if (device_priv->d3d11_map_amd) {
+         cle = device_priv->clEnqueueAcquireD3D11ObjectsKHR(
+             frames_priv->command_queue, 1, &desc->planes[nb_planes],
+@@ -2881,6 +3007,7 @@ static int opencl_frames_derive_from_d3d
+                                            AVHWFramesContext *src_fc, int flags)
+ {
+     AVOpenCLDeviceContext    *dst_dev = dst_fc->device_ctx->hwctx;
++    AVD3D11VADeviceContext *device_hwctx = src_fc->device_ctx->hwctx;
+     AVD3D11VAFramesContext *src_hwctx = src_fc->hwctx;
+     OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->internal->priv;
+     OpenCLFramesContext  *frames_priv = dst_fc->internal->priv;
+@@ -2923,6 +3050,14 @@ static int opencl_frames_derive_from_d3d
+     if (!frames_priv->mapped_frames)
+         return AVERROR(ENOMEM);
+ 
++    if (src_hwctx->require_sync) {
++        err = opencl_init_d3d11_sync_point(frames_priv,
++                                           device_hwctx,
++                                           src_hwctx->texture, dst_fc);
++        if (err < 0)
++            return err;
++    }
++
+     for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
+         AVOpenCLFrameDescriptor *desc = &frames_priv->mapped_frames[i];
+         desc->nb_planes = nb_planes;
+Index: jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_qsv.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+@@ -1868,6 +1868,7 @@ static int qsv_frames_derive_to(AVHWFram
+             } else {
+                 dst_hwctx->frame_type |= MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET;
+             }
++            dst_hwctx->require_sync = src_hwctx->require_sync;
+         }
+         break;
+ #endif
+Index: jellyfin-ffmpeg/libavutil/hwcontext_qsv.h
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_qsv.h
++++ jellyfin-ffmpeg/libavutil/hwcontext_qsv.h
+@@ -64,6 +64,11 @@ typedef struct AVQSVFramesContext {
+      * A combination of MFX_MEMTYPE_* describing the frame pool.
+      */
+     int frame_type;
++
++    /**
++     * Whether the frames require extra sync when exporting as external memory.
++     */
++    int require_sync;
+ } AVQSVFramesContext;
+ 
+ #endif /* AVUTIL_HWCONTEXT_QSV_H */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -55,3 +55,4 @@
 0055-use-contiguous-linear-vulkan-images-for-amd-encoder.patch
 0056-fix-libplacebo-filter-build-with-v6-api.patch
 0057-fix-x86-mathops-assembly-build-with-newer-binutil.patch
+0058-sync-intel-d3d11va-textures-before-mapping-to-opencl.patch

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -456,7 +456,7 @@ popd
 popd
 
 # SVT-AV1
-git clone -b v1.6.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v1.7.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 pushd SVT-AV1
 mkdir build
 pushd build

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -138,7 +138,7 @@ prepare_extra_amd64() {
     # SVT-AV1
     # nasm >= 2.14
     pushd ${SOURCE_DIR}
-    git clone -b v1.6.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+    git clone -b v1.7.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
     pushd SVT-AV1
     mkdir build
     pushd build
@@ -174,7 +174,7 @@ prepare_extra_amd64() {
     pushd ${SOURCE_DIR}
     mkdir libdrm
     pushd libdrm
-    libdrm_ver="2.4.115"
+    libdrm_ver="2.4.116"
     libdrm_link="https://dri.freedesktop.org/libdrm/libdrm-${libdrm_ver}.tar.xz"
     wget ${libdrm_link} -O libdrm.tar.xz
     tar xaf libdrm.tar.xz
@@ -237,7 +237,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.3.9 --depth=1 https://github.com/intel/gmmlib.git
+    git clone -b intel-gmmlib-22.3.10 --depth=1 https://github.com/intel/gmmlib.git
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -292,7 +292,7 @@ prepare_extra_amd64() {
     # ONEVPL-INTEL-GPU (RT only)
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-23.3.0 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu.git
+    git clone -b intel-onevpl-23.3.2 --depth=1 https://github.com/oneapi-src/oneVPL-intel-gpu.git
     pushd oneVPL-intel-gpu
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
@@ -312,7 +312,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-23.3.0 --depth=1 https://github.com/intel/media-driver.git
+    git clone -b intel-media-23.3.2 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
@@ -331,7 +331,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.260 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
+    git clone -b v1.3.261 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -344,7 +344,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.260 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
+    git clone -b v1.3.261 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \


### PR DESCRIPTION
**Changes**
- Sync intel D3D11VA textures before mapping to OpenCL
- Tune the default param of QSV AV1e
- Backport upstream QSV fixes
- Update dependencies
- Bump version to 6.0-6

**Issues**
`clEnqueueAcquireD3D11ObjectsKHR()` on intel NEO runtime is not enough to synchronize D3D11 textures, especially when the source comes from DXVA decoder or video processor.

This violates one OpenCL spec since the `cl_khr_d3d11_sharing` extension claimed that the [driver is responsible for providing the synchronization guarantee](https://man.opencl.org/clEnqueueAcquireD3D11ObjectsKHR.html) if user set `CL_CONTEXT_INTEROP_USER_SYNC=0` on context creation.

So implement functions to manually synchronize it.

![image](https://github.com/jellyfin/jellyfin-ffmpeg/assets/14953024/7742cbd1-a367-44b9-950c-d35ed966460e)