### PR TITLE
[6.0] Fix the brightness issue in HLG-2-SDR tonemap

### DIFF
--- a/debian/patches/0005-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0005-add-cuda-tonemap-impl.patch
@@ -244,12 +244,12 @@ Index: jellyfin-ffmpeg/libavfilter/colorspace.c
 +
 +// linearizer for HLG/ARIB-B67
 +float eotf_arib_b67(float x) {
-+    return ootf_1_2(inverse_oetf_arib_b67(x));
++    return ootf_1_2(inverse_oetf_arib_b67(x)) * 5.0f;
 +}
 +
 +// delinearizer for HLG/ARIB-B67
 +float inverse_eotf_arib_b67(float x) {
-+    return oetf_arib_b67(inverse_ootf_1_2(x));
++    return oetf_arib_b67(inverse_ootf_1_2(x / 5.0f));
 +}
 +
 +// delinearizer for BT709, BT2020-10
@@ -468,12 +468,12 @@ Index: jellyfin-ffmpeg/libavfilter/cuda/colorspace_common.h
 +
 +// linearizer for HLG/ARIB-B67
 +static __inline__ __device__ float eotf_arib_b67(float x) {
-+    return ootf_1_2(inverse_oetf_arib_b67(x));
++    return ootf_1_2(inverse_oetf_arib_b67(x)) * 5.0f;
 +}
 +
 +// delinearizer for HLG/ARIB-B67
 +static __inline__ __device__ float inverse_eotf_arib_b67(float x) {
-+    return oetf_arib_b67(inverse_ootf_1_2(x));
++    return oetf_arib_b67(inverse_ootf_1_2(x / 5.0f));
 +}
 +
 +// delinearizer for BT709, BT2020-10

--- a/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -214,12 +214,12 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/colorspace_common.cl
 +
 +// linearizer for HLG/ARIB-B67
 +float eotf_arib_b67(float x) {
-+    return ootf_1_2(inverse_oetf_arib_b67(x));
++    return ootf_1_2(inverse_oetf_arib_b67(x)) * 5.0f;
 +}
 +
 +// delinearizer for HLG/ARIB-B67
 +float inverse_eotf_arib_b67(float x) {
-+    return oetf_arib_b67(inverse_ootf_1_2(x));
++    return oetf_arib_b67(inverse_ootf_1_2(x / 5.0f));
  }
  
 -float inverse_eotf_bt1886(float c) {


### PR DESCRIPTION
**Changes**
- Fix the brightness issue in HLG-2-SDR tonemap

**Issues**
- Fixes https://forum.jellyfin.org/t-hdr-dv-tone-mapping-very-dark-in-this-example