### PR TITLE
Update CI to work with new repository layout

### DIFF
--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -104,7 +104,7 @@ jobs:
           key: ${{ secrets.REPO_KEY }}
           source: artifact/*
           strip_components: 1
-          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}/
+          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}
 
       - name: Move incoming release into repository
         uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1

--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -73,10 +73,13 @@ jobs:
             const tag = context.ref.substring(10)
             const no_v = tag.replace('v', '')
             const dash_index = no_v.lastIndexOf('-')
+            const major_index = no_v.firstIndexOf('.')
             const no_dash = (dash_index > -1) ?  no_v.substring(0, dash_index) : no_v
+            const major = (major_index > -1) ?  no_v.substring(0, major_index) : no_v
             core.setOutput('tag', tag)
             core.setOutput('no-v', no_v)
             core.setOutput('no-dash', no_dash)
+            core.setOutput('major', major)
 
       - name: Download Artifacts
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
@@ -84,14 +87,6 @@ jobs:
           name: ${{ inputs.distro }}-${{ matrix.release }}-${{ matrix.arch }}
           path: artifact
 
-      - name: Prepare Release Assets
-        run: |-
-          pushd artifact
-          find * -type f -name "*.deb" | while read file; do
-            sha256sum "${file}" | tee "${file}.sha256sum"
-          done
-          popd
-          
       - name: Upload GH Release Assets
         uses: shogo82148/actions-upload-release-asset@5bd52f05dd8076794da5975d4c0a4f3bce7dd8f5 # v1.7.4
         with:
@@ -100,7 +95,6 @@ jobs:
           asset_path: |
             ./artifact/**/*.zip
             ./artifact/**/*.deb
-            ./artifact/**/*.sha256sum
 
       - name: Make Sure Release Directory Exists
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
@@ -110,14 +104,14 @@ jobs:
           key: ${{ secrets.deploy-key }}
           script_stop: true
           script: |-
-            mkdir -p /srv/repository/releases/server/${{ inputs.distro }}/versions/jellyfin-ffmpeg/${{ steps.set_version.outputs.no-v }}/
+            mkdir -p /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
 
       - name: Upload Release Assets
         uses: burnett01/rsync-deployments@93f02b856fbeaf9a8fbfdd8ce1a4adfd0843f849 # 7.0.0
         with:
           switches: -vrptz
           path: ./artifact/*
-          remote_path: /srv/repository/releases/server/${{ inputs.distro }}/versions/jellyfin-ffmpeg/${{ steps.set_version.outputs.no-v }}/
+          remote_path: /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}/
           remote_host: ${{ secrets.deploy-host }}
           remote_user: ${{ secrets.deploy-user }}
           remote_key: ${{ secrets.deploy-key }}

--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -97,14 +97,14 @@ jobs:
             ./artifact/**/*.deb
 
       - name: Upload release archive to repo.jellyfin.org
-        uses: burnett01/rsync-deployments@45d84ad5f6c174f3e0ffc50e9060a9666d09c16e # 6.0.0
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
-          switches: -vrptz
-          path: ./artifact/*
-          remote_path: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}/
-          remote_host: ${{ secrets.REPO_HOST }}
-          remote_user: ${{ secrets.REPO_USER }}
-          remote_key: ${{ secrets.REPO_KEY }}
+          host: ${{ secrets.REPO_HOST }}
+          username: ${{ secrets.REPO_USER }}
+          key: ${{ secrets.REPO_KEY }}
+          source: artifact/*
+          strip_components: 1
+          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}/
 
       - name: Move incoming release into repository
         uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1

--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -96,22 +96,26 @@ jobs:
             ./artifact/**/*.zip
             ./artifact/**/*.deb
 
-      - name: Make Sure Release Directory Exists
-        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
-        with:
-          host: ${{ secrets.deploy-host }}
-          username: ${{ secrets.deploy-user }}
-          key: ${{ secrets.deploy-key }}
-          script_stop: true
-          script: |-
-            mkdir -p /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
-
-      - name: Upload Release Assets
-        uses: burnett01/rsync-deployments@93f02b856fbeaf9a8fbfdd8ce1a4adfd0843f849 # 7.0.0
+      - name: Upload release archive to repo.jellyfin.org
+        uses: burnett01/rsync-deployments@45d84ad5f6c174f3e0ffc50e9060a9666d09c16e # 6.0.0
         with:
           switches: -vrptz
           path: ./artifact/*
-          remote_path: /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}/
-          remote_host: ${{ secrets.deploy-host }}
-          remote_user: ${{ secrets.deploy-user }}
-          remote_key: ${{ secrets.deploy-key }}
+          remote_path: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}/
+          remote_host: ${{ secrets.REPO_HOST }}
+          remote_user: ${{ secrets.REPO_USER }}
+          remote_key: ${{ secrets.REPO_KEY }}
+
+      - name: Move incoming release into repository
+        uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1
+        with:
+          host: ${{ secrets.REPO_HOST }}
+          username: ${{ secrets.REPO_USER }}
+          key: ${{ secrets.REPO_KEY }}
+          envs: JELLYFIN_VERSION
+          script_stop: true
+          script: |
+            if [ -d "/srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}" ] && [ -n "${{ steps.set_version.outputs.major }}" ] && [ -n "${{ steps.set_version.outputs.no-v }}" ]; then
+                sudo rm -r /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
+            fi
+            sudo mv -t /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }} /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}

--- a/.github/workflows/_meta_mac_portable.yaml
+++ b/.github/workflows/_meta_mac_portable.yaml
@@ -97,7 +97,7 @@ jobs:
           key: ${{ secrets.REPO_KEY }}
           source: artifact/*
           strip_components: 1
-          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/macos/${{ matrix.arch }}/
+          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/macos/${{ matrix.arch }}
 
       - name: Move incoming release into repository
         uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1

--- a/.github/workflows/_meta_mac_portable.yaml
+++ b/.github/workflows/_meta_mac_portable.yaml
@@ -67,10 +67,13 @@ jobs:
             const tag = context.ref.substring(10)
             const no_v = tag.replace('v', '')
             const dash_index = no_v.lastIndexOf('-')
+            const major_index = no_v.firstIndexOf('.')
             const no_dash = (dash_index > -1) ?  no_v.substring(0, dash_index) : no_v
+            const major = (major_index > -1) ?  no_v.substring(0, major_index) : no_v
             core.setOutput('tag', tag)
             core.setOutput('no-v', no_v)
             core.setOutput('no-dash', no_dash)
+            core.setOutput('major', major)
 
       - name: Download Artifacts
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
@@ -85,7 +88,6 @@ jobs:
           overwrite: true
           asset_path: |
             ./artifact/**/*.tar.xz
-            ./artifact/**/*.sha256sum
 
       - name: Make Sure FFmpeg Directory Exists
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
@@ -95,14 +97,14 @@ jobs:
           key: ${{ secrets.deploy-key }}
           script_stop: true
           script: |-
-            mkdir -p /srv/repository/releases/ffmpeg/${{ steps.set_version.outputs.no-v }}/
+            mkdir -p /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
 
       - name: Upload Release Assets
         uses: burnett01/rsync-deployments@93f02b856fbeaf9a8fbfdd8ce1a4adfd0843f849 # 7.0.0
         with:
           switches: -vrptz
           path: ./artifact/*
-          remote_path: /srv/repository/releases/ffmpeg/${{ steps.set_version.outputs.no-v }}/
+          remote_path: /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}/
           remote_host: ${{ secrets.deploy-host }}
           remote_user: ${{ secrets.deploy-user }}
           remote_key: ${{ secrets.deploy-key }}

--- a/.github/workflows/_meta_mac_portable.yaml
+++ b/.github/workflows/_meta_mac_portable.yaml
@@ -90,14 +90,14 @@ jobs:
             ./artifact/**/*.tar.xz
 
       - name: Upload release archive to repo.jellyfin.org
-        uses: burnett01/rsync-deployments@45d84ad5f6c174f3e0ffc50e9060a9666d09c16e # 6.0.0
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
-          switches: -vrptz
-          path: ./artifact/*
-          remote_path: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/macos/${{ matrix.arch }}/
-          remote_host: ${{ secrets.REPO_HOST }}
-          remote_user: ${{ secrets.REPO_USER }}
-          remote_key: ${{ secrets.REPO_KEY }}
+          host: ${{ secrets.REPO_HOST }}
+          username: ${{ secrets.REPO_USER }}
+          key: ${{ secrets.REPO_KEY }}
+          source: artifact/*
+          strip_components: 1
+          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/macos/${{ matrix.arch }}/
 
       - name: Move incoming release into repository
         uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1

--- a/.github/workflows/_meta_mac_portable.yaml
+++ b/.github/workflows/_meta_mac_portable.yaml
@@ -89,22 +89,26 @@ jobs:
           asset_path: |
             ./artifact/**/*.tar.xz
 
-      - name: Make Sure FFmpeg Directory Exists
-        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
-        with:
-          host: ${{ secrets.deploy-host }}
-          username: ${{ secrets.deploy-user }}
-          key: ${{ secrets.deploy-key }}
-          script_stop: true
-          script: |-
-            mkdir -p /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
-
-      - name: Upload Release Assets
-        uses: burnett01/rsync-deployments@93f02b856fbeaf9a8fbfdd8ce1a4adfd0843f849 # 7.0.0
+      - name: Upload release archive to repo.jellyfin.org
+        uses: burnett01/rsync-deployments@45d84ad5f6c174f3e0ffc50e9060a9666d09c16e # 6.0.0
         with:
           switches: -vrptz
           path: ./artifact/*
-          remote_path: /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}/
-          remote_host: ${{ secrets.deploy-host }}
-          remote_user: ${{ secrets.deploy-user }}
-          remote_key: ${{ secrets.deploy-key }}
+          remote_path: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/macos/${{ matrix.arch }}/
+          remote_host: ${{ secrets.REPO_HOST }}
+          remote_user: ${{ secrets.REPO_USER }}
+          remote_key: ${{ secrets.REPO_KEY }}
+
+      - name: Move incoming release into repository
+        uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1
+        with:
+          host: ${{ secrets.REPO_HOST }}
+          username: ${{ secrets.REPO_USER }}
+          key: ${{ secrets.REPO_KEY }}
+          envs: JELLYFIN_VERSION
+          script_stop: true
+          script: |
+            if [ -d "/srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}" ] && [ -n "${{ steps.set_version.outputs.major }}" ] && [ -n "${{ steps.set_version.outputs.no-v }}" ]; then
+                sudo rm -r /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
+            fi
+            sudo mv -t /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }} /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/macos/${{ matrix.arch }}

--- a/.github/workflows/_meta_portable.yaml
+++ b/.github/workflows/_meta_portable.yaml
@@ -86,22 +86,26 @@ jobs:
             ./artifact/**/*.zip
             ./artifact/**/*.tar.xz
 
-      - name: Make Sure FFmpeg Directory Exists
-        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
-        with:
-          host: ${{ secrets.deploy-host }}
-          username: ${{ secrets.deploy-user }}
-          key: ${{ secrets.deploy-key }}
-          script_stop: true
-          script: |-
-            mkdir -p /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
-
-      - name: Upload Release Assets
-        uses: burnett01/rsync-deployments@93f02b856fbeaf9a8fbfdd8ce1a4adfd0843f849 # 7.0.0
+      - name: Upload release archive to repo.jellyfin.org
+        uses: burnett01/rsync-deployments@45d84ad5f6c174f3e0ffc50e9060a9666d09c16e # 6.0.0
         with:
           switches: -vrptz
           path: ./artifact/*
-          remote_path: /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}/
-          remote_host: ${{ secrets.deploy-host }}
-          remote_user: ${{ secrets.deploy-user }}
-          remote_key: ${{ secrets.deploy-key }}
+          remote_path: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.os }}/${{ matrix.arch }}/
+          remote_host: ${{ secrets.REPO_HOST }}
+          remote_user: ${{ secrets.REPO_USER }}
+          remote_key: ${{ secrets.REPO_KEY }}
+
+      - name: Move incoming release into repository
+        uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1
+        with:
+          host: ${{ secrets.REPO_HOST }}
+          username: ${{ secrets.REPO_USER }}
+          key: ${{ secrets.REPO_KEY }}
+          envs: JELLYFIN_VERSION
+          script_stop: true
+          script: |
+            if [ -d "/srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}" ] && [ -n "${{ steps.set_version.outputs.major }}" ] && [ -n "${{ steps.set_version.outputs.no-v }}" ]; then
+                sudo rm -r /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
+            fi
+            sudo mv -t /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }} /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.os }}/${{ matrix.arch }}

--- a/.github/workflows/_meta_portable.yaml
+++ b/.github/workflows/_meta_portable.yaml
@@ -94,7 +94,7 @@ jobs:
           key: ${{ secrets.REPO_KEY }}
           source: artifact/*
           strip_components: 1
-          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.os }}/${{ matrix.arch }}/
+          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.os }}/${{ matrix.arch }}
 
       - name: Move incoming release into repository
         uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1

--- a/.github/workflows/_meta_portable.yaml
+++ b/.github/workflows/_meta_portable.yaml
@@ -63,24 +63,19 @@ jobs:
             const tag = context.ref.substring(10)
             const no_v = tag.replace('v', '')
             const dash_index = no_v.lastIndexOf('-')
+            const major_index = no_v.firstIndexOf('.')
             const no_dash = (dash_index > -1) ?  no_v.substring(0, dash_index) : no_v
+            const major = (major_index > -1) ?  no_v.substring(0, major_index) : no_v
             core.setOutput('tag', tag)
             core.setOutput('no-v', no_v)
             core.setOutput('no-dash', no_dash)
+            core.setOutput('major', major)
 
       - name: Download Artifacts
         uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
         with:
           name: ${{ inputs.os }}-${{ matrix.arch }}-portable
           path: artifact
-
-      - name: Prepare Release Assets
-        run: |-
-          pushd artifact
-          find * -type f \( -name "*.xz" -o -name "*.zip" \) | while read file; do
-            sha256sum "${file}" | tee "${file}.sha256sum"
-          done
-          popd
 
       - name: Upload GH Release Assets
         uses: shogo82148/actions-upload-release-asset@5bd52f05dd8076794da5975d4c0a4f3bce7dd8f5 # v1.7.4
@@ -90,7 +85,6 @@ jobs:
           asset_path: |
             ./artifact/**/*.zip
             ./artifact/**/*.tar.xz
-            ./artifact/**/*.sha256sum
 
       - name: Make Sure FFmpeg Directory Exists
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
@@ -100,14 +94,14 @@ jobs:
           key: ${{ secrets.deploy-key }}
           script_stop: true
           script: |-
-            mkdir -p /srv/repository/releases/ffmpeg/${{ steps.set_version.outputs.no-v }}/
+            mkdir -p /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
 
       - name: Upload Release Assets
         uses: burnett01/rsync-deployments@93f02b856fbeaf9a8fbfdd8ce1a4adfd0843f849 # 7.0.0
         with:
           switches: -vrptz
           path: ./artifact/*
-          remote_path: /srv/repository/releases/ffmpeg/${{ steps.set_version.outputs.no-v }}/
+          remote_path: /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}/
           remote_host: ${{ secrets.deploy-host }}
           remote_user: ${{ secrets.deploy-user }}
           remote_key: ${{ secrets.deploy-key }}

--- a/.github/workflows/_meta_portable.yaml
+++ b/.github/workflows/_meta_portable.yaml
@@ -87,14 +87,14 @@ jobs:
             ./artifact/**/*.tar.xz
 
       - name: Upload release archive to repo.jellyfin.org
-        uses: burnett01/rsync-deployments@45d84ad5f6c174f3e0ffc50e9060a9666d09c16e # 6.0.0
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
-          switches: -vrptz
-          path: ./artifact/*
-          remote_path: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.os }}/${{ matrix.arch }}/
-          remote_host: ${{ secrets.REPO_HOST }}
-          remote_user: ${{ secrets.REPO_USER }}
-          remote_key: ${{ secrets.REPO_KEY }}
+          host: ${{ secrets.REPO_HOST }}
+          username: ${{ secrets.REPO_USER }}
+          key: ${{ secrets.REPO_KEY }}
+          source: artifact/*
+          strip_components: 1
+          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.os }}/${{ matrix.arch }}/
 
       - name: Move incoming release into repository
         uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["focal", "jammy", "lunar", "mantic"]'
+      codenames: '["focal", "jammy"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -95,12 +95,12 @@ jobs:
             basename="jellyfin-ffmpeg*_${version}-${{ matrix.arrays.codename }}"
             basedir="/srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/${major_version}.x/${version}"
             find ${basedir} -type f -name "${basename}_*.deb" | while read file; do
-                reprepro -b /srv/${{ matrix.arrays.distro }} --export=never --keepunreferencedfiles includedeb ${{ matrix.arrays.codename }} ${file}
+                sudo reprepro -b /srv/${{ matrix.arrays.distro }} --export=never --keepunreferencedfiles includedeb ${{ matrix.arrays.codename }} ${file}
             done
-            reprepro -b /srv/${{ matrix.arrays.distro }} deleteunreferenced
-            reprepro -b /srv/${{ matrix.arrays.distro }} export
-            rm -f /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
-            ln -s ${basedir} /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
+            sudo reprepro -b /srv/${{ matrix.arrays.distro }} deleteunreferenced
+            sudo reprepro -b /srv/${{ matrix.arrays.distro }} export
+            sudo rm -f /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
+            sudo ln -s ${basedir} /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
 
   maintain_repository_portable:
     name: Maintain Repository (Portable)
@@ -129,5 +129,5 @@ jobs:
             version="${tag#v}"
             major_version="${version%%.*}
             basedir="/srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/${major_version}.x/${version}"
-            rm -f /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
-            ln -s ${basedir} /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
+            sudo rm -f /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
+            sudo ln -s ${basedir} /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -76,9 +76,7 @@ jobs:
           {distro: 'debian', codename: 'bullseye'},
           {distro: 'debian', codename: 'bookworm'},
           {distro: 'ubuntu', codename: 'focal'},
-          {distro: 'ubuntu', codename: 'jammy'},
-          {distro: 'ubuntu', codename: 'lunar'},
-          {distro: 'ubuntu', codename: 'mantic'}
+          {distro: 'ubuntu', codename: 'jammy'}
         ]
     steps:
       - name: Sync mirrors and update symlinks

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["focal", "jammy", "lunar", "mantic"]'
+      codenames: '["focal", "jammy"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: true
     secrets:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -93,13 +93,16 @@ jobs:
             set -o xtrace
             tag="${{ github.event.release.tag_name }}"
             version="${tag#v}"
+            major_version="${version%%.*}
             basename="jellyfin-ffmpeg*_${version}-${{ matrix.arrays.codename }}"
-            find /srv/repository/releases/server/${{ matrix.arrays.distro }}/ -type l -name "jellyfin-ffmpeg*_*" -exec rm {} \;
-            find /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version} -type f -name "${basename}_*.deb" | while read file; do
-              reprepro -b /srv/repository/${{ matrix.arrays.distro }} --export=never --keepunreferencedfiles includedeb ${{ matrix.arrays.codename }} ${file}
+            basedir="/srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/${major_version}.x/${version}"
+            find ${basedir} -type f -name "${basename}_*.deb" | while read file; do
+                reprepro -b /srv/${{ matrix.arrays.distro }} --export=never --keepunreferencedfiles includedeb ${{ matrix.arrays.codename }} ${file}
             done
-            reprepro -b /srv/repository/${{ matrix.arrays.distro }} deleteunreferenced
-            reprepro -b /srv/repository/${{ matrix.arrays.distro }} export
+            reprepro -b /srv/${{ matrix.arrays.distro }} deleteunreferenced
+            reprepro -b /srv/${{ matrix.arrays.distro }} export
+            rm -f /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
+            ln -s ${basedir} /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
 
   maintain_repository_portable:
     name: Maintain Repository (Portable)
@@ -126,8 +129,7 @@ jobs:
             set -o xtrace
             tag="${{ github.event.release.tag_name }}"
             version="${tag#v}"
-            if [ "${{ matrix.arrays.distro }}" == "windows" ]; then
-              mkdir -p /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}
-              ln -fs /srv/repository/releases/ffmpeg/${version}/*.zip /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}/
-              ln -fs /srv/repository/releases/ffmpeg/${version}/*.zip.sha265sum /srv/repository/releases/server/${{ matrix.arrays.distro }}/versions/jellyfin-ffmpeg/${version}/
-            fi
+            major_version="${version%%.*}
+            basedir="/srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/${major_version}.x/${version}"
+            rm -f /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x
+            ln -s ${basedir} /srv/repository/main/ffmpeg/${{ matrix.arrays.distro }}/latest-${major_version}.x

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,9 +14,9 @@ jobs:
       architectures: '["amd64", "arm64", "armhf"]'
       release: true
     secrets:
-      deploy-host: ${{ secrets.DEPLOY_HOST }}
-      deploy-user: ${{ secrets.DEPLOY_USER }}
-      deploy-key: ${{ secrets.DEPLOY_KEY }}
+      deploy-host: ${{ secrets.REPO_HOST }}
+      deploy-user: ${{ secrets.REPO_USER }}
+      deploy-key: ${{ secrets.REPO_KEY }}
 
   build_publish_ubuntu:
     uses: ./.github/workflows/_meta.yaml
@@ -26,9 +26,9 @@ jobs:
       architectures: '["amd64", "arm64", "armhf"]'
       release: true
     secrets:
-      deploy-host: ${{ secrets.DEPLOY_HOST }}
-      deploy-user: ${{ secrets.DEPLOY_USER }}
-      deploy-key: ${{ secrets.DEPLOY_KEY }}
+      deploy-host: ${{ secrets.REPO_HOST }}
+      deploy-user: ${{ secrets.REPO_USER }}
+      deploy-key: ${{ secrets.REPO_KEY }}
 
   build_publish_windows_portable:
     uses: ./.github/workflows/_meta_portable.yaml
@@ -37,9 +37,9 @@ jobs:
       architectures: '["win64"]'
       release: true
     secrets:
-      deploy-host: ${{ secrets.DEPLOY_HOST }}
-      deploy-user: ${{ secrets.DEPLOY_USER }}
-      deploy-key: ${{ secrets.DEPLOY_KEY }}
+      deploy-host: ${{ secrets.REPO_HOST }}
+      deploy-user: ${{ secrets.REPO_USER }}
+      deploy-key: ${{ secrets.REPO_KEY }}
 
   build_publish_linux_portable:
     uses: ./.github/workflows/_meta_portable.yaml
@@ -48,18 +48,18 @@ jobs:
       architectures: '["amd64", "arm64"]'
       release: true
     secrets:
-      deploy-host: ${{ secrets.DEPLOY_HOST }}
-      deploy-user: ${{ secrets.DEPLOY_USER }}
-      deploy-key: ${{ secrets.DEPLOY_KEY }}
+      deploy-host: ${{ secrets.REPO_HOST }}
+      deploy-user: ${{ secrets.REPO_USER }}
+      deploy-key: ${{ secrets.REPO_KEY }}
 
   build_publish_mac_portable:
       uses: ./.github/workflows/_meta_mac_portable.yaml
       with:
         release: true
       secrets:
-        deploy-host: ${{ secrets.DEPLOY_HOST }}
-        deploy-user: ${{ secrets.DEPLOY_USER }}
-        deploy-key: ${{ secrets.DEPLOY_KEY }}
+        deploy-host: ${{ secrets.REPO_HOST }}
+        deploy-user: ${{ secrets.REPO_USER }}
+        deploy-key: ${{ secrets.REPO_KEY }}
 
   maintain_repository:
     name: Maintain Repository
@@ -84,9 +84,9 @@ jobs:
       - name: Sync mirrors and update symlinks
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_KEY }}
+          host: ${{ secrets.REPO_HOST }}
+          username: ${{ secrets.REPO_USER }}
+          key: ${{ secrets.REPO_KEY }}
           script_stop: true
           script: |-
             set -o errexit
@@ -120,9 +120,9 @@ jobs:
       - name: Update symlinks
         uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262 # v1.0.3
         with:
-          host: ${{ secrets.DEPLOY_HOST }}
-          username: ${{ secrets.DEPLOY_USER }}
-          key: ${{ secrets.DEPLOY_KEY }}
+          host: ${{ secrets.REPO_HOST }}
+          username: ${{ secrets.REPO_USER }}
+          key: ${{ secrets.REPO_KEY }}
           script_stop: true
           script: |-
             set -o errexit


### PR DESCRIPTION
**Changes**
1. Use new path layout.
2. Add major version calculation for use in path.
3. Remove sha256sums.
4. Drop non-LTS Ubuntus from builds (matches main server builds)

**Issues**
N/A