### PR TITLE
Additional non-critical build corrections

### DIFF
--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -122,6 +122,7 @@ jobs:
             # Create the target folder and move arch directory into it
             sudo mkdir -p /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
             sudo mv -t /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/ /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}
+            sudo chown -R root:root /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
             # Update symlink for latest-X.x
             sudo rm -f /srv/repository/main/ffmpeg/${{ inputs.distro }}/latest-${{ steps.set_version.outputs.major }}.x
             sudo ln -s /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }} /srv/repository/main/ffmpeg/${{ inputs.distro }}/latest-${{ steps.set_version.outputs.major }}.x

--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -104,7 +104,7 @@ jobs:
           key: ${{ secrets.deploy-key }}
           source: artifact/*
           strip_components: 1
-          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}
+          target: /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}/${{ matrix.release }}
 
       - name: Move incoming release into repository
         uses: appleboy/ssh-action@8f949198563a347a01c65ffc60399aef2b59d4ab # v1.0.1
@@ -120,9 +120,9 @@ jobs:
                 sudo rm -r /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
             fi
             # Create the target folder and move arch directory into it
-            sudo mkdir -p /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
-            sudo mv -t /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/ /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}
-            sudo chown -R root:root /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
+            sudo mkdir -p /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
+            sudo mv -t /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}/ /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.distro }}/${{ matrix.arch }}/${{ matrix.release }}/*
+            sudo chown -R root:root /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/${{ matrix.arch }}
             # Update symlink for latest-X.x
-            sudo rm -f /srv/repository/main/ffmpeg/${{ inputs.distro }}/latest-${{ steps.set_version.outputs.major }}.x
-            sudo ln -s /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }} /srv/repository/main/ffmpeg/${{ inputs.distro }}/latest-${{ steps.set_version.outputs.major }}.x
+            sudo rm -f /srv/repository/main/ffmpeg/${{ inputs.distro }}/latest-${{ steps.set_version.outputs.major }}.x || true
+            sudo ln -s /srv/repository/main/ffmpeg/${{ inputs.distro }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }} /srv/repository/main/ffmpeg/${{ inputs.distro }}/latest-${{ steps.set_version.outputs.major }}.x || true

--- a/.github/workflows/_meta_mac_portable.yaml
+++ b/.github/workflows/_meta_mac_portable.yaml
@@ -117,5 +117,5 @@ jobs:
             sudo mv -t /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/ /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/macos/${{ matrix.arch }}
             sudo chown -R root:root /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
             # Update symlink for latest-X.x
-            sudo rm -f /srv/repository/main/ffmpeg/macos/latest-${{ steps.set_version.outputs.major }}.x
-            sudo ln -s /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }} /srv/repository/main/ffmpeg/macos/latest-${{ steps.set_version.outputs.major }}.x
+            sudo rm -f /srv/repository/main/ffmpeg/macos/latest-${{ steps.set_version.outputs.major }}.x || true
+            sudo ln -s /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }} /srv/repository/main/ffmpeg/macos/latest-${{ steps.set_version.outputs.major }}.x || true

--- a/.github/workflows/_meta_mac_portable.yaml
+++ b/.github/workflows/_meta_mac_portable.yaml
@@ -115,6 +115,7 @@ jobs:
             # Create the target folder and move arch directory into it
             sudo mkdir -p /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
             sudo mv -t /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/ /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/macos/${{ matrix.arch }}
+            sudo chown -R root:root /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
             # Update symlink for latest-X.x
             sudo rm -f /srv/repository/main/ffmpeg/macos/latest-${{ steps.set_version.outputs.major }}.x
             sudo ln -s /srv/repository/main/ffmpeg/macos/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }} /srv/repository/main/ffmpeg/macos/latest-${{ steps.set_version.outputs.major }}.x

--- a/.github/workflows/_meta_portable.yaml
+++ b/.github/workflows/_meta_portable.yaml
@@ -112,6 +112,7 @@ jobs:
             # Create the target folder and move arch directory into it
             sudo mkdir -p /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
             sudo mv -t /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/ /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.os }}/${{ matrix.arch }}
+            sudo chown -R root:root /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
             # Update symlink for latest-X.x
             sudo rm -f /srv/repository/main/ffmpeg/${{ inputs.os }}/latest-${{ steps.set_version.outputs.major }}.x
             sudo ln -s /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }} /srv/repository/main/ffmpeg/${{ inputs.os }}/latest-${{ steps.set_version.outputs.major }}.x

--- a/.github/workflows/_meta_portable.yaml
+++ b/.github/workflows/_meta_portable.yaml
@@ -114,5 +114,5 @@ jobs:
             sudo mv -t /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}/ /srv/incoming/ffmpeg/${{ steps.set_version.outputs.no-v }}/${{ inputs.os }}/${{ matrix.arch }}
             sudo chown -R root:root /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }}
             # Update symlink for latest-X.x
-            sudo rm -f /srv/repository/main/ffmpeg/${{ inputs.os }}/latest-${{ steps.set_version.outputs.major }}.x
-            sudo ln -s /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }} /srv/repository/main/ffmpeg/${{ inputs.os }}/latest-${{ steps.set_version.outputs.major }}.x
+            sudo rm -f /srv/repository/main/ffmpeg/${{ inputs.os }}/latest-${{ steps.set_version.outputs.major }}.x || true
+            sudo ln -s /srv/repository/main/ffmpeg/${{ inputs.os }}/${{ steps.set_version.outputs.major }}.x/${{ steps.set_version.outputs.no-v }} /srv/repository/main/ffmpeg/${{ inputs.os }}/latest-${{ steps.set_version.outputs.major }}.x || true

--- a/build-linux-amd64
+++ b/build-linux-amd64
@@ -21,4 +21,4 @@ else
     path="${1}"
 fi
 mkdir ${path} &>/dev/null || true
-mv builder/artifacts/jellyfin-ffmpeg*portable_linux64-gpl*.{tar.xz,sha256sum} "${path}"
+mv builder/artifacts/jellyfin-ffmpeg*portable_linux64-gpl*.tar.xz "${path}"

--- a/build-linux-arm64
+++ b/build-linux-arm64
@@ -21,4 +21,4 @@ else
     path="${1}"
 fi
 mkdir ${path} &>/dev/null || true
-mv builder/artifacts/jellyfin-ffmpeg*portable_linuxarm64-gpl*.{tar.xz,sha256sum} "${path}"
+mv builder/artifacts/jellyfin-ffmpeg*portable_linuxarm64-gpl*.tar.xz "${path}"

--- a/build-windows-win64
+++ b/build-windows-win64
@@ -36,4 +36,4 @@ else
     path="${1}"
 fi
 mkdir ${path} &>/dev/null || true
-mv "${package_temporary_dir}"/zip/jellyfin-ffmpeg*.{zip,sha256sum} "${path}"
+mv "${package_temporary_dir}"/zip/jellyfin-ffmpeg*.zip "${path}"

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -100,9 +100,6 @@ else
     tar cJf "${ARTIFACTS_PATH}/${OUTPUT_FNAME}" *
 fi
 cd -
-cd "${ARTIFACTS_PATH}"
-sha256sum ./${OUTPUT_FNAME} > ./${OUTPUT_FNAME}.sha256sum
-cd -
 
 rm -rf ffbuild
 

--- a/builder/buildmac.sh
+++ b/builder/buildmac.sh
@@ -108,8 +108,6 @@ mkdir -p artifacts
 mv ../ffmpeg ./
 mv ../ffprobe ./
 tar -cJf "${ARTIFACTS_PATH}/${OUTPUT_FNAME}" ffmpeg ffprobe
-cd "${ARTIFACTS_PATH}"
-sha256sum ./${OUTPUT_FNAME} > ./${OUTPUT_FNAME}.sha256sum
 cd "$BUILDER_ROOT"/..
 
 if [[ -n "$GITHUB_ACTIONS" ]]; then

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -644,7 +644,6 @@ pushd ${FF_PREFIX}/bin
 ffpackage="jellyfin-ffmpeg_${ffversion}-portable_win64"
 zip -9 -r ${ARTIFACT_DIR}/zip/${ffpackage}.zip ./*.{exe,dll}
 pushd ${ARTIFACT_DIR}/zip
-sha256sum ./${ffpackage}.zip > ./${ffpackage}.zip.sha256sum
 chown -Rc $(stat -c %u:%g ${ARTIFACT_DIR}) ${ARTIFACT_DIR}
 popd
 popd


### PR DESCRIPTION
1. Remove sha256sum from remaining builds; was removed from others.
2. Correct ownership of moved files in repo dir to root.
3. Ensure Debuntu upload into a per-dist folder or things get wonky.
4. Ensure we continue if non-atomic symlinking fails for some reason.