### PR TITLE
[6.0] Add support for Ubuntu 24.04 LTS (Noble)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["focal", "jammy"]'
+      codenames: '["focal", "jammy", "noble"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["focal", "jammy"]'
+      codenames: '["focal", "jammy", "noble"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: true
     secrets:
@@ -76,7 +76,8 @@ jobs:
           {distro: 'debian', codename: 'bullseye'},
           {distro: 'debian', codename: 'bookworm'},
           {distro: 'ubuntu', codename: 'focal'},
-          {distro: 'ubuntu', codename: 'jammy'}
+          {distro: 'ubuntu', codename: 'jammy'},
+          {distro: 'ubuntu', codename: 'noble'}
         ]
     steps:
       - name: Import packages into reprepro

--- a/Dockerfile.make
+++ b/Dockerfile.make
@@ -1,7 +1,7 @@
 #!/usr/bin/make
-DISTRO=bullseye
-GCC_VER=10
-LLVM_VER=13
+DISTRO=noble
+GCC_VER=13
+LLVM_VER=17
 ARCH=amd64
 .PHONY: Dockerfile
 Dockerfile: Dockerfile.in

--- a/Dockerfile.win64.in
+++ b/Dockerfile.win64.in
@@ -17,8 +17,8 @@ ENV DEBIAN_FRONTEND=noninteractive \
     FF_TARGET_FLAGS="--arch=x86_64 --target-os=mingw32 --cross-prefix=x86_64-w64-mingw32- --pkg-config=pkg-config --pkg-config-flags=--static" \
     PKG_CONFIG=pkg-config \
     PKG_CONFIG_LIBDIR=/opt/ffdeps/lib/pkgconfig:/opt/ffdeps/share/pkgconfig \
-    CFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffdeps/include -mtune=generic -O2 -pipe -D_FORTIFY_SOURCE=0" \
-    CXXFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffdeps/include -mtune=generic -O2 -pipe -D_FORTIFY_SOURCE=0" \
+    CFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffdeps/include -mtune=generic -O2 -pipe -D_FORTIFY_SOURCE=0 -D_WIN32_WINNT=0x0601" \
+    CXXFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffdeps/include -mtune=generic -O2 -pipe -D_FORTIFY_SOURCE=0 -D_WIN32_WINNT=0x0601" \
     LDFLAGS="-static-libgcc -static-libstdc++ -L/opt/ffdeps/lib -O2 -pipe" \
     DLLTOOL="x86_64-w64-mingw32-dlltool"
 
@@ -31,7 +31,7 @@ RUN apt-get update \
     help2man flex bison gperf gettext itstool ragel \
     libc6-dev libssl-dev gtk-doc-tools gobject-introspection \
     gawk meson ninja-build p7zip-full python3-distutils \
-    python3-apt python-is-python3 zip quilt \ 
+    python3-apt python-is-python3 zip quilt \
     binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64 \
     g++-mingw-w64-x86-64 gfortran-mingw-w64-x86-64 \
  && apt-get clean autoclean -y \

--- a/Dockerfile.win64.make
+++ b/Dockerfile.win64.make
@@ -1,5 +1,5 @@
 #!/usr/bin/make
-DISTRO=ubuntu:mantic
+DISTRO=ubuntu:noble
 .PHONY: Dockerfile
 Dockerfile: Dockerfile.win64.in
 	sed 's/DISTRO/$(DISTRO)/' $< > $@ || rm -f $@

--- a/build
+++ b/build
@@ -9,8 +9,7 @@ usage() {
     echo -e " * bookworm         * arm64"
     echo -e " * focal"
     echo -e " * jammy"
-    echo -e " * lunar"
-    echo -e " * mantic"
+    echo -e " * noble"
 }
 
 if [[ -z ${1} ]]; then
@@ -28,12 +27,12 @@ case ${cli_release} in
     'bullseye')
         release="debian:bullseye"
         gcc_version="10"
-        llvm_version="13"
+        llvm_version="16"
     ;;
     'bookworm')
         release="debian:bookworm"
         gcc_version="12"
-        llvm_version="15"
+        llvm_version="16"
     ;;
     'focal')
         release="ubuntu:focal"
@@ -45,13 +44,8 @@ case ${cli_release} in
         gcc_version="11"
         llvm_version="15"
     ;;
-    'lunar')
-        release="ubuntu:lunar"
-        gcc_version="12"
-        llvm_version="15"
-    ;;
-    'mantic')
-        release="ubuntu:mantic"
+    'noble')
+        release="ubuntu:noble"
         gcc_version="13"
         llvm_version="17"
     ;;

--- a/build-windows-win64
+++ b/build-windows-win64
@@ -9,7 +9,7 @@ for dep in docker make; do
 done
 
 # Use the latest distro for toolchains
-distro="ubuntu:mantic"
+distro="ubuntu:noble"
 image_name="jellyfin-ffmpeg-build-windows-win64"
 package_temporary_dir="$( mktemp -d )"
 current_user="$( whoami )"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "6.0.1-4"
+version: "6.0.1-5"
 packages:
   - buster-amd64
   - buster-armhf

--- a/build.yaml
+++ b/build.yaml
@@ -18,9 +18,6 @@ packages:
   - jammy-amd64
   - jammy-armhf
   - jammy-arm64
-  - lunar-amd64
-  - lunar-armhf
-  - lunar-arm64
-  - mantic-amd64
-  - mantic-armhf
-  - mantic-arm64
+  - noble-amd64
+  - noble-armhf
+  - noble-arm64

--- a/builder/README.md
+++ b/builder/README.md
@@ -30,8 +30,8 @@ On success, the resulting `zip` or `tar.xz` file will be in the `artifacts` subd
 
 Available targets:
 * `win64` (x86_64 Windows, windows>=7)
-* `linux64` (x86_64 Linux, glibc>=2.23, linux>=4.4)
-* `linuxarm64` (arm64 (aarch64) Linux, glibc>=2.27, linux>=4.15)
+* `linux64` (x86_64 Linux, glibc>=2.28, linux>=4.18)
+* `linuxarm64` (arm64 (aarch64) Linux, glibc>=2.28, linux>=4.18)
 
 Available variants:
 * `gpl` Includes all dependencies, even those that require full GPL instead of just LGPL.

--- a/builder/images/base-linux64/ct-ng-config
+++ b/builder/images/base-linux64/ct-ng-config
@@ -1,12 +1,13 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.25.0.232_c175b21 Configuration
+# crosstool-NG 1.26.0.65_ecc5e41 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
 CT_CONFIGURE_has_wget=y
 CT_CONFIGURE_has_curl=y
-CT_CONFIGURE_has_rsync=y
+CT_CONFIGURE_has_meson=y
+CT_CONFIGURE_has_ninja=y
 CT_CONFIGURE_has_make_3_81_or_newer=y
 CT_CONFIGURE_has_make_4_0_or_newer=y
 CT_CONFIGURE_has_libtool_2_4_or_newer=y
@@ -26,7 +27,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.25.0.232_c175b21"
+CT_VERSION="1.26.0.65_ecc5e41"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -145,6 +146,7 @@ CT_LOG_LEVEL_MAX="DEBUG"
 # CT_ARCH_MOXIE is not set
 # CT_ARCH_MSP430 is not set
 # CT_ARCH_NIOS2 is not set
+# CT_ARCH_PARISC is not set
 # CT_ARCH_POWERPC is not set
 # CT_ARCH_PRU is not set
 # CT_ARCH_RISCV is not set
@@ -163,7 +165,7 @@ CT_ARCH_X86_SHOW=y
 # Options for x86
 #
 CT_ARCH_X86_PKG_KSYM=""
-CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
+CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 PARISC POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
 CT_ARCH_SUFFIX=""
 # CT_OMIT_TARGET_VENDOR is not set
 
@@ -253,9 +255,6 @@ CT_KERNEL_LINUX_SHOW=y
 #
 CT_KERNEL_LINUX_PKG_KSYM="LINUX"
 CT_LINUX_DIR_NAME="linux"
-CT_LINUX_USE_WWW_KERNEL_ORG=y
-# CT_LINUX_USE_ORACLE is not set
-CT_LINUX_USE="LINUX"
 CT_LINUX_PKG_NAME="linux"
 CT_LINUX_SRC_RELEASE=y
 # CT_LINUX_SRC_DEVEL is not set
@@ -267,6 +266,8 @@ CT_LINUX_PATCH_GLOBAL=y
 # CT_LINUX_PATCH_LOCAL_BUNDLED is not set
 # CT_LINUX_PATCH_NONE is not set
 CT_LINUX_PATCH_ORDER="global"
+# CT_LINUX_V_6_6 is not set
+# CT_LINUX_V_6_5 is not set
 # CT_LINUX_V_6_4 is not set
 # CT_LINUX_V_6_3 is not set
 # CT_LINUX_V_6_2 is not set
@@ -293,7 +294,7 @@ CT_LINUX_PATCH_ORDER="global"
 # CT_LINUX_V_5_0 is not set
 # CT_LINUX_V_4_20 is not set
 # CT_LINUX_V_4_19 is not set
-# CT_LINUX_V_4_18 is not set
+CT_LINUX_V_4_18=y
 # CT_LINUX_V_4_17 is not set
 # CT_LINUX_V_4_16 is not set
 # CT_LINUX_V_4_15 is not set
@@ -303,7 +304,7 @@ CT_LINUX_PATCH_ORDER="global"
 # CT_LINUX_V_4_11 is not set
 # CT_LINUX_V_4_10 is not set
 # CT_LINUX_V_4_9 is not set
-CT_LINUX_V_4_4=y
+# CT_LINUX_V_4_4 is not set
 # CT_LINUX_V_4_1 is not set
 # CT_LINUX_V_3_18 is not set
 # CT_LINUX_V_3_16 is not set
@@ -312,8 +313,7 @@ CT_LINUX_V_4_4=y
 # CT_LINUX_V_3_10 is not set
 # CT_LINUX_V_3_4 is not set
 # CT_LINUX_V_3_2 is not set
-# CT_LINUX_V_2_6_32 is not set
-CT_LINUX_VERSION="4.4.302"
+CT_LINUX_VERSION="4.18.20"
 CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -327,12 +327,14 @@ CT_LINUX_5_5_or_older=y
 CT_LINUX_older_than_5_5=y
 CT_LINUX_5_3_or_older=y
 CT_LINUX_older_than_5_3=y
-CT_LINUX_4_8_or_older=y
-CT_LINUX_older_than_4_8=y
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
 CT_LINUX_later_than_3_7=y
 CT_LINUX_3_7_or_later=y
 CT_LINUX_later_than_3_2=y
 CT_LINUX_3_2_or_later=y
+CT_LINUX_REQUIRE_3_2_or_later=y
+CT_KERNEL_has_rsync=y
 CT_KERNEL_DEP_RSYNC=y
 CT_KERNEL_LINUX_VERBOSITY_0=y
 # CT_KERNEL_LINUX_VERBOSITY_1 is not set
@@ -376,7 +378,9 @@ CT_BINUTILS_PATCH_GLOBAL=y
 # CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
 # CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
-CT_BINUTILS_V_2_40=y
+CT_BINUTILS_V_2_42=y
+# CT_BINUTILS_V_2_41 is not set
+# CT_BINUTILS_V_2_40 is not set
 # CT_BINUTILS_V_2_39 is not set
 # CT_BINUTILS_V_2_38 is not set
 # CT_BINUTILS_V_2_37 is not set
@@ -391,7 +395,7 @@ CT_BINUTILS_V_2_40=y
 # CT_BINUTILS_V_2_28 is not set
 # CT_BINUTILS_V_2_27 is not set
 # CT_BINUTILS_V_2_26 is not set
-CT_BINUTILS_VERSION="2.40"
+CT_BINUTILS_VERSION="2.42"
 CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
 CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -453,6 +457,7 @@ CT_GLIBC_PATCH_GLOBAL=y
 # CT_GLIBC_PATCH_LOCAL_BUNDLED is not set
 # CT_GLIBC_PATCH_NONE is not set
 CT_GLIBC_PATCH_ORDER="global"
+# CT_GLIBC_V_2_39 is not set
 # CT_GLIBC_V_2_38 is not set
 # CT_GLIBC_V_2_37 is not set
 # CT_GLIBC_V_2_36 is not set
@@ -463,15 +468,15 @@ CT_GLIBC_PATCH_ORDER="global"
 # CT_GLIBC_V_2_31 is not set
 # CT_GLIBC_V_2_30 is not set
 # CT_GLIBC_V_2_29 is not set
-# CT_GLIBC_V_2_28 is not set
+CT_GLIBC_V_2_28=y
 # CT_GLIBC_V_2_27 is not set
 # CT_GLIBC_V_2_26 is not set
 # CT_GLIBC_V_2_25 is not set
 # CT_GLIBC_V_2_24 is not set
-CT_GLIBC_V_2_23=y
+# CT_GLIBC_V_2_23 is not set
 # CT_GLIBC_V_2_19 is not set
 # CT_GLIBC_V_2_17 is not set
-CT_GLIBC_VERSION="2.23"
+CT_GLIBC_VERSION="2.28"
 CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
 CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -493,18 +498,18 @@ CT_GLIBC_2_30_or_older=y
 CT_GLIBC_older_than_2_30=y
 CT_GLIBC_2_29_or_older=y
 CT_GLIBC_older_than_2_29=y
+CT_GLIBC_2_28_or_later=y
 CT_GLIBC_2_28_or_older=y
-CT_GLIBC_older_than_2_28=y
-CT_GLIBC_2_27_or_older=y
-CT_GLIBC_older_than_2_27=y
-CT_GLIBC_2_26_or_older=y
-CT_GLIBC_older_than_2_26=y
-CT_GLIBC_2_25_or_older=y
-CT_GLIBC_older_than_2_25=y
-CT_GLIBC_2_24_or_older=y
-CT_GLIBC_older_than_2_24=y
+CT_GLIBC_later_than_2_27=y
+CT_GLIBC_2_27_or_later=y
+CT_GLIBC_later_than_2_26=y
+CT_GLIBC_2_26_or_later=y
+CT_GLIBC_later_than_2_25=y
+CT_GLIBC_2_25_or_later=y
+CT_GLIBC_later_than_2_24=y
+CT_GLIBC_2_24_or_later=y
+CT_GLIBC_later_than_2_23=y
 CT_GLIBC_2_23_or_later=y
-CT_GLIBC_2_23_or_older=y
 CT_GLIBC_later_than_2_20=y
 CT_GLIBC_2_20_or_later=y
 CT_GLIBC_later_than_2_17=y
@@ -517,6 +522,7 @@ CT_GLIBC_DEP_GCC=y
 CT_GLIBC_DEP_PYTHON=y
 CT_GLIBC_SPARC_ALLOW_V7=y
 CT_THREADS="nptl"
+CT_GLIBC_BUILD_SSP=y
 CT_GLIBC_HAS_LIBIDN_ADDON=y
 # CT_GLIBC_USE_LIBIDN_ADDON is not set
 CT_GLIBC_NO_SPARC_V8=y
@@ -534,7 +540,13 @@ CT_GLIBC_FORCE_UNWIND=y
 # CT_GLIBC_KERNEL_VERSION_NONE is not set
 CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
 # CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
-CT_GLIBC_MIN_KERNEL="4.4.302"
+CT_GLIBC_MIN_KERNEL="4.18.20"
+# CT_GLIBC_SSP_DEFAULT is not set
+# CT_GLIBC_SSP_NO is not set
+# CT_GLIBC_SSP_YES is not set
+# CT_GLIBC_SSP_ALL is not set
+CT_GLIBC_SSP_STRONG=y
+CT_GLIBC_SSP="strong"
 CT_GLIBC_ENABLE_COMMON_FLAG=y
 CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE PICOLIBC UCLIBC_NG"
 CT_LIBC_SUPPORT_THREADS_ANY=y
@@ -621,6 +633,7 @@ CT_GCC_later_than_5=y
 CT_GCC_5_or_later=y
 CT_GCC_later_than_4_9=y
 CT_GCC_4_9_or_later=y
+CT_GCC_REQUIRE_4_9_or_later=y
 CT_CC_GCC_ENABLE_PLUGINS=y
 CT_CC_GCC_HAS_LIBMPX=y
 CT_CC_GCC_ENABLE_CXX_FLAGS=""
@@ -787,7 +800,6 @@ CT_ISL_V_0_26=y
 # CT_ISL_V_0_17 is not set
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
-# CT_ISL_V_0_11 is not set
 CT_ISL_VERSION="0.26"
 CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
@@ -835,10 +847,9 @@ CT_MPC_PATCH_GLOBAL=y
 # CT_MPC_PATCH_LOCAL_BUNDLED is not set
 # CT_MPC_PATCH_NONE is not set
 CT_MPC_PATCH_ORDER="global"
-CT_MPC_V_1_2=y
-# CT_MPC_V_1_1 is not set
-# CT_MPC_V_1_0 is not set
-CT_MPC_VERSION="1.2.1"
+CT_MPC_V_1_3=y
+# CT_MPC_V_1_2 is not set
+CT_MPC_VERSION="1.3.1"
 CT_MPC_MIRRORS="https://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
 CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -861,9 +872,6 @@ CT_MPFR_PATCH_GLOBAL=y
 # CT_MPFR_PATCH_NONE is not set
 CT_MPFR_PATCH_ORDER="global"
 CT_MPFR_V_4_2=y
-# CT_MPFR_V_4_1 is not set
-# CT_MPFR_V_4_0 is not set
-# CT_MPFR_V_3_1 is not set
 CT_MPFR_VERSION="4.2.1"
 CT_MPFR_MIRRORS="https://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
 CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
@@ -917,9 +925,9 @@ CT_ZLIB_PATCH_GLOBAL=y
 # CT_ZLIB_PATCH_LOCAL_BUNDLED is not set
 # CT_ZLIB_PATCH_NONE is not set
 CT_ZLIB_PATCH_ORDER="global"
-CT_ZLIB_V_1_2_13=y
-# CT_ZLIB_V_1_2_12 is not set
-CT_ZLIB_VERSION="1.2.13"
+CT_ZLIB_V_1_3=y
+# CT_ZLIB_V_1_2_13 is not set
+CT_ZLIB_VERSION="1.3"
 CT_ZLIB_MIRRORS="https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/"
 CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"

--- a/builder/images/base-linuxarm64/ct-ng-config
+++ b/builder/images/base-linuxarm64/ct-ng-config
@@ -1,12 +1,13 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.25.0.232_c175b21 Configuration
+# crosstool-NG 1.26.0.65_ecc5e41 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
 CT_CONFIGURE_has_wget=y
 CT_CONFIGURE_has_curl=y
-CT_CONFIGURE_has_rsync=y
+CT_CONFIGURE_has_meson=y
+CT_CONFIGURE_has_ninja=y
 CT_CONFIGURE_has_make_3_81_or_newer=y
 CT_CONFIGURE_has_make_4_0_or_newer=y
 CT_CONFIGURE_has_libtool_2_4_or_newer=y
@@ -26,7 +27,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.25.0.232_c175b21"
+CT_VERSION="1.26.0.65_ecc5e41"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -145,6 +146,7 @@ CT_ARCH_ARM=y
 # CT_ARCH_MOXIE is not set
 # CT_ARCH_MSP430 is not set
 # CT_ARCH_NIOS2 is not set
+# CT_ARCH_PARISC is not set
 # CT_ARCH_POWERPC is not set
 # CT_ARCH_PRU is not set
 # CT_ARCH_RISCV is not set
@@ -163,7 +165,7 @@ CT_ARCH_ARM_SHOW=y
 # Options for arm
 #
 CT_ARCH_ARM_PKG_KSYM=""
-CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
+CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 PARISC POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
 CT_ARCH_SUFFIX=""
 # CT_OMIT_TARGET_VENDOR is not set
 
@@ -260,9 +262,6 @@ CT_KERNEL_LINUX_SHOW=y
 #
 CT_KERNEL_LINUX_PKG_KSYM="LINUX"
 CT_LINUX_DIR_NAME="linux"
-CT_LINUX_USE_WWW_KERNEL_ORG=y
-# CT_LINUX_USE_ORACLE is not set
-CT_LINUX_USE="LINUX"
 CT_LINUX_PKG_NAME="linux"
 CT_LINUX_SRC_RELEASE=y
 # CT_LINUX_SRC_DEVEL is not set
@@ -274,6 +273,8 @@ CT_LINUX_PATCH_GLOBAL=y
 # CT_LINUX_PATCH_LOCAL_BUNDLED is not set
 # CT_LINUX_PATCH_NONE is not set
 CT_LINUX_PATCH_ORDER="global"
+# CT_LINUX_V_6_6 is not set
+# CT_LINUX_V_6_5 is not set
 # CT_LINUX_V_6_4 is not set
 # CT_LINUX_V_6_3 is not set
 # CT_LINUX_V_6_2 is not set
@@ -300,10 +301,10 @@ CT_LINUX_PATCH_ORDER="global"
 # CT_LINUX_V_5_0 is not set
 # CT_LINUX_V_4_20 is not set
 # CT_LINUX_V_4_19 is not set
-# CT_LINUX_V_4_18 is not set
+CT_LINUX_V_4_18=y
 # CT_LINUX_V_4_17 is not set
 # CT_LINUX_V_4_16 is not set
-CT_LINUX_V_4_15=y
+# CT_LINUX_V_4_15 is not set
 # CT_LINUX_V_4_14 is not set
 # CT_LINUX_V_4_13 is not set
 # CT_LINUX_V_4_12 is not set
@@ -317,7 +318,7 @@ CT_LINUX_V_4_15=y
 # CT_LINUX_V_3_13 is not set
 # CT_LINUX_V_3_12 is not set
 # CT_LINUX_V_3_10 is not set
-CT_LINUX_VERSION="4.15.18"
+CT_LINUX_VERSION="4.18.20"
 CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
 CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -339,6 +340,7 @@ CT_LINUX_REQUIRE_3_7_or_later=y
 CT_LINUX_later_than_3_2=y
 CT_LINUX_3_2_or_later=y
 CT_LINUX_REQUIRE_3_2_or_later=y
+CT_KERNEL_has_rsync=y
 CT_KERNEL_DEP_RSYNC=y
 CT_KERNEL_LINUX_VERBOSITY_0=y
 # CT_KERNEL_LINUX_VERBOSITY_1 is not set
@@ -382,7 +384,9 @@ CT_BINUTILS_PATCH_GLOBAL=y
 # CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
 # CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
-CT_BINUTILS_V_2_40=y
+CT_BINUTILS_V_2_42=y
+# CT_BINUTILS_V_2_41 is not set
+# CT_BINUTILS_V_2_40 is not set
 # CT_BINUTILS_V_2_39 is not set
 # CT_BINUTILS_V_2_38 is not set
 # CT_BINUTILS_V_2_37 is not set
@@ -397,7 +401,7 @@ CT_BINUTILS_V_2_40=y
 # CT_BINUTILS_V_2_28 is not set
 # CT_BINUTILS_V_2_27 is not set
 # CT_BINUTILS_V_2_26 is not set
-CT_BINUTILS_VERSION="2.40"
+CT_BINUTILS_VERSION="2.42"
 CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
 CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -459,6 +463,7 @@ CT_GLIBC_PATCH_GLOBAL=y
 # CT_GLIBC_PATCH_LOCAL_BUNDLED is not set
 # CT_GLIBC_PATCH_NONE is not set
 CT_GLIBC_PATCH_ORDER="global"
+# CT_GLIBC_V_2_39 is not set
 # CT_GLIBC_V_2_38 is not set
 # CT_GLIBC_V_2_37 is not set
 # CT_GLIBC_V_2_36 is not set
@@ -469,15 +474,15 @@ CT_GLIBC_PATCH_ORDER="global"
 # CT_GLIBC_V_2_31 is not set
 # CT_GLIBC_V_2_30 is not set
 # CT_GLIBC_V_2_29 is not set
-# CT_GLIBC_V_2_28 is not set
-CT_GLIBC_V_2_27=y
+CT_GLIBC_V_2_28=y
+# CT_GLIBC_V_2_27 is not set
 # CT_GLIBC_V_2_26 is not set
 # CT_GLIBC_V_2_25 is not set
 # CT_GLIBC_V_2_24 is not set
 # CT_GLIBC_V_2_23 is not set
 # CT_GLIBC_V_2_19 is not set
 # CT_GLIBC_V_2_17 is not set
-CT_GLIBC_VERSION="2.27"
+CT_GLIBC_VERSION="2.28"
 CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
 CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -499,10 +504,10 @@ CT_GLIBC_2_30_or_older=y
 CT_GLIBC_older_than_2_30=y
 CT_GLIBC_2_29_or_older=y
 CT_GLIBC_older_than_2_29=y
+CT_GLIBC_2_28_or_later=y
 CT_GLIBC_2_28_or_older=y
-CT_GLIBC_older_than_2_28=y
+CT_GLIBC_later_than_2_27=y
 CT_GLIBC_2_27_or_later=y
-CT_GLIBC_2_27_or_older=y
 CT_GLIBC_later_than_2_26=y
 CT_GLIBC_2_26_or_later=y
 CT_GLIBC_later_than_2_25=y
@@ -541,7 +546,7 @@ CT_GLIBC_FORCE_UNWIND=y
 # CT_GLIBC_KERNEL_VERSION_NONE is not set
 CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
 # CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
-CT_GLIBC_MIN_KERNEL="4.15.18"
+CT_GLIBC_MIN_KERNEL="4.18.20"
 CT_GLIBC_SSP_DEFAULT=y
 # CT_GLIBC_SSP_NO is not set
 # CT_GLIBC_SSP_YES is not set
@@ -799,7 +804,6 @@ CT_ISL_V_0_26=y
 # CT_ISL_V_0_17 is not set
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
-# CT_ISL_V_0_11 is not set
 CT_ISL_VERSION="0.26"
 CT_ISL_MIRRORS="https://libisl.sourceforge.io"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
@@ -847,10 +851,9 @@ CT_MPC_PATCH_GLOBAL=y
 # CT_MPC_PATCH_LOCAL_BUNDLED is not set
 # CT_MPC_PATCH_NONE is not set
 CT_MPC_PATCH_ORDER="global"
-CT_MPC_V_1_2=y
-# CT_MPC_V_1_1 is not set
-# CT_MPC_V_1_0 is not set
-CT_MPC_VERSION="1.2.1"
+CT_MPC_V_1_3=y
+# CT_MPC_V_1_2 is not set
+CT_MPC_VERSION="1.3.1"
 CT_MPC_MIRRORS="https://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
 CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -873,9 +876,6 @@ CT_MPFR_PATCH_GLOBAL=y
 # CT_MPFR_PATCH_NONE is not set
 CT_MPFR_PATCH_ORDER="global"
 CT_MPFR_V_4_2=y
-# CT_MPFR_V_4_1 is not set
-# CT_MPFR_V_4_0 is not set
-# CT_MPFR_V_3_1 is not set
 CT_MPFR_VERSION="4.2.1"
 CT_MPFR_MIRRORS="https://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
 CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
@@ -929,9 +929,9 @@ CT_ZLIB_PATCH_GLOBAL=y
 # CT_ZLIB_PATCH_LOCAL_BUNDLED is not set
 # CT_ZLIB_PATCH_NONE is not set
 CT_ZLIB_PATCH_ORDER="global"
-CT_ZLIB_V_1_2_13=y
-# CT_ZLIB_V_1_2_12 is not set
-CT_ZLIB_VERSION="1.2.13"
+CT_ZLIB_V_1_3=y
+# CT_ZLIB_V_1_2_13 is not set
+CT_ZLIB_VERSION="1.3"
 CT_ZLIB_MIRRORS="https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/"
 CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"

--- a/builder/images/base-win64/ct-ng-config
+++ b/builder/images/base-win64/ct-ng-config
@@ -1,12 +1,13 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.25.0.232_c175b21 Configuration
+# crosstool-NG 1.26.0.65_ecc5e41 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
 CT_CONFIGURE_has_wget=y
 CT_CONFIGURE_has_curl=y
-CT_CONFIGURE_has_rsync=y
+CT_CONFIGURE_has_meson=y
+CT_CONFIGURE_has_ninja=y
 CT_CONFIGURE_has_make_3_81_or_newer=y
 CT_CONFIGURE_has_make_4_0_or_newer=y
 CT_CONFIGURE_has_libtool_2_4_or_newer=y
@@ -26,7 +27,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.25.0.232_c175b21"
+CT_VERSION="1.26.0.65_ecc5e41"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -145,6 +146,7 @@ CT_LOG_LEVEL_MAX="DEBUG"
 # CT_ARCH_MOXIE is not set
 # CT_ARCH_MSP430 is not set
 # CT_ARCH_NIOS2 is not set
+# CT_ARCH_PARISC is not set
 # CT_ARCH_POWERPC is not set
 # CT_ARCH_PRU is not set
 # CT_ARCH_RISCV is not set
@@ -163,7 +165,7 @@ CT_ARCH_X86_SHOW=y
 # Options for x86
 #
 CT_ARCH_X86_PKG_KSYM=""
-CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
+CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 PARISC POWERPC PRU RISCV S390 SH SPARC X86 XTENSA"
 CT_ARCH_SUFFIX=""
 # CT_OMIT_TARGET_VENDOR is not set
 
@@ -293,7 +295,9 @@ CT_BINUTILS_PATCH_GLOBAL=y
 # CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
 # CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
-CT_BINUTILS_V_2_40=y
+CT_BINUTILS_V_2_42=y
+# CT_BINUTILS_V_2_41 is not set
+# CT_BINUTILS_V_2_40 is not set
 # CT_BINUTILS_V_2_39 is not set
 # CT_BINUTILS_V_2_38 is not set
 # CT_BINUTILS_V_2_37 is not set
@@ -308,7 +312,7 @@ CT_BINUTILS_V_2_40=y
 # CT_BINUTILS_V_2_28 is not set
 # CT_BINUTILS_V_2_27 is not set
 # CT_BINUTILS_V_2_26 is not set
-CT_BINUTILS_VERSION="2.40"
+CT_BINUTILS_VERSION="2.42"
 CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
 CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -366,14 +370,15 @@ CT_MINGW_W64_PATCH_GLOBAL=y
 # CT_MINGW_W64_PATCH_LOCAL_BUNDLED is not set
 # CT_MINGW_W64_PATCH_NONE is not set
 CT_MINGW_W64_PATCH_ORDER="global"
-CT_MINGW_W64_V_V10_0=y
+CT_MINGW_W64_V_V11_0=y
+# CT_MINGW_W64_V_V10_0 is not set
 # CT_MINGW_W64_V_V9_0 is not set
 # CT_MINGW_W64_V_V8_0 is not set
 # CT_MINGW_W64_V_V7_0 is not set
 # CT_MINGW_W64_V_V6_0 is not set
 # CT_MINGW_W64_V_V5_0 is not set
 # CT_MINGW_W64_V_V4_0 is not set
-CT_MINGW_W64_VERSION="v10.0.0"
+CT_MINGW_W64_VERSION="v11.0.1"
 CT_MINGW_W64_MIRRORS="http://downloads.sourceforge.net/sourceforge/mingw-w64 https://downloads.sourceforge.net/project/mingw-w64/mingw-w64/mingw-w64-release/"
 CT_MINGW_W64_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_MINGW_W64_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -664,8 +669,8 @@ CT_MPC_PATCH_GLOBAL=y
 # CT_MPC_PATCH_LOCAL_BUNDLED is not set
 # CT_MPC_PATCH_NONE is not set
 CT_MPC_PATCH_ORDER="global"
-CT_MPC_V_1_2=y
-CT_MPC_VERSION="1.2.1"
+CT_MPC_V_1_3=y
+CT_MPC_VERSION="1.3.1"
 CT_MPC_MIRRORS="https://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
 CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
@@ -711,8 +716,9 @@ CT_ZLIB_PATCH_GLOBAL=y
 # CT_ZLIB_PATCH_LOCAL_BUNDLED is not set
 # CT_ZLIB_PATCH_NONE is not set
 CT_ZLIB_PATCH_ORDER="global"
-CT_ZLIB_V_1_2_13=y
-CT_ZLIB_VERSION="1.2.13"
+CT_ZLIB_V_1_3=y
+# CT_ZLIB_V_1_2_13 is not set
+CT_ZLIB_VERSION="1.3"
 CT_ZLIB_MIRRORS="https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/"
 CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"

--- a/builder/images/base/Dockerfile
+++ b/builder/images/base/Dockerfile
@@ -8,7 +8,7 @@ RUN \
         xxd pkgconf curl wget unzip git subversion mercurial \
         autoconf automake libtool libtool-bin autopoint gettext cmake clang meson ninja-build \
         texinfo texi2html help2man flex bison groff \
-        gperf itstool ragel libc6-dev libssl-dev \
+        gperf itstool ragel libc6-dev zlib1g-dev libssl-dev \
         gtk-doc-tools gobject-introspection gawk \
         ocaml ocamlbuild libnum-ocaml-dev indent p7zip-full \
         python3-distutils python3-jinja2 python3-apt python-is-python3 && \

--- a/builder/images/base/Dockerfile
+++ b/builder/images/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:mantic
+FROM ubuntu:noble
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN \

--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -34,7 +34,8 @@ ffbuild_dockerbuild() {
     local myconf=(
         --prefix="$GCC_SYSROOT/usr/$FFBUILD_TOOLCHAIN"
         --host="$FFBUILD_TOOLCHAIN"
-        --with-default-win32-winnt="0x601"
+        --with-default-win32-winnt="0x0601"
+        --with-default-msvcrt="ucrt"
         --enable-idl
     )
 

--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/mingw-w64/mingw-w64.git"
-SCRIPT_COMMIT="dbfdf802580c0d6b90b91995dab019f2a7787a8e"
+SCRIPT_COMMIT="0bac2d3cdb122dadcdee90009f7e24a69d56939f"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/builder/scripts.d/20-libxml2.sh
+++ b/builder/scripts.d/20-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="186562a182d2e27f90631d1a1f63ad5079fe62fb"
+SCRIPT_COMMIT="d4d1f3f33d6d4a5e31511281637a857944946e65"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-fribidi.sh
+++ b/builder/scripts.d/25-fribidi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/fribidi/fribidi.git"
-SCRIPT_COMMIT="3002ffea02581b514d70c56d972af12082c4e70c"
+SCRIPT_COMMIT="e01a424c7cef4e805879ddcdc47f163f2a2f39dc"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="cfbb6a68722361dc7a1a5ea016921930552bbec7"
+SCRIPT_COMMIT="f1ac867deec0500fed94f965b6da25f9fcd434de"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="872e470ebf3e65b0b956f3a70329e885a2df1c2a"
+SCRIPT_COMMIT="8e08426468a76d8a667e8a79d92bafd85d7411ac"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="7fb8ceccf92c35cd5131b05c0502916715ebc76b"
+SCRIPT_COMMIT="cab4f31e1d474c75c1dfd54312d0e9d9c16f4839"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="eba03acb05383c4cd8ff9a3d18a213fbdcda865d"
+SCRIPT_COMMIT="40e85a0b563593bb51b05228e9e30b582604de97"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-openmpt.sh
+++ b/builder/scripts.d/50-openmpt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://source.openmpt.org/svn/openmpt/trunk/OpenMPT"
-SCRIPT_REV="20347"
+SCRIPT_REV="20417"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="aa69c3db0daa221b0a9b4e86fee2efd80c6e6f2b"
+SCRIPT_COMMIT="84b5bb8c2bfd331ac55aba70fe09e5d3cbb00dee"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-vaapi/30-libpciaccess.sh
+++ b/builder/scripts.d/50-vaapi/30-libpciaccess.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libpciaccess.git"
-SCRIPT_COMMIT="04271a93ed65bfde82469509120214424eb918d0"
+SCRIPT_COMMIT="ad7e9cb4b291a46812eea321f0634cfc46fb94e2"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vaapi/40-libdrm.sh
+++ b/builder/scripts.d/50-vaapi/40-libdrm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/mesa/drm.git"
-SCRIPT_COMMIT="ee558cea20d1f9d822fe1a28e97beaf365bf9d38"
+SCRIPT_COMMIT="75254bf2390c10644ffb35a90fc8f18f196f9f0c"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/50-shaderc.sh
+++ b/builder/scripts.d/50-vulkan/50-shaderc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/google/shaderc.git"
-SCRIPT_COMMIT="5b892551dd02bbf8704adbc3fcde2fd645f333b2"
+SCRIPT_COMMIT="3882b16417077aa8eaa7b5775920e7ba4b8a224d"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="2a7c8184921897ff3d6c6c3f70af4099e2e00331"
+SCRIPT_COMMIT="7d92d7d8794b102f550ad33dbedbd82203b755a9"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-x264.sh
+++ b/builder/scripts.d/50-x264.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/x264.git"
-SCRIPT_COMMIT="585e01997f0c7e6d72c8ca466406d955c07de912"
+SCRIPT_COMMIT="7ed753b10a61d0be95f683289dfb925b800b0676"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/builder/scripts.d/50-x265.sh
+++ b/builder/scripts.d/50-x265.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
-SCRIPT_COMMIT="74abf80c70a3969fca2e112691cecfb50c0c2259"
+SCRIPT_COMMIT="3cf6c1e53037eb9e198860365712e1bafb22f7c6"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+jellyfin-ffmpeg (6.0.1-5) unstable; urgency=medium
+
+  * Add VideoToolbox tonemap filter
+  * Add support for Ubuntu 24.04 LTS (Noble)
+  * Add customized surface alignment for AMD VA-API
+  * Check PCIID when deriving from VA-API to Vulkan
+  * Upgrade to Mesa 24.0.x on newer distros (LLVM 15+)
+  * Update build dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Tue, 21 Mar 2024 17:57:37 +0800
+
 jellyfin-ffmpeg (6.0.1-4) unstable; urgency=medium
 
   * Add VideoToolBox overlay filter

--- a/debian/patches/0070-add-customized-surf-align-for-amd-vaapi.patch
+++ b/debian/patches/0070-add-customized-surf-align-for-amd-vaapi.patch
@@ -1,0 +1,59 @@
+Index: jellyfin-ffmpeg/libavcodec/vaapi_encode.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/vaapi_encode.c
++++ jellyfin-ffmpeg/libavcodec/vaapi_encode.c
+@@ -2714,6 +2714,17 @@ static av_cold int vaapi_encode_create_r
+     av_log(avctx, AV_LOG_DEBUG, "Using %s as format of "
+            "reconstructed frames.\n", av_get_pix_fmt_name(recon_format));
+ 
++    if (constraints->width_align || constraints->height_align) {
++        if (constraints->width_align) {
++            ctx->surface_width = FFALIGN(avctx->width, constraints->width_align);
++        }
++        if (constraints->height_align) {
++            ctx->surface_height = FFALIGN(avctx->height, constraints->height_align);
++        }
++        av_log(avctx, AV_LOG_VERBOSE, "Using customized alignment size "
++               "[%dx%d].\n", constraints->width_align, constraints->height_align);
++    }
++
+     if (ctx->surface_width  < constraints->min_width  ||
+         ctx->surface_height < constraints->min_height ||
+         ctx->surface_width  > constraints->max_width ||
+Index: jellyfin-ffmpeg/libavutil/hwcontext.h
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext.h
++++ jellyfin-ffmpeg/libavutil/hwcontext.h
+@@ -478,6 +478,13 @@ typedef struct AVHWFramesConstraints {
+      */
+     int max_width;
+     int max_height;
++
++    /**
++     * The frame width/height alignment when available
++     * (Zero is not applied, use the default value.)
++     */
++    int width_align;
++    int height_align;
+ } AVHWFramesConstraints;
+ 
+ /**
+Index: jellyfin-ffmpeg/libavutil/hwcontext_vaapi.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_vaapi.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_vaapi.c
+@@ -276,6 +276,14 @@ static int vaapi_frames_get_constraints(
+             case VASurfaceAttribMaxHeight:
+                 constraints->max_height = attr_list[i].value.value.i;
+                 break;
++#if VA_CHECK_VERSION(1, 21, 0)
++            case VASurfaceAttribAlignmentSize:
++                if (attr_list[i].value.value.i) {
++                    constraints->width_align  = 1 << (attr_list[i].value.value.i & 0xf);
++                    constraints->height_align = 1 << ((attr_list[i].value.value.i & 0xf0) >> 4);
++                }
++                break;
++#endif
+             }
+         }
+         if (pix_fmt_count == 0) {

--- a/debian/patches/0071-check-pciid-when-deriving-from-va-to-vk.patch
+++ b/debian/patches/0071-check-pciid-when-deriving-from-va-to-vk.patch
@@ -1,0 +1,47 @@
+Index: jellyfin-ffmpeg/libavutil/hwcontext_vulkan.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_vulkan.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_vulkan.c
+@@ -1581,17 +1581,33 @@ static int vulkan_device_derive(AVHWDevi
+ #if CONFIG_VAAPI
+     case AV_HWDEVICE_TYPE_VAAPI: {
+         AVVAAPIDeviceContext *src_hwctx = src_ctx->hwctx;
++        VADisplay dpy = src_hwctx->display;
++#if VA_CHECK_VERSION(1, 15, 0)
++        VAStatus vas;
++        VADisplayAttribute attr = {
++            .type = VADisplayPCIID,
++        };
++#endif
++        const char *vendor;
+ 
+-        const char *vendor = vaQueryVendorString(src_hwctx->display);
+-        if (!vendor) {
+-            av_log(ctx, AV_LOG_ERROR, "Unable to get device info from VAAPI!\n");
+-            return AVERROR_EXTERNAL;
+-        }
++#if VA_CHECK_VERSION(1, 15, 0)
++        vas = vaGetDisplayAttributes(dpy, &attr, 1);
++        if (vas == VA_STATUS_SUCCESS && attr.flags != VA_DISPLAY_ATTRIB_NOT_SUPPORTED)
++            dev_select.pci_device = (attr.value & 0xFFFF);
++#endif
++
++        if (!dev_select.pci_device) {
++            vendor = vaQueryVendorString(dpy);
++            if (!vendor) {
++                av_log(ctx, AV_LOG_ERROR, "Unable to get device info from VAAPI!\n");
++                return AVERROR_EXTERNAL;
++            }
+ 
+-        if (strstr(vendor, "Intel"))
+-            dev_select.vendor_id = 0x8086;
+-        if (strstr(vendor, "AMD"))
+-            dev_select.vendor_id = 0x1002;
++            if (strstr(vendor, "Intel"))
++                dev_select.vendor_id = 0x8086;
++            if (strstr(vendor, "AMD"))
++                dev_select.vendor_id = 0x1002;
++        }
+ 
+         return vulkan_device_create_internal(ctx, &dev_select, opts, flags);
+     }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -68,3 +68,4 @@
 0068-backport-upstream-svt-av1-encoder-changes.patch
 0069-add-tonemap-videotoolbox.patch
 0070-add-customized-surf-align-for-amd-vaapi.patch
+0071-check-pciid-when-deriving-from-va-to-vk.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -67,3 +67,4 @@
 0067-backport-transpose_vt.patch
 0068-backport-upstream-svt-av1-encoder-changes.patch
 0069-add-tonemap-videotoolbox.patch
+0070-add-customized-surf-align-for-amd-vaapi.patch

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -6,12 +6,15 @@ set -o errexit
 set -o xtrace
 
 # Update mingw-w64 headers
-git clone -b v11.0.1 --depth=1 https://git.code.sf.net/p/mingw-w64/mingw-w64.git
+mingw_commit="0bac2d3cdb122dadcdee90009f7e24a69d56939f"
+git clone https://git.code.sf.net/p/mingw-w64/mingw-w64.git
 pushd mingw-w64/mingw-w64-headers
+git checkout ${mingw_commit}
 ./configure \
     --prefix=/usr/${FF_TOOLCHAIN} \
     --host=${FF_TOOLCHAIN} \
-    --with-default-win32-winnt="0x601" \
+    --with-default-win32-winnt="0x0601" \
+    --with-default-msvcrt="msvcrt" \
     --enable-idl
 make -j$(nproc)
 make install

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -325,7 +325,7 @@ popd
 # OPENMPT
 mkdir mpt
 pushd mpt
-mpt_ver="0.7.4"
+mpt_ver="0.7.5"
 mpt_link="https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${mpt_ver}+release.autotools.tar.gz"
 wget ${mpt_link} -O mpt.tar.gz
 tar xaf mpt.tar.gz
@@ -476,7 +476,7 @@ popd
 popd
 
 # DAV1D
-git clone -b 1.4.0 --depth=1 https://code.videolan.org/videolan/dav1d.git
+git clone -b 1.4.1 --depth=1 https://code.videolan.org/videolan/dav1d.git
 pushd dav1d
 mkdir build
 pushd build


### PR DESCRIPTION
~~Mark as WIP since the new packages are not finalized yet.~~
Let's assume that the [Feature Freeze & Debian Import Freeze](https://discourse.ubuntu.com/t/noble-numbat-release-schedule/35649) guarantees package freezing.

**Changes**
  * Add support for Ubuntu 24.04 LTS (Noble)
  * Add customized surface alignment for AMD VA-API
  * Check PCIID when deriving from VA-API to Vulkan
  * Upgrade to Mesa 24.0.x on newer distros (LLVM 15+)
  * Update build dependencies