### PR TITLE
avcodec/libopusenc: Allow 5.1(side) channel inputs

### DIFF
--- a/debian/patches/0073-opus-allow-5point1-side-inputs.patch
+++ b/debian/patches/0073-opus-allow-5point1-side-inputs.patch
@@ -12,7 +12,7 @@ diff --git a/libavcodec/libopusenc.c b/libavcodec/libopusenc.c
          av_log(avctx, AV_LOG_WARNING,
                 "No channel layout specified. Opus encoder will use Vorbis "
                 "channel layout for %d channels.\n", avctx->ch_layout.nb_channels);
-+    } else if (avctx->ch_layout.nb_channels == 6 && av_channel_layout_compare(&avctx->ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0) {
++    } else if (av_channel_layout_compare(&avctx->ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0) {
 +        av_log(avctx, AV_LOG_WARNING,
 +               "Input channel layout 5.1(side) detected, side channels will be mapped to back channels.\n");
 +        return 0;

--- a/debian/patches/0073-opus-allow-5point1-side-inputs.patch
+++ b/debian/patches/0073-opus-allow-5point1-side-inputs.patch
@@ -1,0 +1,21 @@
+Subject: [PATCH] avcodec/libopusenc: Allow 5.1(side) channel inputs
+---
+Index: libavcodec/libopusenc.c
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/libavcodec/libopusenc.c b/libavcodec/libopusenc.c
+--- a/libavcodec/libopusenc.c	(revision 38aaefefec762dd185b631298752d489dcf084fe)
++++ b/libavcodec/libopusenc.c	(revision 104006c9a93f3cd72b21b243884ea91449cbdd10)
+@@ -196,6 +196,10 @@
+         av_log(avctx, AV_LOG_WARNING,
+                "No channel layout specified. Opus encoder will use Vorbis "
+                "channel layout for %d channels.\n", avctx->ch_layout.nb_channels);
++    } else if (avctx->ch_layout.nb_channels == 6 && av_channel_layout_compare(&avctx->ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0) {
++        av_log(avctx, AV_LOG_WARNING,
++               "Input channel layout 5.1(side) detected, side channels will be mapped to back channels.\n");
++        return 0;
+     } else if (av_channel_layout_compare(&avctx->ch_layout, &ff_vorbis_ch_layouts[avctx->ch_layout.nb_channels - 1])) {
+         char name[32];
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -70,3 +70,4 @@
 0070-add-customized-surf-align-for-amd-vaapi.patch
 0071-check-pciid-when-deriving-from-va-to-vk.patch
 0072-add-mjpeg-videotoolbox.patch
+0073-opus-allow-5point1-side-inputs.patch


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->
Previously the 5.1(side) channel layouts will get rejected by libopus encoder because vorbis layout expects 5.1(back) channel layout. However, the side channels and back channels have same position in the layout mapping.
Relax the layout checking to allow such side to back mappings.


**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #248

Prepare for jellyfin/jellyfin-web#5434