### PR TITLE
Add DOVI descriptor support in mpegtsenc

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "6.0.1-6"
+version: "6.0.1-7"
 packages:
   - buster-amd64
   - buster-armhf

--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/mingw-w64/mingw-w64.git"
-SCRIPT_COMMIT="93059a6ae05d8e0b42bec5039818003a9f6329b1"
+SCRIPT_COMMIT="cff4b8fda1b577b99144020fb81b27f5bc633a5e"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/builder/scripts.d/10-xorg-macros.sh
+++ b/builder/scripts.d/10-xorg-macros.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/util/macros.git"
-SCRIPT_COMMIT="1031f8cc5c7a170e278372ccdf2e70151b096ef7"
+SCRIPT_COMMIT="7ed2b3798c030bd1729b699b446b43aba2ec606e"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/20-libxml2.sh
+++ b/builder/scripts.d/20-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="20b0bd9800ae83cbd70f4407ce67058164e16227"
+SCRIPT_COMMIT="1371d0bda20f5e909e94054f6f49d0a967ac5291"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-fftw3f.sh
+++ b/builder/scripts.d/25-fftw3f.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/FFTW/fftw3.git"
-SCRIPT_COMMIT="394fa85ab5f8914b82b3404844444c53f5c7f095"
+SCRIPT_COMMIT="cab901fe465324cb46bd4953e18ddc610ade29b9"
 
 ffbuild_enabled() {
     # Dependency of GPL-Only librubberband

--- a/builder/scripts.d/25-freetype.sh
+++ b/builder/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
-SCRIPT_COMMIT="f42ce25563b73fed0123d18a2556b9ba01d2c76b"
+SCRIPT_COMMIT="39f2fbf80c5ab9ad7b380080395c987f4922a038"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-fribidi.sh
+++ b/builder/scripts.d/25-fribidi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/fribidi/fribidi.git"
-SCRIPT_COMMIT="bfb0385ef862cd40af7d5d33648fbb4bfe8eee65"
+SCRIPT_COMMIT="bca04dc3cd3af85a9d9220c430737333634d622a"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/35-fontconfig.sh
+++ b/builder/scripts.d/35-fontconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
-SCRIPT_COMMIT="5a6fef681bfd27e6b733a48f3c43a5da042745a8"
+SCRIPT_COMMIT="3b4641ae7a7bf961221cd7b55cc0e25d9d1a6365"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="c053e8f29257814e11ad61493dbbe29f27656de4"
+SCRIPT_COMMIT="bc90b29b37fe3809f9e48aa7be08fbf2208e481a"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-x11/10-xcbproto.sh
+++ b/builder/scripts.d/45-x11/10-xcbproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xcbproto.git"
-SCRIPT_COMMIT="1388374c7149114888a6a5cd6e9bf6ad4b42adf8"
+SCRIPT_COMMIT="77d7fc04da729ddc5ed4aacf30253726fac24dca"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/30-libxcb.sh
+++ b/builder/scripts.d/45-x11/30-libxcb.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxcb.git"
-SCRIPT_COMMIT="389f22d1cb53e47337e96d9f78a3ef0001e8e588"
+SCRIPT_COMMIT="622152ee42a310876f10602601206954b8d0613e"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/40-libx11.sh
+++ b/builder/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="a465588218c1643eedc35b3c24409cb775454eee"
+SCRIPT_COMMIT="97fb5bda3d0777380cd4b964f48771a82ef3f2a7"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/50-libxi.sh
+++ b/builder/scripts.d/45-x11/50-libxi.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxi.git"
-SCRIPT_COMMIT="57ce2e8ba4c1f1bc5792e14bc7082f3ebd0915be"
+SCRIPT_COMMIT="56b11459f833df8f324587847534a548b070da94"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/60-libglvnd.sh
+++ b/builder/scripts.d/45-x11/60-libglvnd.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/glvnd/libglvnd.git"
-SCRIPT_COMMIT="908086d22dc307d17d0eb35c522c35fd190718cc"
+SCRIPT_COMMIT="606f6627cf481ee6dcb32387edc010c502cdf38b"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="dc9490134f8a3665843f287f721dc587e7c48ea2"
+SCRIPT_COMMIT="3623543c4117f413110b27b5c20c6ae1638a22f9"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libass.sh
+++ b/builder/scripts.d/50-libass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libass/libass.git"
-SCRIPT_COMMIT="6eaa67daabdba10248fd13692403691effec0d8e"
+SCRIPT_COMMIT="cbb48cc4f2f076300004b8b06a86bec55281d0c2"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xiph/opus.git"
-SCRIPT_COMMIT="ddbe48383984d56acd9e1ab6a090c54ca6b735a6"
+SCRIPT_COMMIT="eb39efaa154fab96bf12b5cab932418cd3807eb2"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libvpl.sh
+++ b/builder/scripts.d/50-libvpl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/intel/libvpl.git"
-SCRIPT_COMMIT="383b5caac6df614e76ade5a07c4f53be702e9176"
+SCRIPT_COMMIT="18b63f421a016ea34d2fcfc6c63e16dba13b71f1"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="3dbab0e66479e1b5368d4b7a069051dba85843cf"
+SCRIPT_COMMIT="602e2e8979d111b02c959470da5322797dd96a19"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="b3d1b2cbf7e6286832876cc720dee96cd1945aec"
+SCRIPT_COMMIT="845d5476a866141ba35ac133f856fa62f0b7445f"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-openmpt.sh
+++ b/builder/scripts.d/50-openmpt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://source.openmpt.org/svn/openmpt/trunk/OpenMPT"
-SCRIPT_REV="20563"
+SCRIPT_REV="20832"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="c156dab75b83c12bb8dbbda77dab569db22b3b78"
+SCRIPT_COMMIT="38a3a165a1af92f6423de8c97646de07cba5e120"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-svtav1.sh
+++ b/builder/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="bd9e31f16afb43a176a9ba39e9b04e0a9a12c907"
+SCRIPT_COMMIT="bbcff785881b320f7e1b1f77a2f5ed025f8bfd75"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/builder/scripts.d/50-vaapi/30-libpciaccess.sh
+++ b/builder/scripts.d/50-vaapi/30-libpciaccess.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libpciaccess.git"
-SCRIPT_COMMIT="2ec2576cabefef1eaa5dd9307c97de2e887fc347"
+SCRIPT_COMMIT="f73f4ca720ccb2e9939545177b54f2be099e3b54"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/45-vulkan.sh
+++ b/builder/scripts.d/50-vulkan/45-vulkan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/Vulkan-Headers.git"
-SCRIPT_COMMIT="v1.3.283"
+SCRIPT_COMMIT="v1.3.285"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="06407561ece7d7e78544112189f3eee13adf9959"
+SCRIPT_COMMIT="1f68d0f420730ccdde6ec9d0b36f56ffed014193"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-x264.sh
+++ b/builder/scripts.d/50-x264.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/x264.git"
-SCRIPT_COMMIT="7ed753b10a61d0be95f683289dfb925b800b0676"
+SCRIPT_COMMIT="4613ac3c15fd75cebc4b9f65b7fb95e70a3acce1"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/builder/scripts.d/50-x265.sh
+++ b/builder/scripts.d/50-x265.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
-SCRIPT_COMMIT="dd1ef69b25ec26cc80be0fc8d9afeeef6563762b"
+SCRIPT_COMMIT="f3c5fbaffaf54b5f79aa8983d59f1b0232d5eccf"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+jellyfin-ffmpeg (6.0.1-7) unstable; urgency=medium
+
+  * Add DOVI descriptor support in mpegtsenc
+  * Sync RKMPP fixes from ffmpeg-rockchip
+  * Fix a typo in the CUDA/OpenCL transpose filter
+  * Fix some warnings-as-errors in GCC 14
+  * Update dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Tue, 21 May 2024 17:09:43 +0800
+
 jellyfin-ffmpeg (6.0.1-6) unstable; urgency=medium
 
   * Fix Noble builds and update dependencies

--- a/debian/patches/0005-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0005-add-cuda-tonemap-impl.patch
@@ -98,7 +98,7 @@ Index: jellyfin-ffmpeg/libavfilter/colorspace.c
  void ff_matrix_mul_3x3(double dst[3][3],
                 const double src1[3][3], const double src2[3][3])
  {
-@@ -191,3 +203,157 @@ void ff_update_hdr_metadata(AVFrame *in,
+@@ -191,3 +203,155 @@ void ff_update_hdr_metadata(AVFrame *in,
              metadata->max_luminance = av_d2q(peak * REFERENCE_WHITE, 10000);
      }
  }
@@ -183,8 +183,7 @@ Index: jellyfin-ffmpeg/libavfilter/colorspace.c
 +// linearizer for PQ/ST2084
 +float eotf_st2084_common(float x)
 +{
-+    x = FFMAX(x, 0.0f);
-+    float xpow = powf(x, 1.0f / ST2084_M2);
++    float xpow = powf(FFMAX(x, 0.0f), 1.0f / ST2084_M2);
 +    float num = FFMAX(xpow - ST2084_C1, 0.0f);
 +    float den = FFMAX(ST2084_C2 - ST2084_C3 * xpow, FLOAT_EPS);
 +    x = powf(num / den, 1.0f / ST2084_M1);
@@ -199,8 +198,7 @@ Index: jellyfin-ffmpeg/libavfilter/colorspace.c
 +// delinearizer for PQ/ST2084
 +float inverse_eotf_st2084_common(float x)
 +{
-+    x = FFMAX(x, 0.0f);
-+    float xpow = powf(x, ST2084_M1);
++    float xpow = powf(FFMAX(x, 0.0f), ST2084_M1);
 +#if 0
 +    // Original formulation from SMPTE ST 2084:2014 publication.
 +    float num = ST2084_C1 + ST2084_C2 * xpow;
@@ -599,7 +597,7 @@ Index: jellyfin-ffmpeg/libavfilter/cuda/host_util.c
 ===================================================================
 --- /dev/null
 +++ jellyfin-ffmpeg/libavfilter/cuda/host_util.c
-@@ -0,0 +1,78 @@
+@@ -0,0 +1,77 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -637,15 +635,14 @@ Index: jellyfin-ffmpeg/libavfilter/cuda/host_util.c
 +        dst->data[i] = src->data[i];
 +        dst->linesize[i] = src->linesize[i];
 +        dst->tex[i] = 0;
++    }
 +
-+        if (!make_cuTex)
-+            continue;
-+
++    for (i = 0; make_cuTex && (i < dst->planes); i++) {
 +#ifndef CU_TRSF_NORMALIZED_COORDINATES
 +  #define CU_TRSF_NORMALIZED_COORDINATES 2
 +#endif
 +        CUDA_TEXTURE_DESC tex_desc = {
-+            .addressMode = CU_TR_ADDRESS_MODE_CLAMP,
++            .addressMode = { CU_TR_ADDRESS_MODE_CLAMP },
 +            .filterMode = i == 0 ? CU_TR_FILTER_MODE_POINT : CU_TR_FILTER_MODE_LINEAR,
 +            .flags = i == 0 ? 0 : CU_TRSF_NORMALIZED_COORDINATES,
 +        };
@@ -1688,7 +1685,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
 +        return AVERROR(ENOMEM);
 +
 +    s->dovi = NULL;
-+    s->doviBuffer = NULL;
++    s->doviBuffer = 0;
 +
 +    return 0;
 +}
@@ -1786,7 +1783,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
 +  #define CU_TRSF_NORMALIZED_COORDINATES 2
 +#endif
 +    CUDA_TEXTURE_DESC tex_desc = {
-+        .addressMode = CU_TR_ADDRESS_MODE_WRAP,
++        .addressMode = { CU_TR_ADDRESS_MODE_WRAP },
 +        .filterMode = CU_TR_FILTER_MODE_POINT,
 +        .flags = CU_TRSF_NORMALIZED_COORDINATES,
 +    };
@@ -2270,13 +2267,13 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_cuda.c
 +    if (ret < 0)
 +        goto fail;
 +
-+    ret = CHECK_CU(cu->cuLinkAddData(link_state, CU_JIT_INPUT_PTX, constants.str,
-+                                     constants.len, "constants", 0, NULL, NULL));
++    ret = CHECK_CU(cu->cuLinkAddData(link_state, CU_JIT_INPUT_PTX, (void *)constants.str,
++                                     (size_t)constants.len, "constants", 0, NULL, NULL));
 +    if (ret < 0)
 +        goto fail2;
 +
-+    ret = CHECK_CU(cu->cuLinkAddData(link_state, CU_JIT_INPUT_PTX, ff_tonemap_ptx_data,
-+                                     ff_tonemap_ptx_len, "ff_tonemap_ptx_data", 0, NULL, NULL));
++    ret = CHECK_CU(cu->cuLinkAddData(link_state, CU_JIT_INPUT_PTX, (void *)ff_tonemap_ptx_data,
++                                     (size_t)ff_tonemap_ptx_len, "ff_tonemap_ptx_data", 0, NULL, NULL));
 +    if (ret < 0)
 +        goto fail2;
 +

--- a/debian/patches/0006-add-amf-refactor-and-hevc-10-bit-encoding.patch
+++ b/debian/patches/0006-add-amf-refactor-and-hevc-10-bit-encoding.patch
@@ -1132,23 +1132,20 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
              break;
          case AV_CODEC_ID_AV1:
              buffer->pVtbl->GetProperty(buffer, AMF_VIDEO_ENCODER_AV1_OUTPUT_FRAME_TYPE, &var);
-@@ -476,44 +368,27 @@ static int amf_copy_buffer(AVCodecContex
+@@ -476,7 +368,6 @@ static int amf_copy_buffer(AVCodecContex
  
      pkt->pts = var.int64Value; // original pts
  
 -
--    AMF_RETURN_IF_FALSE(ctx, av_fifo_read(ctx->timestamp_list, &timestamp, 1) >= 0,
--                        AVERROR_UNKNOWN, "timestamp_list is empty\n");
-+    AMF_RETURN_IF_FALSE(ctx, av_fifo_read(ctx->timestamp_list, &timestamp, 1) >= 0, AVERROR_UNKNOWN, "timestamp_list is empty\n");
+     AMF_RETURN_IF_FALSE(ctx, av_fifo_read(ctx->timestamp_list, &timestamp, 1) >= 0,
+                         AVERROR_UNKNOWN, "timestamp_list is empty\n");
  
-     // calc dts shift if max_b_frames > 0
-     if (avctx->max_b_frames > 0 && ctx->dts_delay == 0) {
-         int64_t timestamp_last = AV_NOPTS_VALUE;
+@@ -486,34 +377,20 @@ static int amf_copy_buffer(AVCodecContex
          size_t can_read = av_fifo_can_read(ctx->timestamp_list);
  
--        AMF_RETURN_IF_FALSE(ctx, can_read > 0, AVERROR_UNKNOWN,
+         AMF_RETURN_IF_FALSE(ctx, can_read > 0, AVERROR_UNKNOWN,
 -            "timestamp_list is empty while max_b_frames = %d\n", avctx->max_b_frames);
-+        AMF_RETURN_IF_FALSE(ctx, can_read > 0, AVERROR_UNKNOWN, AVERROR_UNKNOWN, "timestamp_list is empty while max_b_frames = %d\n", avctx->max_b_frames);
++                            "timestamp_list is empty while max_b_frames = %d\n", avctx->max_b_frames);
 +
          av_fifo_peek(ctx->timestamp_list, &timestamp_last, 1, can_read - 1);
 -        if (timestamp < 0 || timestamp_last < AV_NOPTS_VALUE) {
@@ -1184,7 +1181,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
  {
      AMF_RESULT res;
      AMFVariantStruct var;
-@@ -527,15 +402,16 @@ static AMF_RESULT amf_set_property_buffe
+@@ -527,15 +404,16 @@ static AMF_RESULT amf_set_property_buffe
              res = AMFVariantAssignInterface(&var, amf_interface);
              amf_interface->pVtbl->Release(amf_interface);
          }
@@ -1204,7 +1201,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
  {
      AMF_RESULT res;
      AMFVariantStruct var;
-@@ -583,9 +459,60 @@ static void amf_release_buffer_with_fram
+@@ -583,9 +461,60 @@ static void amf_release_buffer_with_fram
      frame_ref_storage_buffer->pVtbl->Release(frame_ref_storage_buffer);
  }
  
@@ -1266,7 +1263,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
      AMFSurface *surface;
      AMF_RESULT  res;
      int         ret;
-@@ -612,10 +539,9 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -612,10 +541,9 @@ int ff_amf_receive_packet(AVCodecContext
                  if (res == AMF_INPUT_FULL) {
                      ctx->delayed_drain = 1; // input queue is full: resubmit Drain() in ff_amf_receive_packet
                  } else {
@@ -1279,7 +1276,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
                  }
              }
          }
-@@ -631,13 +557,10 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -631,13 +559,10 @@ int ff_amf_receive_packet(AVCodecContext
                  ID3D11Texture2D *texture = (ID3D11Texture2D*)frame->data[0]; // actual texture
                  int index = (intptr_t)frame->data[1]; // index is a slice in texture array is - set to tell AMF which slice to use
  
@@ -1295,7 +1292,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
  
                  hw_surface = 1;
              }
-@@ -648,8 +571,8 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -648,8 +573,8 @@ int ff_amf_receive_packet(AVCodecContext
              {
                  IDirect3DSurface9 *texture = (IDirect3DSurface9 *)frame->data[3]; // actual texture
  
@@ -1306,7 +1303,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
  
                  hw_surface = 1;
              }
-@@ -657,8 +580,8 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -657,8 +582,8 @@ int ff_amf_receive_packet(AVCodecContext
  #endif
          default:
              {
@@ -1317,7 +1314,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
                  amf_copy_surface(avctx, frame, surface);
              }
              break;
-@@ -670,28 +593,49 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -670,28 +595,49 @@ int ff_amf_receive_packet(AVCodecContext
              // input HW surfaces can be vertically aligned by 16; tell AMF the real size
              surface->pVtbl->SetCrop(surface, 0, 0, frame->width, frame->height);
  
@@ -1376,7 +1373,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
          }
  
          // submit surface
-@@ -702,7 +646,7 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -702,7 +648,7 @@ int ff_amf_receive_packet(AVCodecContext
          } else {
              int64_t pts = frame->pts;
              surface->pVtbl->Release(surface);
@@ -1385,7 +1382,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
  
              av_frame_unref(frame);
              ret = av_fifo_write(ctx->timestamp_list, &pts, 1);
-@@ -711,7 +655,6 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -711,7 +657,6 @@ int ff_amf_receive_packet(AVCodecContext
          }
      }
  
@@ -1393,7 +1390,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
      do {
          block_and_wait = 0;
          // poll data
-@@ -728,23 +671,37 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -728,23 +673,37 @@ int ff_amf_receive_packet(AVCodecContext
              if (data->pVtbl->HasProperty(data, L"av_frame_ref")) {
                  AMFBuffer *frame_ref_storage_buffer;
                  res = amf_get_property_buffer(data, L"av_frame_ref", &frame_ref_storage_buffer);
@@ -1434,7 +1431,7 @@ Index: jellyfin-ffmpeg/libavcodec/amfenc.c
  
                      ret = av_fifo_write(ctx->timestamp_list, &pts, 1);
                      if (ret < 0)
-@@ -757,24 +714,26 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -757,24 +716,26 @@ int ff_amf_receive_packet(AVCodecContext
                  if (res != AMF_INPUT_FULL) {
                      ctx->delayed_drain = 0;
                      ctx->eof = 1; // drain started

--- a/debian/patches/0007-add-opencl-scaler-and-pixfmt-converter-impl.patch
+++ b/debian/patches/0007-add-opencl-scaler-and-pixfmt-converter-impl.patch
@@ -315,11 +315,23 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/scale.cl
 +#endif
 +}
 +#endif
+Index: jellyfin-ffmpeg/libavfilter/opencl_source.h
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/opencl_source.h
++++ jellyfin-ffmpeg/libavfilter/opencl_source.h
+@@ -27,6 +27,7 @@ extern const char *ff_opencl_source_desh
+ extern const char *ff_opencl_source_neighbor;
+ extern const char *ff_opencl_source_nlmeans;
+ extern const char *ff_opencl_source_overlay;
++extern const char *ff_opencl_source_scale;
+ extern const char *ff_opencl_source_pad;
+ extern const char *ff_opencl_source_remap;
+ extern const char *ff_opencl_source_tonemap;
 Index: jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
 ===================================================================
 --- /dev/null
 +++ jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
-@@ -0,0 +1,770 @@
+@@ -0,0 +1,776 @@
 +/*
 + * Copyright (c) 2018 Gabriel Machado
 + * Copyright (c) 2021 NyanMisaka
@@ -664,8 +676,6 @@ Index: jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
 +    }
 +
 +    if (ctx->in_desc->comp[0].depth > ctx->out_desc->comp[0].depth) {
-+        av_assert0(sizeof(ff_fruit_dither_matrix) == sizeof(ff_fruit_dither_matrix[0]) * ff_fruit_dither_size * ff_fruit_dither_size);
-+
 +        cl_image_format image_format = {
 +            .image_channel_data_type = CL_UNORM_INT16,
 +            .image_channel_order     = CL_R,
@@ -676,6 +686,8 @@ Index: jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
 +            .image_height    = ff_fruit_dither_size,
 +            .image_row_pitch = 0,
 +        };
++
++        av_assert0(sizeof(ff_fruit_dither_matrix) == sizeof(ff_fruit_dither_matrix[0]) * ff_fruit_dither_size * ff_fruit_dither_size);
 +
 +        ctx->dither_image = clCreateImage(ctx->ocf.hwctx->context, CL_MEM_READ_ONLY,
 +                                          &image_format, &image_desc, NULL, &cle);
@@ -796,8 +808,8 @@ Index: jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
 +    ff_scale_adjust_dimensions(inlink, &ctx->dst_w, &ctx->dst_h,
 +                               ctx->force_original_aspect_ratio, ctx->force_divisible_by);
 +
-+    if (((int64_t)(ctx->dst_h * inlink->w)) > INT_MAX  ||
-+        ((int64_t)(ctx->dst_w * inlink->h)) > INT_MAX)
++    if (((int64_t)ctx->dst_h * inlink->w) > INT_MAX ||
++        ((int64_t)ctx->dst_w * inlink->h) > INT_MAX)
 +        av_log(ctx, AV_LOG_ERROR, "Rescaled value for width or height is too big.\n");
 +
 +    ctx->src_w = inlink->w;
@@ -894,12 +906,15 @@ Index: jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
 +        CL_SET_KERNEL_ARG(ctx->kernel, 3, cl_mem, &input->data[1]);
 +
 +        idx_arg1 = 4;
-+        if (ctx->out_planes > 2)
++        if (ctx->out_planes > 2) {
 +            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg1++, cl_mem, &output->data[2]);
-+        if (ctx->in_planes > 2)
++        }
++        if (ctx->in_planes > 2) {
 +            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg1++, cl_mem, &input->data[2]);
-+        if (ctx->dither_image)
++        }
++        if (ctx->dither_image) {
 +            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg1++, cl_mem, &ctx->dither_image);
++        }
 +
 +        // conv_yuv
 +        global_work[0] = output->width / x_subsample;
@@ -917,14 +932,17 @@ Index: jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
 +        CL_SET_KERNEL_ARG(ctx->kernel_uv, 1, cl_mem, &input->data[1]);
 +
 +        idx_arg1 = 2;
-+        if (ctx->out_planes > 2)
++        if (ctx->out_planes > 2) {
 +            CL_SET_KERNEL_ARG(ctx->kernel_uv, idx_arg1++, cl_mem, &output->data[2]);
-+        if (ctx->in_planes > 2)
++        }
++        if (ctx->in_planes > 2) {
 +            CL_SET_KERNEL_ARG(ctx->kernel_uv, idx_arg1++, cl_mem, &input->data[2]);
++        }
 +
 +        idx_arg2 = 2;
-+        if (ctx->dither_image)
++        if (ctx->dither_image) {
 +            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg2++, cl_mem, &ctx->dither_image);
++        }
 +        if (ctx->algorithm != F_NEIGHBOR) {
 +            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg2++, cl_mem, &ctx->cx);
 +            CL_SET_KERNEL_ARG(ctx->kernel, idx_arg2++, cl_mem, &ctx->cy);
@@ -1090,15 +1108,3 @@ Index: jellyfin-ffmpeg/libavfilter/vf_scale_opencl.c
 +    FILTER_SINGLE_PIXFMT(AV_PIX_FMT_OPENCL),
 +    .flags_internal = FF_FILTER_FLAG_HWFRAME_AWARE,
 +};
-Index: jellyfin-ffmpeg/libavfilter/opencl_source.h
-===================================================================
---- jellyfin-ffmpeg.orig/libavfilter/opencl_source.h
-+++ jellyfin-ffmpeg/libavfilter/opencl_source.h
-@@ -27,6 +27,7 @@ extern const char *ff_opencl_source_desh
- extern const char *ff_opencl_source_neighbor;
- extern const char *ff_opencl_source_nlmeans;
- extern const char *ff_opencl_source_overlay;
-+extern const char *ff_opencl_source_scale;
- extern const char *ff_opencl_source_pad;
- extern const char *ff_opencl_source_remap;
- extern const char *ff_opencl_source_tonemap;

--- a/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0008-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -1476,13 +1476,11 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
      opencl_sources[0] = header.str;
-@@ -254,46 +586,170 @@ static int tonemap_opencl_init(AVFilterC
+@@ -254,46 +586,171 @@ static int tonemap_opencl_init(AVFilterC
      CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create OpenCL "
                       "command queue %d.\n", cle);
  
 +    if (ctx->in_desc->comp[0].depth > ctx->out_desc->comp[0].depth) {
-+        av_assert0(sizeof(ff_fruit_dither_matrix) == sizeof(ff_fruit_dither_matrix[0]) * ff_fruit_dither_size * ff_fruit_dither_size);
-+
 +        cl_image_format image_format = {
 +            .image_channel_data_type = CL_UNORM_INT16,
 +            .image_channel_order     = CL_R,
@@ -1493,6 +1491,8 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 +            .image_height    = ff_fruit_dither_size,
 +            .image_row_pitch = 0,
 +        };
++
++        av_assert0(sizeof(ff_fruit_dither_matrix) == sizeof(ff_fruit_dither_matrix[0]) * ff_fruit_dither_size * ff_fruit_dither_size);
 +
 +        ctx->dither_image = clCreateImage(ctx->ocf.hwctx->context, CL_MEM_READ_ONLY,
 +                                          &image_format, &image_desc, NULL, &cle);
@@ -1523,9 +1523,10 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 -                       (2 * DETECTION_FRAMES + 7) * sizeof(unsigned),
 -                       NULL, &cle);
 -    CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create util buffer: %d.\n", cle);
-+    if (ctx->dovi)
++    if (ctx->dovi) {
 +        CL_CREATE_BUFFER_FLAGS(ctx, dovi_buf, dovi_buf_flags,
 +                               3*(params_sz+pivots_sz+coeffs_sz+mmr_sz), NULL);
++    }
  
      ctx->initialised = 1;
      return 0;
@@ -1666,7 +1667,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      ret = ff_opencl_filter_config_output(outlink);
      if (ret < 0)
          return ret;
-@@ -308,13 +764,42 @@ static int launch_kernel(AVFilterContext
+@@ -308,13 +765,46 @@ static int launch_kernel(AVFilterContext
      size_t global_work[2];
      size_t local_work[2];
      cl_int cle;
@@ -1695,23 +1696,27 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
 -    CL_SET_KERNEL_ARG(kernel, 5, cl_float, &peak);
 +
 +    idx_arg = 4;
-+    if (ctx->out_planes > 2)
++    if (ctx->out_planes > 2) {
 +        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &output->data[2]);
++    }
 +
-+    if (ctx->in_planes > 2)
++    if (ctx->in_planes > 2) {
 +        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &input->data[2]);
++    }
 +
-+    if (ctx->dither_image)
++    if (ctx->dither_image) {
 +        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &ctx->dither_image);
++    }
 +
-+    if (ctx->dovi_buf)
++    if (ctx->dovi_buf) {
 +        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &ctx->dovi_buf);
++    }
 +
 +    CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_float, &peak);
  
      local_work[0]  = 16;
      local_work[1]  = 16;
-@@ -338,13 +823,10 @@ static int tonemap_opencl_filter_frame(A
+@@ -338,13 +828,10 @@ static int tonemap_opencl_filter_frame(A
      AVFilterContext    *avctx = inlink->dst;
      AVFilterLink     *outlink = avctx->outputs[0];
      TonemapOpenCLContext *ctx = avctx->priv;
@@ -1726,7 +1731,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(input->format),
-@@ -363,9 +845,6 @@ static int tonemap_opencl_filter_frame(A
+@@ -363,9 +850,6 @@ static int tonemap_opencl_filter_frame(A
      if (err < 0)
          goto fail;
  
@@ -1736,7 +1741,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      if (ctx->trc != -1)
          output->color_trc = ctx->trc;
      if (ctx->primaries != -1)
-@@ -385,72 +864,92 @@ static int tonemap_opencl_filter_frame(A
+@@ -385,72 +869,92 @@ static int tonemap_opencl_filter_frame(A
      ctx->range_out = output->color_range;
      ctx->chroma_loc = output->chroma_location;
  
@@ -1869,7 +1874,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
      av_frame_free(&input);
      av_frame_free(&output);
      return err;
-@@ -458,24 +957,9 @@ fail:
+@@ -458,24 +962,9 @@ fail:
  
  static av_cold void tonemap_opencl_uninit(AVFilterContext *avctx)
  {
@@ -1896,7 +1901,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_tonemap_opencl.c
  
      ff_opencl_filter_uninit(avctx);
  }
-@@ -483,37 +967,47 @@ static av_cold void tonemap_opencl_unini
+@@ -483,37 +972,47 @@ static av_cold void tonemap_opencl_unini
  #define OFFSET(x) offsetof(TonemapOpenCLContext, x)
  #define FLAGS (AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_VIDEO_PARAM)
  static const AVOption tonemap_opencl_options[] = {

--- a/debian/patches/0032-add-fixes-for-vulkan-scale-and-overlay-filters.patch
+++ b/debian/patches/0032-add-fixes-for-vulkan-scale-and-overlay-filters.patch
@@ -21,18 +21,18 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
  } OverlayVulkanContext;
  
  static const char overlay_noalpha[] = {
-@@ -81,6 +86,7 @@ static av_cold int init_filter(AVFilterC
+@@ -80,17 +85,78 @@ static const char overlay_alpha[] = {
+ static av_cold int init_filter(AVFilterContext *ctx)
  {
      int err;
-     FFVkSampler *sampler;
+-    FFVkSampler *sampler;
 +    FFVkSPIRVShader *shd;
      OverlayVulkanContext *s = ctx->priv;
      FFVulkanContext *vkctx = &s->vkctx;
++    FFVkSampler *sampler = ff_vk_init_sampler(vkctx, 1, VK_FILTER_NEAREST);
      const int planes = av_pix_fmt_count_planes(s->vkctx.output_format);
-@@ -91,6 +97,67 @@ static av_cold int init_filter(AVFilterC
-     if (!sampler)
-         return AVERROR_EXTERNAL;
  
+-    ff_vk_qf_init(vkctx, &s->qf, VK_QUEUE_COMPUTE_BIT, 0);
 +    FFVulkanDescriptorSetBinding desc_i[3] = {
 +        {
 +            .name       = "main_img",
@@ -63,6 +63,12 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
 +            .updater    = s->output_images,
 +        },
 +    };
+ 
+-    sampler = ff_vk_init_sampler(vkctx, 1, VK_FILTER_NEAREST);
+     if (!sampler)
+         return AVERROR_EXTERNAL;
+ 
++    ff_vk_qf_init(vkctx, &s->qf, VK_QUEUE_COMPUTE_BIT, 0);
 +
 +    s->pl_pass = ff_vk_create_pipeline(vkctx, &s->qf);
 +    if (!s->pl_pass)
@@ -97,7 +103,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
      s->pl = ff_vk_create_pipeline(vkctx, &s->qf);
      if (!s->pl)
          return AVERROR(ENOMEM);
-@@ -98,37 +165,6 @@ static av_cold int init_filter(AVFilterC
+@@ -98,37 +164,6 @@ static av_cold int init_filter(AVFilterC
      { /* Create the shader */
          const int ialpha = av_pix_fmt_desc_get(s->vkctx.input_format)->flags & AV_PIX_FMT_FLAG_ALPHA;
  
@@ -135,7 +141,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
          FFVulkanDescriptorSetBinding desc_b = {
              .name        = "params",
              .type        = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-@@ -139,8 +175,8 @@ static av_cold int init_filter(AVFilterC
+@@ -139,8 +174,8 @@ static av_cold int init_filter(AVFilterC
              .buf_content = "ivec2 o_offset[3], o_size[3];",
          };
  
@@ -146,7 +152,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
          if (!shd)
              return AVERROR(ENOMEM);
  
-@@ -229,7 +265,7 @@ fail:
+@@ -229,7 +264,7 @@ fail:
  }
  
  static int process_frames(AVFilterContext *avctx, AVFrame *out_f,
@@ -155,7 +161,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
  {
      int err;
      VkCommandBuffer cmd_buf;
-@@ -240,14 +276,20 @@ static int process_frames(AVFilterContex
+@@ -240,14 +275,20 @@ static int process_frames(AVFilterContex
  
      AVVkFrame *out     = (AVVkFrame *)out_f->data[0];
      AVVkFrame *main    = (AVVkFrame *)main_f->data[0];
@@ -179,7 +185,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
  
      /* Update descriptors and init the exec context */
      ff_vk_start_exec_recording(vkctx, s->exec);
-@@ -255,92 +297,128 @@ static int process_frames(AVFilterContex
+@@ -255,92 +296,128 @@ static int process_frames(AVFilterContex
  
      for (int i = 0; i < planes; i++) {
          RET(ff_vk_create_imageview(vkctx, s->exec,
@@ -374,7 +380,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
      ff_vk_add_exec_dep(vkctx, s->exec, out_f, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
  
      err = ff_vk_submit_exec_queue(vkctx, s->exec);
-@@ -358,7 +436,7 @@ fail:
+@@ -358,7 +435,7 @@ fail:
  
  static int overlay_vulkan_blend(FFFrameSync *fs)
  {
@@ -383,7 +389,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
      AVFilterContext *ctx = fs->parent;
      OverlayVulkanContext *s = ctx->priv;
      AVFilterLink *outlink = ctx->outputs[0];
-@@ -371,22 +449,14 @@ static int overlay_vulkan_blend(FFFrameS
+@@ -371,22 +448,14 @@ static int overlay_vulkan_blend(FFFrameS
      if (err < 0)
          goto fail;
  
@@ -411,7 +417,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
  
      out = ff_get_video_buffer(outlink, outlink->w, outlink->h);
      if (!out) {
-@@ -394,7 +464,7 @@ static int overlay_vulkan_blend(FFFrameS
+@@ -394,7 +463,7 @@ static int overlay_vulkan_blend(FFFrameS
          goto fail;
      }
  
@@ -420,7 +426,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
  
      err = av_frame_copy_props(out, input_main);
      if (err < 0)
-@@ -412,6 +482,18 @@ static int overlay_vulkan_config_output(
+@@ -412,6 +481,18 @@ static int overlay_vulkan_config_output(
      int err;
      AVFilterContext *avctx = outlink->src;
      OverlayVulkanContext *s = avctx->priv;
@@ -439,7 +445,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
  
      err = ff_vk_filter_config_output(outlink);
      if (err < 0)
-@@ -421,6 +503,11 @@ static int overlay_vulkan_config_output(
+@@ -421,6 +502,11 @@ static int overlay_vulkan_config_output(
      if (err < 0)
          return err;
  
@@ -451,7 +457,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_overlay_vulkan.c
      return ff_framesync_configure(&s->fs);
  }
  
-@@ -456,6 +543,14 @@ static void overlay_vulkan_uninit(AVFilt
+@@ -456,6 +542,14 @@ static void overlay_vulkan_uninit(AVFilt
  static const AVOption overlay_vulkan_options[] = {
      { "x", "Set horizontal offset", OFFSET(overlay_x), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, .flags = FLAGS },
      { "y", "Set vertical offset",   OFFSET(overlay_y), AV_OPT_TYPE_INT, {.i64 = 0}, 0, INT_MAX, .flags = FLAGS },
@@ -493,7 +499,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_scale_vulkan.c
          }
  
          GLSLC(0, }                                                               );
-@@ -305,7 +308,8 @@ static int process_frames(AVFilterContex
+@@ -299,7 +302,8 @@ static int process_frames(AVFilterContex
      AVVkFrame *out = (AVVkFrame *)out_f->data[0];
      VkImageMemoryBarrier barriers[AV_NUM_DATA_POINTERS*2];
      int barrier_count = 0;
@@ -503,7 +509,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_scale_vulkan.c
      const VkFormat *input_formats = av_vkfmt_from_pixfmt(s->vkctx.input_format);
      const VkFormat *output_formats = av_vkfmt_from_pixfmt(s->vkctx.output_format);
  
-@@ -313,24 +317,27 @@ static int process_frames(AVFilterContex
+@@ -307,24 +311,27 @@ static int process_frames(AVFilterContex
      ff_vk_start_exec_recording(vkctx, s->exec);
      cmd_buf = ff_vk_get_exec_buf(s->exec);
  
@@ -534,7 +540,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_scale_vulkan.c
          VkImageMemoryBarrier bar = {
              .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
              .srcAccessMask = 0,
-@@ -351,7 +358,7 @@ static int process_frames(AVFilterContex
+@@ -345,7 +352,7 @@ static int process_frames(AVFilterContex
          in->access[i]  = bar.dstAccessMask;
      }
  

--- a/debian/patches/0058-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0058-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -37,18 +37,22 @@ Index: jellyfin-ffmpeg/configure
  h264_amf_encoder_deps="amf"
  h264_crystalhd_decoder_select="crystalhd h264_mp4toannexb_bsf h264_parser"
  h264_cuvid_decoder_deps="cuvid"
-@@ -3184,6 +3189,7 @@ h264_qsv_decoder_select="h264_mp4toannex
+@@ -3183,7 +3188,8 @@ h264_omx_encoder_deps="omx"
+ h264_qsv_decoder_select="h264_mp4toannexb_bsf qsvdec"
  h264_qsv_encoder_select="atsc_a53 qsvenc"
  h264_rkmpp_decoder_deps="rkmpp"
- h264_rkmpp_decoder_select="h264_mp4toannexb_bsf"
+-h264_rkmpp_decoder_select="h264_mp4toannexb_bsf"
++h264_rkmpp_decoder_select="h264_mp4toannexb_bsf dump_extradata_bsf"
 +h264_rkmpp_encoder_deps="rkmpp"
  h264_vaapi_encoder_select="atsc_a53 cbs_h264 vaapi_encode"
  h264_v4l2m2m_decoder_deps="v4l2_m2m h264_v4l2_m2m"
  h264_v4l2m2m_decoder_select="h264_mp4toannexb_bsf"
-@@ -3204,6 +3210,7 @@ hevc_qsv_decoder_select="hevc_mp4toannex
+@@ -3203,7 +3209,8 @@ hevc_nvenc_encoder_select="atsc_a53"
+ hevc_qsv_decoder_select="hevc_mp4toannexb_bsf qsvdec"
  hevc_qsv_encoder_select="hevcparse qsvenc"
  hevc_rkmpp_decoder_deps="rkmpp"
- hevc_rkmpp_decoder_select="hevc_mp4toannexb_bsf"
+-hevc_rkmpp_decoder_select="hevc_mp4toannexb_bsf"
++hevc_rkmpp_decoder_select="hevc_mp4toannexb_bsf dump_extradata_bsf"
 +hevc_rkmpp_encoder_deps="rkmpp"
  hevc_vaapi_encoder_deps="VAEncPictureParameterBufferHEVC"
  hevc_vaapi_encoder_select="atsc_a53 cbs_h265 vaapi_encode"
@@ -153,6 +157,64 @@ Index: jellyfin-ffmpeg/configure
          enable opencl_drm_arm
  fi
  
+Index: jellyfin-ffmpeg/libavcodec/allcodecs.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavcodec/allcodecs.c
++++ jellyfin-ffmpeg/libavcodec/allcodecs.c
+@@ -150,6 +150,7 @@ extern const FFCodec ff_h263i_decoder;
+ extern const FFCodec ff_h263p_encoder;
+ extern const FFCodec ff_h263p_decoder;
+ extern const FFCodec ff_h263_v4l2m2m_decoder;
++extern const FFCodec ff_h263_rkmpp_decoder;
+ extern const FFCodec ff_h264_decoder;
+ extern const FFCodec ff_h264_crystalhd_decoder;
+ extern const FFCodec ff_h264_v4l2m2m_decoder;
+@@ -212,13 +213,16 @@ extern const FFCodec ff_mpeg4_decoder;
+ extern const FFCodec ff_mpeg4_crystalhd_decoder;
+ extern const FFCodec ff_mpeg4_v4l2m2m_decoder;
+ extern const FFCodec ff_mpeg4_mmal_decoder;
++extern const FFCodec ff_mpeg4_rkmpp_decoder;
+ extern const FFCodec ff_mpegvideo_decoder;
+ extern const FFCodec ff_mpeg1_v4l2m2m_decoder;
++extern const FFCodec ff_mpeg1_rkmpp_decoder;
+ extern const FFCodec ff_mpeg2_mmal_decoder;
+ extern const FFCodec ff_mpeg2_crystalhd_decoder;
+ extern const FFCodec ff_mpeg2_v4l2m2m_decoder;
+ extern const FFCodec ff_mpeg2_qsv_decoder;
+ extern const FFCodec ff_mpeg2_mediacodec_decoder;
++extern const FFCodec ff_mpeg2_rkmpp_decoder;
+ extern const FFCodec ff_msa1_decoder;
+ extern const FFCodec ff_mscc_decoder;
+ extern const FFCodec ff_msmpeg4v1_decoder;
+@@ -839,6 +843,7 @@ extern const FFCodec ff_av1_qsv_decoder;
+ extern const FFCodec ff_av1_qsv_encoder;
+ extern const FFCodec ff_av1_amf_encoder;
+ extern const FFCodec ff_av1_vaapi_encoder;
++extern const FFCodec ff_av1_rkmpp_decoder;
+ extern const FFCodec ff_libopenh264_encoder;
+ extern const FFCodec ff_libopenh264_decoder;
+ extern const FFCodec ff_h264_amf_encoder;
+@@ -850,6 +855,7 @@ extern const FFCodec ff_h264_qsv_encoder
+ extern const FFCodec ff_h264_v4l2m2m_encoder;
+ extern const FFCodec ff_h264_vaapi_encoder;
+ extern const FFCodec ff_h264_videotoolbox_encoder;
++extern const FFCodec ff_h264_rkmpp_encoder;
+ extern const FFCodec ff_hevc_amf_encoder;
+ extern const FFCodec ff_hevc_cuvid_decoder;
+ extern const FFCodec ff_hevc_mediacodec_decoder;
+@@ -860,10 +866,12 @@ extern const FFCodec ff_hevc_qsv_encoder
+ extern const FFCodec ff_hevc_v4l2m2m_encoder;
+ extern const FFCodec ff_hevc_vaapi_encoder;
+ extern const FFCodec ff_hevc_videotoolbox_encoder;
++extern const FFCodec ff_hevc_rkmpp_encoder;
+ extern const FFCodec ff_libkvazaar_encoder;
+ extern const FFCodec ff_mjpeg_cuvid_decoder;
+ extern const FFCodec ff_mjpeg_qsv_encoder;
+ extern const FFCodec ff_mjpeg_qsv_decoder;
++extern const FFCodec ff_mjpeg_rkmpp_encoder;
+ extern const FFCodec ff_mjpeg_vaapi_encoder;
+ extern const FFCodec ff_mp3_mf_encoder;
+ extern const FFCodec ff_mpeg1_cuvid_decoder;
 Index: jellyfin-ffmpeg/libavcodec/Makefile
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavcodec/Makefile
@@ -221,64 +283,6 @@ Index: jellyfin-ffmpeg/libavcodec/Makefile
  OBJS-$(CONFIG_MPL2_DECODER)            += mpl2dec.o ass.o
  OBJS-$(CONFIG_MSA1_DECODER)            += mss3.o
  OBJS-$(CONFIG_MSCC_DECODER)            += mscc.o
-Index: jellyfin-ffmpeg/libavcodec/allcodecs.c
-===================================================================
---- jellyfin-ffmpeg.orig/libavcodec/allcodecs.c
-+++ jellyfin-ffmpeg/libavcodec/allcodecs.c
-@@ -150,6 +150,7 @@ extern const FFCodec ff_h263i_decoder;
- extern const FFCodec ff_h263p_encoder;
- extern const FFCodec ff_h263p_decoder;
- extern const FFCodec ff_h263_v4l2m2m_decoder;
-+extern const FFCodec ff_h263_rkmpp_decoder;
- extern const FFCodec ff_h264_decoder;
- extern const FFCodec ff_h264_crystalhd_decoder;
- extern const FFCodec ff_h264_v4l2m2m_decoder;
-@@ -212,13 +213,16 @@ extern const FFCodec ff_mpeg4_decoder;
- extern const FFCodec ff_mpeg4_crystalhd_decoder;
- extern const FFCodec ff_mpeg4_v4l2m2m_decoder;
- extern const FFCodec ff_mpeg4_mmal_decoder;
-+extern const FFCodec ff_mpeg4_rkmpp_decoder;
- extern const FFCodec ff_mpegvideo_decoder;
- extern const FFCodec ff_mpeg1_v4l2m2m_decoder;
-+extern const FFCodec ff_mpeg1_rkmpp_decoder;
- extern const FFCodec ff_mpeg2_mmal_decoder;
- extern const FFCodec ff_mpeg2_crystalhd_decoder;
- extern const FFCodec ff_mpeg2_v4l2m2m_decoder;
- extern const FFCodec ff_mpeg2_qsv_decoder;
- extern const FFCodec ff_mpeg2_mediacodec_decoder;
-+extern const FFCodec ff_mpeg2_rkmpp_decoder;
- extern const FFCodec ff_msa1_decoder;
- extern const FFCodec ff_mscc_decoder;
- extern const FFCodec ff_msmpeg4v1_decoder;
-@@ -839,6 +843,7 @@ extern const FFCodec ff_av1_qsv_decoder;
- extern const FFCodec ff_av1_qsv_encoder;
- extern const FFCodec ff_av1_amf_encoder;
- extern const FFCodec ff_av1_vaapi_encoder;
-+extern const FFCodec ff_av1_rkmpp_decoder;
- extern const FFCodec ff_libopenh264_encoder;
- extern const FFCodec ff_libopenh264_decoder;
- extern const FFCodec ff_h264_amf_encoder;
-@@ -850,6 +855,7 @@ extern const FFCodec ff_h264_qsv_encoder
- extern const FFCodec ff_h264_v4l2m2m_encoder;
- extern const FFCodec ff_h264_vaapi_encoder;
- extern const FFCodec ff_h264_videotoolbox_encoder;
-+extern const FFCodec ff_h264_rkmpp_encoder;
- extern const FFCodec ff_hevc_amf_encoder;
- extern const FFCodec ff_hevc_cuvid_decoder;
- extern const FFCodec ff_hevc_mediacodec_decoder;
-@@ -860,10 +866,12 @@ extern const FFCodec ff_hevc_qsv_encoder
- extern const FFCodec ff_hevc_v4l2m2m_encoder;
- extern const FFCodec ff_hevc_vaapi_encoder;
- extern const FFCodec ff_hevc_videotoolbox_encoder;
-+extern const FFCodec ff_hevc_rkmpp_encoder;
- extern const FFCodec ff_libkvazaar_encoder;
- extern const FFCodec ff_mjpeg_cuvid_decoder;
- extern const FFCodec ff_mjpeg_qsv_encoder;
- extern const FFCodec ff_mjpeg_qsv_decoder;
-+extern const FFCodec ff_mjpeg_rkmpp_encoder;
- extern const FFCodec ff_mjpeg_vaapi_encoder;
- extern const FFCodec ff_mp3_mf_encoder;
- extern const FFCodec ff_mpeg1_cuvid_decoder;
 Index: jellyfin-ffmpeg/libavcodec/rkmppdec.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavcodec/rkmppdec.c
@@ -1636,10 +1640,10 @@ Index: jellyfin-ffmpeg/libavcodec/rkmppdec.c
 +DEFINE_RKMPP_DECODER(h263, H263, NULL)
 +#endif
 +#if CONFIG_H264_RKMPP_DECODER
-+DEFINE_RKMPP_DECODER(h264, H264, "h264_mp4toannexb")
++DEFINE_RKMPP_DECODER(h264, H264, "h264_mp4toannexb,dump_extra")
 +#endif
 +#if CONFIG_HEVC_RKMPP_DECODER
-+DEFINE_RKMPP_DECODER(hevc, HEVC, "hevc_mp4toannexb")
++DEFINE_RKMPP_DECODER(hevc, HEVC, "hevc_mp4toannexb,dump_extra")
 +#endif
 +#if CONFIG_VP8_RKMPP_DECODER
 +DEFINE_RKMPP_DECODER(vp8, VP8, NULL)
@@ -1821,7 +1825,7 @@ Index: jellyfin-ffmpeg/libavcodec/rkmppenc.c
 ===================================================================
 --- /dev/null
 +++ jellyfin-ffmpeg/libavcodec/rkmppenc.c
-@@ -0,0 +1,1102 @@
+@@ -0,0 +1,1103 @@
 +/*
 + * Copyright (c) 2023 Huseyin BIYIK
 + * Copyright (c) 2023 NyanMisaka
@@ -2275,6 +2279,7 @@ Index: jellyfin-ffmpeg/libavcodec/rkmppenc.c
 +            qp_init = r->qp_init >= 1 ? r->qp_init : 80;
 +            qp_max = r->qp_max >= 1 ? r->qp_max : 99;
 +            qp_min = r->qp_min >= 1 ? r->qp_min : 1;
++            qp_max_i = qp_min_i = 0;
 +            /* jpeg use special codec config to control qtable */
 +            mpp_enc_cfg_set_s32(cfg, "jpeg:q_factor", qp_init);
 +            mpp_enc_cfg_set_s32(cfg, "jpeg:qf_max", qp_max);
@@ -3205,6 +3210,34 @@ Index: jellyfin-ffmpeg/libavcodec/rkmppenc.h
 +};
 +
 +#endif /* AVCODEC_RKMPPENC_H */
+Index: jellyfin-ffmpeg/libavfilter/allfilters.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/allfilters.c
++++ jellyfin-ffmpeg/libavfilter/allfilters.c
+@@ -379,6 +379,7 @@ extern const AVFilter ff_vf_overlay_qsv;
+ extern const AVFilter ff_vf_overlay_vaapi;
+ extern const AVFilter ff_vf_overlay_vulkan;
+ extern const AVFilter ff_vf_overlay_cuda;
++extern const AVFilter ff_vf_overlay_rkrga;
+ extern const AVFilter ff_vf_owdenoise;
+ extern const AVFilter ff_vf_pad;
+ extern const AVFilter ff_vf_pad_opencl;
+@@ -424,6 +425,7 @@ extern const AVFilter ff_vf_scale_opencl
+ extern const AVFilter ff_vf_scale_qsv;
+ extern const AVFilter ff_vf_scale_vaapi;
+ extern const AVFilter ff_vf_scale_vulkan;
++extern const AVFilter ff_vf_scale_rkrga;
+ extern const AVFilter ff_vf_scale2ref;
+ extern const AVFilter ff_vf_scale2ref_npp;
+ extern const AVFilter ff_vf_scdet;
+@@ -509,6 +511,7 @@ extern const AVFilter ff_vf_vif;
+ extern const AVFilter ff_vf_vignette;
+ extern const AVFilter ff_vf_vmafmotion;
+ extern const AVFilter ff_vf_vpp_qsv;
++extern const AVFilter ff_vf_vpp_rkrga;
+ extern const AVFilter ff_vf_vstack;
+ extern const AVFilter ff_vf_w3fdif;
+ extern const AVFilter ff_vf_waveform;
 Index: jellyfin-ffmpeg/libavfilter/Makefile
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavfilter/Makefile
@@ -3249,34 +3282,6 @@ Index: jellyfin-ffmpeg/libavfilter/Makefile
  SKIPHEADERS-$(CONFIG_OPENCL)                 += opencl.h
  SKIPHEADERS-$(CONFIG_VAAPI)                  += vaapi_vpp.h
  SKIPHEADERS-$(CONFIG_VULKAN)                 += vulkan.h vulkan_filter.h
-Index: jellyfin-ffmpeg/libavfilter/allfilters.c
-===================================================================
---- jellyfin-ffmpeg.orig/libavfilter/allfilters.c
-+++ jellyfin-ffmpeg/libavfilter/allfilters.c
-@@ -379,6 +379,7 @@ extern const AVFilter ff_vf_overlay_qsv;
- extern const AVFilter ff_vf_overlay_vaapi;
- extern const AVFilter ff_vf_overlay_vulkan;
- extern const AVFilter ff_vf_overlay_cuda;
-+extern const AVFilter ff_vf_overlay_rkrga;
- extern const AVFilter ff_vf_owdenoise;
- extern const AVFilter ff_vf_pad;
- extern const AVFilter ff_vf_pad_opencl;
-@@ -424,6 +425,7 @@ extern const AVFilter ff_vf_scale_opencl
- extern const AVFilter ff_vf_scale_qsv;
- extern const AVFilter ff_vf_scale_vaapi;
- extern const AVFilter ff_vf_scale_vulkan;
-+extern const AVFilter ff_vf_scale_rkrga;
- extern const AVFilter ff_vf_scale2ref;
- extern const AVFilter ff_vf_scale2ref_npp;
- extern const AVFilter ff_vf_scdet;
-@@ -509,6 +511,7 @@ extern const AVFilter ff_vf_vif;
- extern const AVFilter ff_vf_vignette;
- extern const AVFilter ff_vf_vmafmotion;
- extern const AVFilter ff_vf_vpp_qsv;
-+extern const AVFilter ff_vf_vpp_rkrga;
- extern const AVFilter ff_vf_vstack;
- extern const AVFilter ff_vf_w3fdif;
- extern const AVFilter ff_vf_waveform;
 Index: jellyfin-ffmpeg/libavfilter/rkrga_common.c
 ===================================================================
 --- /dev/null
@@ -5619,34 +5624,6 @@ Index: jellyfin-ffmpeg/libavfilter/vf_vpp_rkrga.c
 +};
 +
 +#endif
-Index: jellyfin-ffmpeg/libavutil/Makefile
-===================================================================
---- jellyfin-ffmpeg.orig/libavutil/Makefile
-+++ jellyfin-ffmpeg/libavutil/Makefile
-@@ -50,6 +50,7 @@ HEADERS = adler32.h
-           hwcontext_videotoolbox.h                                      \
-           hwcontext_vdpau.h                                             \
-           hwcontext_vulkan.h                                            \
-+          hwcontext_rkmpp.h                                             \
-           imgutils.h                                                    \
-           intfloat.h                                                    \
-           intreadwrite.h                                                \
-@@ -196,6 +197,7 @@ OBJS-$(CONFIG_VAAPI)
- OBJS-$(CONFIG_VIDEOTOOLBOX)             += hwcontext_videotoolbox.o
- OBJS-$(CONFIG_VDPAU)                    += hwcontext_vdpau.o
- OBJS-$(CONFIG_VULKAN)                   += hwcontext_vulkan.o
-+OBJS-$(CONFIG_RKMPP)                    += hwcontext_rkmpp.o
- 
- OBJS-$(!CONFIG_VULKAN)                  += hwcontext_stub.o
- 
-@@ -218,6 +220,7 @@ SKIPHEADERS-$(CONFIG_VDPAU)            +
- SKIPHEADERS-$(CONFIG_VULKAN)           += hwcontext_vulkan.h vulkan.h   \
-                                           vulkan_functions.h            \
-                                           vulkan_loader.h
-+SKIPHEADERS-$(CONFIG_RKMPP)            += hwcontext_rkmpp.h
- 
- TESTPROGS = adler32                                                     \
-             aes                                                         \
 Index: jellyfin-ffmpeg/libavutil/hwcontext.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavutil/hwcontext.c
@@ -6487,6 +6464,34 @@ Index: jellyfin-ffmpeg/libavutil/hwcontext_rkmpp.h
 +} AVRKMPPDeviceContext;
 +
 +#endif /* AVUTIL_HWCONTEXT_RKMPP_H */
+Index: jellyfin-ffmpeg/libavutil/Makefile
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/Makefile
++++ jellyfin-ffmpeg/libavutil/Makefile
+@@ -50,6 +50,7 @@ HEADERS = adler32.h
+           hwcontext_videotoolbox.h                                      \
+           hwcontext_vdpau.h                                             \
+           hwcontext_vulkan.h                                            \
++          hwcontext_rkmpp.h                                             \
+           imgutils.h                                                    \
+           intfloat.h                                                    \
+           intreadwrite.h                                                \
+@@ -196,6 +197,7 @@ OBJS-$(CONFIG_VAAPI)
+ OBJS-$(CONFIG_VIDEOTOOLBOX)             += hwcontext_videotoolbox.o
+ OBJS-$(CONFIG_VDPAU)                    += hwcontext_vdpau.o
+ OBJS-$(CONFIG_VULKAN)                   += hwcontext_vulkan.o
++OBJS-$(CONFIG_RKMPP)                    += hwcontext_rkmpp.o
+ 
+ OBJS-$(!CONFIG_VULKAN)                  += hwcontext_stub.o
+ 
+@@ -218,6 +220,7 @@ SKIPHEADERS-$(CONFIG_VDPAU)            +
+ SKIPHEADERS-$(CONFIG_VULKAN)           += hwcontext_vulkan.h vulkan.h   \
+                                           vulkan_functions.h            \
+                                           vulkan_loader.h
++SKIPHEADERS-$(CONFIG_RKMPP)            += hwcontext_rkmpp.h
+ 
+ TESTPROGS = adler32                                                     \
+             aes                                                         \
 Index: jellyfin-ffmpeg/libavutil/pixdesc.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libavutil/pixdesc.c
@@ -6621,6 +6626,92 @@ Index: jellyfin-ffmpeg/libswscale/input.c
      case AV_PIX_FMT_P010LE:
      case AV_PIX_FMT_P210LE:
      case AV_PIX_FMT_P410LE:
+Index: jellyfin-ffmpeg/libswscale/swscale_unscaled.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libswscale/swscale_unscaled.c
++++ jellyfin-ffmpeg/libswscale/swscale_unscaled.c
+@@ -221,6 +221,61 @@ static int nv24ToPlanarWrapper(SwsContex
+     return srcSliceH;
+ }
+ 
++static int nv15_20ToPlanarWrapper(SwsContext *c, const uint8_t *src[],
++                                  int srcStride[], int srcSliceY,
++                                  int srcSliceH, uint8_t *dstParam[],
++                                  int dstStride[])
++{
++    const AVPixFmtDescriptor *src_format = av_pix_fmt_desc_get(c->srcFormat);
++    const AVPixFmtDescriptor *dst_format = av_pix_fmt_desc_get(c->dstFormat);
++    int vsub = 1 << dst_format->log2_chroma_h;
++    uint16_t *dstY = (uint16_t*)(dstParam[0] + dstStride[0] * srcSliceY);
++    uint16_t *dstU = (uint16_t*)(dstParam[1] + dstStride[1] * srcSliceY / vsub);
++    uint16_t *dstV = (uint16_t*)(dstParam[2] + dstStride[2] * srcSliceY / vsub);
++    int x, y;
++
++    /* Calculate net shift required for values. */
++    const int shift[3] = {
++        dst_format->comp[0].depth + dst_format->comp[0].shift -
++        src_format->comp[0].depth - src_format->comp[0].shift,
++        dst_format->comp[1].depth + dst_format->comp[1].shift -
++        src_format->comp[1].depth - src_format->comp[1].shift,
++        dst_format->comp[2].depth + dst_format->comp[2].shift -
++        src_format->comp[2].depth - src_format->comp[2].shift,
++    };
++
++    for (y = srcSliceH; y > 0; y--) {
++        const uint8_t *tsrcY = src[0];
++        uint16_t *tdstY = dstY;
++        for (x = c->srcW / 4; x > 0; x--) {
++            *tdstY++ = (((tsrcY[1] & 0x3 ) << 8) | (tsrcY[0]        & 0xFF)) << shift[0];
++            *tdstY++ = (((tsrcY[2] & 0xF ) << 6) | ((tsrcY[1] >> 2) & 0x3F)) << shift[0];
++            *tdstY++ = (((tsrcY[3] & 0x3F) << 4) | ((tsrcY[2] >> 4) & 0xF )) << shift[0];
++            *tdstY++ = (((tsrcY[4] & 0xFF) << 2) | ((tsrcY[3] >> 6) & 0x3 )) << shift[0];
++            tsrcY += 5;
++        }
++        src[0] += srcStride[0];
++        dstY += dstStride[0] / sizeof(uint16_t);
++    }
++
++    for (y = srcSliceH / vsub; y > 0; y--) {
++        const uint8_t *tsrcUV = src[1];
++        uint16_t *tdstU = dstU, *tdstV = dstV;
++        for (x = c->chrSrcW / 2; x > 0; x--) {
++            *tdstU++ = (((tsrcUV[1] & 0x3 ) << 8) | (tsrcUV[0]        & 0xFF)) << shift[1];
++            *tdstV++ = (((tsrcUV[2] & 0xf ) << 6) | ((tsrcUV[1] >> 2) & 0x3F)) << shift[2];
++            *tdstU++ = (((tsrcUV[3] & 0x3F) << 4) | ((tsrcUV[2] >> 4) & 0xF )) << shift[1];
++            *tdstV++ = (((tsrcUV[4] & 0xFF) << 2) | ((tsrcUV[3] >> 6) & 0x3 )) << shift[2];
++            tsrcUV += 5;
++        }
++        src[1] += srcStride[1];
++        dstU += dstStride[1] / sizeof(uint16_t);
++        dstV += dstStride[2] / sizeof(uint16_t);
++    }
++
++    return srcSliceH;
++}
++
+ static int planarToP01xWrapper(SwsContext *c, const uint8_t *src8[],
+                                int srcStride[], int srcSliceY,
+                                int srcSliceH, uint8_t *dstParam8[],
+@@ -2004,6 +2059,19 @@ void ff_get_unscaled_swscale(SwsContext
+         (srcFormat == AV_PIX_FMT_NV24 || srcFormat == AV_PIX_FMT_NV42)) {
+         c->convert_unscaled = nv24ToPlanarWrapper;
+     }
++    /* nv15_to_yuv420p1x & nv20_to_yuv422p1x */
++    if ((srcFormat == AV_PIX_FMT_NV15 &&
++         (dstFormat == AV_PIX_FMT_YUV420P10 ||
++          dstFormat == AV_PIX_FMT_YUV420P12 ||
++          dstFormat == AV_PIX_FMT_YUV420P14 ||
++          dstFormat == AV_PIX_FMT_YUV420P16)) ||
++        (srcFormat == AV_PIX_FMT_NV20 &&
++         (dstFormat == AV_PIX_FMT_YUV422P10 ||
++          dstFormat == AV_PIX_FMT_YUV422P12 ||
++          dstFormat == AV_PIX_FMT_YUV422P14 ||
++          dstFormat == AV_PIX_FMT_YUV422P16))) {
++        c->convert_unscaled = nv15_20ToPlanarWrapper;
++    }
+     /* yuv2bgr */
+     if ((srcFormat == AV_PIX_FMT_YUV420P || srcFormat == AV_PIX_FMT_YUV422P ||
+          srcFormat == AV_PIX_FMT_YUVA420P) && isAnyRGB(dstFormat) &&
 Index: jellyfin-ffmpeg/libswscale/utils.c
 ===================================================================
 --- jellyfin-ffmpeg.orig/libswscale/utils.c

--- a/debian/patches/0065-add-cuda-transpose-filter-impl.patch
+++ b/debian/patches/0065-add-cuda-transpose-filter-impl.patch
@@ -556,7 +556,7 @@ Index: jellyfin-ffmpeg/libavfilter/vf_transpose_cuda.cu
 +        return;
 +
 +    int xi = (dir < 4) ? ((dir &  2) ? (dst_height - 1 - yo) : yo)
-+                       : ((dir &  5) ? (dst_width  - 1 - xo) : xo);
++                       : ((dir == 5) ? (dst_width  - 1 - xo) : xo);
 +    int yi = (dir < 4) ? ((dir &  1) ? (dst_width  - 1 - xo) : xo)
 +                       : ((dir == 5) ? yo : (dst_height - 1 - yo));
 +    if (xi >= src_width || yi >= src_height)

--- a/debian/patches/0066-add-flip-feat-to-opencl-transpose-filter.patch
+++ b/debian/patches/0066-add-flip-feat-to-opencl-transpose-filter.patch
@@ -9,7 +9,7 @@ Index: jellyfin-ffmpeg/libavfilter/opencl/transpose.cl
 -    int xin = (dir & 2) ? (size.y - 1 - y) : y;
 -    int yin = (dir & 1) ? (size.x - 1 - x) : x;
 +    int xin = (dir < 4) ? ((dir &  2) ? (size.y - 1 - y) : y)
-+                        : ((dir &  5) ? (size.x - 1 - x) : x);
++                        : ((dir == 5) ? (size.x - 1 - x) : x);
 +    int yin = (dir < 4) ? ((dir &  1) ? (size.x - 1 - x) : x)
 +                        : ((dir == 5) ? y : (size.y - 1 - y));
      float4 data = read_imagef(src, sampler, (int2)(xin, yin));

--- a/debian/patches/0074-add-dovi-descriptor-support-in-mpegtsenc.patch
+++ b/debian/patches/0074-add-dovi-descriptor-support-in-mpegtsenc.patch
@@ -1,0 +1,82 @@
+Index: jellyfin-ffmpeg/libavformat/mpegtsenc.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavformat/mpegtsenc.c
++++ jellyfin-ffmpeg/libavformat/mpegtsenc.c
+@@ -23,6 +23,7 @@
+ #include "libavutil/bswap.h"
+ #include "libavutil/crc.h"
+ #include "libavutil/dict.h"
++#include "libavutil/dovi_meta.h"
+ #include "libavutil/intreadwrite.h"
+ #include "libavutil/mathematics.h"
+ #include "libavutil/opt.h"
+@@ -348,6 +349,52 @@ static void put_registration_descriptor(
+     *q_ptr = q;
+ }
+ 
++static int put_dovi_descriptor(AVFormatContext *s, uint8_t **q_ptr,
++                               const AVDOVIDecoderConfigurationRecord *dovi)
++{
++    uint16_t val16;
++    uint8_t *q = *q_ptr;
++
++    if (!dovi)
++        return AVERROR(ENOMEM);
++
++    if (!dovi->bl_present_flag) {
++        av_log(s, AV_LOG_ERROR,
++               "EL only DOVI stream is not supported!\n");
++        return AVERROR_INVALIDDATA;
++    }
++
++    put_registration_descriptor(&q, MKTAG('D', 'O', 'V', 'I')); // format_identifier
++
++    /* DOVI Video Stream Descriptor Syntax */
++    *q++ = 0xb0;        // descriptor_tag
++    *q++ = 0x05;        // descriptor_length
++    *q++ = dovi->dv_version_major;
++    *q++ = dovi->dv_version_minor;
++
++    val16 = (dovi->dv_profile       & 0x7f) << 9 | // 7 bits
++            (dovi->dv_level         & 0x3f) << 3 | // 6 bits
++            (dovi->rpu_present_flag & 0x01) << 2 | // 1 bits
++            (dovi->el_present_flag  & 0x01) << 1 | // 1 bits
++            (dovi->bl_present_flag  & 0x01);       // 1 bits
++    put16(&q, val16);
++
++#if 0
++    // TODO: support dependency_pid (EL only stream)
++    // descriptor_length: 0x05->0x07
++    if (!bl_present_flag) {
++        val16 = (dependency_pid & 0x1fff) << 3; // 13+3 bits
++        put16(&q, val16);
++    }
++#endif
++
++    *q++ = (dovi->dv_bl_signal_compatibility_id & 0x0f) << 4; // 4+4 bits
++
++    *q_ptr = q;
++
++    return 0;
++}
++
+ static int get_dvb_stream_type(AVFormatContext *s, AVStream *st)
+ {
+     MpegTSWrite *ts = s->priv_data;
+@@ -795,7 +842,15 @@ static int mpegts_write_pmt(AVFormatCont
+             } else if (stream_type == STREAM_TYPE_VIDEO_VC1) {
+                 put_registration_descriptor(&q, MKTAG('V', 'C', '-', '1'));
+             } else if (stream_type == STREAM_TYPE_VIDEO_HEVC && s->strict_std_compliance <= FF_COMPLIANCE_NORMAL) {
+-                put_registration_descriptor(&q, MKTAG('H', 'E', 'V', 'C'));
++                const AVDOVIDecoderConfigurationRecord *dovi = (const AVDOVIDecoderConfigurationRecord *)
++                                                               av_stream_get_side_data(st, AV_PKT_DATA_DOVI_CONF, NULL);
++
++                if (dovi && dovi->bl_present_flag && s->strict_std_compliance <= FF_COMPLIANCE_UNOFFICIAL) {
++                    if (put_dovi_descriptor(s, &q, dovi) < 0)
++                        break;
++                } else {
++                    put_registration_descriptor(&q, MKTAG('H', 'E', 'V', 'C'));
++                }
+             } else if (stream_type == STREAM_TYPE_VIDEO_CAVS || stream_type == STREAM_TYPE_VIDEO_AVS2 ||
+                        stream_type == STREAM_TYPE_VIDEO_AVS3) {
+                 put_registration_descriptor(&q, MKTAG('A', 'V', 'S', 'V'));

--- a/debian/patches/0075-fix-gcc-14-warnings-in-qsv-hwcontext.patch
+++ b/debian/patches/0075-fix-gcc-14-warnings-in-qsv-hwcontext.patch
@@ -1,0 +1,82 @@
+Index: jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavutil/hwcontext_qsv.c
++++ jellyfin-ffmpeg/libavutil/hwcontext_qsv.c
+@@ -36,6 +36,7 @@
+ #include "hwcontext_d3d11va.h"
+ #endif
+ #if CONFIG_DXVA2
++#include <initguid.h>
+ #include "hwcontext_dxva2.h"
+ #endif
+ 
+@@ -737,9 +738,11 @@ static int qsv_d3d9_update_config(void *
+ #if CONFIG_DXVA2
+     mfxStatus sts;
+     IDirect3DDeviceManager9* devmgr = handle;
+-    IDirect3DDevice9Ex *device = NULL;
++    IDirect3DDevice9 *device = NULL;
++    IDirect3DDevice9Ex *device_ex = NULL;
+     HANDLE device_handle = 0;
+     IDirect3D9Ex *d3d9ex = NULL;
++    IDirect3D9 *d3d9 = NULL;
+     LUID luid;
+     D3DDEVICE_CREATION_PARAMETERS params;
+     HRESULT hr;
+@@ -757,18 +760,31 @@ static int qsv_d3d9_update_config(void *
+         IDirect3DDeviceManager9_CloseDeviceHandle(devmgr, device_handle);
+         goto fail;
+     }
++    hr = IDirect3DDevice9_QueryInterface(device, &IID_IDirect3DDevice9Ex, (void **)&device_ex);
++    IDirect3DDevice9_Release(device);
++    if (FAILED(hr)) {
++        av_log(ctx, AV_LOG_ERROR, "Error IDirect3DDevice9_QueryInterface %d\n", hr);
++        goto unlock;
++    }
+ 
+-    hr = IDirect3DDevice9Ex_GetCreationParameters(device, &params);
++    hr = IDirect3DDevice9Ex_GetCreationParameters(device_ex, &params);
+     if (FAILED(hr)) {
+         av_log(ctx, AV_LOG_ERROR, "Error IDirect3DDevice9_GetCreationParameters %d\n", hr);
+-        IDirect3DDevice9Ex_Release(device);
++        IDirect3DDevice9Ex_Release(device_ex);
+         goto unlock;
+     }
+ 
+-    hr = IDirect3DDevice9Ex_GetDirect3D(device, &d3d9ex);
++    hr = IDirect3DDevice9Ex_GetDirect3D(device_ex, &d3d9);
+     if (FAILED(hr)) {
+-        av_log(ctx, AV_LOG_ERROR, "Error IDirect3DDevice9Ex_GetAdapterLUID %d\n", hr);
+-        IDirect3DDevice9Ex_Release(device);
++        av_log(ctx, AV_LOG_ERROR, "Error IDirect3DDevice9Ex_GetDirect3D %d\n", hr);
++        IDirect3DDevice9Ex_Release(device_ex);
++        goto unlock;
++    }
++    hr = IDirect3D9_QueryInterface(d3d9, &IID_IDirect3D9Ex, (void **)&d3d9ex);
++    IDirect3D9_Release(d3d9);
++    if (FAILED(hr)) {
++        av_log(ctx, AV_LOG_ERROR, "Error IDirect3D9_QueryInterface3D %d\n", hr);
++        IDirect3DDevice9Ex_Release(device_ex);
+         goto unlock;
+     }
+ 
+@@ -792,7 +808,7 @@ static int qsv_d3d9_update_config(void *
+ 
+ release:
+     IDirect3D9Ex_Release(d3d9ex);
+-    IDirect3DDevice9Ex_Release(device);
++    IDirect3DDevice9Ex_Release(device_ex);
+ 
+ unlock:
+     IDirect3DDeviceManager9_UnlockDevice(devmgr, device_handle, FALSE);
+@@ -1340,8 +1356,9 @@ static int qsv_frames_derive_from(AVHWFr
+     case AV_HWDEVICE_TYPE_D3D11VA:
+         {
+             D3D11_TEXTURE2D_DESC texDesc;
++            AVD3D11VAFramesContext *dst_hwctx;
+             dst_ctx->initial_pool_size = src_ctx->initial_pool_size;
+-            AVD3D11VAFramesContext *dst_hwctx = dst_ctx->hwctx;
++            dst_hwctx = dst_ctx->hwctx;
+             dst_hwctx->texture_infos = av_calloc(src_hwctx->nb_surfaces,
+                                                  sizeof(*dst_hwctx->texture_infos));
+             if (!dst_hwctx->texture_infos)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -72,3 +72,4 @@
 0072-add-mjpeg-videotoolbox.patch
 0073-opus-allow-5point1-side-inputs.patch
 0074-add-dovi-descriptor-support-in-mpegtsenc.patch
+0075-fix-gcc-14-warnings-in-qsv-hwcontext.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -71,3 +71,4 @@
 0071-check-pciid-when-deriving-from-va-to-vk.patch
 0072-add-mjpeg-videotoolbox.patch
 0073-opus-allow-5point1-side-inputs.patch
+0074-add-dovi-descriptor-support-in-mpegtsenc.patch

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Update mingw-w64 headers
-mingw_commit="cd4cf9b279f8fb0815f8b9665d3cea60a30290bc"
+mingw_commit="cff4b8fda1b577b99144020fb81b27f5bc633a5e"
 git clone https://git.code.sf.net/p/mingw-w64/mingw-w64.git
 pushd mingw-w64/mingw-w64-headers
 git checkout ${mingw_commit}
@@ -325,7 +325,7 @@ popd
 # OPENMPT
 mkdir mpt
 pushd mpt
-mpt_ver="0.7.6"
+mpt_ver="0.7.7"
 mpt_link="https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-${mpt_ver}+release.autotools.tar.gz"
 wget ${mpt_link} -O mpt.tar.gz
 tar xaf mpt.tar.gz
@@ -342,7 +342,7 @@ popd
 popd
 
 # LIBWEBP
-git clone -b v1.3.2 --depth=1 https://chromium.googlesource.com/webm/libwebp
+git clone -b v1.4.0 --depth=1 https://chromium.googlesource.com/webm/libwebp
 pushd libwebp
 ./autogen.sh
 ./configure \
@@ -459,10 +459,8 @@ popd
 popd
 
 # SVT-AV1
-git clone -b v2.0.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+git clone -b v2.1.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
 pushd SVT-AV1
-# Fix performance regression for systems with multiple processor groups
-wget -q -O - https://gitlab.com/AOMediaCodec/SVT-AV1/-/commit/4579ddcf.patch | git apply
 mkdir build
 pushd build
 cmake \
@@ -562,7 +560,7 @@ mv * ${FF_DEPS_PREFIX}/include/AMF
 popd
 
 # VPL
-git clone -b v2.10.2 --depth=1 https://github.com/intel/libvpl.git
+git clone -b v2.11.0 --depth=1 https://github.com/intel/libvpl.git
 pushd libvpl
 mkdir build && pushd build
 cmake \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -97,7 +97,7 @@ prepare_extra_common() {
 
     # FRIBIDI
     pushd ${SOURCE_DIR}
-    git clone -b v1.0.13 --depth=1 https://github.com/fribidi/fribidi.git
+    git clone -b v1.0.14 --depth=1 https://github.com/fribidi/fribidi.git
     meson setup fribidi fribidi_build \
         ${MESON_CROSS_OPT} \
         --prefix=${TARGET_DIR} \
@@ -135,7 +135,7 @@ prepare_extra_common() {
 
     # HARFBUZZ
     pushd ${SOURCE_DIR}
-    git clone -b 8.4.0 --depth=1 https://github.com/harfbuzz/harfbuzz.git
+    git clone -b 8.5.0 --depth=1 https://github.com/harfbuzz/harfbuzz.git
     pushd harfbuzz
     ./autogen.sh \
         ${CROSS_OPT} \
@@ -150,7 +150,7 @@ prepare_extra_common() {
 
     # LIBASS
     pushd ${SOURCE_DIR}
-    git clone -b 0.17.1 --depth=1 https://github.com/libass/libass.git
+    git clone -b 0.17.2 --depth=1 https://github.com/libass/libass.git
     pushd libass
     ./autogen.sh
     ./configure \
@@ -257,10 +257,8 @@ prepare_extra_common() {
     # SVT-AV1
     # nasm >= 2.14
     pushd ${SOURCE_DIR}
-    git clone -b v2.0.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
+    git clone -b v2.1.0 --depth=1 https://gitlab.com/AOMediaCodec/SVT-AV1.git
     pushd SVT-AV1
-    # Fix performance regression for systems with multiple processor groups
-    wget -q -O - https://gitlab.com/AOMediaCodec/SVT-AV1/-/commit/4579ddcf.patch | git apply
     mkdir build
     pushd build
     if [ "${ARCH}" = "amd64" ]; then
@@ -414,7 +412,7 @@ prepare_extra_amd64() {
     # Provides VPL header and dispatcher (libvpl.so.2) for FFmpeg
     # Both MSDK and VPL runtime can be loaded by VPL dispatcher
     pushd ${SOURCE_DIR}
-    git clone -b v2.10.2 --depth=1 https://github.com/intel/libvpl.git
+    git clone -b v2.11.0 --depth=1 https://github.com/intel/libvpl.git
     pushd libvpl
     sed -i 's|ParseEnvSearchPaths(ONEVPL_PRIORITY_PATH_VAR, searchDirList)|searchDirList.push_back("/usr/lib/jellyfin-ffmpeg/lib")|g' libvpl/src/mfx_dispatcher_vpl_loader.cpp
     mkdir build && pushd build
@@ -437,7 +435,7 @@ prepare_extra_amd64() {
     # VPL-GPU-RT (RT only)
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-24.2.1 --depth=1 https://github.com/intel/vpl-gpu-rt.git
+    git clone -b intel-onevpl-24.2.3 --depth=1 https://github.com/intel/vpl-gpu-rt.git
     pushd vpl-gpu-rt
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
@@ -457,7 +455,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-24.2.1 --depth=1 https://github.com/intel/media-driver.git
+    git clone -b intel-media-24.2.3 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
@@ -476,7 +474,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.283 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
+    git clone -b v1.3.285 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -489,7 +487,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.283 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
+    git clone -b v1.3.285 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \


### PR DESCRIPTION
**Changes**
- Add DOVI descriptor support in mpegtsenc (only tested in MPV and MPC-BE)
- Sync RKMPP fixes from ffmpeg-rockchip
- Fix a typo in the CUDA/OpenCL transpose filter
- Fix some warnings-as-errors in GCC 14
- Update dependencies
- Bump version to 6.0.1-7

**Issues**
It should be helpful to https://github.com/jellyfin/jellyfin-web/pull/5553, where TV expects DOVI in MPEG-TS HLS.
```
Input #0, mpegts, from 'test.ts':
  Duration: 00:28:16.19, start: 1.400000, bitrate: 5245 kb/s
  Program 1
    Metadata:
      service_name    : Service01
      service_provider: FFmpeg
  Stream #0:0[0x100]: Video: hevc (Main 10) (DOVI / 0x49564F44), yuv420p10le(pc), 1920x1080 [SAR 1:1 DAR 16:9], 23.98 fps, 23.98 tbr, 90k tbn
    Side data:
      DOVI configuration record: version: 1.0, profile: 5, level: 3, rpu flag: 1, el flag: 0, bl flag: 1, compatibility id: 0
```
[ffprobe-show-streams.json](https://github.com/jellyfin/jellyfin-ffmpeg/files/15388960/ffprobe-show-streams.json)