### PR TITLE
avfilter/colorspace: fix dovi peak calculation

### DIFF
--- a/debian/patches/0005-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0005-add-cuda-tonemap-impl.patch
@@ -98,7 +98,7 @@ Index: jellyfin-ffmpeg/libavfilter/colorspace.c
  void ff_matrix_mul_3x3(double dst[3][3],
                 const double src1[3][3], const double src2[3][3])
  {
-@@ -191,3 +203,155 @@ void ff_update_hdr_metadata(AVFrame *in,
+@@ -191,3 +202,155 @@ void ff_update_hdr_metadata(AVFrame *in,
              metadata->max_luminance = av_d2q(peak * REFERENCE_WHITE, 10000);
      }
  }
@@ -120,8 +120,7 @@ Index: jellyfin-ffmpeg/libavfilter/colorspace.c
 +    peak = powf(peak, 1.0f / ST2084_M2);
 +    peak = fmaxf(peak - ST2084_C1, 0.0f) / (ST2084_C2 - ST2084_C3 * peak);
 +    peak = powf(peak, 1.0f / ST2084_M1);
-+    peak *= 10000.0f;
-+    peak *= REFERENCE_WHITE_ALT;
++    peak *= 100.0f;
 +
 +    return peak;
 +}

--- a/debian/patches/0005-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0005-add-cuda-tonemap-impl.patch
@@ -98,7 +98,7 @@ Index: jellyfin-ffmpeg/libavfilter/colorspace.c
  void ff_matrix_mul_3x3(double dst[3][3],
                 const double src1[3][3], const double src2[3][3])
  {
-@@ -191,3 +202,155 @@ void ff_update_hdr_metadata(AVFrame *in,
+@@ -191,3 +203,154 @@ void ff_update_hdr_metadata(AVFrame *in,
              metadata->max_luminance = av_d2q(peak * REFERENCE_WHITE, 10000);
      }
  }


### PR DESCRIPTION
The max PQ to max mastering display luminance calculation is wrong and not within the scale of ffmpeg. This will overflow the pixels during tone mapping unless the user supplies a peak value to overwrite this.

- No need to multiply by reference white for PQ to luminance
- The ffmpeg brightness scale for SMPTE ST.2084 is 100 not 10000

Before: 811943.437500
After: 399.9721366995 (4000 nit master display)

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->