### PR TITLE
Fix installing pip3

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -37,7 +37,7 @@ RUN apt-get update \
  && apt-get autoremove -y
 
 # Install newer tools from pip3
-RUN pip3 install $(pip3 help install | grep -o "\-\-break-system-packages") --upgrade pip \
+RUN pip3 install $(pip3 help install | grep -o "\-\-break-system-packages") --ignore-installed pip \
  && pip3 install $(pip3 help install | grep -o "\-\-break-system-packages") meson cmake mako jinja2
 
 # Avoids timeouts when using git and disable the detachedHead advice


### PR DESCRIPTION
The latest `python3-pip` pkg on noble is somehow broken and cannot be upgraded gracefully.

**Changes**
- Fix installing pip3

**Issues**
- `ERROR: Cannot uninstall pip 24.0, RECORD file not found. Hint: The package was installed by debian.`