### PR TITLE
Fix current CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'debian'
-      codenames: '["buster", "bullseye", "bookworm"]'
+      codenames: '["bullseye", "bookworm"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'debian'
-      codenames: '["buster", "bullseye", "bookworm"]'
+      codenames: '["bullseye", "bookworm"]'
       architectures: '["amd64", "arm64", "armhf"]'
       release: true
     secrets:
@@ -72,7 +72,6 @@ jobs:
       max-parallel: 1
       matrix:
         arrays: [
-          {distro: 'debian', codename: 'buster'},
           {distro: 'debian', codename: 'bullseye'},
           {distro: 'debian', codename: 'bookworm'},
           {distro: 'ubuntu', codename: 'focal'},

--- a/build
+++ b/build
@@ -4,10 +4,9 @@ usage() {
     echo -e "Build Jellyfin FFMPEG deb packages"
     echo -e " $0 <release> <arch>"
     echo -e "Releases:          Arches:"
-    echo -e " * buster           * amd64"
-    echo -e " * bullseye         * armhf"
-    echo -e " * bookworm         * arm64"
-    echo -e " * focal"
+    echo -e " * bullseye         * amd64"
+    echo -e " * bookworm         * armhf"
+    echo -e " * focal            * arm64"
     echo -e " * jammy"
     echo -e " * noble"
 }
@@ -19,11 +18,6 @@ fi
 
 cli_release="${1}"
 case ${cli_release} in
-    'buster')
-        release="debian:buster"
-        gcc_version="8"
-        llvm_version="13"
-    ;;
     'bullseye')
         release="debian:bullseye"
         gcc_version="10"

--- a/build.yaml
+++ b/build.yaml
@@ -3,9 +3,6 @@
 name: "jellyfin-ffmpeg"
 version: "6.0.1-7"
 packages:
-  - buster-amd64
-  - buster-armhf
-  - buster-arm64
   - bullseye-amd64
   - bullseye-armhf
   - bullseye-arm64

--- a/builder/images/macos/01-gettext.sh
+++ b/builder/images/macos/01-gettext.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ffbuild_macbase() {
-  wget https://ftpmirror.gnu.org/gettext/gettext-0.22.5.tar.gz -O gettext.tar.gz
+  wget https://mirrors.kernel.org/gnu/gettext/gettext-0.22.5.tar.gz -O gettext.tar.gz
   tar xvf gettext.tar.gz
   cd gettext-0.22.5
   ./configure --disable-silent-rules --disable-shared --enable-static --with-included-glib --with-included-libcroco --with-included-libunistring --with-included-libxml --with-emacs --with-lispdir="$FFBUILD_PREFIX"/share --disable-java --disable-csharp --without-git --without-cvs --without-xz --with-included-gettext --prefix="$FFBUILD_PREFIX"

--- a/builder/scripts.d/20-libiconv.sh
+++ b/builder/scripts.d/20-libiconv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_REPO="https://git.savannah.gnu.org/git/libiconv.git"
+SCRIPT_REPO="https://skia.googlesource.com/third_party/libiconv"
 SCRIPT_COMMIT="v1.17"
 SCRIPT_TAGFILTER="v?.*"
 
@@ -17,7 +17,7 @@ ffbuild_dockerbuild() {
 
     cat <<EOF > ./.gitmodules
 [subcheckout "gnulib"]
-	url = https://git.savannah.gnu.org/git/gnulib.git
+	url = https://github.com/coreutils/gnulib.git
 	path = gnulib
 EOF
 

--- a/builder/scripts.d/25-gmp.sh
+++ b/builder/scripts.d/25-gmp.sh
@@ -2,7 +2,7 @@
 
 SCRIPT_VERSION="6.3.0"
 SCRIPT_SHA512="e85a0dab5195889948a3462189f0e0598d331d3457612e2d3350799dba2e244316d256f8161df5219538eb003e4b5343f989aaa00f96321559063ed8c8f29fd2"
-SCRIPT_URL="https://ftp.gnu.org/gnu/gmp/gmp-${SCRIPT_VERSION}.tar.xz"
+SCRIPT_URL="https://mirrors.kernel.org/gnu/gmp/gmp-${SCRIPT_VERSION}.tar.xz"
 
 ffbuild_enabled() {
     return 0

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -197,6 +197,7 @@ popd
 # HARFBUZZ
 git clone --depth=1 https://github.com/harfbuzz/harfbuzz.git
 pushd harfbuzz
+git checkout bc90b29b37fe3809f9e48aa7be08fbf2208e481a
 ./autogen.sh \
     --prefix=${FF_DEPS_PREFIX} \
     --host=${FF_TOOLCHAIN} \

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -31,7 +31,7 @@ popd
 mkdir iconv
 pushd iconv
 iconv_ver="1.17"
-iconv_link="https://ftp.gnu.org/pub/gnu/libiconv/libiconv-${iconv_ver}.tar.gz"
+iconv_link="https://mirrors.kernel.org/gnu/libiconv/libiconv-${iconv_ver}.tar.gz"
 wget ${iconv_link} -O iconv.tar.gz
 tar xaf iconv.tar.gz
 pushd libiconv-${iconv_ver}
@@ -104,7 +104,7 @@ popd
 mkdir gmp
 pushd gmp
 gmp_ver="6.3.0"
-gmp_link="https://ftp.gnu.org/gnu/gmp/gmp-${gmp_ver}.tar.xz"
+gmp_link="https://mirrors.kernel.org/gnu/gmp/gmp-${gmp_ver}.tar.xz"
 wget ${gmp_link} -O gmp.tar.gz
 tar xaf gmp.tar.gz
 pushd gmp-${gmp_ver}

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -195,7 +195,7 @@ popd
 popd
 
 # HARFBUZZ
-git clone --depth=1 https://github.com/harfbuzz/harfbuzz.git
+git clone https://github.com/harfbuzz/harfbuzz.git
 pushd harfbuzz
 git checkout bc90b29b37fe3809f9e48aa7be08fbf2208e481a
 ./autogen.sh \

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -195,9 +195,10 @@ popd
 popd
 
 # HARFBUZZ
+harfbuzz_commit="bc90b29b37fe3809f9e48aa7be08fbf2208e481a"
 git clone https://github.com/harfbuzz/harfbuzz.git
 pushd harfbuzz
-git checkout bc90b29b37fe3809f9e48aa7be08fbf2208e481a
+git checkout ${harfbuzz_commit}
 ./autogen.sh \
     --prefix=${FF_DEPS_PREFIX} \
     --host=${FF_TOOLCHAIN} \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -37,7 +37,7 @@ prepare_extra_common() {
     mkdir iconv
     pushd iconv
     iconv_ver="1.17"
-    iconv_link="https://ftp.gnu.org/pub/gnu/libiconv/libiconv-${iconv_ver}.tar.gz"
+    iconv_link="https://mirrors.kernel.org/gnu/libiconv/libiconv-${iconv_ver}.tar.gz"
     wget ${iconv_link} -O iconv.tar.gz
     tar xaf iconv.tar.gz
     pushd libiconv-${iconv_ver}

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -596,9 +596,6 @@ prepare_extra_amd64() {
 
     # LIBPLACEBO
     pl_ver="v6.338.2"
-    if [[ $( lsb_release -c -s ) == "buster" ]]; then
-        pl_ver="v5.264.1"
-    fi
     pushd ${SOURCE_DIR}
     git clone -b ${pl_ver} --recursive --depth=1 https://github.com/haasn/libplacebo.git
     sed -i 's|env: python_env,||g' libplacebo/src/vulkan/meson.build


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

Our current CI is partially broken and this tries to fix it.

- Debian Buster is coming to EOL and we are not building server packages for it. The GCC it uses also lacks certain SIMD intrinsics required for the tonemapx filter.
- Harfbuzz dropped autoconf build in 9.0 and we are still using that.
- gnu website is not reliable

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

- Drop Debian Buster from CI build matrix.
- Use more reliable Linux Kernel mirror (mirrors.kernel.org) to replace the fragile ftp.gnu.org and ftpmirror.gnu.org
- Pin harfbuzz commit until we are ready to for its new version
- Use googlesource.com and github mirror instead of git.savannah.gnu.org

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

#407 Would require these changes to have the pipeline succeed. 