### PR TITLE
Fix QSV deint 3:2 pulldown undefined behavior

### DIFF
--- a/debian/patches/0081-fix-qsv-deint-3-2-pulldown-undefined-behavior.patch
+++ b/debian/patches/0081-fix-qsv-deint-3-2-pulldown-undefined-behavior.patch
@@ -1,0 +1,21 @@
+Index: jellyfin-ffmpeg/libavfilter/qsvvpp.c
+===================================================================
+--- jellyfin-ffmpeg.orig/libavfilter/qsvvpp.c
++++ jellyfin-ffmpeg/libavfilter/qsvvpp.c
+@@ -463,11 +463,13 @@ static QSVFrame *submit_frame(QSVVPPCont
+             !qsv_frame->frame->interlaced_frame ? MFX_PICSTRUCT_PROGRESSIVE :
+             (qsv_frame->frame->top_field_first ? MFX_PICSTRUCT_FIELD_TFF :
+                                                  MFX_PICSTRUCT_FIELD_BFF);
+-    if (qsv_frame->frame->repeat_pict == 1)
++    if (qsv_frame->frame->repeat_pict == 1) {
+         qsv_frame->surface.Info.PicStruct |= MFX_PICSTRUCT_FIELD_REPEATED;
+-    else if (qsv_frame->frame->repeat_pict == 2)
++        qsv_frame->surface.Info.PicStruct |= qsv_frame->frame->top_field_first ? MFX_PICSTRUCT_FIELD_TFF :
++                                                                                 MFX_PICSTRUCT_FIELD_BFF;
++    } else if (qsv_frame->frame->repeat_pict == 2) {
+         qsv_frame->surface.Info.PicStruct |= MFX_PICSTRUCT_FRAME_DOUBLING;
+-    else if (qsv_frame->frame->repeat_pict == 4)
++    } else if (qsv_frame->frame->repeat_pict == 4)
+         qsv_frame->surface.Info.PicStruct |= MFX_PICSTRUCT_FRAME_TRIPLING;
+ 
+     return qsv_frame;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -78,3 +78,4 @@
 0078-add-detection-of-atmos-in-eac3.patch
 0079-add-detection-of-atmos-in-truehd.patch
 0080-add-tonemapx-filter.patch
+0081-fix-qsv-deint-3-2-pulldown-undefined-behavior.patch


### PR DESCRIPTION
**Changes**
- Fix QSV deint 3:2 pulldown undefined behavior

**Issues**
- Fixes: https://forum.jellyfin.org/t-solved-issues-hardware-decoding-mpeg2
`[Parsed_scale_qsv_5 @ 0000020dde09f880] Error running VPP: undefined behavior (-16)`