### PR TITLE
Enable libxml2 in deb builds

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -11,6 +11,8 @@ jellyfin-ffmpeg (6.0.1-8) unstable; urgency=medium
   * Add AC-4 decoder for ATSC 3.0 audio
   * Add relative luminance mode to vt/cuda/ocl tonemap
   * Update build scripts and dependencies
+  * Sync fixes from ffmpeg-rockchip
+  * Enable libxml2
 
  -- nyanmisaka <nst799610810@gmail.com>  Wed, 24 Jul 2024 20:57:11 +0800
 

--- a/debian/rules
+++ b/debian/rules
@@ -25,6 +25,7 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-chromaprint \
 	--enable-opencl \
 	--enable-libdrm \
+	--enable-libxml2 \
 	--enable-libass \
 	--enable-libfreetype \
 	--enable-libfribidi \


### PR DESCRIPTION
**Changes**
- Enable libxml2 in deb builds

**Issues**
- Fixes https://github.com/jellyfin/jellyfin/issues/12333