### PR TITLE
Fix compilation of CL kernel on Intel

### DIFF
--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -598,7 +598,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    sig_g = eotf_st2084x4(sig_g);
 +    sig_b = eotf_st2084x4(sig_b);
 +  #else
-+    sig = inverse_eotf_st2084x4(sig)
++    sig = inverse_eotf_st2084x4(sig);
 +    MAP_FOUR_PIXELS(sig, src_peak_delin_pq, dst_peak_delin_pq)
 +    sig = eotf_st2084x4(sig);
 +  #endif


### PR DESCRIPTION
Intel legacy driver on Windows can't tolerate this.

**Changes**
- Fix compilation of CL kernel on Intel