### PR TITLE
Strip the HDR metadata from tonemapx output

### DIFF
--- a/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
@@ -1477,7 +1477,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.c
-@@ -0,0 +1,1260 @@
+@@ -0,0 +1,1261 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -2488,7 +2488,8 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +
 +    av_frame_free(&in);
 +
-+    ff_update_hdr_metadata(out, peak);
++    av_frame_remove_side_data(out, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
++    av_frame_remove_side_data(out, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
 +
 +    return ff_filter_frame(outlink, out);
 +fail:


### PR DESCRIPTION
**Changes**
- Strip the HDR metadata from tonemapx output

**Issues**
- The `tonemapx` filter currently only produces SDR output, so HDR metadata will cause problems with the `libx264` encoder in FFmpeg 7.0+ due to an upstream commit https://github.com/FFmpeg/FFmpeg/commit/471c0a34c13acfecf62403efec335b9b012d72c4
```
[tonemapx @ 00000169f41dd200] Using CPU capabilities: AVX2 FMA3
[libx264 @ 00000169db439e40] content light levels out of range [0,65535]
[vost#0:0/libx264 @ 00000169d2e48b80] Error while opening encoder - maybe incorrect parameters such as bit_rate, rate, width or height.
```