### PR TITLE
Fix reversal in cuda/ocl transpose filter

### DIFF
--- a/debian/patches/0056-add-cuda-transpose-filter-impl.patch
+++ b/debian/patches/0056-add-cuda-transpose-filter-impl.patch
@@ -555,7 +555,7 @@ Index: FFmpeg/libavfilter/vf_transpose_cuda.cu
 +        return;
 +
 +    int xi = (dir < 4) ? ((dir &  2) ? (dst_height - 1 - yo) : yo)
-+                       : ((dir == 5) ? (dst_width  - 1 - xo) : xo);
++                       : ((dir == 6) ? xo : (dst_width  - 1 - xo));
 +    int yi = (dir < 4) ? ((dir &  1) ? (dst_width  - 1 - xo) : xo)
 +                       : ((dir == 5) ? yo : (dst_height - 1 - yo));
 +    if (xi >= src_width || yi >= src_height)

--- a/debian/patches/0057-add-flip-feat-to-opencl-transpose-filter.patch
+++ b/debian/patches/0057-add-flip-feat-to-opencl-transpose-filter.patch
@@ -9,7 +9,7 @@ Index: FFmpeg/libavfilter/opencl/transpose.cl
 -    int xin = (dir & 2) ? (size.y - 1 - y) : y;
 -    int yin = (dir & 1) ? (size.x - 1 - x) : x;
 +    int xin = (dir < 4) ? ((dir &  2) ? (size.y - 1 - y) : y)
-+                        : ((dir == 5) ? (size.x - 1 - x) : x);
++                        : ((dir == 6) ? x : (size.x - 1 - x));
 +    int yin = (dir < 4) ? ((dir &  1) ? (size.x - 1 - x) : x)
 +                        : ((dir == 5) ? y : (size.y - 1 - y));
      float4 data = read_imagef(src, sampler, (int2)(xin, yin));


### PR DESCRIPTION
**Changes**
- Fix reversal in cuda/ocl transpose filter

**Issues**
- There's a regression is the last [typo fix](https://github.com/jellyfin/jellyfin-ffmpeg/commit/5234bdcc7318db33c16aeb2e3f30b7aa5b5ea7d7). It fixed flip but broke reversal.