### PR TITLE
lavc/videotoolbox: allow software fallback for all codecs

### DIFF
--- a/debian/patches/0071-allow-vt-sw-decoder-for-every-codec.patch
+++ b/debian/patches/0071-allow-vt-sw-decoder-for-every-codec.patch
@@ -1,0 +1,15 @@
+Index: FFmpeg/libavcodec/videotoolbox.c
+===================================================================
+--- FFmpeg.orig/libavcodec/videotoolbox.c
++++ FFmpeg/libavcodec/videotoolbox.c
+@@ -812,9 +812,7 @@ static CFDictionaryRef videotoolbox_deco
+                                                                    &kCFTypeDictionaryValueCallBacks);
+ 
+     CFDictionarySetValue(config_info,
+-                         codec_type == kCMVideoCodecType_HEVC ?
+-                            kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder :
+-                            kVTVideoDecoderSpecification_RequireHardwareAcceleratedVideoDecoder,
++                         kVTVideoDecoderSpecification_EnableHardwareAcceleratedVideoDecoder,
+                          kCFBooleanTrue);
+ 
+     avc_info = CFDictionaryCreateMutable(kCFAllocatorDefault,

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -68,3 +68,4 @@
 0068-add-pgs-support-to-vulkan-overlay.patch
 0069-add-fixes-x265-build-from-upstream.patch
 0070-fix-yuv420p-to-p01x-unscaled-conversion.patch
+0071-allow-vt-sw-decoder-for-every-codec.patch


### PR DESCRIPTION
Apple disabled hardware decoding for some h264 files with certain condition and now ffmpeg will error out for such inputs because the software fallback is disabled. Allow software fallback for all codecs instead of only for HEVC to workaround this as the error handling outside ffmpeg would be harder. Allowing software fallback has no measurable performance impact when the hardware decoder is not overloaded.

Refer: macOS 14.6 release note: https://developer.apple.com/documentation/macos-release-notes/macos-14_6-release-notes#Video-Toolbox

The impacted videos are rare but still exist. 

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->