### PR TITLE
Release windows ffmpeg built with clang

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,6 +41,15 @@ jobs:
       deploy-user: ${{ secrets.REPO_USER }}
       deploy-key: ${{ secrets.REPO_KEY }}
 
+  build_publish_windows_clang_portable:
+      uses: ./.github/workflows/_meta_win_clang_portable.yaml
+      with:
+        release: true
+      secrets:
+        deploy-host: ${{ secrets.REPO_HOST }}
+        deploy-user: ${{ secrets.REPO_USER }}
+        deploy-key: ${{ secrets.REPO_KEY }}
+
   build_publish_linux_portable:
     uses: ./.github/workflows/_meta_portable.yaml
     with:


### PR DESCRIPTION
Keep the gcc build in case of regressions.

**Changes**
- Release windows ffmpeg built with clang (For better intrin perf in vf_tonemapx filter)