### PR TITLE
Fix the default pkt thread queue size on certain platform

### DIFF
--- a/debian/patches/0062-tune-the-default-inter-thread-queue-sizes.patch
+++ b/debian/patches/0062-tune-the-default-inter-thread-queue-sizes.patch
@@ -2,13 +2,7 @@ Index: FFmpeg/fftools/ffmpeg_sched.h
 ===================================================================
 --- FFmpeg.orig/fftools/ffmpeg_sched.h
 +++ FFmpeg/fftools/ffmpeg_sched.h
-@@ -238,12 +238,15 @@ int sch_add_mux(Scheduler *sch, SchThrea
-  * Default size of a packet thread queue.  For muxing this can be overridden by
-  * the thread_queue_size option as passed to a call to sch_add_mux().
-  */
--#define DEFAULT_PACKET_THREAD_QUEUE_SIZE 8
-+#define DEFAULT_PACKET_THREAD_QUEUE_SIZE 1
- 
+@@ -243,7 +243,10 @@ int sch_add_mux(Scheduler *sch, SchThrea
  /**
   * Default size of a frame thread queue.
   */


### PR DESCRIPTION
Leave `DEFAULT_PACKET_THREAD_QUEUE_SIZE` untouched since we only care about `DEFAULT_FRAME_THREAD_QUEUE_SIZE`.

**Changes**
- Fix the default pkt thread queue size on certain platform

**Issues**
Otherwise encoding certain files using RKMPP failed with:
```
[ 3440.087443] rkvenc2_wait_result:2064: session 00000000140b6729 pending list is empty!
[ 3440.087462] rk_vcodec: mpp_msgs_wait:1612: session 63 wait result ret -5
[ 3440.132356] rk_vcodec: mpp_task_attach_fd:1760: can't import dma-buf 41
[ 3440.132375] rk_vcodec: mpp_translate_reg_address:1816: reg[  9]: 0x00000029 fd 41 failed
[ 3440.132386] rk_vcodec: mpp_task_dump_mem_region:2003: --- dump task 0 mem region ---
[ 3440.132395] rk_vcodec: mpp_task_dump_mem_region:2008: reg[  0]: 0x00000000ff800000, size 4e6000
[ 3440.132406] rk_vcodec: mpp_task_dump_mem_region:2008: reg[  1]: 0x00000000ff800000, size 4e6000
[ 3440.132414] rk_vcodec: mpp_task_dump_mem_region:2008: reg[  2]: 0x00000000ff800000, size 4e6000
[ 3440.132423] rk_vcodec: mpp_task_dump_mem_region:2008: reg[  3]: 0x00000000fac00000, size 334000
[ 3440.132431] rk_vcodec: mpp_task_dump_mem_region:2008: reg[  4]: 0x00000000fac00000, size 334000
[ 3440.132439] rk_vcodec: mpp_task_dump_mem_region:2008: reg[  5]: 0x00000000fe400000, size 334000
[ 3440.132446] rk_vcodec: mpp_task_dump_mem_region:2008: reg[  6]: 0x00000000fe400000, size 334000
[ 3440.132454] rk_vcodec: mpp_task_dump_mem_region:2008: reg[  7]: 0x00000000ff370000, size d000
[ 3440.132462] rk_vcodec: mpp_task_dump_mem_region:2008: reg[  8]: 0x00000000fe340000, size d000
[ 3440.132475] rk_vcodec: mpp_process_task_default:614: alloc_task failed.
[ 3440.464435] rkvenc2_wait_result:2064: session 00000000140b6729 pending list is empty!
[ 3440.464456] rk_vcodec: mpp_msgs_wait:1612: session 63 wait result ret -5
```