### PR TITLE
hevc: add 12bit videotoolbox decoding support

### DIFF
--- a/debian/patches/0073-add-12bit-decoding-on-videotoolbox.patch
+++ b/debian/patches/0073-add-12bit-decoding-on-videotoolbox.patch
@@ -1,0 +1,24 @@
+Index: FFmpeg/libavcodec/hevcdec.c
+===================================================================
+--- FFmpeg.orig/libavcodec/hevcdec.c
++++ FFmpeg/libavcodec/hevcdec.c
+@@ -533,6 +533,9 @@ static enum AVPixelFormat get_format(HEV
+ #if CONFIG_HEVC_NVDEC_HWACCEL
+         *fmt++ = AV_PIX_FMT_CUDA;
+ #endif
++#if CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL
++        *fmt++ = AV_PIX_FMT_VIDEOTOOLBOX;
++#endif
+         break;
+     case AV_PIX_FMT_YUV422P12:
+ #if CONFIG_HEVC_DXVA2_HWACCEL
+@@ -548,6 +551,9 @@ static enum AVPixelFormat get_format(HEV
+ #if CONFIG_HEVC_VULKAN_HWACCEL
+         *fmt++ = AV_PIX_FMT_VULKAN;
+ #endif
++#if CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL
++        *fmt++ = AV_PIX_FMT_VIDEOTOOLBOX;
++#endif
+         break;
+     }
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -70,3 +70,4 @@
 0070-fix-yuv420p-to-p01x-unscaled-conversion.patch
 0071-allow-vt-sw-decoder-for-every-codec.patch
 0072-add-bwdif-videotoolbox-filter.patch
+0073-add-12bit-decoding-on-videotoolbox.patch


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

12bit HEVC works with minimal changes if we process all filters using downsampled `yuv420p10`. However, it's important to note that Intel Macs never had hardware support for 12-bit processing, so they will always fall back on software decoding. Even on M1 series, hardware acceleration for 12-bit is incomplete and likely uses hybrid decoding. This is evident by the higher CPU usage compared to 10-bit 4:4:4 inputs, though the M1 still achieves better framerates with lower CPU usage than FFmpeg's native software decoder when decoding 4K HDR 12-bit 4:4:4 inputs.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->