### PR TITLE
Fix the sub2video perf regressions

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.0.2-1"
+version: "7.0.2-2"
 packages:
   - bullseye-amd64
   - bullseye-armhf

--- a/builder/scripts.d/50-rkmpp.sh
+++ b/builder/scripts.d/50-rkmpp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/nyanmisaka/mpp.git"
-SCRIPT_COMMIT="4ded78b9510145fa79bcd51beb1591450c872277"
+SCRIPT_COMMIT="d7f8a2f7cd59f4c38c0d28d85fbb5e4eb307290e"
 
 ffbuild_enabled() {
     [[ $TARGET == linux* ]] && [[ $TARGET == *arm64 ]] && return 0

--- a/builder/scripts.d/50-rkrga.sh
+++ b/builder/scripts.d/50-rkrga.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/nyanmisaka/rk-mirrors.git"
-SCRIPT_COMMIT="a9fc19e6b906d7cecd6bcefbd45e5e151831d33f"
+SCRIPT_COMMIT="e97e327662d1c0867d4cbcc01d5caf15250fc4e7"
 
 ffbuild_enabled() {
     [[ $TARGET == linux* ]] && [[ $TARGET == *arm64 ]] && return 0

--- a/builder/scripts.d/50-x264.sh
+++ b/builder/scripts.d/50-x264.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/x264.git"
-SCRIPT_COMMIT="4613ac3c15fd75cebc4b9f65b7fb95e70a3acce1"
+SCRIPT_COMMIT="c24e06c2e184345ceb33eb20a15d1024d9fd3497"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/builder/scripts.d/50-x265.sh
+++ b/builder/scripts.d/50-x265.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
-SCRIPT_COMMIT="f6735953b90e4ff74849e20156a520f5bfd410fc"
+SCRIPT_COMMIT="cdf897bfba098666e673a64a96fda4c057318699"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+jellyfin-ffmpeg (7.0.2-2) unstable; urgency=medium
+
+  * Add bwdif_videotoolbox filter
+  * Fix the default pkt thread queue size on certain platform
+  * Add 12bit videotoolbox decoding support for HEVC
+  * Fix the sub2video perf regressions
+  * Update dependencies
+
+ -- nyanmisaka <nst799610810@gmail.com>  Wed, 18 Sep 2024 20:37:24 +0800
+
 jellyfin-ffmpeg (7.0.2-1) unstable; urgency=medium
 
   * New upstream version 7.0.2

--- a/debian/patches/0070-fix-yuv420p-to-p01x-unscaled-conversion.patch
+++ b/debian/patches/0070-fix-yuv420p-to-p01x-unscaled-conversion.patch
@@ -2,7 +2,7 @@ Index: FFmpeg/libswscale/swscale_unscaled.c
 ===================================================================
 --- FFmpeg.orig/libswscale/swscale_unscaled.c
 +++ FFmpeg/libswscale/swscale_unscaled.c
-@@ -297,7 +297,7 @@ static int planar8ToP01xleWrapper(SwsCon
+@@ -352,7 +352,7 @@ static int planar8ToP01xleWrapper(SwsCon
          const uint8_t *tsrc0 = src[0];
          for (x = c->srcW; x > 0; x--) {
              t = *tsrc0++;
@@ -11,7 +11,7 @@ Index: FFmpeg/libswscale/swscale_unscaled.c
          }
          src[0] += srcStride[0];
          dstY += dstStride[0] / 2;
-@@ -308,9 +308,9 @@ static int planar8ToP01xleWrapper(SwsCon
+@@ -363,9 +363,9 @@ static int planar8ToP01xleWrapper(SwsCon
              const uint8_t *tsrc2 = src[2];
              for (x = c->srcW / 2; x > 0; x--) {
                  t = *tsrc1++;
@@ -145,6 +145,22 @@ Index: FFmpeg/tests/ref/fate/filter-pixfmts-null
  p210be              847e9c6e292b17349e69570829252b3e
  p210le              c06e4b76cf504e908128081f92b60ce2
  p212be              4df641ed058718ad27a01889f923b04f
+Index: FFmpeg/tests/ref/fate/filter-pixfmts-pad
+===================================================================
+--- FFmpeg.orig/tests/ref/fate/filter-pixfmts-pad
++++ FFmpeg/tests/ref/fate/filter-pixfmts-pad
+@@ -28,9 +28,9 @@ nv16                d3a50501d2ea8535489f
+ nv21                0fdeb2cdd56cf5a7147dc273456fa217
+ nv24                193b9eadcc06ad5081609f76249b3e47
+ nv42                1738ad3c31c6c16e17679f5b09ce4677
+-p010le              fbbc23cc1d764a5e6fb71883d985f3ed
++p010le              3a92c1bd3e9de050bf6abcc3fd911ab7
+ p012le              3a92c1bd3e9de050bf6abcc3fd911ab7
+-p016le              fbbc23cc1d764a5e6fb71883d985f3ed
++p016le              3a92c1bd3e9de050bf6abcc3fd911ab7
+ p210le              680912c059de39c3401cac856bd1b0c1
+ p212le              a2f88017bcce2383ba60bc4872e639ba
+ p216le              8718662e226a4581561e7bb532af2d83
 Index: FFmpeg/tests/ref/fate/filter-pixfmts-scale
 ===================================================================
 --- FFmpeg.orig/tests/ref/fate/filter-pixfmts-scale

--- a/debian/patches/0074-fix-the-sub2video-perf-regressions.patch
+++ b/debian/patches/0074-fix-the-sub2video-perf-regressions.patch
@@ -1,0 +1,47 @@
+Index: FFmpeg/fftools/ffmpeg_filter.c
+===================================================================
+--- FFmpeg.orig/fftools/ffmpeg_filter.c
++++ FFmpeg/fftools/ffmpeg_filter.c
+@@ -2458,7 +2458,8 @@ static void sub2video_heartbeat(InputFil
+            or if we need to initialize the system, update the
+            overlayed subpicture and its start/end times */
+         sub2video_update(ifp, pts2 + 1, NULL);
+-    else
++
++    if (av_buffersrc_get_nb_failed_requests(ifp->filter))
+         sub2video_push_ref(ifp, pts2);
+ }
+ 
+Index: FFmpeg/tests/ref/fate/filter-overlay-dvdsub-2397
+===================================================================
+--- FFmpeg.orig/tests/ref/fate/filter-overlay-dvdsub-2397
++++ FFmpeg/tests/ref/fate/filter-overlay-dvdsub-2397
+@@ -489,12 +489,12 @@
+ 1,       3877,       3877,       10,     2013, 0x95a39f9c
+ 1,       3887,       3887,       10,     2013, 0x4f7ea123
+ 1,       3897,       3897,       10,     2013, 0x9efb9ba1
+-0,        117,        117,        1,   518400, 0x61e0f688
++0,        117,        117,        1,   518400, 0xbf8523da
+ 1,       3907,       3907,       10,     2013, 0xf395b2cd
+ 1,       3917,       3917,       10,     2013, 0x261a881e
+ 1,       3927,       3927,       10,     2013, 0x7f2d9f72
+ 1,       3937,       3937,       10,     2013, 0x0105b38d
+-0,        118,        118,        1,   518400, 0xa47de755
++0,        118,        118,        1,   518400, 0x41890ed6
+ 1,       3952,       3952,       10,     2013, 0x0e5db67e
+ 1,       3962,       3962,       10,     2013, 0xfc9baf97
+ 0,        119,        119,        1,   518400, 0x588534fc
+Index: FFmpeg/tests/ref/fate/sub2video
+===================================================================
+--- FFmpeg.orig/tests/ref/fate/sub2video
++++ FFmpeg/tests/ref/fate/sub2video
+@@ -68,8 +68,7 @@
+ 0,        258,        258,        1,   518400, 0x34cdddee
+ 0,        269,        269,        1,   518400, 0xbab197ea
+ 1,   53910000,   53910000,  2696000,     2095, 0x61bb15ed
+-0,        270,        270,        1,   518400, 0xbab197ea
+-0,        271,        271,        1,   518400, 0x4db4ce51
++0,        270,        270,        1,   518400, 0x4db4ce51
+ 0,        283,        283,        1,   518400, 0xbab197ea
+ 1,   56663000,   56663000,  1262000,     1013, 0xc9ae89b7
+ 0,        284,        284,        1,   518400, 0xe6bc0ea9

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -71,3 +71,4 @@
 0071-allow-vt-sw-decoder-for-every-codec.patch
 0072-add-bwdif-videotoolbox-filter.patch
 0073-add-12bit-decoding-on-videotoolbox.patch
+0074-fix-the-sub2video-perf-regressions.patch

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -382,7 +382,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.5.1 --depth=1 https://github.com/intel/gmmlib.git
+    git clone -b intel-gmmlib-22.5.2 --depth=1 https://github.com/intel/gmmlib.git
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..

--- a/msys2/PKGBUILD/40-mingw-w64-x264/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-x264/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=x264
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-libx264")
-pkgver=0.164.r3191.4613ac3
+pkgver=0.164.r3191.c24e06c
 pkgrel=1
 pkgdesc="Library for encoding H264/AVC video streams (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
                 || echo "${MINGW_PACKAGE_PREFIX}-nasm" )
              "git")
 options=('strip' 'staticlibs')
-_commit="4613ac3c15fd75cebc4b9f65b7fb95e70a3acce1"
+_commit="c24e06c2e184345ceb33eb20a15d1024d9fd3497"
 source=("${_realname}"::"git+https://code.videolan.org/videolan/${_realname}.git#commit=${_commit}"
         0001-beautify-pc.all.patch
         0002-install-avisynth_c.h.mingw.patch

--- a/msys2/PKGBUILD/40-mingw-w64-x265/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-x265/PKGBUILD
@@ -23,7 +23,7 @@ msys2_references=(
   "cpe: cpe:/a:multicorewareinc:x265"
   "cpe: cpe:/a:multicorewareinc:x265_high_efficiency_video_coding"
 )
-_commit="f6735953b90e4ff74849e20156a520f5bfd410fc"
+_commit="cdf897bfba098666e673a64a96fda4c057318699"
 source=("${_realname}"::"git+https://bitbucket.org/multicoreware/x265_git.git#commit=${_commit}")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
**Changes**
- Fix the sub2video perf regressions
- Fix missing changes in fate test
- Update dependencies
- Bump version to 7.0.2-2

**Issues**
- Revert upstream https://github.com/FFmpeg/FFmpeg/commit/4b8a171beb385c949cbe73fa3f5366c4cdccf72f

This hurts our PGSSUB burning perf badly vs 6.x releases, but brings no significant benefit to us.