### PR TITLE
Allow VPL QSV to init with the legacy MSDK path

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.0.2-2"
+version: "7.0.2-3"
 packages:
   - bullseye-amd64
   - bullseye-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (7.0.2-3) unstable; urgency=medium
+
+  * Allow VPL QSV to init with the legacy MSDK path
+
+ -- nyanmisaka <nst799610810@gmail.com>  Tue, 24 Sep 2024 20:03:23 +0800
+
 jellyfin-ffmpeg (7.0.2-2) unstable; urgency=medium
 
   * Add bwdif_videotoolbox filter

--- a/debian/patches/0075-allow-vpl-qsv-to-init-with-the-legacy-msdk-path.patch
+++ b/debian/patches/0075-allow-vpl-qsv-to-init-with-the-legacy-msdk-path.patch
@@ -1,0 +1,236 @@
+Index: FFmpeg/configure
+===================================================================
+--- FFmpeg.orig/configure
++++ FFmpeg/configure
+@@ -2528,6 +2528,7 @@ HAVE_LIST="
+     xmllint
+     zlib_gzip
+     openvino2
++    libvpl_legacy_mfxinit
+ "
+ 
+ # options emitted with CONFIG_ prefix but not available on the command line
+@@ -6947,6 +6948,9 @@ elif enabled libvpl; then
+             die "ERROR: libvpl >= 2.6 not found"
+     add_cflags -DMFX_DEPRECATED_OFF
+     check_type "vpl/mfxdefs.h vpl/mfxvideo.h" "struct mfxConfigInterface"
++# Ancient Intel driver on Windows still require the legacy init functions.
++# No compiler option is changed if the test fails, just needs to add back the disabled libmfx.
++    { test_pkg_config libmfx "vpl >= 2.6" "mfxvideo.h mfxdispatcher.h" "MFXInit MFXInitEx" && enable libvpl_legacy_mfxinit; } || enable libmfx
+ fi
+ 
+ if enabled libmfx; then
+Index: FFmpeg/libavcodec/qsv.c
+===================================================================
+--- FFmpeg.orig/libavcodec/qsv.c
++++ FFmpeg/libavcodec/qsv.c
+@@ -496,6 +496,17 @@ static int ff_qsv_set_display_handle(AVC
+ }
+ #endif //AVCODEC_QSV_LINUX_SESSION_HANDLE
+ 
++#if !QSV_ONEVPL || HAVE_LIBVPL_LEGACY_MFXINIT
++
++static int qsv_create_mfx_session_legacy(AVCodecContext *avctx,
++                                         mfxIMPL implementation,
++                                         mfxVersion *pver,
++                                         int gpu_copy,
++                                         mfxSession *psession,
++                                         void **ploader);
++
++#endif
++
+ #if QSV_ONEVPL
+ static int qsv_new_mfx_loader(AVCodecContext *avctx,
+                               mfxIMPL implementation,
+@@ -636,6 +647,16 @@ static int qsv_create_mfx_session(AVCode
+     return 0;
+ 
+ fail:
++#if HAVE_LIBVPL_LEGACY_MFXINIT
++    av_log(avctx, AV_LOG_VERBOSE, "Error creating a MFX session using oneVPL, "
++           "falling back to retry with the legacy Media SDK path\n");
++    if (!qsv_create_mfx_session_legacy(avctx, implementation, pver, gpu_copy, psession, ploader)) {
++        if (!*ploader)
++            *ploader = loader;
++        return 0;
++    }
++#endif
++
+     if (!*ploader && loader)
+         MFXUnload(loader);
+ 
+@@ -651,6 +672,20 @@ static int qsv_create_mfx_session(AVCode
+                                   mfxSession *psession,
+                                   void **ploader)
+ {
++    return qsv_create_mfx_session_legacy(avctx, implementation, pver, gpu_copy, psession, ploader);
++}
++
++#endif
++
++#if !QSV_ONEVPL || HAVE_LIBVPL_LEGACY_MFXINIT
++
++static int qsv_create_mfx_session_legacy(AVCodecContext *avctx,
++                                         mfxIMPL implementation,
++                                         mfxVersion *pver,
++                                         int gpu_copy,
++                                         mfxSession *psession,
++                                         void **ploader)
++{
+     mfxInitParam init_par = { MFX_IMPL_AUTO_ANY };
+     mfxSession session = NULL;
+     mfxStatus sts;
+Index: FFmpeg/libavcodec/qsvenc.c
+===================================================================
+--- FFmpeg.orig/libavcodec/qsvenc.c
++++ FFmpeg/libavcodec/qsvenc.c
+@@ -1192,7 +1192,7 @@ static int init_video_param(AVCodecConte
+ 
+ #if QSV_HAVE_EXT_AV1_PARAM
+     if (avctx->codec_id == AV_CODEC_ID_AV1) {
+-        if (QSV_RUNTIME_VERSION_ATLEAST(q->ver, 2, 5)) {
++        if (QSV_RUNTIME_VERSION_ATLEAST(q->ver, 1, 255)) { // (2, 5)
+             q->extav1tileparam.Header.BufferId = MFX_EXTBUFF_AV1_TILE_PARAM;
+             q->extav1tileparam.Header.BufferSz = sizeof(q->extav1tileparam);
+             q->extav1tileparam.NumTileColumns  = q->tile_cols;
+@@ -1416,7 +1416,7 @@ static int qsv_retrieve_enc_av1_params(A
+         (mfxExtBuffer*)&co3,
+     };
+ 
+-    if (!QSV_RUNTIME_VERSION_ATLEAST(q->ver, 2, 5)) {
++    if (!QSV_RUNTIME_VERSION_ATLEAST(q->ver, 1, 255)) { // (2, 5)
+         av_log(avctx, AV_LOG_ERROR,
+                "This version of runtime doesn't support AV1 encoding\n");
+         return AVERROR_UNKNOWN;
+Index: FFmpeg/libavfilter/qsvvpp.c
+===================================================================
+--- FFmpeg.orig/libavfilter/qsvvpp.c
++++ FFmpeg/libavfilter/qsvvpp.c
+@@ -1067,6 +1067,16 @@ int ff_qsvvpp_filter_frame(QSVVPPContext
+     return 0;
+ }
+ 
++#if !QSV_ONEVPL || HAVE_LIBVPL_LEGACY_MFXINIT
++
++static int qsvvpp_create_mfx_session_legacy(void *ctx,
++                                            void *loader,
++                                            mfxIMPL implementation,
++                                            mfxVersion *pver,
++                                            mfxSession *psession);
++
++#endif
++
+ #if QSV_ONEVPL
+ 
+ int ff_qsvvpp_create_mfx_session(void *ctx,
+@@ -1110,6 +1120,15 @@ int ff_qsvvpp_create_mfx_session(void *c
+         impl_idx++;
+     }
+ 
++#if HAVE_LIBVPL_LEGACY_MFXINIT
++    if (sts < 0) {
++        av_log(ctx, AV_LOG_VERBOSE, "Error creating a MFX session using oneVPL, "
++               "falling back to retry with the legacy Media SDK path\n");
++        if (!qsvvpp_create_mfx_session_legacy(ctx, loader, implementation, pver, psession))
++            return 0;
++    }
++#endif
++
+     if (sts < 0)
+         return ff_qsvvpp_print_error(ctx, sts,
+                                      "Error creating a MFX session");
+@@ -1127,6 +1146,19 @@ int ff_qsvvpp_create_mfx_session(void *c
+                                  mfxVersion *pver,
+                                  mfxSession *psession)
+ {
++    return qsvvpp_create_mfx_session_legacy(ctx, loader, implementation, pver, psession);
++}
++
++#endif
++
++#if !QSV_ONEVPL || HAVE_LIBVPL_LEGACY_MFXINIT
++
++static int qsvvpp_create_mfx_session_legacy(void *ctx,
++                                            void *loader,
++                                            mfxIMPL implementation,
++                                            mfxVersion *pver,
++                                            mfxSession *psession)
++{
+     mfxSession session = NULL;
+     mfxStatus sts;
+ 
+Index: FFmpeg/libavfilter/vf_vpp_qsv.c
+===================================================================
+--- FFmpeg.orig/libavfilter/vf_vpp_qsv.c
++++ FFmpeg/libavfilter/vf_vpp_qsv.c
+@@ -426,7 +426,7 @@ static int vpp_set_frame_ext_params(AVFi
+     fp->num_ext_buf = 0;
+ 
+     if (!in || !out ||
+-        !QSV_RUNTIME_VERSION_ATLEAST(qsvvpp->ver, 2, 0))
++        !QSV_RUNTIME_VERSION_ATLEAST(qsvvpp->ver, 1, 255)) // (2, 0)
+         return 0;
+ 
+     memset(&invsi_conf, 0, sizeof(mfxExtVideoSignalInfo));
+Index: FFmpeg/libavutil/hwcontext_qsv.c
+===================================================================
+--- FFmpeg.orig/libavutil/hwcontext_qsv.c
++++ FFmpeg/libavutil/hwcontext_qsv.c
+@@ -827,6 +827,18 @@ static mfxStatus frame_get_hdl(mfxHDL pt
+     return MFX_ERR_NONE;
+ }
+ 
++#if !QSV_ONEVPL || HAVE_LIBVPL_LEGACY_MFXINIT
++
++static int qsv_create_mfx_session_legacy(void *ctx,
++                                         mfxHDL handle,
++                                         mfxHandleType handle_type,
++                                         mfxIMPL implementation,
++                                         mfxVersion *pver,
++                                         mfxSession *psession,
++                                         void **ploader);
++
++#endif
++
+ #if QSV_ONEVPL
+ 
+ static int qsv_d3d11_update_config(void *ctx, mfxHDL handle, mfxConfig cfg)
+@@ -1218,6 +1230,16 @@ static int qsv_create_mfx_session(void *
+     return 0;
+ 
+ fail:
++#if HAVE_LIBVPL_LEGACY_MFXINIT
++    av_log(ctx, AV_LOG_VERBOSE, "Error creating a MFX session using oneVPL, "
++           "falling back to retry with the legacy Media SDK path\n");
++    if (!qsv_create_mfx_session_legacy(ctx, handle, handle_type, implementation, pver, psession, ploader)) {
++        if (!*ploader)
++            *ploader = loader;
++        return 0;
++    }
++#endif
++
+     if (!*ploader && loader)
+         MFXUnload(loader);
+ 
+@@ -1234,6 +1256,21 @@ static int qsv_create_mfx_session(void *
+                                   mfxSession *psession,
+                                   void **ploader)
+ {
++    return qsv_create_mfx_session_legacy(ctx, handle, handle_type, implementation, pver, psession, ploader);
++}
++
++#endif
++
++#if !QSV_ONEVPL || HAVE_LIBVPL_LEGACY_MFXINIT
++
++static int qsv_create_mfx_session_legacy(void *ctx,
++                                         mfxHDL handle,
++                                         mfxHandleType handle_type,
++                                         mfxIMPL implementation,
++                                         mfxVersion *pver,
++                                         mfxSession *psession,
++                                         void **ploader)
++{
+     mfxVersion ver;
+     mfxStatus sts;
+     mfxSession session = NULL;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -72,3 +72,4 @@
 0072-add-bwdif-videotoolbox-filter.patch
 0073-add-12bit-decoding-on-videotoolbox.patch
 0074-fix-the-sub2video-perf-regressions.patch
+0075-allow-vpl-qsv-to-init-with-the-legacy-msdk-path.patch


### PR DESCRIPTION
**Changes**
- Allow VPL QSV to init with the legacy MSDK path

```
Stream mapping:
  Stream #0:0 -> #0:0 (av1 (av1_qsv) -> h264 (h264_qsv))
[vost#0:0/h264_qsv @ 00000214f52ea380] Starting thread...
[vf#0:0 @ 00000214f5311b00] Starting thread...
[vist#0:0/av1 @ 00000214f51059c0] [dec:av1_qsv @ 00000214f5a04e80] Starting thread...
[in#0/matroska,webm @ 00000214f5298540] Starting thread...
Press [q] to stop, [?] for help
[av1_qsv @ 00000214f50a7780] Decoder: output is video memory surface
[av1_qsv @ 00000214f50a7780] Use Intel(R) oneVPL to create MFX session with the specified MFX loader
[av1_qsv @ 00000214f50a7780] Error creating a MFX session: -9.
[av1_qsv @ 00000214f50a7780] Error creating a MFX session using oneVPL, falling back to retry with the legacy Media SDK path
[av1_qsv @ 00000214f50a7780] Use Intel(R) Media SDK to create MFX session, the required implementation version is 1.255
[av1_qsv @ 00000214f50a7780] Decoder: output is video memory surface
[av1_qsv @ 00000214f50a7780] Use Intel(R) oneVPL to create MFX session with the specified MFX loader
[av1_qsv @ 00000214f50a7780] Error creating a MFX session: -9.
[av1_qsv @ 00000214f50a7780] Error creating a MFX session using oneVPL, falling back to retry with the legacy Media SDK path
[av1_qsv @ 00000214f50a7780] Use Intel(R) Media SDK to create MFX session, the required implementation version is 1.255
[graph 0 input from stream 0:0 @ 00000214f8483380] w:3840 h:2160 pixfmt:qsv tb:1/1000 fr:19001/317 sar:1/1 csp:bt2020nc range:tv
[Parsed_vpp_qsv_0 @ 00000214f8481b80] Use Intel(R) oneVPL to create MFX session with the specified MFX loader
[Parsed_vpp_qsv_0 @ 00000214f8481b80] Error creating a MFX session using oneVPL, falling back to retry with the legacy Media SDK path
[Parsed_vpp_qsv_0 @ 00000214f8481b80] Use Intel(R) Media SDK to create MFX session, API version is 2.13, the required implementation version is 1.255
[Parsed_vpp_qsv_0 @ 00000214f8481b80] VPP: input is video memory surface
[Parsed_vpp_qsv_0 @ 00000214f8481b80] VPP: output is video memory surface
[graph 0 input from stream 0:0 @ 00000214f8483380] video frame properties congruent with link at pts_time: 0.007
[h264_qsv @ 00000214f5c3f7c0] Using input frames context (format qsv) with h264_qsv encoder.
[h264_qsv @ 00000214f5c3f7c0] Encoder: input is video memory surface
[h264_qsv @ 00000214f5c3f7c0] Use Intel(R) oneVPL to create MFX session with the specified MFX loader
[h264_qsv @ 00000214f5c3f7c0] Error creating a MFX session: -9.
[h264_qsv @ 00000214f5c3f7c0] Error creating a MFX session using oneVPL, falling back to retry with the legacy Media SDK path
[h264_qsv @ 00000214f5c3f7c0] Use Intel(R) Media SDK to create MFX session, the required implementation version is 1.255
...
```

**Issues**
- Fixes https://github.com/jellyfin/jellyfin-server-windows/issues/135
- Fixes https://github.com/jellyfin/jellyfin/issues/12694