### PR TITLE
avfilter/transpose_vt: fix build on xcode 16

### DIFF
--- a/debian/patches/0051-add-coreimage-based-vf-transpose-vt-filter.patch
+++ b/debian/patches/0051-add-coreimage-based-vf-transpose-vt-filter.patch
@@ -305,7 +305,7 @@ Index: FFmpeg/libavfilter/vf_transpose_vt.m
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_transpose_vt.m
-@@ -0,0 +1,383 @@
+@@ -0,0 +1,379 @@
 +/*
 + * Copyright (c) 2023 Zhao Zhili <zhilizhao@tencent.com>
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
@@ -345,15 +345,11 @@ Index: FFmpeg/libavfilter/vf_transpose_vt.m
 +    #define LEGACY_VT_SDK
 +#endif
 +
-+#ifdef LEGACY_VT_SDK
-+typedef void*  VTPixelRotationSessionRef;
-+#endif
-+
 +typedef struct TransposeVtContext {
 +    AVClass *class;
 +    CIContext *ci_ctx;
 +    CGImagePropertyOrientation orientation;
-+    VTPixelRotationSessionRef session;
++    void* session;
 +
 +    int dir;
 +    int passthrough;
@@ -366,7 +362,7 @@ Index: FFmpeg/libavfilter/vf_transpose_vt.m
 +    if (@available(macOS 13.0, iOS 16, *)) {
 +        int ret;
 +
-+        ret = VTPixelRotationSessionCreate(kCFAllocatorDefault, &s->session);
++        ret = VTPixelRotationSessionCreate(kCFAllocatorDefault, (VTPixelRotationSessionRef *) &s->session);
 +        if (ret != noErr) {
 +            av_log(avctx, AV_LOG_ERROR, "Rotation session create failed, %d\n", ret);
 +            return AVERROR_EXTERNAL;


### PR DESCRIPTION
Xcode 16 marks VTPixelRotationSessionRef as macOS 13+ only type as well. As it is technically only a pointer, use type void* in the struct and cast to VTPixelRotationSessionRef when using.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->