### PR TITLE
Fix libiconv/gnulib build failure

### DIFF
--- a/builder/scripts.d/20-libiconv.sh
+++ b/builder/scripts.d/20-libiconv.sh
@@ -22,6 +22,7 @@ ffbuild_dockerbuild() {
 EOF
 
     ./gitsub.sh pull
+    ./gitsub.sh checkout gnulib d4ec02b3cc70cddaaa5183cc5a45814e0afb2292 # tag v1.0
 
     local myconf=(
         --prefix="$FFBUILD_PREFIX"


### PR DESCRIPTION
**Changes**
- Fix libiconv/gnulib build failure

**Issues**
- The submodule gnulib of libiconv fails due to https://github.com/coreutils/gnulib/commit/d34065436725869d4d3fd7f46c8f51e65c33ae3c.

```
2024-09-26T10:41:40.9630047Z #9 125.5 checking whether to activate relocatable installation... no
2024-09-26T10:41:40.9631143Z #9 125.5 ./configure: line 13015: syntax error near unexpected token `reloc_final_prefix'
2024-09-26T10:41:40.9632263Z #9 125.5 ./configure: line 13015: `    gl_BUILD_TO_HOST(reloc_final_prefix)'
2024-09-26T10:41:40.9633197Z #9 125.5 configure: error: ./configure failed for libcharset
2024-09-26T10:41:41.1474850Z #9 ERROR: process "/bin/sh -c run_stage /stage.sh" did not complete successfully: exit code: 2
```