### PR TITLE
Adjust default knee_offset for bt2390 tonemapper

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.0.2-3"
+version: "7.0.2-4"
 packages:
   - bullseye-amd64
   - bullseye-armhf

--- a/builder/scripts.d/50-x265.sh
+++ b/builder/scripts.d/50-x265.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
-SCRIPT_COMMIT="a009ec07721b1e7fcf5289619a3cd5dd6b67a546"
+SCRIPT_COMMIT="26d2bab0063cee453b7d8012e76539a7786c032f"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+jellyfin-ffmpeg (7.0.2-4) unstable; urgency=medium
+
+  * Use more stable range and peak handling in tonemap filters
+  * Adjust default knee_offset for bt2390 tonemapper
+  * Respect bl_video_full_range_flag for DoVi video
+
+ -- nyanmisaka <nst799610810@gmail.com>  Sun, 6 Oct 2024 21:13:39 +0800
+
 jellyfin-ffmpeg (7.0.2-3) unstable; urgency=medium
 
   * Allow VPL QSV to init with the legacy MSDK path

--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -1162,7 +1162,7 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +    float s_pq = s * scale;
 +    float max_lum = inverse_eotf_st2084(dst_peak) * scale;
 +
-+    float ks = 1.5f * max_lum - 0.5f;
++    float ks = (1.0f + tone_param) * max_lum - tone_param;
 +    float tb = (s_pq - ks) / (1.0f - ks);
 +    float tb2 = tb * tb;
 +    float tb3 = tb2 * tb;
@@ -1775,7 +1775,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_cuda.c
-@@ -0,0 +1,1123 @@
+@@ -0,0 +1,1129 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -2313,6 +2313,12 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +        if (isnan(s->param))
 +            s->param = 0.3f;
 +        break;
++    case TONEMAP_BT2390:
++        if (isnan(s->param))
++            s->param = 1.0f; // diff from the spec-defined 0.5f
++        else
++            s->param = FFMIN(FFMAX(s->param, 0.5f), 2.0f);
++        break;
 +    }
 +
 +    if (isnan(s->param))
@@ -2812,7 +2818,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +#define OFFSET(x) offsetof(TonemapCUDAContext, x)
 +#define FLAGS (AV_OPT_FLAG_FILTERING_PARAM|AV_OPT_FLAG_VIDEO_PARAM)
 +static const AVOption options[] = {
-+    { "tonemap",       "Tonemap algorithm selection", OFFSET(tonemap), AV_OPT_TYPE_INT, {.i64 = TONEMAP_NONE}, TONEMAP_NONE, TONEMAP_COUNT - 1, FLAGS, .unit = "tonemap" },
++    { "tonemap",       "Tonemap algorithm selection", OFFSET(tonemap), AV_OPT_TYPE_INT, {.i64 = TONEMAP_BT2390}, TONEMAP_NONE, TONEMAP_COUNT - 1, FLAGS, .unit = "tonemap" },
 +    {     "none",      0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_NONE},              0, 0, FLAGS, .unit = "tonemap" },
 +    {     "linear",    0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_LINEAR},            0, 0, FLAGS, .unit = "tonemap" },
 +    {     "gamma",     0, 0, AV_OPT_TYPE_CONST, {.i64 = TONEMAP_GAMMA},             0, 0, FLAGS, .unit = "tonemap" },

--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -1775,7 +1775,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_cuda.c
-@@ -0,0 +1,1129 @@
+@@ -0,0 +1,1131 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -2741,6 +2741,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +            in->color_trc = AVCOL_TRC_SMPTE2084;
 +            in->colorspace = AVCOL_SPC_UNSPECIFIED;
 +            in->color_primaries = AVCOL_PRI_BT2020;
++            if (rpu->bl_video_full_range_flag)
++                in->color_range = AVCOL_RANGE_JPEG;
 +        }
 +    }
 +

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -586,7 +586,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    float s_pq = s * scale;
 +    float max_lum = target_peak_inv_pq * scale;
 +
-+    float ks = 1.5f * max_lum - 0.5f;
++    float ks = (1.0f + tone_param) * max_lum - tone_param;
 +    float tb = (s_pq - ks) / (1.0f - ks);
 +    float tb2 = tb * tb;
 +    float tb3 = tb2 * tb;
@@ -1450,7 +1450,18 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      switch(ctx->tonemap) {
      case TONEMAP_GAMMA:
-@@ -144,48 +358,167 @@ static int tonemap_opencl_init(AVFilterC
+@@ -139,53 +353,178 @@ static int tonemap_opencl_init(AVFilterC
+         if (isnan(ctx->param))
+             ctx->param = 0.3f;
+         break;
++    case TONEMAP_BT2390:
++        if (isnan(ctx->param))
++            ctx->param = 1.0f; // diff from the spec-defined 0.5f
++        else
++            ctx->param = FFMIN(FFMAX(ctx->param, 0.5f), 2.0f);
++        break;
+     }
+ 
      if (isnan(ctx->param))
          ctx->param = 1.0f;
  
@@ -1633,7 +1644,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      if (ctx->range_in == AVCOL_RANGE_JPEG)
          av_bprintf(&header, "#define FULL_RANGE_IN\n");
  
-@@ -199,19 +532,41 @@ static int tonemap_opencl_init(AVFilterC
+@@ -199,19 +538,41 @@ static int tonemap_opencl_init(AVFilterC
      else
          ff_opencl_print_const_matrix_3x3(&header, "rgb2rgb", rgb2rgb);
  
@@ -1682,7 +1693,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
                 ctx->colorspace_out, av_color_space_name(ctx->colorspace_out));
          goto fail;
      }
-@@ -219,24 +574,23 @@ static int tonemap_opencl_init(AVFilterC
+@@ -219,24 +580,23 @@ static int tonemap_opencl_init(AVFilterC
      ff_fill_rgb2yuv_table(luma_dst, rgb2yuv);
      ff_opencl_print_const_matrix_3x3(&header, "yuv_matrix", rgb2yuv);
  
@@ -1722,7 +1733,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
      opencl_sources[0] = header.str;
-@@ -254,46 +608,171 @@ static int tonemap_opencl_init(AVFilterC
+@@ -254,46 +614,171 @@ static int tonemap_opencl_init(AVFilterC
      CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create OpenCL "
                       "command queue %d.\n", cle);
  
@@ -1888,7 +1899,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported input format: %s\n",
 +               av_get_pix_fmt_name(in_format));
 +        return AVERROR(ENOSYS);
-     }
++    }
 +    if (!format_is_supported(out_format)) {
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported output format: %s\n",
 +               av_get_pix_fmt_name(out_format));
@@ -1898,8 +1909,9 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported input format depth: %d\n",
 +               in_desc->comp[0].depth);
 +        return AVERROR(ENOSYS);
-+    }
-+
+     }
+ 
+-    s->ocf.output_format = s->format == AV_PIX_FMT_NONE ? AV_PIX_FMT_NV12 : s->format;
 +    ctx->in_fmt     = in_format;
 +    ctx->out_fmt    = out_format;
 +    ctx->in_desc    = in_desc;
@@ -1907,12 +1919,11 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    ctx->in_planes  = av_pix_fmt_count_planes(in_format);
 +    ctx->out_planes = av_pix_fmt_count_planes(out_format);
 +    ctx->ocf.output_format = out_format;
- 
--    s->ocf.output_format = s->format == AV_PIX_FMT_NONE ? AV_PIX_FMT_NV12 : s->format;
++
      ret = ff_opencl_filter_config_output(outlink);
      if (ret < 0)
          return ret;
-@@ -308,13 +787,46 @@ static int launch_kernel(AVFilterContext
+@@ -308,13 +793,46 @@ static int launch_kernel(AVFilterContext
      size_t global_work[2];
      size_t local_work[2];
      cl_int cle;
@@ -1961,7 +1972,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      local_work[0]  = 16;
      local_work[1]  = 16;
-@@ -338,13 +850,10 @@ static int tonemap_opencl_filter_frame(A
+@@ -338,13 +856,10 @@ static int tonemap_opencl_filter_frame(A
      AVFilterContext    *avctx = inlink->dst;
      AVFilterLink     *outlink = avctx->outputs[0];
      TonemapOpenCLContext *ctx = avctx->priv;
@@ -1976,7 +1987,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(input->format),
-@@ -363,9 +872,6 @@ static int tonemap_opencl_filter_frame(A
+@@ -363,9 +878,6 @@ static int tonemap_opencl_filter_frame(A
      if (err < 0)
          goto fail;
  
@@ -1986,7 +1997,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      if (ctx->trc != -1)
          output->color_trc = ctx->trc;
      if (ctx->primaries != -1)
-@@ -385,72 +891,92 @@ static int tonemap_opencl_filter_frame(A
+@@ -385,72 +897,92 @@ static int tonemap_opencl_filter_frame(A
      ctx->range_out = output->color_range;
      ctx->chroma_loc = output->chroma_location;
  
@@ -2022,7 +2033,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
          }
 +        av_log(ctx, AV_LOG_DEBUG, "Computed signal peak: %f\n", ctx->peak);
 +    }
- 
++
 +    if (dovi_sd) {
 +        const AVDOVIMetadata *metadata = (AVDOVIMetadata *) dovi_sd->data;
 +        const AVDOVIRpuDataHeader *rpu = av_dovi_get_header(metadata);
@@ -2042,7 +2053,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +
 +    if (!ctx->init_with_dovi && ctx->dovi && ctx->initialised)
 +        tonemap_opencl_uninit_common(avctx);
-+
+ 
 +    if (!ctx->initialised) {
          err = tonemap_opencl_init(avctx);
          if (err < 0)
@@ -2079,11 +2090,11 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_frame_remove_side_data(output, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
 +        av_frame_remove_side_data(output, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
 +    }
-+
-+    av_frame_remove_side_data(output, AV_FRAME_DATA_DOVI_RPU_BUFFER);
-+    av_frame_remove_side_data(output, AV_FRAME_DATA_DOVI_METADATA);
  
 -    av_log(ctx, AV_LOG_DEBUG, "Tone-mapping output: %s, %ux%u (%"PRId64").\n",
++    av_frame_remove_side_data(output, AV_FRAME_DATA_DOVI_RPU_BUFFER);
++    av_frame_remove_side_data(output, AV_FRAME_DATA_DOVI_METADATA);
++
 +    av_log(ctx, AV_LOG_DEBUG, "Tonemapping output: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(output->format),
             output->width, output->height, output->pts);
@@ -2119,7 +2130,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_frame_free(&input);
      av_frame_free(&output);
      return err;
-@@ -458,24 +984,9 @@ fail:
+@@ -458,24 +990,9 @@ fail:
  
  static av_cold void tonemap_opencl_uninit(AVFilterContext *avctx)
  {
@@ -2146,7 +2157,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      ff_opencl_filter_uninit(avctx);
  }
-@@ -483,37 +994,50 @@ static av_cold void tonemap_opencl_unini
+@@ -483,37 +1000,50 @@ static av_cold void tonemap_opencl_unini
  #define OFFSET(x) offsetof(TonemapOpenCLContext, x)
  #define FLAGS (AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_VIDEO_PARAM)
  static const AVOption tonemap_opencl_options[] = {
@@ -2181,7 +2192,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 -    { "param",     "tonemap parameter",   OFFSET(param), AV_OPT_TYPE_DOUBLE, {.dbl = NAN}, DBL_MIN, DBL_MAX, FLAGS },
 -    { "desat",     "desaturation parameter",   OFFSET(desat_param), AV_OPT_TYPE_DOUBLE, {.dbl = 0.5}, 0, DBL_MAX, FLAGS },
 -    { "threshold", "scene detection threshold",   OFFSET(scene_threshold), AV_OPT_TYPE_DOUBLE, {.dbl = 0.2}, 0, DBL_MAX, FLAGS },
-+    { "tonemap", "Tonemap algorithm selection", OFFSET(tonemap), AV_OPT_TYPE_INT, { .i64 = TONEMAP_NONE }, TONEMAP_NONE, TONEMAP_COUNT - 1, FLAGS, "tonemap" },
++    { "tonemap", "Tonemap algorithm selection", OFFSET(tonemap), AV_OPT_TYPE_INT, { .i64 = TONEMAP_BT2390 }, TONEMAP_NONE, TONEMAP_COUNT - 1, FLAGS, "tonemap" },
 +        { "none",     0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_NONE },              0, 0, FLAGS, "tonemap" },
 +        { "linear",   0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_LINEAR },            0, 0, FLAGS, "tonemap" },
 +        { "gamma",    0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_GAMMA },             0, 0, FLAGS, "tonemap" },

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -1240,15 +1240,15 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      [TONEMAP_HABLE]    = "hable",
      [TONEMAP_MOBIUS]   = "mobius",
 +    [TONEMAP_BT2390]   = "bt2390",
-+};
-+
+ };
+ 
 +static const double dovi_lms2rgb_matrix[3][3] =
 +{
 +    { 3.06441879, -2.16597676,  0.10155818},
 +    {-0.65612108,  1.78554118, -0.12943749},
 +    { 0.01736321, -0.04725154,  1.03004253},
- };
- 
++};
++
 +static float linearize(float x, float ref_white, enum AVColorTransferCharacteristic trc_in)
 +{
 +    if (trc_in == AVCOL_TRC_SMPTE2084)
@@ -1904,14 +1904,13 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported output format: %s\n",
 +               av_get_pix_fmt_name(out_format));
 +        return AVERROR(ENOSYS);
-+    }
+     }
 +    if (in_desc->comp[0].depth != 10 && in_desc->comp[0].depth != 16) {
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported input format depth: %d\n",
 +               in_desc->comp[0].depth);
 +        return AVERROR(ENOSYS);
-     }
- 
--    s->ocf.output_format = s->format == AV_PIX_FMT_NONE ? AV_PIX_FMT_NV12 : s->format;
++    }
++
 +    ctx->in_fmt     = in_format;
 +    ctx->out_fmt    = out_format;
 +    ctx->in_desc    = in_desc;
@@ -1919,7 +1918,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    ctx->in_planes  = av_pix_fmt_count_planes(in_format);
 +    ctx->out_planes = av_pix_fmt_count_planes(out_format);
 +    ctx->ocf.output_format = out_format;
-+
+ 
+-    s->ocf.output_format = s->format == AV_PIX_FMT_NONE ? AV_PIX_FMT_NV12 : s->format;
      ret = ff_opencl_filter_config_output(outlink);
      if (ret < 0)
          return ret;
@@ -1987,24 +1987,12 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(input->format),
-@@ -363,9 +878,6 @@ static int tonemap_opencl_filter_frame(A
+@@ -363,8 +878,49 @@ static int tonemap_opencl_filter_frame(A
      if (err < 0)
          goto fail;
  
 -    if (!peak)
 -        peak = ff_determine_signal_peak(input);
--
-     if (ctx->trc != -1)
-         output->color_trc = ctx->trc;
-     if (ctx->primaries != -1)
-@@ -385,72 +897,92 @@ static int tonemap_opencl_filter_frame(A
-     ctx->range_out = output->color_range;
-     ctx->chroma_loc = output->chroma_location;
- 
--    if (!ctx->initialised) {
--        if (!(input->color_trc == AVCOL_TRC_SMPTE2084 ||
--            input->color_trc == AVCOL_TRC_ARIB_STD_B67)) {
--            av_log(ctx, AV_LOG_ERROR, "unsupported transfer function characteristic.\n");
 +    if (ctx->apply_dovi)
 +        dovi_sd = av_frame_get_side_data(input, AV_FRAME_DATA_DOVI_METADATA);
 +
@@ -2015,22 +2003,18 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +            av_log(ctx, AV_LOG_ERROR, "No DOVI metadata and "
 +                   "unsupported transfer function characteristic: %s\n",
 +                   av_color_transfer_name(input->color_trc));
-             err = AVERROR(ENOSYS);
-             goto fail;
-         }
++            err = AVERROR(ENOSYS);
++            goto fail;
++        }
 +    }
- 
--        if (input_frames_ctx->sw_format != AV_PIX_FMT_P010) {
--            av_log(ctx, AV_LOG_ERROR, "unsupported format in tonemap_opencl.\n");
--            err = AVERROR(ENOSYS);
--            goto fail;
++
 +    if (!ctx->peak) {
 +        if (dovi_sd) {
 +            const AVDOVIMetadata *metadata = (AVDOVIMetadata *) dovi_sd->data;
 +            ctx->peak = ff_determine_dovi_signal_peak(metadata);
 +        } else {
 +            ctx->peak = ff_determine_signal_peak(input);
-         }
++        }
 +        av_log(ctx, AV_LOG_DEBUG, "Computed signal peak: %f\n", ctx->peak);
 +    }
 +
@@ -2045,12 +2029,33 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +                goto fail;
 +
 +            ff_map_dovi_metadata(ctx->dovi, metadata);
-+            ctx->trc_in = AVCOL_TRC_SMPTE2084;
-+            ctx->colorspace_in = AVCOL_SPC_UNSPECIFIED;
-+            ctx->primaries_in = AVCOL_PRI_BT2020;
++            output->color_trc = input->color_trc = AVCOL_TRC_SMPTE2084;
++            output->colorspace = input->colorspace = AVCOL_SPC_BT2020_NCL;
++            output->color_primaries = input->color_primaries = AVCOL_PRI_BT2020;
++            if (rpu->bl_video_full_range_flag)
++                output->color_range = input->color_range = AVCOL_RANGE_JPEG;
 +        }
 +    }
-+
+ 
+     if (ctx->trc != -1)
+         output->color_trc = ctx->trc;
+@@ -385,72 +941,50 @@ static int tonemap_opencl_filter_frame(A
+     ctx->range_out = output->color_range;
+     ctx->chroma_loc = output->chroma_location;
+ 
+-    if (!ctx->initialised) {
+-        if (!(input->color_trc == AVCOL_TRC_SMPTE2084 ||
+-            input->color_trc == AVCOL_TRC_ARIB_STD_B67)) {
+-            av_log(ctx, AV_LOG_ERROR, "unsupported transfer function characteristic.\n");
+-            err = AVERROR(ENOSYS);
+-            goto fail;
+-        }
+-
+-        if (input_frames_ctx->sw_format != AV_PIX_FMT_P010) {
+-            av_log(ctx, AV_LOG_ERROR, "unsupported format in tonemap_opencl.\n");
+-            err = AVERROR(ENOSYS);
+-            goto fail;
+-        }
 +    if (!ctx->init_with_dovi && ctx->dovi && ctx->initialised)
 +        tonemap_opencl_uninit_common(avctx);
  
@@ -2090,11 +2095,11 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_frame_remove_side_data(output, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
 +        av_frame_remove_side_data(output, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
 +    }
- 
--    av_log(ctx, AV_LOG_DEBUG, "Tone-mapping output: %s, %ux%u (%"PRId64").\n",
++
 +    av_frame_remove_side_data(output, AV_FRAME_DATA_DOVI_RPU_BUFFER);
 +    av_frame_remove_side_data(output, AV_FRAME_DATA_DOVI_METADATA);
-+
+ 
+-    av_log(ctx, AV_LOG_DEBUG, "Tone-mapping output: %s, %ux%u (%"PRId64").\n",
 +    av_log(ctx, AV_LOG_DEBUG, "Tonemapping output: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(output->format),
             output->width, output->height, output->pts);
@@ -2130,7 +2135,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_frame_free(&input);
      av_frame_free(&output);
      return err;
-@@ -458,24 +990,9 @@ fail:
+@@ -458,24 +992,9 @@ fail:
  
  static av_cold void tonemap_opencl_uninit(AVFilterContext *avctx)
  {
@@ -2157,7 +2162,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      ff_opencl_filter_uninit(avctx);
  }
-@@ -483,37 +1000,50 @@ static av_cold void tonemap_opencl_unini
+@@ -483,37 +1002,50 @@ static av_cold void tonemap_opencl_unini
  #define OFFSET(x) offsetof(TonemapOpenCLContext, x)
  #define FLAGS (AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_VIDEO_PARAM)
  static const AVOption tonemap_opencl_options[] = {

--- a/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
+++ b/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
@@ -507,7 +507,7 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +    float s_pq = s * scale;
 +    float max_lum = target_peak_inv_pq * scale;
 +
-+    float ks = 1.5f * max_lum - 0.5f;
++    float ks = (1.0f + tone_param) * max_lum - tone_param;
 +    float tb = (s_pq - ks) / (1.0f - ks);
 +    float tb2 = tb * tb;
 +    float tb3 = tb2 * tb;
@@ -939,7 +939,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
-@@ -0,0 +1,1149 @@
+@@ -0,0 +1,1155 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -1311,6 +1311,12 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +        case TONEMAP_MOBIUS:
 +            if (isnan(ctx->param))
 +                ctx->param = 0.3f;
++            break;
++        case TONEMAP_BT2390:
++            if (isnan(ctx->param))
++                ctx->param = 1.0f; // diff from the spec-defined 0.5f
++            else
++                ctx->param = FFMIN(FFMAX(ctx->param, 0.5f), 2.0f);
 +            break;
 +    }
 +
@@ -2017,7 +2023,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +#define OFFSET(x) offsetof(TonemapVideoToolboxContext, x)
 +
 +static const AVOption tonemap_videotoolbox_options[] = {
-+    { "tonemap", "Tonemap algorithm selection", OFFSET(tonemap), AV_OPT_TYPE_INT, { .i64 = TONEMAP_NONE }, TONEMAP_NONE, TONEMAP_COUNT - 1, FLAGS, .unit = "tonemap" },
++    { "tonemap", "Tonemap algorithm selection", OFFSET(tonemap), AV_OPT_TYPE_INT, { .i64 = TONEMAP_BT2390 }, TONEMAP_NONE, TONEMAP_COUNT - 1, FLAGS, .unit = "tonemap" },
 +        { "none",     0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_NONE },              0, 0, FLAGS, .unit = "tonemap" },
 +        { "linear",   0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_LINEAR },            0, 0, FLAGS, .unit = "tonemap" },
 +        { "gamma",    0, 0, AV_OPT_TYPE_CONST, { .i64 = TONEMAP_GAMMA },             0, 0, FLAGS, .unit = "tonemap" },

--- a/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
+++ b/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
@@ -939,7 +939,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
-@@ -0,0 +1,1155 @@
+@@ -0,0 +1,1157 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -1812,25 +1812,6 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    if (err < 0)
 +        goto fail;
 +
-+    if (ctx->trc != -1)
-+        output->color_trc = ctx->trc;
-+    if (ctx->primaries != -1)
-+        output->color_primaries = ctx->primaries;
-+    if (ctx->colorspace != -1)
-+        output->colorspace = ctx->colorspace;
-+    if (ctx->range != -1)
-+        output->color_range = ctx->range;
-+
-+    ctx->trc_in = input->color_trc;
-+    ctx->trc_out = output->color_trc;
-+    ctx->colorspace_in = input->colorspace;
-+    ctx->colorspace_out = output->colorspace;
-+    ctx->primaries_in = input->color_primaries;
-+    ctx->primaries_out = output->color_primaries;
-+    ctx->range_in = input->color_range;
-+    ctx->range_out = output->color_range;
-+    ctx->chroma_loc = output->chroma_location;
-+
 +    if (ctx->apply_dovi)
 +        dovi_sd = av_frame_get_side_data(input, AV_FRAME_DATA_DOVI_METADATA);
 +
@@ -1867,11 +1848,32 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +                goto fail;
 +
 +            ff_map_dovi_metadata(ctx->dovi, metadata);
-+            ctx->trc_in = AVCOL_TRC_SMPTE2084;
-+            ctx->colorspace_in = AVCOL_SPC_UNSPECIFIED;
-+            ctx->primaries_in = AVCOL_PRI_BT2020;
++            output->color_trc = input->color_trc = AVCOL_TRC_SMPTE2084;
++            output->colorspace = input->colorspace = AVCOL_SPC_BT2020_NCL;
++            output->color_primaries = input->color_primaries = AVCOL_PRI_BT2020;
++            if (rpu->bl_video_full_range_flag)
++                output->color_range = input->color_range = AVCOL_RANGE_JPEG;
 +        }
 +    }
++
++    if (ctx->trc != -1)
++        output->color_trc = ctx->trc;
++    if (ctx->primaries != -1)
++        output->color_primaries = ctx->primaries;
++    if (ctx->colorspace != -1)
++        output->colorspace = ctx->colorspace;
++    if (ctx->range != -1)
++        output->color_range = ctx->range;
++
++    ctx->trc_in = input->color_trc;
++    ctx->trc_out = output->color_trc;
++    ctx->colorspace_in = input->colorspace;
++    ctx->colorspace_out = output->colorspace;
++    ctx->primaries_in = input->color_primaries;
++    ctx->primaries_out = output->color_primaries;
++    ctx->range_in = input->color_range;
++    ctx->range_out = output->color_range;
++    ctx->chroma_loc = output->chroma_location;
 +
 +    // Some DOVI video does not carry metadata in the first few frames, and we have to reset the pipeline.
 +    if (!ctx->init_with_dovi && ctx->dovi && ctx->initialised) {

--- a/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
@@ -2406,7 +2406,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.c
-@@ -0,0 +1,1791 @@
+@@ -0,0 +1,1797 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -2847,7 +2847,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    return (b * b + 2.0f * b * j + j * j) / (b - a) * (in + a) / (in + b);
 +}
 +
-+static float bt2390(float s, float peak)
++static float bt2390(float s, float knee_offset, float peak)
 +{
 +    float peak_pq = inverse_eotf_st2084(peak, REFERENCE_WHITE_ALT);
 +    float scale = peak_pq > 0.0f ? (1.0f / peak_pq) : 1.0f;
@@ -2857,7 +2857,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    float s_pq = inverse_eotf_st2084(s, REFERENCE_WHITE_ALT) * scale;
 +    float max_lum = inverse_eotf_st2084(dst_peak, REFERENCE_WHITE_ALT) * scale;
 +
-+    float ks = 1.5f * max_lum - 0.5f;
++    float ks = (1.0f + knee_offset) * max_lum - knee_offset;
 +    float tb = (s_pq - ks) / (1.0f - ks);
 +    float tb2 = tb * tb;
 +    float tb3 = tb2 * tb;
@@ -2897,7 +2897,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +        sig = mobius(sig, param, peak);
 +        break;
 +    case TONEMAP_BT2390:
-+        sig = bt2390(sig, peak);
++        sig = bt2390(sig, param, peak);
 +        break;
 +    }
 +
@@ -4126,6 +4126,12 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +        case TONEMAP_MOBIUS:
 +            if (isnan(s->param))
 +                s->param = 0.3f;
++            break;
++        case TONEMAP_BT2390:
++            if (isnan(s->param))
++                s->param = 1.0f; // diff from the spec-defined 0.5f
++            else
++                s->param = FFMIN(FFMAX(s->param, 0.5f), 2.0f);
 +            break;
 +    }
 +

--- a/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
@@ -2406,7 +2406,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.c
-@@ -0,0 +1,1797 @@
+@@ -0,0 +1,1799 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -3832,6 +3832,42 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +        }
 +    }
 +
++    if (dovi_sd) {
++        const AVDOVIMetadata *metadata = (AVDOVIMetadata *) dovi_sd->data;
++        const AVDOVIRpuDataHeader *rpu = av_dovi_get_header(metadata);
++        // only map dovi rpus that don't require an EL and has rpu profile == 0
++        // for performance reason we only want to do reshaping when absolutely needed
++        // such videos usually have vdr_rpu_profile == 0, for example profile 5 videos
++        // this could be wrong as there is no public documentation on this field
++        if (rpu->disable_residual_flag && rpu->vdr_rpu_profile == 0) {
++            struct DoviMetadata *dovi = av_malloc(sizeof(*dovi));
++            s->dovi = dovi;
++            if (!s->dovi)
++                goto fail;
++
++            ff_map_dovi_metadata(s->dovi, metadata);
++            in->color_trc = AVCOL_TRC_SMPTE2084;
++            in->colorspace = AVCOL_SPC_BT2020_NCL;
++            in->color_primaries = AVCOL_PRI_BT2020;
++            if (rpu->bl_video_full_range_flag)
++                in->color_range = AVCOL_RANGE_JPEG;
++        }
++    }
++
++    if (s->dovi) {
++        if (desc->comp[2].plane == 1) {
++            av_log(s, AV_LOG_ERROR, "Input pixel format has to be yuv420p10 for Dolby Vision reshaping\n");
++            av_assert0(0);
++        }
++        update_dovi_buf(ctx);
++        ff_matrix_mul_3x3(s->lms2rgb_matrix, dovi_lms2rgb_matrix, s->dovi->linear);
++        s->ycc_offset[0] = s->dovi->nonlinear_offset[0] * (float)s->dovi->nonlinear[0][0] + s->dovi->nonlinear_offset[1] * (float)s->dovi->nonlinear[0][1] + s->dovi->nonlinear_offset[2] * (float)s->dovi->nonlinear[0][2];
++        s->ycc_offset[1] = s->dovi->nonlinear_offset[0] * (float)s->dovi->nonlinear[1][0] + s->dovi->nonlinear_offset[1] * (float)s->dovi->nonlinear[1][1] + s->dovi->nonlinear_offset[2] * (float)s->dovi->nonlinear[1][2];
++        s->ycc_offset[2] = s->dovi->nonlinear_offset[0] * (float)s->dovi->nonlinear[2][0] + s->dovi->nonlinear_offset[1] * (float)s->dovi->nonlinear[2][1] + s->dovi->nonlinear_offset[2] * (float)s->dovi->nonlinear[2][2];
++        s->tonemap_func_planar8 = s->tonemap_func_dovi8;
++        s->tonemap_func_planar10 = s->tonemap_func_dovi10;
++    }
++
 +    out->color_trc = s->trc == -1 ? AVCOL_TRC_UNSPECIFIED : s->trc;
 +    out->colorspace = s->spc == -1 ? AVCOL_SPC_UNSPECIFIED : s->spc;
 +    out->color_primaries = s->pri == -1 ? AVCOL_PRI_UNSPECIFIED : s->pri;
@@ -3856,40 +3892,6 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +        in->color_range = AVCOL_RANGE_MPEG;
 +    if (out->color_range == AVCOL_RANGE_UNSPECIFIED)
 +        out->color_range = AVCOL_RANGE_MPEG;
-+
-+    if (dovi_sd) {
-+        const AVDOVIMetadata *metadata = (AVDOVIMetadata *) dovi_sd->data;
-+        const AVDOVIRpuDataHeader *rpu = av_dovi_get_header(metadata);
-+        // only map dovi rpus that don't require an EL and has rpu profile == 0
-+        // for performance reason we only want to do reshaping when absolutely needed
-+        // such videos usually have vdr_rpu_profile == 0, for example profile 5 videos
-+        // this could be wrong as there is no public documentation on this field
-+        if (rpu->disable_residual_flag && rpu->vdr_rpu_profile == 0) {
-+            struct DoviMetadata *dovi = av_malloc(sizeof(*dovi));
-+            s->dovi = dovi;
-+            if (!s->dovi)
-+                goto fail;
-+
-+            ff_map_dovi_metadata(s->dovi, metadata);
-+            in->color_trc = AVCOL_TRC_SMPTE2084;
-+            in->colorspace = AVCOL_SPC_BT2020_NCL;
-+            in->color_primaries = AVCOL_PRI_BT2020;
-+        }
-+    }
-+
-+    if (s->dovi) {
-+        if (desc->comp[2].plane == 1) {
-+            av_log(s, AV_LOG_ERROR, "Input pixel format has to be yuv420p10 for Dolby Vision reshaping\n");
-+            av_assert0(0);
-+        }
-+        update_dovi_buf(ctx);
-+        ff_matrix_mul_3x3(s->lms2rgb_matrix, dovi_lms2rgb_matrix, s->dovi->linear);
-+        s->ycc_offset[0] = s->dovi->nonlinear_offset[0] * (float)s->dovi->nonlinear[0][0] + s->dovi->nonlinear_offset[1] * (float)s->dovi->nonlinear[0][1] + s->dovi->nonlinear_offset[2] * (float)s->dovi->nonlinear[0][2];
-+        s->ycc_offset[1] = s->dovi->nonlinear_offset[0] * (float)s->dovi->nonlinear[1][0] + s->dovi->nonlinear_offset[1] * (float)s->dovi->nonlinear[1][1] + s->dovi->nonlinear_offset[2] * (float)s->dovi->nonlinear[1][2];
-+        s->ycc_offset[2] = s->dovi->nonlinear_offset[0] * (float)s->dovi->nonlinear[2][0] + s->dovi->nonlinear_offset[1] * (float)s->dovi->nonlinear[2][1] + s->dovi->nonlinear_offset[2] * (float)s->dovi->nonlinear[2][2];
-+        s->tonemap_func_planar8 = s->tonemap_func_dovi8;
-+        s->tonemap_func_planar10 = s->tonemap_func_dovi10;
-+    }
 +
 +    if (!s->lin_lut || !s->delin_lut) {
 +        if ((ret = compute_trc_luts(s, in->color_trc, out->color_trc)) < 0)

--- a/debian/patches/0069-add-fixes-x265-build-from-upstream.patch
+++ b/debian/patches/0069-add-fixes-x265-build-from-upstream.patch
@@ -7,7 +7,7 @@ Index: FFmpeg/libavcodec/libx265.c
      libx265Context *ctx = avctx->priv_data;
      x265_picture x265pic;
 -    x265_picture x265pic_out = { 0 };
-+#if X265_BUILD >= 210
++#if (X265_BUILD >= 210) && (X265_BUILD < 213)
 +    x265_picture x265pic_layers_out[MAX_SCALABLE_LAYERS];
 +    x265_picture* x265pic_lyrptr_out[MAX_SCALABLE_LAYERS];
 +#else
@@ -21,7 +21,7 @@ Index: FFmpeg/libavcodec/libx265.c
          }
      }
  
-+#if X265_BUILD >= 210
++#if (X265_BUILD >= 210) && (X265_BUILD < 213)
 +    for (i = 0; i < MAX_SCALABLE_LAYERS; i++)
 +        x265pic_lyrptr_out[i] = &x265pic_layers_out[i];
 +
@@ -41,7 +41,7 @@ Index: FFmpeg/libavcodec/libx265.c
  
 -    pkt->pts = x265pic_out.pts;
 -    pkt->dts = x265pic_out.dts;
-+#if X265_BUILD >= 210
++#if (X265_BUILD >= 210) && (X265_BUILD < 213)
 +    x265pic_out = x265pic_lyrptr_out[0];
 +#else
 +    x265pic_out = &x265pic_solo_out;

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -390,8 +390,10 @@ make install
 popd
 
 # X265
-git clone --depth=1 https://bitbucket.org/multicoreware/x265_git.git
+x265_commit="26d2bab0063cee453b7d8012e76539a7786c032f"
+git clone https://bitbucket.org/multicoreware/x265_git.git
 pushd x265_git
+git checkout ${x265_commit}
 # Wa for https://bitbucket.org/multicoreware/x265_git/issues/624
 rm -rf .git
 x265_conf="

--- a/msys2/PKGBUILD/40-mingw-w64-x265/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-x265/PKGBUILD
@@ -23,7 +23,7 @@ msys2_references=(
   "cpe: cpe:/a:multicorewareinc:x265"
   "cpe: cpe:/a:multicorewareinc:x265_high_efficiency_video_coding"
 )
-_commit="a009ec07721b1e7fcf5289619a3cd5dd6b67a546"
+_commit="26d2bab0063cee453b7d8012e76539a7786c032f"
 source=("${_realname}"::"git+https://bitbucket.org/multicoreware/x265_git.git#commit=${_commit}")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
**Changes**
- Adjust default knee_offset for bt2390 tonemapper
- Respect `bl_video_full_range_flag` for DoVi video
- Unbreak `X265_BUILD` >= 213
- Pin x265 commit
- Bump version to 7.0.2-4

**Issues**
- Continuation of https://github.com/jellyfin/jellyfin-ffmpeg/pull/472#issuecomment-2394880048

> Alternatively, we can adjust the BT.2390 EETF similar to how it's done in libplacebo. They modify the 0.5 knee offset from the ITU standard to a 1.0 knee offset, which makes the curve to roll off earlier. This makes the overall brightness transition smoother for such videos with extreme highlights.