### PR TITLE
avcodec: add remove_dovi and remove_hdr10plus option to hevc,av1_metadata bsf

### DIFF
--- a/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
+++ b/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
@@ -83,3 +83,103 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
      { NULL }
  };
  
+Index: FFmpeg/libavcodec/bsf/av1_metadata.c
+===================================================================
+--- FFmpeg.orig/libavcodec/bsf/av1_metadata.c
++++ FFmpeg/libavcodec/bsf/av1_metadata.c
+@@ -17,6 +17,7 @@
+  */
+ 
+ #include "libavutil/common.h"
++#include "libavutil/intreadwrite.h"
+ #include "libavutil/opt.h"
+ 
+ #include "bsf.h"
+@@ -24,6 +25,7 @@
+ #include "cbs.h"
+ #include "cbs_bsf.h"
+ #include "cbs_av1.h"
++#include "itut35.h"
+ 
+ typedef struct AV1MetadataContext {
+     CBSBSFContext common;
+@@ -42,6 +44,9 @@ typedef struct AV1MetadataContext {
+     int num_ticks_per_picture;
+ 
+     int delete_padding;
++
++    int remove_dovi;
++    int remove_hdr10plus;
+ } AV1MetadataContext;
+ 
+ 
+@@ -140,6 +145,42 @@ static int av1_metadata_update_fragment(
+         }
+     }
+ 
++    if (ctx->remove_dovi ||ctx->remove_hdr10plus) {
++        int provider_code, provider_oriented_code, application_identifier;
++        for (i = frag->nb_units - 1; i >= 0; i--) {
++            if (frag->units[i].type == AV1_OBU_METADATA) {
++                AV1RawOBU *obu = frag->units[i].content;
++                AV1RawMetadataITUTT35 *t35 = &obu->obu.metadata.metadata.itut_t35;
++                if (obu->obu.metadata.metadata_type != AV1_METADATA_TYPE_ITUT_T35 ||
++                    t35->itu_t_t35_country_code != ITU_T_T35_COUNTRY_CODE_US ||
++                    t35->payload_size < 6) {
++                    continue;
++                }
++
++                provider_code = AV_RB16(t35->payload);
++
++                if (ctx->remove_dovi && provider_code == ITU_T_T35_PROVIDER_CODE_DOLBY) {
++                    provider_oriented_code = AV_RB32(t35->payload + 2);
++                    // Dolby Vision RPU
++                    if (provider_oriented_code == 0x800) {
++                        av_log(bsf, AV_LOG_DEBUG, "Removing Dolby Vision RPU\n");
++                        ff_cbs_delete_unit(frag, i);
++                    }
++                }
++
++                if (ctx->remove_hdr10plus && provider_code == ITU_T_T35_PROVIDER_CODE_SMTPE) {
++                    provider_oriented_code = AV_RB16(t35->payload + 2);
++                    application_identifier = AV_RB8(t35->payload + 4);
++                    // HDR10+ Metadata
++                    if (provider_oriented_code == 0x01 && application_identifier == 0x04) {
++                        av_log(bsf, AV_LOG_DEBUG, "Removing HDR10+ Metadata\n");
++                        ff_cbs_delete_unit(frag, i);
++                    }
++                }
++            }
++        }
++    }
++
+     return 0;
+ }
+ 
+@@ -158,6 +199,12 @@ static int av1_metadata_init(AVBSFContex
+         .header.obu_type = AV1_OBU_TEMPORAL_DELIMITER,
+     };
+ 
++    if (ctx->remove_dovi) {
++        av_packet_side_data_remove(bsf->par_out->coded_side_data,
++                                   &bsf->par_out->nb_coded_side_data,
++                                   AV_PKT_DATA_DOVI_CONF);
++    }
++
+     return ff_cbs_bsf_generic_init(bsf, &av1_metadata_type);
+ }
+ 
+@@ -206,6 +253,13 @@ static const AVOption av1_metadata_optio
+         OFFSET(delete_padding), AV_OPT_TYPE_BOOL,
+         { .i64 = 0 }, 0, 1, FLAGS},
+ 
++    { "remove_dovi", "Remove Dolby Vision RPU",
++      OFFSET(remove_dovi), AV_OPT_TYPE_BOOL,
++      { .i64 = 0 }, 0, 1, FLAGS },
++    { "remove_hdr10plus", "Remove HDR10+ metadata",
++      OFFSET(remove_hdr10plus), AV_OPT_TYPE_BOOL,
++      { .i64 = 0 }, 0, 1, FLAGS },
++
+     { NULL }
+ };
+ 

--- a/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
+++ b/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
@@ -57,12 +57,11 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
      }
  
      return 0;
-@@ -399,6 +433,12 @@ static const CBSBSFType h265_metadata_ty
+@@ -399,6 +433,11 @@ static const CBSBSFType h265_metadata_ty
  
  static int h265_metadata_init(AVBSFContext *bsf)
  {
 +    if (((H265MetadataContext *)bsf->priv_data)->remove_dovi) {
-+        av_log(bsf, AV_LOG_WARNING, "Removing Dolby Vision config\n");
 +        av_packet_side_data_remove(bsf->par_out->coded_side_data,
 +                                   &bsf->par_out->nb_coded_side_data,
 +                                   AV_PKT_DATA_DOVI_CONF);
@@ -70,7 +69,7 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
      return ff_cbs_bsf_generic_init(bsf, &h265_metadata_type);
  }
  
-@@ -478,6 +518,13 @@ static const AVOption h265_metadata_opti
+@@ -478,6 +517,13 @@ static const AVOption h265_metadata_opti
      { LEVEL("8.5", 255) },
  #undef LEVEL
  

--- a/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
+++ b/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
@@ -19,7 +19,7 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
  } H265MetadataContext;
  
  
-@@ -385,6 +388,40 @@ static int h265_metadata_update_fragment
+@@ -385,6 +388,37 @@ static int h265_metadata_update_fragment
              if (err < 0)
                  return err;
          }
@@ -32,9 +32,6 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
 +                ff_cbs_delete_unit(au, i);
 +                av_log(bsf, AV_LOG_DEBUG, "Removing Dolby Vision EL\n");
 +            }
-+            av_packet_side_data_remove(bsf->par_out->coded_side_data,
-+                                       &bsf->par_out->nb_coded_side_data,
-+                                       AV_PKT_DATA_DOVI_CONF);
 +        }
 +        if (ctx->remove_hdr10plus) {
 +            // This implementation is not strictly correct as it does not decode the entire NAL.
@@ -60,7 +57,20 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
      }
  
      return 0;
-@@ -478,6 +515,13 @@ static const AVOption h265_metadata_opti
+@@ -399,6 +433,12 @@ static const CBSBSFType h265_metadata_ty
+ 
+ static int h265_metadata_init(AVBSFContext *bsf)
+ {
++    if (((H265MetadataContext *)bsf->priv_data)->remove_dovi) {
++        av_log(bsf, AV_LOG_WARNING, "Removing Dolby Vision config\n");
++        av_packet_side_data_remove(bsf->par_out->coded_side_data,
++                                   &bsf->par_out->nb_coded_side_data,
++                                   AV_PKT_DATA_DOVI_CONF);
++    }
+     return ff_cbs_bsf_generic_init(bsf, &h265_metadata_type);
+ }
+ 
+@@ -478,6 +518,13 @@ static const AVOption h265_metadata_opti
      { LEVEL("8.5", 255) },
  #undef LEVEL
  

--- a/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
+++ b/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
@@ -1,0 +1,73 @@
+Index: FFmpeg/libavcodec/bsf/h265_metadata.c
+===================================================================
+--- FFmpeg.orig/libavcodec/bsf/h265_metadata.c
++++ FFmpeg/libavcodec/bsf/h265_metadata.c
+@@ -27,6 +27,7 @@
+ #include "h2645data.h"
+ #include "hevc.h"
+ #include "h265_profile_level.h"
++#include "itut35.h"
+ 
+ enum {
+     LEVEL_UNSET = -2,
+@@ -62,6 +63,8 @@ typedef struct H265MetadataContext {
+     int level;
+     int level_guess;
+     int level_warned;
++    int remove_dovi;
++    int remove_hdr10plus;
+ } H265MetadataContext;
+ 
+ 
+@@ -385,6 +388,37 @@ static int h265_metadata_update_fragment
+             if (err < 0)
+                 return err;
+         }
++        if (ctx->remove_dovi) {
++            if (au->units[i].type == HEVC_NAL_UNSPEC62) { // Dolby Vision RPU
++                ff_cbs_delete_unit(au, i);
++                av_log(bsf, AV_LOG_DEBUG, "Removing Dolby Vision RPU\n");
++            }
++            if (au->units[i].type == HEVC_NAL_UNSPEC63) { // Dolby Vision EL
++                ff_cbs_delete_unit(au, i);
++                av_log(bsf, AV_LOG_DEBUG, "Removing Dolby Vision EL\n");
++            }
++        }
++        if (ctx->remove_hdr10plus) {
++            // This implementation is not strictly correct as it does not decode the entire NAL.
++            // There could be multiple SEIs packed within a single NAL, and some of them may not be HDR10+ metadata.
++            // The current implementation simply removes the entire NAL without further inspection.
++            if (au->units[i].type == HEVC_NAL_SEI_PREFIX && au->units[i].data_size > 8 * sizeof(uint8_t)) {
++                uint8_t *nal_sei = au->units[i].data;
++                // This Matches ITU-T T.35 SMPTE ST 2094-40
++                if (nal_sei[0] == 0x4E && nal_sei[1] == 0x01 && nal_sei[2] == 0x04) {
++                    if (nal_sei[4] == ITU_T_T35_COUNTRY_CODE_US && nal_sei[6] == ITU_T_T35_PROVIDER_CODE_SMTPE) {
++                        // identifier for HDR10+
++                        const uint8_t smpte2094_40_provider_oriented_code = 0x01;
++                        const uint8_t smpte2094_40_application_identifier = 0x04;
++                        if (nal_sei[8] == smpte2094_40_provider_oriented_code && nal_sei[9] == smpte2094_40_application_identifier) {
++                            av_log(bsf, AV_LOG_DEBUG, "Found HDR10+ metadata, removing NAL\n");
++                            ff_cbs_delete_unit(au, i);
++                        }
++                    }
++
++                }
++            }
++        }
+     }
+ 
+     return 0;
+@@ -478,6 +512,13 @@ static const AVOption h265_metadata_opti
+     { LEVEL("8.5", 255) },
+ #undef LEVEL
+ 
++    { "remove_dovi", "Remove Dolby Vision BL and RPU",
++      OFFSET(remove_dovi), AV_OPT_TYPE_BOOL,
++      { .i64 = 0 }, 0, 1, FLAGS },
++    { "remove_hdr10plus", "Remove NALs including HDR10+ metadata",
++      OFFSET(remove_hdr10plus), AV_OPT_TYPE_BOOL,
++      { .i64 = 0 }, 0, 1, FLAGS },
++
+     { NULL }
+ };
+ 

--- a/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
+++ b/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
@@ -73,7 +73,7 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
      { LEVEL("8.5", 255) },
  #undef LEVEL
  
-+    { "remove_dovi", "Remove Dolby Vision BL and RPU",
++    { "remove_dovi", "Remove Dolby Vision EL and RPU",
 +      OFFSET(remove_dovi), AV_OPT_TYPE_BOOL,
 +      { .i64 = 0 }, 0, 1, FLAGS },
 +    { "remove_hdr10plus", "Remove NALs including HDR10+ metadata",

--- a/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
+++ b/debian/patches/0077-add-remove-dovi-hdr10plus-bsf.patch
@@ -19,7 +19,7 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
  } H265MetadataContext;
  
  
-@@ -385,6 +388,37 @@ static int h265_metadata_update_fragment
+@@ -385,6 +388,40 @@ static int h265_metadata_update_fragment
              if (err < 0)
                  return err;
          }
@@ -32,6 +32,9 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
 +                ff_cbs_delete_unit(au, i);
 +                av_log(bsf, AV_LOG_DEBUG, "Removing Dolby Vision EL\n");
 +            }
++            av_packet_side_data_remove(bsf->par_out->coded_side_data,
++                                       &bsf->par_out->nb_coded_side_data,
++                                       AV_PKT_DATA_DOVI_CONF);
 +        }
 +        if (ctx->remove_hdr10plus) {
 +            // This implementation is not strictly correct as it does not decode the entire NAL.
@@ -57,7 +60,7 @@ Index: FFmpeg/libavcodec/bsf/h265_metadata.c
      }
  
      return 0;
-@@ -478,6 +512,13 @@ static const AVOption h265_metadata_opti
+@@ -478,6 +515,13 @@ static const AVOption h265_metadata_opti
      { LEVEL("8.5", 255) },
  #undef LEVEL
  

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -74,3 +74,4 @@
 0074-fix-the-sub2video-perf-regressions.patch
 0075-allow-vpl-qsv-to-init-with-the-legacy-msdk-path.patch
 0076-alway-set-videotoolboxenc-pixel-buffer-info.patch
+0077-add-remove-dovi-hdr10plus-bsf.patch


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

This adds two options, `remove_dovi` and `remove_hdr10plus`, to the `hevc_metadata` bitstream filter. These options are useful in cases where certain types of dynamic metadata trigger player bugs, such as on some smart TVs and set-top boxes. With these options, clients can have the video remuxed with the selected dynamic metadata removed.

For example:

```
./ffmpeg -i 'hdr10+.mkv' -bsf:v hevc_metadata=remove_hdr10plus=1 -c:v copy -c:a copy -tag:v hvc1 hdr10.mkv
./ffmpeg -i 'dovi.mp4' -bsf:v hevc_metadata=remove_dovi=1 -c:v copy -c:a copy -tag:v hvc1 hdr10.mp4
```

One thing to note is that current ffmpeg implementation of matroska is bugged where it will always attempt to carry over dolby vision metadata when the input has one, and if that is removed by this bsf it will complain and exit. Fixing the mkv handling is out of the scope of this PR. The workaround is to use mp4 as target container when stripping dovi meatadata.

The upstream made an overhaul on the dovi rpu related code so this is not useful in the future when we upgrade to that version. A back-port might be too heavy as that is a big refactor.


**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->