### PR TITLE
Sync RKMPP fixes from ffmpeg-rockchip

### DIFF
--- a/builder/images/base-linux64/ct-ng-config
+++ b/builder/images/base-linux64/ct-ng-config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.26.0.106_ed12fa6 Configuration
+# crosstool-NG 1.26.0.120_4d36f27 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -29,7 +29,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.26.0.106_ed12fa6"
+CT_VERSION="1.26.0.120_4d36f27"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -384,7 +384,8 @@ CT_BINUTILS_PATCH_GLOBAL=y
 # CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
 # CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
-CT_BINUTILS_V_2_42=y
+CT_BINUTILS_V_2_43=y
+# CT_BINUTILS_V_2_42 is not set
 # CT_BINUTILS_V_2_41 is not set
 # CT_BINUTILS_V_2_40 is not set
 # CT_BINUTILS_V_2_39 is not set
@@ -401,7 +402,7 @@ CT_BINUTILS_V_2_42=y
 # CT_BINUTILS_V_2_28 is not set
 # CT_BINUTILS_V_2_27 is not set
 # CT_BINUTILS_V_2_26 is not set
-CT_BINUTILS_VERSION="2.42"
+CT_BINUTILS_VERSION="2.43.1"
 CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
 CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"

--- a/builder/images/base-linuxarm64/ct-ng-config
+++ b/builder/images/base-linuxarm64/ct-ng-config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.26.0.106_ed12fa6 Configuration
+# crosstool-NG 1.26.0.120_4d36f27 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -29,7 +29,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.26.0.106_ed12fa6"
+CT_VERSION="1.26.0.120_4d36f27"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -390,7 +390,8 @@ CT_BINUTILS_PATCH_GLOBAL=y
 # CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
 # CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
-CT_BINUTILS_V_2_42=y
+CT_BINUTILS_V_2_43=y
+# CT_BINUTILS_V_2_42 is not set
 # CT_BINUTILS_V_2_41 is not set
 # CT_BINUTILS_V_2_40 is not set
 # CT_BINUTILS_V_2_39 is not set
@@ -407,7 +408,7 @@ CT_BINUTILS_V_2_42=y
 # CT_BINUTILS_V_2_28 is not set
 # CT_BINUTILS_V_2_27 is not set
 # CT_BINUTILS_V_2_26 is not set
-CT_BINUTILS_VERSION="2.42"
+CT_BINUTILS_VERSION="2.43.1"
 CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
 CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"

--- a/builder/images/base-win64/ct-ng-config
+++ b/builder/images/base-win64/ct-ng-config
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# crosstool-NG 1.26.0.106_ed12fa6 Configuration
+# crosstool-NG 1.26.0.120_4d36f27 Configuration
 #
 CT_CONFIGURE_has_static_link=y
 CT_CONFIGURE_has_cxx11=y
@@ -29,7 +29,7 @@ CT_CONFIGURE_has_sha1sum=y
 CT_CONFIGURE_has_sha256sum=y
 CT_CONFIGURE_has_sha512sum=y
 CT_CONFIGURE_has_install_with_strip_program=y
-CT_VERSION="1.26.0.106_ed12fa6"
+CT_VERSION="1.26.0.120_4d36f27"
 CT_VCHECK=""
 CT_CONFIG_VERSION_ENV="4"
 CT_CONFIG_VERSION_CURRENT="4"
@@ -297,7 +297,8 @@ CT_BINUTILS_PATCH_GLOBAL=y
 # CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
 # CT_BINUTILS_PATCH_NONE is not set
 CT_BINUTILS_PATCH_ORDER="global"
-CT_BINUTILS_V_2_42=y
+CT_BINUTILS_V_2_43=y
+# CT_BINUTILS_V_2_42 is not set
 # CT_BINUTILS_V_2_41 is not set
 # CT_BINUTILS_V_2_40 is not set
 # CT_BINUTILS_V_2_39 is not set
@@ -314,7 +315,7 @@ CT_BINUTILS_V_2_42=y
 # CT_BINUTILS_V_2_28 is not set
 # CT_BINUTILS_V_2_27 is not set
 # CT_BINUTILS_V_2_26 is not set
-CT_BINUTILS_VERSION="2.42"
+CT_BINUTILS_VERSION="2.43.1"
 CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
 CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"

--- a/builder/scripts.d/10-mingw.sh
+++ b/builder/scripts.d/10-mingw.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://git.code.sf.net/p/mingw-w64/mingw-w64.git"
-SCRIPT_COMMIT="d2491a9358bddc9573d0ff2fa73989e3175c2009"
+SCRIPT_COMMIT="cdf6b16b805ce7d02f6b1b742911ba0770b49bbb"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] || return -1

--- a/builder/scripts.d/25-freetype.sh
+++ b/builder/scripts.d/25-freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/freetype/freetype.git"
-SCRIPT_COMMIT="c82745878da1acef2ce6bd7e17a8d59b8612d509"
+SCRIPT_COMMIT="139443663368617b30b70cf6912e9577ecbb845f"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-libxml2.sh
+++ b/builder/scripts.d/25-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="d67833a3c5db7999820a73e356327d47ec76bea9"
+SCRIPT_COMMIT="513949293d7ee2a11acc36bcdf5016a8fc5cc438"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/25-xz.sh
+++ b/builder/scripts.d/25-xz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/tukaani-project/xz.git"
-SCRIPT_COMMIT="v5.6.2"
+SCRIPT_COMMIT="v5.6.3"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/35-fontconfig.sh
+++ b/builder/scripts.d/35-fontconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/fontconfig/fontconfig.git"
-SCRIPT_COMMIT="bd83c04aa6f3cb864ba60dc5eaf2b41c4c269c63"
+SCRIPT_COMMIT="6d0580b2427f50b45e1432ba0fb6128c19b6dbd4"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/harfbuzz/harfbuzz.git"
-SCRIPT_COMMIT="c7ef6a2ed58ae8ec108ee0962bef46f42c73a60c"
+SCRIPT_COMMIT="825bc1964374eed7d19ffa327989d0ee841dda71"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/45-x11/10-xcbproto.sh
+++ b/builder/scripts.d/45-x11/10-xcbproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xcbproto.git"
-SCRIPT_COMMIT="77d7fc04da729ddc5ed4aacf30253726fac24dca"
+SCRIPT_COMMIT="4d2879ad9e394ff832762e8961eca9415cc9934c"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/10-xproto.sh
+++ b/builder/scripts.d/45-x11/10-xproto.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/proto/xorgproto.git"
-SCRIPT_COMMIT="3076552555c32cb89ec20ddef638317f0ea303b9"
+SCRIPT_COMMIT="af7cb6a643db810536605feab1402654a9818569"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/10-xtrans.sh
+++ b/builder/scripts.d/45-x11/10-xtrans.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libxtrans.git"
-SCRIPT_COMMIT="0f153064bfa4bb69e86f3f2383f2f421f2360319"
+SCRIPT_COMMIT="ae99ac32f61e0db92a45179579030a23fe1b5770"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/45-x11/40-libx11.sh
+++ b/builder/scripts.d/45-x11/40-libx11.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/xorg/lib/libx11.git"
-SCRIPT_COMMIT="86e71472bc826ac5c850e200cb3820485b5689cf"
+SCRIPT_COMMIT="f2ebbce6d0978d2d84f840196b03ee35a3ca1736"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-amf.sh
+++ b/builder/scripts.d/50-amf.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GPUOpen-LibrariesAndSDKs/AMF.git"
-SCRIPT_COMMIT="3db6164375ca62337e068193658f7cb10f0c42f9"
+SCRIPT_COMMIT="8e271daf1d6991337a87dec9355a2f11994d7292"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="f2c3ccd6a649a25d718cb0c8e8b6196fdbd2407f"
+SCRIPT_COMMIT="389450f61ea0b2057fc9ea393d3065859c4ba7f2"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libass.sh
+++ b/builder/scripts.d/50-libass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/libass/libass.git"
-SCRIPT_COMMIT="5298859c298d3c570d8d7e3b883a0d63490659b8"
+SCRIPT_COMMIT="6a759836e5e76bb7b69b0ac244eea76b0d290512"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/xiph/opus.git"
-SCRIPT_COMMIT="ff6dea5e1a72b8a2aeb7fc3656857d86a420ab89"
+SCRIPT_COMMIT="7db26934e4156597cb0586bb4d2e44dccdde1a59"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libvpx"
-SCRIPT_COMMIT="32de9c2becdd5d96d84d37be9f7fb9de43f24a4d"
+SCRIPT_COMMIT="906334ac1de2b0afa666472dce5545b82c1251fb"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-libwebp.sh
+++ b/builder/scripts.d/50-libwebp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://chromium.googlesource.com/webm/libwebp"
-SCRIPT_COMMIT="220ee52967c121adf3c690fbd0605a7de6371943"
+SCRIPT_COMMIT="dfdcb7f95ca280b2555020115b8f288a5a3453c2"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-openmpt.sh
+++ b/builder/scripts.d/50-openmpt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://source.openmpt.org/svn/openmpt/trunk/OpenMPT"
-SCRIPT_REV="21767"
+SCRIPT_REV="21833"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-rkmpp.sh
+++ b/builder/scripts.d/50-rkmpp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/nyanmisaka/mpp.git"
-SCRIPT_COMMIT="cfad02b76ad90e8e3ad765fef0382a1901e75895"
+SCRIPT_COMMIT="ba5c98ac8dbf485de9f03e625e1dd024afdc2eb9"
 SCRIPT_BRANCH="jellyfin-mpp"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-srt.sh
+++ b/builder/scripts.d/50-srt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/Haivision/srt.git"
-SCRIPT_COMMIT="a7b3711a8a862e697f641b296743cc7c921f5fba"
+SCRIPT_COMMIT="e2f133b95c06dd3c157b1669de34b2432e640029"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-svtav1.sh
+++ b/builder/scripts.d/50-svtav1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.com/AOMediaCodec/SVT-AV1.git"
-SCRIPT_COMMIT="aa853f1d4f31491916a9b6ccf16ab8be410de399"
+SCRIPT_COMMIT="34d4d591d87aeba6d347f09bfb5a7429fe58bd46"
 
 ffbuild_enabled() {
     [[ $TARGET == win32 ]] && return -1

--- a/builder/scripts.d/50-vulkan/45-vulkan.sh
+++ b/builder/scripts.d/50-vulkan/45-vulkan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/Vulkan-Headers.git"
-SCRIPT_COMMIT="v1.3.296"
+SCRIPT_COMMIT="v1.3.298"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-vulkan/55-spirv-cross.sh
+++ b/builder/scripts.d/50-vulkan/55-spirv-cross.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/SPIRV-Cross.git"
-SCRIPT_COMMIT="b28b3559d3882f918825cd90342dcfa955770bad"
+SCRIPT_COMMIT="e670b39cfced2f7258c73dc7cd708c6c639beaf0"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1

--- a/builder/scripts.d/50-x264.sh
+++ b/builder/scripts.d/50-x264.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/x264.git"
-SCRIPT_COMMIT="c24e06c2e184345ceb33eb20a15d1024d9fd3497"
+SCRIPT_COMMIT="1243d9ffb04dac7005ee9ecc79459034429dd5aa"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/builder/scripts.d/50-x265.sh
+++ b/builder/scripts.d/50-x265.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://bitbucket.org/multicoreware/x265_git.git"
-SCRIPT_COMMIT="26d2bab0063cee453b7d8012e76539a7786c032f"
+SCRIPT_COMMIT="487105dcd21d0f36a7a9e0ec50de85577b9bed04"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/debian/patches/0047-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0047-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -295,7 +295,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
   *
   * This file is part of FFmpeg.
   *
-@@ -19,569 +20,952 @@
+@@ -19,569 +20,1017 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
  
@@ -305,7 +305,11 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -#include <rockchip/rk_mpi.h>
 -#include <time.h>
 -#include <unistd.h>
--
++/**
++ * @file
++ * Rockchip MPP (Media Process Platform) video decoder
++ */
+ 
 -#include "avcodec.h"
 -#include "codec_internal.h"
 -#include "decode.h"
@@ -343,17 +347,14 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    MppFrame frame;
 -    AVBufferRef *decoder_ref;
 -} RKMPPFrameContext;
-+/**
-+ * @file
-+ * Rockchip MPP (Media Process Platform) video decoder
-+ */
-+
 +#include "config.h"
 +#include "config_components.h"
  
 -static MppCodingType rkmpp_get_codingtype(AVCodecContext *avctx)
 +#include "rkmppdec.h"
 +
++#include <fcntl.h>
++#include <unistd.h>
 +#if CONFIG_RKRGA
 +#include <rga/im2d.h>
 +#endif
@@ -387,6 +388,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    case MPP_FMT_YUV420SP_10BIT:    return DRM_FORMAT_NV15;
 +    case MPP_FMT_YUV422SP:          return DRM_FORMAT_NV16;
 +    case MPP_FMT_YUV422SP_10BIT:    return DRM_FORMAT_NV20;
++    case MPP_FMT_YUV444SP:          return DRM_FORMAT_NV24;
 +    default:                        return DRM_FORMAT_INVALID;
      }
  }
@@ -423,6 +425,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    case MPP_FMT_YUV420SP_10BIT:    return DRM_FORMAT_YUV420_10BIT;
 +    case MPP_FMT_YUV422SP:          return DRM_FORMAT_YUYV;
 +    case MPP_FMT_YUV422SP_10BIT:    return DRM_FORMAT_Y210;
++    case MPP_FMT_YUV444SP:          return DRM_FORMAT_VUY888;
 +    default:                        return DRM_FORMAT_INVALID;
      }
 -    else
@@ -439,6 +442,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    case MPP_FMT_YUV420SP_10BIT:    return AV_PIX_FMT_NV15;
 +    case MPP_FMT_YUV422SP:          return AV_PIX_FMT_NV16;
 +    case MPP_FMT_YUV422SP_10BIT:    return AV_PIX_FMT_NV20;
++    case MPP_FMT_YUV444SP:          return AV_PIX_FMT_NV24;
 +    default:                        return AV_PIX_FMT_NONE;
 +    }
  }
@@ -472,25 +476,57 @@ Index: FFmpeg/libavcodec/rkmppdec.c
  }
  
 -static void rkmpp_release_decoder(void *opaque, uint8_t *data)
-+static av_cold int rkmpp_decode_close(AVCodecContext *avctx)
++static void read_soc_name(AVCodecContext *avctx, char *name, int size)
  {
 -    RKMPPDecoder *decoder = (RKMPPDecoder *)data;
-+    RKMPPDecContext *r = avctx->priv_data;
++    const char *dt_path = "/proc/device-tree/compatible";
++    int fd = open(dt_path, O_RDONLY);
  
 -    if (decoder->mpi) {
 -        decoder->mpi->reset(decoder->ctx);
 -        mpp_destroy(decoder->ctx);
 -        decoder->ctx = NULL;
 -    }
++    if (fd < 0) {
++        av_log(avctx, AV_LOG_VERBOSE, "Unable to open '%s' for reading SoC name\n", dt_path);
++    } else {
++        ssize_t soc_name_len = 0;
++
++        snprintf(name, size - 1, "unknown");
++        soc_name_len = read(fd, name, size - 1);
++        if (soc_name_len > 0) {
++            name[soc_name_len] = '\0';
++            /* replacing the termination character to space */
++            for (char *ptr = name;; ptr = name) {
++                ptr += av_strnlen(name, size);
++                if (ptr >= name + soc_name_len - 1)
++                    break;
++                *ptr = ' ';
++            }
++
++            av_log(avctx, AV_LOG_VERBOSE, "Found SoC name from device-tree: '%s'\n", name);
++        }
+ 
+-    if (decoder->frame_group) {
+-        mpp_buffer_group_put(decoder->frame_group);
+-        decoder->frame_group = NULL;
++        close(fd);
+     }
++}
++
++static av_cold int rkmpp_decode_close(AVCodecContext *avctx)
++{
++    RKMPPDecContext *r = avctx->priv_data;
+ 
+-    av_buffer_unref(&decoder->frames_ref);
+-    av_buffer_unref(&decoder->device_ref);
 +    r->eof = 0;
 +    r->draining = 0;
 +    r->info_change = 0;
 +    r->errinfo_cnt = 0;
 +    r->got_frame = 0;
- 
--    if (decoder->frame_group) {
--        mpp_buffer_group_put(decoder->frame_group);
--        decoder->frame_group = NULL;
++    r->use_rfbc = 0;
++
 +    if (r->mapi) {
 +        r->mapi->reset(r->mctx);
 +        mpp_destroy(r->mctx);
@@ -500,10 +536,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        r->buf_mode == RKMPP_DEC_PURE_EXTERNAL) {
 +        mpp_buffer_group_put(r->buf_group);
 +        r->buf_group = NULL;
-     }
- 
--    av_buffer_unref(&decoder->frames_ref);
--    av_buffer_unref(&decoder->device_ref);
++    }
++
 +    if (r->hwframe)
 +        av_buffer_unref(&r->hwframe);
 +    if (r->hwdevice)
@@ -526,6 +560,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    avctx->pix_fmt = AV_PIX_FMT_DRM_PRIME;
 +    RKMPPDecContext *r = avctx->priv_data;
 +    MppCodingType coding_type = MPP_VIDEO_CodingUnused;
++    char soc_name[MAX_SOC_NAME_LENGTH];
 +    int ret, is_fmt_supported = 0;
 +    enum AVPixelFormat pix_fmts[3] = { AV_PIX_FMT_DRM_PRIME,
 +                                       AV_PIX_FMT_NV12,
@@ -534,9 +569,11 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    switch (avctx->pix_fmt) {
 +    case AV_PIX_FMT_YUV420P:
 +    case AV_PIX_FMT_YUVJ420P:
++        pix_fmts[1] = AV_PIX_FMT_NV12;
 +        is_fmt_supported = 1;
 +        break;
 +    case AV_PIX_FMT_YUV420P10:
++        pix_fmts[1] = AV_PIX_FMT_NV15;
 +        is_fmt_supported =
 +            avctx->codec_id == AV_CODEC_ID_H264 ||
 +            avctx->codec_id == AV_CODEC_ID_HEVC ||
@@ -544,9 +581,19 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            avctx->codec_id == AV_CODEC_ID_AV1;
 +        break;
 +    case AV_PIX_FMT_YUV422P:
-+    case AV_PIX_FMT_YUV422P10:
++        pix_fmts[1] = AV_PIX_FMT_NV16;
 +        is_fmt_supported =
 +            avctx->codec_id == AV_CODEC_ID_H264;
++        break;
++    case AV_PIX_FMT_YUV422P10:
++        pix_fmts[1] = AV_PIX_FMT_NV20;
++        is_fmt_supported =
++            avctx->codec_id == AV_CODEC_ID_H264;
++        break;
++    case AV_PIX_FMT_YUV444P:
++        pix_fmts[1] = AV_PIX_FMT_NV24;
++        is_fmt_supported =
++            avctx->codec_id == AV_CODEC_ID_HEVC;
 +        break;
 +    case AV_PIX_FMT_NONE: /* fallback to drm_prime */
 +        is_fmt_supported = 1;
@@ -645,16 +692,27 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    if (avctx->pix_fmt != AV_PIX_FMT_DRM_PRIME)
 +        r->afbc = 0;
 +
++    if (r->afbc > RKMPP_DEC_AFBC_OFF) {
++        read_soc_name(avctx, soc_name, sizeof(soc_name));
++        r->use_rfbc = !!strstr(soc_name, "rk3576");
++    }
++
 +    if (r->afbc == RKMPP_DEC_AFBC_ON_RGA) {
 +#if CONFIG_RKRGA
 +        const char *rga_ver = querystring(RGA_VERSION);
-+        int has_rga3 = !!strstr(rga_ver, "RGA_3");
-+        int is_rga3_compat = avctx->width >= 68 &&
-+                             avctx->width <= 8176 &&
-+                             avctx->height >= 2 &&
-+                             avctx->height <= 8176;
++        int has_rga2p = !!strstr(rga_ver, "RGA_2_PRO");
++        int has_rga3  = !!strstr(rga_ver, "RGA_3");
++        int is_rga2p_compat = avctx->width >= 2 &&
++                              avctx->width <= 8192 &&
++                              avctx->height >= 2 &&
++                              avctx->height <= 8192;
++        int is_rga3_compat  = avctx->width >= 68 &&
++                              avctx->width <= 8176 &&
++                              avctx->height >= 2 &&
++                              avctx->height <= 8176;
 +
-+        if (!has_rga3 || !is_rga3_compat) {
++        r->use_rfbc = r->use_rfbc || has_rga2p;
++        if (!((has_rga2p && is_rga2p_compat) || (has_rga3 && is_rga3_compat))) {
 +#endif
 +            av_log(avctx, AV_LOG_VERBOSE, "AFBC is requested without capable RGA, ignoring\n");
 +            r->afbc = RKMPP_DEC_AFBC_OFF;
@@ -725,6 +783,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +{
 +    RKMPPDecContext *r = avctx->priv_data;
 +    AVHWFramesContext *hwfc = NULL;
++    AVRKMPPFramesContext *rkmpp_fc = NULL;
 +    int i, ret, decoder_pool_size;
 +
 +    if (!r->hwdevice)
@@ -752,15 +811,15 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    hwfc->width     = FFALIGN(width,  16);
 +    hwfc->height    = FFALIGN(height, 16);
 +
-+    if (r->buf_mode == RKMPP_DEC_HALF_INTERNAL) {
-+        AVRKMPPFramesContext *rkmpp_fc = NULL;
++    rkmpp_fc = hwfc->hwctx;
++    rkmpp_fc->flags |= MPP_BUFFER_FLAGS_CACHABLE;
 +
++    if (r->buf_mode == RKMPP_DEC_HALF_INTERNAL) {
 +        if ((ret = av_hwframe_ctx_init(r->hwframe)) < 0) {
 +            av_log(avctx, AV_LOG_ERROR, "Failed to init RKMPP frame pool\n");
 +            goto fail;
 +        }
 +
-+        rkmpp_fc = hwfc->hwctx;
 +        r->buf_group = rkmpp_fc->buf_group;
 +        goto attach;
 +    } else if (r->buf_mode != RKMPP_DEC_PURE_EXTERNAL) {
@@ -941,7 +1000,10 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    AVBufferRef *framecontextref = (AVBufferRef *)opaque;
 -    RKMPPFrameContext *framecontext = (RKMPPFrameContext *)framecontextref->data;
 +    AVContentLightMetadata *light = NULL;
-+
+ 
+-    mpp_frame_deinit(&framecontext->frame);
+-    av_buffer_unref(&framecontext->decoder_ref);
+-    av_buffer_unref(&framecontextref);
 +    AVFrameSideData *sd = av_frame_get_side_data(frame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
 +    if (sd)
 +        light = (AVContentLightMetadata *)sd->data;
@@ -953,21 +1015,12 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    light->MaxCLL  = mpp_light.MaxCLL;
 +    light->MaxFALL = mpp_light.MaxFALL;
  
--    mpp_frame_deinit(&framecontext->frame);
--    av_buffer_unref(&framecontext->decoder_ref);
--    av_buffer_unref(&framecontextref);
-+    return 0;
-+}
- 
 -    av_free(desc);
-+static void rkmpp_free_mpp_frame(void *opaque, uint8_t *data)
-+{
-+    MppFrame mpp_frame = (MppFrame)opaque;
-+    mpp_frame_deinit(&mpp_frame);
++    return 0;
  }
  
 -static int rkmpp_retrieve_frame(AVCodecContext *avctx, AVFrame *frame)
-+static void rkmpp_free_drm_desc(void *opaque, uint8_t *data)
++static void rkmpp_free_mpp_frame(void *opaque, uint8_t *data)
  {
 -    RKMPPDecodeContext *rk_context = avctx->priv_data;
 -    RKMPPDecoder *decoder = (RKMPPDecoder *)rk_context->decoder_ref->data;
@@ -977,6 +1030,12 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    MppFrame mppframe = NULL;
 -    MppBuffer buffer = NULL;
 -    AVDRMFrameDescriptor *desc = NULL;
++    MppFrame mpp_frame = (MppFrame)opaque;
++    mpp_frame_deinit(&mpp_frame);
++}
++
++static void rkmpp_free_drm_desc(void *opaque, uint8_t *data)
++{
 +    AVRKMPPDRMFrameDescriptor *drm_desc = (AVRKMPPDRMFrameDescriptor *)opaque;
 +    av_free(drm_desc);
 +}
@@ -1037,7 +1096,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +
 +    if (is_afbc) {
 +        desc->drm_desc.objects[0].format_modifier =
-+            DRM_FORMAT_MOD_ARM_AFBC(AFBC_FORMAT_MOD_SPARSE | AFBC_FORMAT_MOD_BLOCK_SIZE_16x16);
++            r->use_rfbc ? DRM_FORMAT_MOD_ROCKCHIP_RFBC(ROCKCHIP_RFBC_BLOCK_SIZE_64x4)
++                        : DRM_FORMAT_MOD_ARM_AFBC(AFBC_FORMAT_MOD_SPARSE | AFBC_FORMAT_MOD_BLOCK_SIZE_16x16);
 +
 +        layer->format = rkmpp_get_drm_afbc_format(mpp_fmt);
 +        layer->nb_planes = 1;
@@ -1053,7 +1113,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            return ret;
 +
 +        /* MPP specific AFBC src_y offset, not memory address offset */
-+        frame->crop_top = mpp_frame_get_offset_y(mpp_frame);
++        frame->crop_top = r->use_rfbc ? 0 : mpp_frame_get_offset_y(mpp_frame);
 +    } else {
 +        layer->format = rkmpp_get_drm_format(mpp_fmt);
 +        layer->nb_planes = 2;
@@ -1063,6 +1123,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        layer->planes[1].object_index = 0;
 +        layer->planes[1].offset = layer->planes[0].pitch * mpp_frame_get_ver_stride(mpp_frame);
 +        layer->planes[1].pitch  = layer->planes[0].pitch;
++
++        if (avctx->sw_pix_fmt == AV_PIX_FMT_NV24)
++            layer->planes[1].pitch *= 2;
      }
  
 -    if (mppframe) {
@@ -1125,11 +1188,15 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        if (ret < 0)
 +            return ret;
 +    }
++
++    return 0;
++}
  
 -            mppformat = mpp_frame_get_fmt(mppframe);
 -            drmformat = rkmpp_get_frameformat(mppformat);
-+    return 0;
-+}
++static void rkmpp_export_avctx_color_props(AVCodecContext *avctx, MppFrame mpp_frame)
++{
++    int val;
  
 -            hwframes = (AVHWFramesContext*)decoder->frames_ref->data;
 -            hwframes->format    = AV_PIX_FMT_DRM_PRIME;
@@ -1139,9 +1206,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -            ret = av_hwframe_ctx_init(decoder->frames_ref);
 -            if (ret < 0)
 -                goto fail;
-+static void rkmpp_export_avctx_color_props(AVCodecContext *avctx, MppFrame mpp_frame)
-+{
-+    int val;
++    if (!avctx || !mpp_frame)
++        return;
  
 -            // here decoder is fully initialized, we need to feed it again with data
 -            ret = AVERROR(EAGAIN);
@@ -1149,142 +1215,49 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -        } else if (mpp_frame_get_eos(mppframe)) {
 -            av_log(avctx, AV_LOG_DEBUG, "Received a EOS frame.\n");
 -            decoder->eos_reached = 1;
--            ret = AVERROR_EOF;
--            goto fail;
--        } else if (mpp_frame_get_discard(mppframe)) {
--            av_log(avctx, AV_LOG_DEBUG, "Received a discard frame.\n");
--            ret = AVERROR(EAGAIN);
--            goto fail;
--        } else if (mpp_frame_get_errinfo(mppframe)) {
--            av_log(avctx, AV_LOG_ERROR, "Received a errinfo frame.\n");
--            ret = AVERROR_UNKNOWN;
--            goto fail;
--        }
-+    if (!avctx || !mpp_frame)
-+        return;
- 
--        // here we should have a valid frame
--        av_log(avctx, AV_LOG_DEBUG, "Received a frame.\n");
 +    if (avctx->color_primaries == AVCOL_PRI_RESERVED0)
 +        avctx->color_primaries = AVCOL_PRI_UNSPECIFIED;
 +    if ((val = mpp_frame_get_color_primaries(mpp_frame)) &&
 +        val != MPP_FRAME_PRI_RESERVED0 &&
 +        val != MPP_FRAME_PRI_UNSPECIFIED)
 +        avctx->color_primaries = val;
- 
--        // setup general frame fields
--        frame->format           = AV_PIX_FMT_DRM_PRIME;
--        frame->width            = mpp_frame_get_width(mppframe);
--        frame->height           = mpp_frame_get_height(mppframe);
--        frame->pts              = mpp_frame_get_pts(mppframe);
--        frame->color_range      = mpp_frame_get_color_range(mppframe);
--        frame->color_primaries  = mpp_frame_get_color_primaries(mppframe);
--        frame->color_trc        = mpp_frame_get_color_trc(mppframe);
--        frame->colorspace       = mpp_frame_get_colorspace(mppframe);
--
--        mode = mpp_frame_get_mode(mppframe);
--        if ((mode & MPP_FRAME_FLAG_FIELD_ORDER_MASK) == MPP_FRAME_FLAG_DEINTERLACED)
--            frame->flags |= AV_FRAME_FLAG_INTERLACED;
--        if ((mode & MPP_FRAME_FLAG_FIELD_ORDER_MASK) == MPP_FRAME_FLAG_TOP_FIRST)
--            frame->flags |= AV_FRAME_FLAG_TOP_FIELD_FIRST;
--
--        mppformat = mpp_frame_get_fmt(mppframe);
--        drmformat = rkmpp_get_frameformat(mppformat);
--
--        // now setup the frame buffer info
--        buffer = mpp_frame_get_buffer(mppframe);
--        if (buffer) {
--            desc = av_mallocz(sizeof(AVDRMFrameDescriptor));
--            if (!desc) {
--                ret = AVERROR(ENOMEM);
--                goto fail;
--            }
++
 +    if (avctx->color_trc == AVCOL_TRC_RESERVED0)
 +        avctx->color_trc = AVCOL_TRC_UNSPECIFIED;
 +    if ((val = mpp_frame_get_color_trc(mpp_frame)) &&
 +        val != MPP_FRAME_TRC_RESERVED0 &&
 +        val != MPP_FRAME_TRC_UNSPECIFIED)
 +        avctx->color_trc = val;
- 
--            desc->nb_objects = 1;
--            desc->objects[0].fd = mpp_buffer_get_fd(buffer);
--            desc->objects[0].size = mpp_buffer_get_size(buffer);
--
--            desc->nb_layers = 1;
--            layer = &desc->layers[0];
--            layer->format = drmformat;
--            layer->nb_planes = 2;
--
--            layer->planes[0].object_index = 0;
--            layer->planes[0].offset = 0;
--            layer->planes[0].pitch = mpp_frame_get_hor_stride(mppframe);
--
--            layer->planes[1].object_index = 0;
--            layer->planes[1].offset = layer->planes[0].pitch * mpp_frame_get_ver_stride(mppframe);
--            layer->planes[1].pitch = layer->planes[0].pitch;
--
--            // we also allocate a struct in buf[0] that will allow to hold additionnal information
--            // for releasing properly MPP frames and decoder
--            framecontextref = av_buffer_allocz(sizeof(*framecontext));
--            if (!framecontextref) {
--                ret = AVERROR(ENOMEM);
--                goto fail;
--            }
++
 +    if (avctx->colorspace == AVCOL_SPC_RESERVED)
 +        avctx->colorspace = AVCOL_SPC_UNSPECIFIED;
 +    if ((val = mpp_frame_get_colorspace(mpp_frame)) &&
 +        val != MPP_FRAME_SPC_RESERVED &&
 +        val != MPP_FRAME_SPC_UNSPECIFIED)
 +        avctx->colorspace = val;
- 
--            // MPP decoder needs to be closed only when all frames have been released.
--            framecontext = (RKMPPFrameContext *)framecontextref->data;
--            framecontext->decoder_ref = av_buffer_ref(rk_context->decoder_ref);
--            framecontext->frame = mppframe;
--
--            frame->data[0]  = (uint8_t *)desc;
--            frame->buf[0]   = av_buffer_create((uint8_t *)desc, sizeof(*desc), rkmpp_release_frame,
--                                               framecontextref, AV_BUFFER_FLAG_READONLY);
++
 +    if ((val = mpp_frame_get_color_range(mpp_frame)) > MPP_FRAME_RANGE_UNSPECIFIED)
 +        avctx->color_range = val;
- 
--            if (!frame->buf[0]) {
--                ret = AVERROR(ENOMEM);
--                goto fail;
--            }
++
 +    if ((val = mpp_frame_get_chroma_location(mpp_frame)) > MPP_CHROMA_LOC_UNSPECIFIED)
 +        avctx->chroma_sample_location = val;
 +}
- 
--            frame->hw_frames_ctx = av_buffer_ref(decoder->frames_ref);
--            if (!frame->hw_frames_ctx) {
--                ret = AVERROR(ENOMEM);
--                goto fail;
--            }
++
 +static int rkmpp_get_frame(AVCodecContext *avctx, AVFrame *frame, int timeout)
 +{
 +    RKMPPDecContext *r = avctx->priv_data;
 +    MppFrame mpp_frame = NULL;
 +    int ret;
- 
--            return 0;
--        } else {
--            av_log(avctx, AV_LOG_ERROR, "Failed to retrieve the frame buffer, frame is dropped (code = %d)\n", ret);
--            mpp_frame_deinit(&mppframe);
--        }
--    } else if (decoder->eos_reached) {
++
 +    /* should not provide any frame after EOS */
 +    if (r->eof)
-         return AVERROR_EOF;
--    } else if (ret == MPP_ERR_TIMEOUT) {
--        av_log(avctx, AV_LOG_DEBUG, "Timeout when trying to get a frame from MPP\n");
++        return AVERROR_EOF;
 +
 +    if ((ret = r->mapi->control(r->mctx, MPP_SET_OUTPUT_TIMEOUT, (MppParam)&timeout)) != MPP_OK) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to set output timeout: %d\n", ret);
 +        return AVERROR_EXTERNAL;
-     }
- 
--    return AVERROR(EAGAIN);
++    }
++
 +    ret = r->mapi->decode_get_frame(r->mctx, &mpp_frame);
 +    if (ret != MPP_OK && ret != MPP_ERR_TIMEOUT) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to get frame: %d\n", ret);
@@ -1300,7 +1273,16 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        /* EOS frame may contain valid data */
 +        if (!mpp_frame_get_buffer(mpp_frame)) {
 +            r->eof = 1;
-+            ret = AVERROR_EOF;
+             ret = AVERROR_EOF;
+-            goto fail;
+-        } else if (mpp_frame_get_discard(mppframe)) {
+-            av_log(avctx, AV_LOG_DEBUG, "Received a discard frame.\n");
+-            ret = AVERROR(EAGAIN);
+-            goto fail;
+-        } else if (mpp_frame_get_errinfo(mppframe)) {
+-            av_log(avctx, AV_LOG_ERROR, "Received a errinfo frame.\n");
+-            ret = AVERROR_UNKNOWN;
+-            goto fail;
 +            goto exit;
 +        }
 +    }
@@ -1328,15 +1310,64 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        if (r->afbc && !(mpp_fmt & MPP_FRAME_FBC_MASK)) {
 +            av_log(avctx, AV_LOG_VERBOSE, "AFBC is requested but not supported\n");
 +            r->afbc = 0;
-+        }
+         }
  
--fail:
--    if (mppframe)
--        mpp_frame_deinit(&mppframe);
+-        // here we should have a valid frame
+-        av_log(avctx, AV_LOG_DEBUG, "Received a frame.\n");
+-
+-        // setup general frame fields
+-        frame->format           = AV_PIX_FMT_DRM_PRIME;
+-        frame->width            = mpp_frame_get_width(mppframe);
+-        frame->height           = mpp_frame_get_height(mppframe);
+-        frame->pts              = mpp_frame_get_pts(mppframe);
+-        frame->color_range      = mpp_frame_get_color_range(mppframe);
+-        frame->color_primaries  = mpp_frame_get_color_primaries(mppframe);
+-        frame->color_trc        = mpp_frame_get_color_trc(mppframe);
+-        frame->colorspace       = mpp_frame_get_colorspace(mppframe);
+-
+-        mode = mpp_frame_get_mode(mppframe);
+-        if ((mode & MPP_FRAME_FLAG_FIELD_ORDER_MASK) == MPP_FRAME_FLAG_DEINTERLACED)
+-            frame->flags |= AV_FRAME_FLAG_INTERLACED;
+-        if ((mode & MPP_FRAME_FLAG_FIELD_ORDER_MASK) == MPP_FRAME_FLAG_TOP_FIRST)
+-            frame->flags |= AV_FRAME_FLAG_TOP_FIELD_FIRST;
+-
+-        mppformat = mpp_frame_get_fmt(mppframe);
+-        drmformat = rkmpp_get_frameformat(mppformat);
+-
+-        // now setup the frame buffer info
+-        buffer = mpp_frame_get_buffer(mppframe);
+-        if (buffer) {
+-            desc = av_mallocz(sizeof(AVDRMFrameDescriptor));
+-            if (!desc) {
+-                ret = AVERROR(ENOMEM);
+-                goto fail;
+-            }
 +        pix_fmts[1] = rkmpp_get_av_format(mpp_fmt & MPP_FRAME_FMT_MASK);
  
--    if (framecontext)
--        av_buffer_unref(&framecontext->decoder_ref);
+-            desc->nb_objects = 1;
+-            desc->objects[0].fd = mpp_buffer_get_fd(buffer);
+-            desc->objects[0].size = mpp_buffer_get_size(buffer);
+-
+-            desc->nb_layers = 1;
+-            layer = &desc->layers[0];
+-            layer->format = drmformat;
+-            layer->nb_planes = 2;
+-
+-            layer->planes[0].object_index = 0;
+-            layer->planes[0].offset = 0;
+-            layer->planes[0].pitch = mpp_frame_get_hor_stride(mppframe);
+-
+-            layer->planes[1].object_index = 0;
+-            layer->planes[1].offset = layer->planes[0].pitch * mpp_frame_get_ver_stride(mppframe);
+-            layer->planes[1].pitch = layer->planes[0].pitch;
+-
+-            // we also allocate a struct in buf[0] that will allow to hold additionnal information
+-            // for releasing properly MPP frames and decoder
+-            framecontextref = av_buffer_allocz(sizeof(*framecontext));
+-            if (!framecontextref) {
+-                ret = AVERROR(ENOMEM);
+-                goto fail;
+-            }
 +        if (avctx->pix_fmt == AV_PIX_FMT_DRM_PRIME)
 +            avctx->sw_pix_fmt = pix_fmts[1];
 +        else {
@@ -1345,8 +1376,14 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            avctx->pix_fmt = ret;
 +        }
  
--    if (framecontextref)
--        av_buffer_unref(&framecontextref);
+-            // MPP decoder needs to be closed only when all frames have been released.
+-            framecontext = (RKMPPFrameContext *)framecontextref->data;
+-            framecontext->decoder_ref = av_buffer_ref(rk_context->decoder_ref);
+-            framecontext->frame = mppframe;
+-
+-            frame->data[0]  = (uint8_t *)desc;
+-            frame->buf[0]   = av_buffer_create((uint8_t *)desc, sizeof(*desc), rkmpp_release_frame,
+-                                               framecontextref, AV_BUFFER_FLAG_READONLY);
 +        avctx->width        = mpp_frame_get_width(mpp_frame);
 +        avctx->height       = mpp_frame_get_height(mpp_frame);
 +        avctx->coded_width  = FFALIGN(avctx->width,  64);
@@ -1373,8 +1410,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            goto exit;
 +        }
  
--    if (desc)
--        av_free(desc);
+-            if (!frame->buf[0]) {
+-                ret = AVERROR(ENOMEM);
+-                goto fail;
 +        if ((ret = r->mapi->control(r->mctx, MPP_DEC_SET_INFO_CHANGE_READY, NULL)) != MPP_OK) {
 +            av_log(avctx, AV_LOG_ERROR, "Failed to set info change ready: %d\n", ret);
 +            ret = AVERROR_EXTERNAL;
@@ -1392,10 +1430,16 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                if ((ret = rkmpp_export_frame(avctx, frame, mpp_frame)) < 0)
 +                    goto exit;
 +                return 0;
-+            }
+             }
+-
+-            frame->hw_frames_ctx = av_buffer_ref(decoder->frames_ref);
+-            if (!frame->hw_frames_ctx) {
+-                ret = AVERROR(ENOMEM);
+-                goto fail;
 +            break;
 +        case AV_PIX_FMT_NV12:
 +        case AV_PIX_FMT_NV16:
++        case AV_PIX_FMT_NV24:
 +        case AV_PIX_FMT_NV15:
 +        case AV_PIX_FMT_NV20:
 +            {
@@ -1424,7 +1468,12 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                }
 +                av_frame_free(&tmp_frame);
 +                return 0;
-+            }
+             }
+-
+-            return 0;
+-        } else {
+-            av_log(avctx, AV_LOG_ERROR, "Failed to retrieve the frame buffer, frame is dropped (code = %d)\n", ret);
+-            mpp_frame_deinit(&mppframe);
 +            break;
 +        default:
 +            {
@@ -1432,17 +1481,54 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                goto exit;
 +            }
 +            break;
-+        }
-+    }
+         }
+-    } else if (decoder->eos_reached) {
+-        return AVERROR_EOF;
+-    } else if (ret == MPP_ERR_TIMEOUT) {
+-        av_log(avctx, AV_LOG_DEBUG, "Timeout when trying to get a frame from MPP\n");
+     }
  
+-    return AVERROR(EAGAIN);
 +exit:
 +    if (mpp_frame)
 +        mpp_frame_deinit(&mpp_frame);
-     return ret;
++    return ret;
++}
+ 
+-fail:
+-    if (mppframe)
+-        mpp_frame_deinit(&mppframe);
++static int rkmpp_send_eos(AVCodecContext *avctx)
++{
++    RKMPPDecContext *r = avctx->priv_data;
++    MppPacket mpp_pkt = NULL;
++    int ret;
+ 
+-    if (framecontext)
+-        av_buffer_unref(&framecontext->decoder_ref);
++    if ((ret = mpp_packet_init(&mpp_pkt, NULL, 0)) != MPP_OK) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to init 'EOS' packet: %d\n", ret);
++        return AVERROR_EXTERNAL;
++    }
++    mpp_packet_set_eos(mpp_pkt);
+ 
+-    if (framecontextref)
+-        av_buffer_unref(&framecontextref);
++    do {
++        ret = r->mapi->decode_put_packet(r->mctx, mpp_pkt);
++    } while (ret != MPP_OK);
+ 
+-    if (desc)
+-        av_free(desc);
++    r->draining = 1;
+ 
+-    return ret;
++    mpp_packet_deinit(&mpp_pkt);
++    return 0;
  }
  
 -static int rkmpp_receive_frame(AVCodecContext *avctx, AVFrame *frame)
-+static int rkmpp_send_eos(AVCodecContext *avctx)
++static int rkmpp_send_packet(AVCodecContext *avctx, AVPacket *pkt)
  {
 -    RKMPPDecodeContext *rk_context = avctx->priv_data;
 -    RKMPPDecoder *decoder = (RKMPPDecoder *)rk_context->decoder_ref->data;
@@ -1459,6 +1545,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -        }
 +    RKMPPDecContext *r = avctx->priv_data;
 +    MppPacket mpp_pkt = NULL;
++    int64_t pts = PTS_TO_MPP_PTS(pkt->pts, avctx->pkt_timebase);
 +    int ret;
  
 -        freeslots = INPUT_MAX_PACKETS - usedslots;
@@ -1467,34 +1554,6 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -            if (ret < 0 && ret != AVERROR_EOF) {
 -                return ret;
 -            }
-+    if ((ret = mpp_packet_init(&mpp_pkt, NULL, 0)) != MPP_OK) {
-+        av_log(avctx, AV_LOG_ERROR, "Failed to init 'EOS' packet: %d\n", ret);
-+        return AVERROR_EXTERNAL;
-+    }
-+    mpp_packet_set_eos(mpp_pkt);
- 
--            ret = rkmpp_send_packet(avctx, &pkt);
--            av_packet_unref(&pkt);
-+    do {
-+        ret = r->mapi->decode_put_packet(r->mctx, mpp_pkt);
-+    } while (ret != MPP_OK);
- 
--            if (ret < 0) {
--                av_log(avctx, AV_LOG_ERROR, "Failed to send packet to decoder (code = %d)\n", ret);
--                return ret;
-+    r->draining = 1;
-+
-+    mpp_packet_deinit(&mpp_pkt);
-+    return 0;
-+}
-+
-+static int rkmpp_send_packet(AVCodecContext *avctx, AVPacket *pkt)
-+{
-+    RKMPPDecContext *r = avctx->priv_data;
-+    MppPacket mpp_pkt = NULL;
-+    int64_t pts = PTS_TO_MPP_PTS(pkt->pts, avctx->pkt_timebase);
-+    int ret;
-+
 +    /* avoid sending new data after EOS */
 +    if (r->draining)
 +        return AVERROR(EOF);
@@ -1520,11 +1579,16 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        return AVERROR(EAGAIN);
 +    }
 +    av_log(avctx, AV_LOG_DEBUG, "Wrote %d bytes to decoder\n", pkt->size);
-+
+ 
+-            ret = rkmpp_send_packet(avctx, &pkt);
+-            av_packet_unref(&pkt);
 +    mpp_packet_deinit(&mpp_pkt);
 +    return 0;
 +}
-+
+ 
+-            if (ret < 0) {
+-                av_log(avctx, AV_LOG_ERROR, "Failed to send packet to decoder (code = %d)\n", ret);
+-                return ret;
 +static int rkmpp_decode_receive_frame(AVCodecContext *avctx, AVFrame *frame)
 +{
 +    RKMPPDecContext *r = avctx->priv_data;
@@ -1685,7 +1749,7 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppdec.h
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,147 @@
 +/*
 + * Copyright (c) 2017 Lionel CHAZALLON
 + * Copyright (c) 2023 Huseyin BIYIK
@@ -1723,12 +1787,14 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 +#include "hwconfig.h"
 +#include "internal.h"
 +
++#include "libavutil/avstring.h"
 +#include "libavutil/hwcontext_rkmpp.h"
 +#include "libavutil/mastering_display_metadata.h"
 +#include "libavutil/opt.h"
 +#include "libavutil/pixdesc.h"
 +
-+#define MAX_ERRINFO_COUNT 100
++#define MAX_ERRINFO_COUNT   100
++#define MAX_SOC_NAME_LENGTH 128
 +
 +typedef struct RKMPPDecContext {
 +    AVClass       *class;
@@ -1746,6 +1812,7 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 +    int            info_change;
 +    int            errinfo_cnt;
 +    int            got_frame;
++    int            use_rfbc;
 +
 +    int            deint;
 +    int            afbc;
@@ -1834,7 +1901,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppenc.c
-@@ -0,0 +1,1103 @@
+@@ -0,0 +1,1114 @@
 +/*
 + * Copyright (c) 2023 Huseyin BIYIK
 + * Copyright (c) 2023 NyanMisaka
@@ -2096,6 +2163,11 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +
 +    pix_desc = av_pix_fmt_desc_get(r->pix_fmt);
 +    is_afbc = drm_is_afbc(drm_desc->objects[0].format_modifier);
++    if (!is_afbc &&
++        drm_desc->objects[0].format_modifier != DRM_FORMAT_MOD_LINEAR) {
++        av_log(avctx, AV_LOG_ERROR, "Only linear and AFBC modifiers are supported\n");
++        return AVERROR(ENOSYS);
++    }
 +    if (is_afbc &&
 +        !(avctx->codec_id == AV_CODEC_ID_H264 ||
 +          avctx->codec_id == AV_CODEC_ID_HEVC)) {
@@ -2369,7 +2441,8 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +            return AVERROR_EXTERNAL;
 +        }
 +
-+        header_mode = MPP_ENC_HEADER_MODE_EACH_IDR;
++        header_mode = (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER)
++                      ? MPP_ENC_HEADER_MODE_DEFAULT : MPP_ENC_HEADER_MODE_EACH_IDR;
 +        if ((ret = r->mapi->control(r->mctx, MPP_ENC_SET_HEADER_MODE, &header_mode)) != MPP_OK) {
 +            av_log(avctx, AV_LOG_ERROR, "Failed to set header mode: %d\n", ret);
 +            return AVERROR_EXTERNAL;
@@ -2473,6 +2546,11 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    plane0 = &layer->planes[0];
 +
 +    is_afbc = drm_is_afbc(drm_desc->objects[0].format_modifier);
++    if (!is_afbc &&
++        drm_desc->objects[0].format_modifier != DRM_FORMAT_MOD_LINEAR) {
++        av_log(avctx, AV_LOG_ERROR, "Only linear and AFBC modifiers are supported\n");
++        goto exit;
++    }
 +    if (is_afbc &&
 +        !(avctx->codec_id == AV_CODEC_ID_H264 ||
 +          avctx->codec_id == AV_CODEC_ID_HEVC)) {
@@ -3295,7 +3373,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/rkrga_common.c
-@@ -0,0 +1,1249 @@
+@@ -0,0 +1,1324 @@
 +/*
 + * Copyright (c) 2023 NyanMisaka
 + *
@@ -3340,6 +3418,9 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    enum _Rga_SURF_FORMAT rga_fmt;
 +} RGAFormatMap;
 +
++#define RK_FORMAT_YCbCr_444_SP (0x32 << 8)
++#define RK_FORMAT_YCrCb_444_SP (0x33 << 8)
++
 +#define YUV_FORMATS \
 +    { AV_PIX_FMT_GRAY8,    RK_FORMAT_YCbCr_400 },        /* RGA2 only */ \
 +    { AV_PIX_FMT_YUV420P,  RK_FORMAT_YCbCr_420_P },      /* RGA2 only */ \
@@ -3347,6 +3428,8 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    { AV_PIX_FMT_NV12,     RK_FORMAT_YCbCr_420_SP }, \
 +    { AV_PIX_FMT_NV21,     RK_FORMAT_YCrCb_420_SP }, \
 +    { AV_PIX_FMT_NV16,     RK_FORMAT_YCbCr_422_SP }, \
++    { AV_PIX_FMT_NV24,     RK_FORMAT_YCbCr_444_SP },     /* RGA2-Pro only */ \
++    { AV_PIX_FMT_NV42,     RK_FORMAT_YCrCb_444_SP },     /* RGA2-Pro only */ \
 +    { AV_PIX_FMT_P010,     RK_FORMAT_YCbCr_420_SP_10B }, /* RGA3 only */ \
 +    { AV_PIX_FMT_P210,     RK_FORMAT_YCbCr_422_SP_10B }, /* RGA3 only */ \
 +    { AV_PIX_FMT_NV15,     RK_FORMAT_YCbCr_420_SP_10B }, /* RGA2 only input, aka P010 compact */ \
@@ -3452,6 +3535,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    case AV_PIX_FMT_NV15:     return DRM_FORMAT_YUV420_10BIT;
 +    case AV_PIX_FMT_NV16:     return DRM_FORMAT_YUYV;
 +    case AV_PIX_FMT_NV20:     return DRM_FORMAT_Y210;
++    case AV_PIX_FMT_NV24:     return DRM_FORMAT_VUY888;
 +    case AV_PIX_FMT_RGB565LE: return DRM_FORMAT_RGB565;
 +    case AV_PIX_FMT_BGR565LE: return DRM_FORMAT_BGR565;
 +    case AV_PIX_FMT_RGB24:    return DRM_FORMAT_RGB888;
@@ -3460,6 +3544,18 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    case AV_PIX_FMT_RGB0:     return DRM_FORMAT_XBGR8888;
 +    case AV_PIX_FMT_BGRA:     return DRM_FORMAT_ARGB8888;
 +    case AV_PIX_FMT_BGR0:     return DRM_FORMAT_XRGB8888;
++    default:                  return DRM_FORMAT_INVALID;
++    }
++}
++
++static uint32_t get_drm_rfbc_format(enum AVPixelFormat pix_fmt)
++{
++    switch (pix_fmt) {
++    case AV_PIX_FMT_NV12:     return DRM_FORMAT_YUV420_8BIT;
++    case AV_PIX_FMT_NV15:     return DRM_FORMAT_YUV420_10BIT;
++    case AV_PIX_FMT_NV16:     return DRM_FORMAT_YUYV;
++    case AV_PIX_FMT_NV20:     return DRM_FORMAT_Y210;
++    case AV_PIX_FMT_NV24:     return DRM_FORMAT_VUY888;
 +    default:                  return DRM_FORMAT_INVALID;
 +    }
 +}
@@ -3637,14 +3733,24 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +               av_get_pix_fmt_name(out->pix_fmt));
 +        return AVERROR(ENOSYS);
 +    }
-+    if (r->is_rga2_used && in->crop && in->pix_desc->comp[0].depth >= 10) {
-+        av_log(avctx, AV_LOG_ERROR, "Cropping 10-bit '%s' input is not supported if RGA2 is requested\n",
++    if (!r->has_rga2p && r->is_rga2_used && in->crop && in->pix_desc->comp[0].depth >= 10) {
++        av_log(avctx, AV_LOG_ERROR, "Cropping 10-bit '%s' input is not supported if RGA2 (non-Pro) is requested\n",
 +               av_get_pix_fmt_name(in->pix_fmt));
 +        return AVERROR(ENOSYS);
 +    }
-+    if (r->is_rga2_used &&
++    if (r->is_rga2_used && !r->has_rga2p &&
 +        (out->act_w > 4096 || out->act_h > 4096)) {
-+        av_log(avctx, AV_LOG_ERROR, "Max supported output size of RGA2 is 4096x4096\n");
++        av_log(avctx, AV_LOG_ERROR, "Max supported output size of RGA2 (non-Pro) is 4096x4096\n");
++        return AVERROR(EINVAL);
++    }
++    if (!r->is_rga2_used &&
++        (in->act_w < 68 || in->act_h < 2)) {
++        av_log(avctx, AV_LOG_ERROR, "Min supported input size of RGA3 is 68x2\n");
++        return AVERROR(EINVAL);
++    }
++    if (!r->is_rga2_used &&
++        (out->act_w > 8128 || out->act_h > 8128)) {
++        av_log(avctx, AV_LOG_ERROR, "Max supported output size of RGA3 is 8128x8128\n");
 +        return AVERROR(EINVAL);
 +    }
 +
@@ -3665,7 +3771,8 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    const AVDRMLayerDescriptor *layer;
 +    const AVDRMPlaneDescriptor *plane0;
 +    RGAFrame **frame_list = NULL;
-+    int ret, is_afbc = 0;
++    int is_afbc = 0, is_rfbc = 0;
++    int ret, is_fbc = 0;
 +
 +    if (pat_preproc && !nb_link)
 +        return NULL;
@@ -3690,7 +3797,9 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +        return NULL;
 +
 +    is_afbc = drm_is_afbc(desc->objects[0].format_modifier);
-+    if (!is_afbc) {
++    is_rfbc = drm_is_rfbc(desc->objects[0].format_modifier);
++    is_fbc = is_afbc || is_rfbc;
++    if (!is_fbc) {
 +        ret = get_pixel_stride(&desc->objects[0],
 +                               &desc->layers[0],
 +                               (in_info->pix_desc->flags & AV_PIX_FMT_FLAG_RGB),
@@ -3715,8 +3824,8 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +        info.blend    = (do_overlay && !pat_preproc) ? in_info->blend_mode : 0;
 +    }
 +
-+    if (is_afbc && (r->is_rga2_used || out_info->scheduler_core == 0x4)) {
-+        av_log(ctx, AV_LOG_ERROR, "Input format '%s' with AFBC modifier is not supported by RGA2\n",
++    if (is_fbc && !r->has_rga2p && (r->is_rga2_used || out_info->scheduler_core == 0x4)) {
++        av_log(ctx, AV_LOG_ERROR, "Input format '%s' with AFBC modifier is not supported by RGA2 (non-Pro)\n",
 +               av_get_pix_fmt_name(in_info->pix_fmt));
 +        return NULL;
 +    }
@@ -3748,33 +3857,40 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +                     in_info->act_w, in_info->act_h,
 +                     w_stride, h_stride, in_info->rga_fmt);
 +
-+    if (is_afbc) {
++    if (is_fbc) {
 +        int afbc_offset_y = 0;
-+        uint32_t drm_afbc_fmt = get_drm_afbc_format(in_info->pix_fmt);
++        int fbc_align_w =
++            is_afbc ? RK_RGA_AFBC_16x16_STRIDE_ALIGN : RK_RGA_RFBC_64x4_STRIDE_ALIGN_W;
++        int fbc_align_h =
++            is_afbc ? RK_RGA_AFBC_16x16_STRIDE_ALIGN : RK_RGA_RFBC_64x4_STRIDE_ALIGN_H;
++        uint32_t drm_fbc_fmt =
++            is_afbc ? get_drm_afbc_format(in_info->pix_fmt) : get_drm_rfbc_format(in_info->pix_fmt);
 +
 +        if (rga_frame->frame->crop_top > 0) {
-+            afbc_offset_y = rga_frame->frame->crop_top;
++            afbc_offset_y = is_afbc ? rga_frame->frame->crop_top : 0;
 +            info.rect.yoffset += afbc_offset_y;
 +        }
 +
 +        layer = &desc->layers[0];
 +        plane0 = &layer->planes[0];
-+        if (drm_afbc_fmt == layer->format) {
++        if (drm_fbc_fmt == layer->format) {
 +            info.rect.wstride = plane0->pitch;
 +            if ((ret = get_afbc_pixel_stride(in_info->bytes_pp, &info.rect.wstride, 1)) < 0)
 +                return NULL;
 +
-+            if (info.rect.wstride % RK_RGA_AFBC_STRIDE_ALIGN)
-+                info.rect.wstride = FFALIGN(inlink->w, RK_RGA_AFBC_STRIDE_ALIGN);
++            if (info.rect.wstride % fbc_align_w)
++                info.rect.wstride = FFALIGN(inlink->w, fbc_align_w);
 +
-+            info.rect.hstride = FFALIGN(inlink->h + afbc_offset_y, RK_RGA_AFBC_STRIDE_ALIGN);
++            info.rect.hstride = FFALIGN(inlink->h + afbc_offset_y, fbc_align_h);
 +        } else {
-+            av_log(ctx, AV_LOG_ERROR, "Input format '%s' with AFBC modifier is not supported\n",
++            av_log(ctx, AV_LOG_ERROR, "Input format '%s' with AFBC/RFBC modifier is not supported\n",
 +                   av_get_pix_fmt_name(in_info->pix_fmt));
 +            return NULL;
 +        }
 +
-+        info.rd_mode = 1 << 1; /* IM_FBC_MODE */
++        info.rd_mode =
++            is_afbc ? (1 << 1)  /* IM_AFBC16x16_MODE */
++                    : (1 << 4); /* IM_RKFBC64x4_MODE */
 +    }
 +
 +    rga_frame->info = info;
@@ -3830,8 +3946,8 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +        goto fail;
 +
 +    if (r->is_rga2_used || out_info->scheduler_core == 0x4) {
-+        if (pat_preproc && (info.rect.width > 4096 || info.rect.height > 4096)) {
-+            av_log(ctx, AV_LOG_ERROR, "Max supported output size of RGA2 is 4096x4096\n");
++        if (!r->has_rga2p && pat_preproc && (info.rect.width > 4096 || info.rect.height > 4096)) {
++            av_log(ctx, AV_LOG_ERROR, "Max supported output size of RGA2 (non-Pro) is 4096x4096\n");
 +            goto fail;
 +        }
 +        if (r->afbc_out && !pat_preproc) {
@@ -3885,8 +4001,8 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +            goto exit;
 +        }
 +
-+        w_stride = FFALIGN(pat_preproc ? inlink->w : outlink->w, RK_RGA_AFBC_STRIDE_ALIGN);
-+        h_stride = FFALIGN(pat_preproc ? inlink->h : outlink->h, RK_RGA_AFBC_STRIDE_ALIGN);
++        w_stride = FFALIGN(pat_preproc ? inlink->w : outlink->w, RK_RGA_AFBC_16x16_STRIDE_ALIGN);
++        h_stride = FFALIGN(pat_preproc ? inlink->h : outlink->h, RK_RGA_AFBC_16x16_STRIDE_ALIGN);
 +
 +        if ((info.rect.format == RK_FORMAT_YCbCr_420_SP_10B ||
 +             info.rect.format == RK_FORMAT_YCbCr_422_SP_10B) && (w_stride % 64)) {
@@ -3908,7 +4024,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +
 +        info.rect.wstride = w_stride;
 +        info.rect.hstride = h_stride;
-+        info.rd_mode = 1 << 1; /* IM_FBC_MODE */
++        info.rd_mode = 1 << 1; /* IM_AFBC16x16_MODE */
 +
 +        desc->objects[0].format_modifier =
 +            DRM_FORMAT_MOD_ARM_AFBC(AFBC_FORMAT_MOD_SPARSE | AFBC_FORMAT_MOD_BLOCK_SIZE_16x16);
@@ -3944,12 +4060,19 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    AVHWFramesContext *hwfc_in;
 +    AVHWFramesContext *hwfc_out;
 +    AVBufferRef       *hwfc_out_ref;
++    AVHWDeviceContext *device_ctx;
++    AVRKMPPFramesContext *rkmpp_fc;
 +    int                ret;
 +
 +    if (!inlink->hw_frames_ctx)
 +        return AVERROR(EINVAL);
 +
 +    hwfc_in = (AVHWFramesContext *)inlink->hw_frames_ctx->data;
++    device_ctx = (AVHWDeviceContext *)hwfc_in->device_ref->data;
++
++    if (!device_ctx || device_ctx->type != AV_HWDEVICE_TYPE_RKMPP)
++        return AVERROR(EINVAL);
++
 +    hwfc_out_ref = av_hwframe_ctx_alloc(hwfc_in->device_ref);
 +    if (!hwfc_out_ref)
 +        return AVERROR(ENOMEM);
@@ -3959,6 +4082,9 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    hwfc_out->sw_format = r->out_sw_format;
 +    hwfc_out->width     = outlink->w;
 +    hwfc_out->height    = outlink->h;
++
++    rkmpp_fc = hwfc_out->hwctx;
++    rkmpp_fc->flags |= MPP_BUFFER_FLAGS_CACHABLE;
 +
 +    ret = av_hwframe_ctx_init(hwfc_out_ref);
 +    if (ret < 0) {
@@ -3981,6 +4107,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    AVHWFramesContext *hwfc_in0, *hwfc_in1;
 +    AVHWFramesContext *hwfc_pat;
 +    AVBufferRef       *hwfc_pat_ref;
++    AVHWDeviceContext *device_ctx0;
 +    int                ret;
 +
 +    if (!inlink0->hw_frames_ctx || !inlink1->hw_frames_ctx)
@@ -3988,6 +4115,11 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +
 +    hwfc_in0 = (AVHWFramesContext *)inlink0->hw_frames_ctx->data;
 +    hwfc_in1 = (AVHWFramesContext *)inlink1->hw_frames_ctx->data;
++    device_ctx0 = (AVHWDeviceContext *)hwfc_in0->device_ref->data;
++
++    if (!device_ctx0 || device_ctx0->type != AV_HWDEVICE_TYPE_RKMPP)
++        return AVERROR(EINVAL);
++
 +    hwfc_pat_ref = av_hwframe_ctx_alloc(hwfc_in0->device_ref);
 +    if (!hwfc_pat_ref)
 +        return AVERROR(ENOMEM);
@@ -4039,6 +4171,15 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +         dst->pix_fmt == AV_PIX_FMT_P210)) {
 +        av_log(avctx, AV_LOG_ERROR, "'%s' is only supported by RGA3\n",
 +               av_get_pix_fmt_name(AV_PIX_FMT_P210));
++        return AVERROR(ENOSYS);
++    }
++    /* NV24/NV42 requires RGA2-Pro */
++    if (!r->has_rga2p &&
++        (src->pix_fmt == AV_PIX_FMT_NV24 ||
++         dst->pix_fmt == AV_PIX_FMT_NV42)) {
++        av_log(avctx, AV_LOG_ERROR, "'%s' and '%s' are only supported by RGA2-Pro\n",
++               av_get_pix_fmt_name(AV_PIX_FMT_NV24),
++               av_get_pix_fmt_name(AV_PIX_FMT_NV42));
 +        return AVERROR(ENOSYS);
 +    }
 +    /* Input formats that requires RGA2 */
@@ -4101,11 +4242,15 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    if (src->pix_fmt == AV_PIX_FMT_GRAY8 ||
 +        src->pix_fmt == AV_PIX_FMT_YUV420P ||
 +        src->pix_fmt == AV_PIX_FMT_YUV422P ||
++        src->pix_fmt == AV_PIX_FMT_NV24 ||
++        src->pix_fmt == AV_PIX_FMT_NV42 ||
 +        src->pix_fmt == AV_PIX_FMT_RGB555LE ||
 +        src->pix_fmt == AV_PIX_FMT_BGR555LE ||
 +        dst->pix_fmt == AV_PIX_FMT_GRAY8 ||
 +        dst->pix_fmt == AV_PIX_FMT_YUV420P ||
 +        dst->pix_fmt == AV_PIX_FMT_YUV422P ||
++        dst->pix_fmt == AV_PIX_FMT_NV24 ||
++        dst->pix_fmt == AV_PIX_FMT_NV42 ||
 +        dst->pix_fmt == AV_PIX_FMT_RGB555LE ||
 +        dst->pix_fmt == AV_PIX_FMT_BGR555LE ||
 +        dst->pix_fmt == AV_PIX_FMT_ARGB ||
@@ -4139,8 +4284,11 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    if ((ret = verify_rga_frame_info_io_dynamic(avctx, src, dst)) < 0)
 +        return ret;
 +
-+    if (r->is_rga2_used)
++    if (r->is_rga2_used) {
 +        r->scheduler_core = 0x4;
++        if (r->has_rga2p)
++            r->scheduler_core |= 0x8;
++    }
 +
 +    /* Prioritize RGA3 on multicore RGA hw to avoid dma32 & algorithm quirks as much as possible */
 +    if (r->has_rga3 && r->has_rga2e && !r->is_rga2_used &&
@@ -4216,6 +4364,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +{
 +    RKRGAContext *r = avctx->priv;
 +    int i, ret;
++    int rga_core_mask = 0x7;
 +    const char *rga_ver = querystring(RGA_VERSION);
 +
 +    r->got_frame = 0;
@@ -4223,6 +4372,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    r->has_rga2  = !!strstr(rga_ver, "RGA_2");
 +    r->has_rga2l = !!strstr(rga_ver, "RGA_2_lite");
 +    r->has_rga2e = !!strstr(rga_ver, "RGA_2_Enhance");
++    r->has_rga2p = !!strstr(rga_ver, "RGA_2_PRO");
 +    r->has_rga3  = !!strstr(rga_ver, "RGA_3");
 +
 +    if (!(r->has_rga2 || r->has_rga3)) {
@@ -4230,18 +4380,21 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +        return AVERROR(ENOSYS);
 +    }
 +
++    if (r->has_rga2p)
++        rga_core_mask = 0xf;
++
 +    /* RGA core */
-+    if (r->scheduler_core && !(r->has_rga2 && r->has_rga3)) {
++    if (r->scheduler_core && !(r->has_rga2 && r->has_rga3) && !r->has_rga2p) {
 +        av_log(avctx, AV_LOG_WARNING, "Scheduler core cannot be set on non-multicore RGA hw, ignoring\n");
 +        r->scheduler_core = 0;
 +    }
-+    if (r->scheduler_core && r->scheduler_core != (r->scheduler_core & 0x7)) {
++    if (r->scheduler_core && r->scheduler_core != (r->scheduler_core & rga_core_mask)) {
 +        av_log(avctx, AV_LOG_WARNING, "Invalid scheduler core set, ignoring\n");
 +        r->scheduler_core = 0;
 +    }
 +    if (r->scheduler_core && r->scheduler_core == (r->scheduler_core & 0x3))
-+        r->has_rga2 = r->has_rga2l = r->has_rga2e = 0;
-+    if (r->scheduler_core == 0x4)
++        r->has_rga2 = r->has_rga2l = r->has_rga2e = r->has_rga2p = 0;
++    if (r->scheduler_core == 0x4 && !r->has_rga2p)
 +        r->has_rga3 = 0;
 +
 +    r->filter_frame = param->filter_frame;
@@ -4549,7 +4702,7 @@ Index: FFmpeg/libavfilter/rkrga_common.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/rkrga_common.h
-@@ -0,0 +1,127 @@
+@@ -0,0 +1,130 @@
 +/*
 + * Copyright (c) 2023 NyanMisaka
 + *
@@ -4586,10 +4739,12 @@ Index: FFmpeg/libavfilter/rkrga_common.h
 +#include "libavutil/hwcontext.h"
 +#include "libavutil/hwcontext_rkmpp.h"
 +
-+#define ALIGN_DOWN(a, b) ((a) & ~((b)-1))
-+#define RK_RGA_YUV_ALIGN         2
-+#define RK_RGA_AFBC_STRIDE_ALIGN 16
++#define RK_RGA_YUV_ALIGN                2
++#define RK_RGA_AFBC_16x16_STRIDE_ALIGN  16
++#define RK_RGA_RFBC_64x4_STRIDE_ALIGN_W 64
++#define RK_RGA_RFBC_64x4_STRIDE_ALIGN_H 4
 +
++#define ALIGN_DOWN(a, b) ((a) & ~((b)-1))
 +#define FF_INLINK_IDX(link)  ((int)((link)->dstpad - (link)->dst->input_pads))
 +#define FF_OUTLINK_IDX(link) ((int)((link)->srcpad - (link)->src->output_pads))
 +
@@ -4642,6 +4797,7 @@ Index: FFmpeg/libavfilter/rkrga_common.h
 +    int has_rga2;
 +    int has_rga2l;
 +    int has_rga2e;
++    int has_rga2p;
 +    int has_rga3;
 +    int is_rga2_used;
 +    int is_overlay_offset_valid;
@@ -4681,7 +4837,7 @@ Index: FFmpeg/libavfilter/vf_overlay_rkrga.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_overlay_rkrga.c
-@@ -0,0 +1,368 @@
+@@ -0,0 +1,369 @@
 +/*
 + * Copyright (c) 2023 NyanMisaka
 + *
@@ -4826,9 +4982,9 @@ Index: FFmpeg/libavfilter/vf_overlay_rkrga.c
 +
 +    outlink->w = r->var_values[VAR_MW];
 +    outlink->h = r->var_values[VAR_MH];
-+    if (outlink->w < 2 || outlink->w > 8128 ||
-+        outlink->h < 2 || outlink->h > 8128) {
-+        av_log(ctx, AV_LOG_ERROR, "Supported output size is range from 2x2 ~ 8128x8128\n");
++    if (outlink->w < 2 || outlink->w > 8192 ||
++        outlink->h < 2 || outlink->h > 8192) {
++        av_log(ctx, AV_LOG_ERROR, "Supported output size is range from 2x2 ~ 8192x8192\n");
 +        return AVERROR(EINVAL);
 +    }
 +
@@ -5010,6 +5166,7 @@ Index: FFmpeg/libavfilter/vf_overlay_rkrga.c
 +        { "rga3_core0", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 }, 0, 0, FLAGS, .unit = "core" }, /* RGA3_SCHEDULER_CORE0 */
 +        { "rga3_core1", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 }, 0, 0, FLAGS, .unit = "core" }, /* RGA3_SCHEDULER_CORE1 */
 +        { "rga2_core0", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 4 }, 0, 0, FLAGS, .unit = "core" }, /* RGA2_SCHEDULER_CORE0 */
++        { "rga2_core1", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 8 }, 0, 0, FLAGS, .unit = "core" }, /* RGA2_SCHEDULER_CORE1 */
 +    { "async_depth", "Set the internal parallelization depth", OFFSET(rga.async_depth), AV_OPT_TYPE_INT, { .i64 = 2 }, 0, 4, .flags = FLAGS },
 +    { "afbc", "Enable AFBC (Arm Frame Buffer Compression) to save bandwidth", OFFSET(rga.afbc_out), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, .flags = FLAGS },
 +    { NULL },
@@ -5054,7 +5211,7 @@ Index: FFmpeg/libavfilter/vf_vpp_rkrga.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_vpp_rkrga.c
-@@ -0,0 +1,578 @@
+@@ -0,0 +1,579 @@
 +/*
 + * Copyright (c) 2023 NyanMisaka
 + *
@@ -5284,9 +5441,9 @@ Index: FFmpeg/libavfilter/vf_vpp_rkrga.c
 +
 +    outlink->w = w;
 +    outlink->h = h;
-+    if (outlink->w < 2 || outlink->w > 8128 ||
-+        outlink->h < 2 || outlink->h > 8128) {
-+        av_log(ctx, AV_LOG_ERROR, "Supported output size is range from 2x2 ~ 8128x8128\n");
++    if (outlink->w < 2 || outlink->w > 8192 ||
++        outlink->h < 2 || outlink->h > 8192) {
++        av_log(ctx, AV_LOG_ERROR, "Supported output size is range from 2x2 ~ 8192x8192\n");
 +        return AVERROR(EINVAL);
 +    }
 +
@@ -5534,6 +5691,7 @@ Index: FFmpeg/libavfilter/vf_vpp_rkrga.c
 +        { "rga3_core0", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 1 }, 0, 0, FLAGS, .unit = "core" }, /* RGA3_SCHEDULER_CORE0 */ \
 +        { "rga3_core1", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 2 }, 0, 0, FLAGS, .unit = "core" }, /* RGA3_SCHEDULER_CORE1 */ \
 +        { "rga2_core0", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 4 }, 0, 0, FLAGS, .unit = "core" }, /* RGA2_SCHEDULER_CORE0 */ \
++        { "rga2_core1", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = 8 }, 0, 0, FLAGS, .unit = "core" }, /* RGA2_SCHEDULER_CORE1 */ \
 +    { "async_depth", "Set the internal parallelization depth", OFFSET(rga.async_depth), AV_OPT_TYPE_INT, { .i64 = 2 }, 0, 4, .flags = FLAGS }, \
 +    { "afbc", "Enable AFBC (Arm Frame Buffer Compression) to save bandwidth", OFFSET(rga.afbc_out), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, .flags = FLAGS },
 +
@@ -5789,7 +5947,7 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavutil/hwcontext_rkmpp.c
-@@ -0,0 +1,598 @@
+@@ -0,0 +1,600 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -5844,6 +6002,7 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.c
 +    { AV_PIX_FMT_NV21,      DRM_FORMAT_NV21,     },
 +    { AV_PIX_FMT_NV16,      DRM_FORMAT_NV16,     },
 +    { AV_PIX_FMT_NV24,      DRM_FORMAT_NV24,     },
++    { AV_PIX_FMT_NV42,      DRM_FORMAT_NV42,     },
 +    /* semi-planar YUV 10-bit */
 +    { AV_PIX_FMT_P010,      DRM_FORMAT_P010,     },
 +    { AV_PIX_FMT_P210,      DRM_FORMAT_P210,     },
@@ -5888,15 +6047,15 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.c
 +    AVRKMPPDeviceContext *hwctx = hwdev->hwctx;
 +    AVDictionaryEntry *opt_d = NULL;
 +
-+    hwctx->flags = MPP_BUFFER_FLAGS_DMA32 | MPP_BUFFER_FLAGS_CACHABLE;
++    hwctx->flags = MPP_BUFFER_FLAGS_DMA32;
 +
 +    opt_d = av_dict_get(opts, "dma32", NULL, 0);
 +    if (opt_d && !strtol(opt_d->value, NULL, 10))
 +        hwctx->flags &= ~MPP_BUFFER_FLAGS_DMA32;
 +
 +    opt_d = av_dict_get(opts, "cacheable", NULL, 0);
-+    if (opt_d && !strtol(opt_d->value, NULL, 10))
-+        hwctx->flags &= ~MPP_BUFFER_FLAGS_CACHABLE;
++    if (opt_d && strtol(opt_d->value, NULL, 10))
++        hwctx->flags |= MPP_BUFFER_FLAGS_CACHABLE;
 +
 +    return 0;
 +}
@@ -6091,7 +6250,8 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.c
 +            return AVERROR(ENOMEM);
 +    }
 +
-+    ret = mpp_buffer_group_get_internal(&avfc->buf_group, MPP_BUFFER_TYPE_DRM | hwctx->flags);
++    ret = mpp_buffer_group_get_internal(&avfc->buf_group,
++                                        MPP_BUFFER_TYPE_DRM | hwctx->flags | avfc->flags);
 +    if (ret != MPP_OK) {
 +        av_log(hwfc, AV_LOG_ERROR, "Failed to get MPP internal buffer group: %d\n", ret);
 +        return AVERROR_EXTERNAL;
@@ -6148,13 +6308,13 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.c
 +static void rkmpp_unmap_frame(AVHWFramesContext *hwfc,
 +                              HWMapDescriptor *hwmap)
 +{
-+    AVRKMPPDeviceContext *hwctx = hwfc->device_ctx->hwctx;
++    AVRKMPPFramesContext *avfc = hwfc->hwctx;
 +    RKMPPDRMMapping *map = hwmap->priv;
 +
 +    for (int i = 0; i < map->nb_regions; i++) {
 +#if HAVE_LINUX_DMA_BUF_H
 +        struct dma_buf_sync sync = { .flags = DMA_BUF_SYNC_END | map->sync_flags };
-+        if (hwctx->flags & MPP_BUFFER_FLAGS_CACHABLE)
++        if (avfc->flags & MPP_BUFFER_FLAGS_CACHABLE)
 +            ioctl(map->object[i], DMA_BUF_IOCTL_SYNC, &sync);
 +#endif
 +        if (map->address[i] && map->unmap[i])
@@ -6167,7 +6327,7 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.c
 +static int rkmpp_map_frame(AVHWFramesContext *hwfc,
 +                           AVFrame *dst, const AVFrame *src, int flags)
 +{
-+    AVRKMPPDeviceContext *hwctx = hwfc->device_ctx->hwctx;
++    AVRKMPPFramesContext *avfc = hwfc->hwctx;
 +    const AVRKMPPDRMFrameDescriptor *desc = (AVRKMPPDRMFrameDescriptor *)src->data[0];
 +#if HAVE_LINUX_DMA_BUF_H
 +    struct dma_buf_sync sync_start = { 0 };
@@ -6227,7 +6387,7 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.c
 +#if HAVE_LINUX_DMA_BUF_H
 +        /* We're not checking for errors here because the kernel may not
 +         * support the ioctl, in which case its okay to carry on */
-+        if (hwctx->flags & MPP_BUFFER_FLAGS_CACHABLE)
++        if (avfc->flags & MPP_BUFFER_FLAGS_CACHABLE)
 +            ioctl(desc->drm_desc.objects[i].fd, DMA_BUF_IOCTL_SYNC, &sync_start);
 +#endif
 +    }
@@ -6392,7 +6552,7 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavutil/hwcontext_rkmpp.h
-@@ -0,0 +1,110 @@
+@@ -0,0 +1,153 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -6442,17 +6602,56 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.h
 +#ifndef DRM_FORMAT_Y210
 +#define DRM_FORMAT_Y210         fourcc_code('Y', '2', '1', '0')
 +#endif
++#ifndef DRM_FORMAT_VUY888
++#define DRM_FORMAT_VUY888       fourcc_code('V', 'U', '2', '4')
++#endif
 +
++/* ARM AFBC (16x16) */
 +#ifndef DRM_FORMAT_MOD_VENDOR_ARM
-+#define DRM_FORMAT_MOD_VENDOR_ARM 0x08
++#define DRM_FORMAT_MOD_VENDOR_ARM          0x08
 +#endif
 +#ifndef DRM_FORMAT_MOD_ARM_TYPE_AFBC
-+#define DRM_FORMAT_MOD_ARM_TYPE_AFBC 0x00
++#define DRM_FORMAT_MOD_ARM_TYPE_AFBC       0x00
++#endif
++#ifndef AFBC_FORMAT_MOD_BLOCK_SIZE_16x16
++#define AFBC_FORMAT_MOD_BLOCK_SIZE_16x16   (1ULL)
++#endif
++#ifndef AFBC_FORMAT_MOD_SPARSE
++#define AFBC_FORMAT_MOD_SPARSE             (1ULL << 6)
 +#endif
 +
 +#define drm_is_afbc(mod) \
 +        ((mod >> 52) == (DRM_FORMAT_MOD_ARM_TYPE_AFBC | \
 +                (DRM_FORMAT_MOD_VENDOR_ARM << 4)))
++
++/* Rockchip RFBC (64x4) */
++#undef  DRM_FORMAT_MOD_VENDOR_ROCKCHIP
++#define DRM_FORMAT_MOD_VENDOR_ROCKCHIP     0x0b
++#undef  DRM_FORMAT_MOD_ROCKCHIP_TYPE_SHIFT
++#define DRM_FORMAT_MOD_ROCKCHIP_TYPE_SHIFT 52
++#undef  DRM_FORMAT_MOD_ROCKCHIP_TYPE_MASK
++#define DRM_FORMAT_MOD_ROCKCHIP_TYPE_MASK  0xf
++#undef  DRM_FORMAT_MOD_ROCKCHIP_TYPE_RFBC
++#define DRM_FORMAT_MOD_ROCKCHIP_TYPE_RFBC  0x1
++#undef  ROCKCHIP_RFBC_BLOCK_SIZE_64x4
++#define ROCKCHIP_RFBC_BLOCK_SIZE_64x4      (1ULL)
++
++#undef  fourcc_mod_code
++#define fourcc_mod_code(vendor, val) \
++        ((((__u64)DRM_FORMAT_MOD_VENDOR_## vendor) << 56) | ((val) & 0x00ffffffffffffffULL))
++
++#undef  DRM_FORMAT_MOD_ROCKCHIP_CODE
++#define DRM_FORMAT_MOD_ROCKCHIP_CODE(__type, __val) \
++	fourcc_mod_code(ROCKCHIP, ((__u64)(__type) << DRM_FORMAT_MOD_ROCKCHIP_TYPE_SHIFT) | \
++			((__val) & 0x000fffffffffffffULL))
++
++#undef  DRM_FORMAT_MOD_ROCKCHIP_RFBC
++#define DRM_FORMAT_MOD_ROCKCHIP_RFBC(mode) \
++	DRM_FORMAT_MOD_ROCKCHIP_CODE(DRM_FORMAT_MOD_ROCKCHIP_TYPE_RFBC, mode)
++
++#define drm_is_rfbc(mod) \
++        (((mod >> 56) & 0xff) == DRM_FORMAT_MOD_VENDOR_ROCKCHIP) && \
++        (((mod >> 52) & DRM_FORMAT_MOD_ROCKCHIP_TYPE_MASK) == DRM_FORMAT_MOD_ROCKCHIP_TYPE_RFBC)
 +
 +/**
 + * DRM Prime Frame descriptor for RKMPP HWDevice.
@@ -6480,6 +6679,10 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.h
 +     * MPP buffer group.
 +     */
 +    MppBufferGroup buf_group;
++    /**
++     * MPP buffer allocation flags at frames context level.
++     */
++    int flags;
 +
 +    /**
 +     * The descriptors of all frames in the pool after creation.
@@ -6497,7 +6700,7 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.h
 + */
 +typedef struct AVRKMPPDeviceContext {
 +    /**
-+     * MPP buffer allocation flags.
++     * MPP buffer allocation flags at device context level.
 +     */
 +    int flags;
 +} AVRKMPPDeviceContext;

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 # Update mingw-w64 headers
-mingw_commit="d2491a9358bddc9573d0ff2fa73989e3175c2009"
+mingw_commit="cdf6b16b805ce7d02f6b1b742911ba0770b49bbb"
 git clone https://git.code.sf.net/p/mingw-w64/mingw-w64.git
 pushd mingw-w64/mingw-w64-headers
 git checkout ${mingw_commit}
@@ -156,7 +156,7 @@ popd
 popd
 
 # LZMA
-git clone -b v5.6.2 --depth=1 https://github.com/tukaani-project/xz.git
+git clone -b v5.6.3 --depth=1 https://github.com/tukaani-project/xz.git
 pushd xz
 ./autogen.sh --no-po4a --no-doxygen
 ./configure \
@@ -390,7 +390,7 @@ make install
 popd
 
 # X265
-x265_commit="26d2bab0063cee453b7d8012e76539a7786c032f"
+x265_commit="487105dcd21d0f36a7a9e0ec50de85577b9bed04"
 git clone https://bitbucket.org/multicoreware/x265_git.git
 pushd x265_git
 git checkout ${x265_commit}
@@ -546,11 +546,11 @@ popd
 # AMF
 mkdir amf-headers
 pushd amf-headers
-amf_ver="1.4.34"
-amf_link="https://github.com/GPUOpen-LibrariesAndSDKs/AMF/releases/download/v${amf_ver}/AMF-headers.tar.gz"
+amf_ver="1.4.35"
+amf_link="https://github.com/GPUOpen-LibrariesAndSDKs/AMF/releases/download/v${amf_ver}/AMF-headers-v${amf_ver}.tar.gz"
 wget ${amf_link} -O amf.tar.gz
 tar xaf amf.tar.gz
-pushd AMF
+pushd amf-headers-v${amf_ver}/AMF
 mkdir -p ${FF_DEPS_PREFIX}/include/AMF
 mv * ${FF_DEPS_PREFIX}/include/AMF
 popd

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -304,11 +304,11 @@ prepare_extra_amd64() {
     pushd ${SOURCE_DIR}
     mkdir amf-headers
     pushd amf-headers
-    amf_ver="1.4.34"
-    amf_link="https://github.com/GPUOpen-LibrariesAndSDKs/AMF/releases/download/v${amf_ver}/AMF-headers.tar.gz"
+    amf_ver="1.4.35"
+    amf_link="https://github.com/GPUOpen-LibrariesAndSDKs/AMF/releases/download/v${amf_ver}/AMF-headers-v${amf_ver}.tar.gz"
     wget ${amf_link} -O amf.tar.gz
     tar xaf amf.tar.gz
-    pushd AMF
+    pushd amf-headers-v${amf_ver}/AMF
     mkdir -p /usr/include/AMF
     mv * /usr/include/AMF
     popd
@@ -439,7 +439,7 @@ prepare_extra_amd64() {
     # VPL-GPU-RT (RT only)
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-24.3.4 --depth=1 https://github.com/intel/vpl-gpu-rt.git
+    git clone -b intel-onevpl-24.4.0 --depth=1 https://github.com/intel/vpl-gpu-rt.git
     pushd vpl-gpu-rt
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
@@ -459,7 +459,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-24.3.4 --depth=1 https://github.com/intel/media-driver.git
+    git clone -b intel-media-24.4.0 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
     # enable vc1 decode on dg2 (note that mtl+ is not supported)
     wget -q -O - https://github.com/intel/media-driver/commit/d5dd47b.patch | git apply
@@ -480,7 +480,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.296 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
+    git clone -b v1.3.298 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -493,7 +493,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.3.296 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
+    git clone -b v1.3.298 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \

--- a/msys2/PKGBUILD/10-mingw-w64-xz/PKGBUILD
+++ b/msys2/PKGBUILD/10-mingw-w64-xz/PKGBUILD
@@ -4,8 +4,8 @@
 _realname=xz
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}"
-pkgver=5.6.2
-pkgrel=2
+pkgver=5.6.3
+pkgrel=1
 pkgdesc="Library and command line tools for XZ and LZMA compressed files (mingw-w64)"
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clang32' 'clangarm64')
@@ -25,7 +25,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-doxygen"
              "po4a")
 source=("https://github.com/tukaani-project/xz/releases/download/v${pkgver}/xz-${pkgver}.tar.xz")
-sha256sums=('a9db3bb3d64e248a0fae963f8fb6ba851a26ba1822e504dc0efd18a80c626caf')
+sha256sums=('db0590629b6f0fa36e74aea5f9731dc6f8df068ce7b7bafa45301832a5eebc3a')
 validpgpkeys=('3690C240CE51B4670D30AD1C38EE757D69184620') # Lasse Collin <lasse.collin@tukaani.org>
 
 export FF_MINGW_PREFIX="${MINGW_PREFIX}/ffbuild"

--- a/msys2/PKGBUILD/40-mingw-w64-x264/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-x264/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=x264
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-libx264")
-pkgver=0.164.r3191.c24e06c
+pkgver=0.164.r3191.1243d9f
 pkgrel=1
 pkgdesc="Library for encoding H264/AVC video streams (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
                 || echo "${MINGW_PACKAGE_PREFIX}-nasm" )
              "git")
 options=('strip' 'staticlibs')
-_commit="c24e06c2e184345ceb33eb20a15d1024d9fd3497"
+_commit="1243d9ffb04dac7005ee9ecc79459034429dd5aa"
 source=("${_realname}"::"git+https://code.videolan.org/videolan/${_realname}.git#commit=${_commit}"
         0001-beautify-pc.all.patch
         0002-install-avisynth_c.h.mingw.patch

--- a/msys2/PKGBUILD/40-mingw-w64-x265/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-x265/PKGBUILD
@@ -23,7 +23,7 @@ msys2_references=(
   "cpe: cpe:/a:multicorewareinc:x265"
   "cpe: cpe:/a:multicorewareinc:x265_high_efficiency_video_coding"
 )
-_commit="26d2bab0063cee453b7d8012e76539a7786c032f"
+_commit="487105dcd21d0f36a7a9e0ec50de85577b9bed04"
 source=("${_realname}"::"git+https://bitbucket.org/multicoreware/x265_git.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/msys2/PKGBUILD/50-mingw-w64-amf-headers/PKGBUILD
+++ b/msys2/PKGBUILD/50-mingw-w64-amf-headers/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=amf-headers
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}"
-pkgver=1.4.34
+pkgver=1.4.35
 pkgrel=1
 pkgdesc='Header files for AMD Advanced Media Framework'
 arch=('any')


### PR DESCRIPTION
**Changes**
- Sync RKMPP fixes from ffmpeg-rockchip
- Update dependencies

**Issues**
- Respect `-global_header` settings in `h26x_rkmpp` encoders
- Use cacheable buffers only when necessary for better `hwupload` perf
- Initial support for rk3576