### PR TITLE
Fix NV24/NV42 format check on RKRGA

### DIFF
--- a/debian/patches/0047-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0047-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -3373,7 +3373,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/rkrga_common.c
-@@ -0,0 +1,1324 @@
+@@ -0,0 +1,1326 @@
 +/*
 + * Copyright (c) 2023 NyanMisaka
 + *
@@ -4176,6 +4176,8 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    /* NV24/NV42 requires RGA2-Pro */
 +    if (!r->has_rga2p &&
 +        (src->pix_fmt == AV_PIX_FMT_NV24 ||
++         src->pix_fmt == AV_PIX_FMT_NV42 ||
++         dst->pix_fmt == AV_PIX_FMT_NV24 ||
 +         dst->pix_fmt == AV_PIX_FMT_NV42)) {
 +        av_log(avctx, AV_LOG_ERROR, "'%s' and '%s' are only supported by RGA2-Pro\n",
 +               av_get_pix_fmt_name(AV_PIX_FMT_NV24),


### PR DESCRIPTION
**Changes**
- Fix NV24/NV42 format check on RKRGA

**Issues**
- These two formats are not supported on RK3588