### PR TITLE
lavc/videotoolbox: remove opengl compatability key

### DIFF
--- a/debian/patches/0079-videotoolbox-remove-opengl-compatability.patch
+++ b/debian/patches/0079-videotoolbox-remove-opengl-compatability.patch
@@ -1,0 +1,16 @@
+Index: FFmpeg/libavcodec/videotoolbox.c
+===================================================================
+--- FFmpeg.orig/libavcodec/videotoolbox.c
++++ FFmpeg/libavcodec/videotoolbox.c
+@@ -786,11 +786,6 @@ static CFDictionaryRef videotoolbox_buff
+     CFDictionarySetValue(buffer_attributes, kCVPixelBufferIOSurfacePropertiesKey, io_surface_properties);
+     CFDictionarySetValue(buffer_attributes, kCVPixelBufferWidthKey, w);
+     CFDictionarySetValue(buffer_attributes, kCVPixelBufferHeightKey, h);
+-#if TARGET_OS_IPHONE
+-    CFDictionarySetValue(buffer_attributes, kCVPixelBufferOpenGLESCompatibilityKey, kCFBooleanTrue);
+-#else
+-    CFDictionarySetValue(buffer_attributes, kCVPixelBufferIOSurfaceOpenGLTextureCompatibilityKey, kCFBooleanTrue);
+-#endif
+ 
+     CFRelease(io_surface_properties);
+     CFRelease(cv_pix_fmt);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -76,3 +76,4 @@
 0076-alway-set-videotoolboxenc-pixel-buffer-info.patch
 0077-add-remove-dovi-hdr10plus-bsf.patch
 0078-fix-atenc-layout-samplerate.patch
+0079-videotoolbox-remove-opengl-compatability.patch


### PR DESCRIPTION
We are not using OpenGL and this compatability key could introduce performance penalty on some Macs. Performance difference is neglible on Apple Silicon but on old Intel Macs like the 2018 MacBook Air, decoding performance could be reduced by 15% as the IOSurface might make extra frame copies to reshape the pixel buffer.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->