### PR TITLE
Fix MppPacket being released before MppMeta

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.0.2-6"
+version: "7.0.2-7"
 packages:
   - bullseye-amd64
   - bullseye-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (7.0.2-7) unstable; urgency=medium
+
+  * Fix MppPacket being released before MppMeta
+
+ -- nyanmisaka <nst799610810@gmail.com>  Thu, 14 Nov 2024 14:58:41 +0800
+
 jellyfin-ffmpeg (7.0.2-6) unstable; urgency=medium
 
   * Use dynamic pool for VPL QSV hwupload to save VRAM

--- a/debian/patches/0047-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0047-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -2714,7 +2714,6 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +        ret = AVERROR_EXTERNAL;
 +        goto exit;
 +    }
-+    mpp_packet_deinit(&mpp_pkt);
 +
 +    mpp_meta_get_s32(mpp_meta, KEY_OUTPUT_INTRA, &key_frame);
 +    if (key_frame)
@@ -2734,6 +2733,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    mpp_buffer_set_index(mpp_buf, -1);
 +    clear_unused_frames(r->frame_list);
 +
++    mpp_packet_deinit(&mpp_pkt);
 +    return 0;
 +
 +exit:


### PR DESCRIPTION
**Changes**
- Fix MppPacket being released before MppMeta
- Bump version to 7.0.2-7

**Issues**
- The lifecycle of MppMeta is bound to MppPacket, which was ignored in the previous fix.
  This will cause an error to be thrown when multiple encoding instances are used.

We need to release this as a hotfix.