### PR TITLE
avcodec/videotoolbox: backport AV1 hardware acceleration

### DIFF
--- a/debian/patches/0081-backport-av1-videotoolbox.patch
+++ b/debian/patches/0081-backport-av1-videotoolbox.patch
@@ -1,0 +1,352 @@
+Index: FFmpeg/libavcodec/Makefile
+===================================================================
+--- FFmpeg.orig/libavcodec/Makefile
++++ FFmpeg/libavcodec/Makefile
+@@ -1010,6 +1010,7 @@ OBJS-$(CONFIG_AV1_D3D12VA_HWACCEL)
+ OBJS-$(CONFIG_AV1_NVDEC_HWACCEL)          += nvdec_av1.o
+ OBJS-$(CONFIG_AV1_VAAPI_HWACCEL)          += vaapi_av1.o
+ OBJS-$(CONFIG_AV1_VDPAU_HWACCEL)          += vdpau_av1.o
++OBJS-$(CONFIG_AV1_VIDEOTOOLBOX_HWACCEL)   += videotoolbox_av1.o
+ OBJS-$(CONFIG_AV1_VULKAN_HWACCEL)         += vulkan_decode.o vulkan_av1.o
+ OBJS-$(CONFIG_H263_VAAPI_HWACCEL)         += vaapi_mpeg4.o
+ OBJS-$(CONFIG_H263_VIDEOTOOLBOX_HWACCEL)  += videotoolbox.o
+Index: FFmpeg/libavcodec/av1dec.c
+===================================================================
+--- FFmpeg.orig/libavcodec/av1dec.c
++++ FFmpeg/libavcodec/av1dec.c
+@@ -540,6 +540,7 @@ static int get_pixel_format(AVCodecConte
+                      CONFIG_AV1_NVDEC_HWACCEL + \
+                      CONFIG_AV1_VAAPI_HWACCEL + \
+                      CONFIG_AV1_VDPAU_HWACCEL + \
++                     CONFIG_AV1_VIDEOTOOLBOX_HWACCEL + \
+                      CONFIG_AV1_VULKAN_HWACCEL)
+     enum AVPixelFormat pix_fmts[HWACCEL_MAX + 2], *fmtp = pix_fmts;
+ 
+@@ -567,6 +568,9 @@ static int get_pixel_format(AVCodecConte
+ #if CONFIG_AV1_VDPAU_HWACCEL
+         *fmtp++ = AV_PIX_FMT_VDPAU;
+ #endif
++#if CONFIG_AV1_VIDEOTOOLBOX_HWACCEL
++        *fmtp++ = AV_PIX_FMT_VIDEOTOOLBOX;
++#endif
+ #if CONFIG_AV1_VULKAN_HWACCEL
+         *fmtp++ = AV_PIX_FMT_VULKAN;
+ #endif
+@@ -591,6 +595,9 @@ static int get_pixel_format(AVCodecConte
+ #if CONFIG_AV1_VDPAU_HWACCEL
+         *fmtp++ = AV_PIX_FMT_VDPAU;
+ #endif
++#if CONFIG_AV1_VIDEOTOOLBOX_HWACCEL
++        *fmtp++ = AV_PIX_FMT_VIDEOTOOLBOX;
++#endif
+ #if CONFIG_AV1_VULKAN_HWACCEL
+         *fmtp++ = AV_PIX_FMT_VULKAN;
+ #endif
+@@ -1479,6 +1486,10 @@ static int av1_receive_frame_internal(AV
+ 
+         if (raw_tile_group && (s->tile_num == raw_tile_group->tg_end + 1)) {
+             int show_frame = s->raw_frame_header->show_frame;
++            // Set nb_unit to point at the next OBU, to indicate which
++            // OBUs have been processed for this current frame. (If this
++            // frame gets output, we set nb_unit to this value later too.)
++            s->nb_unit = i + 1;
+             if (avctx->hwaccel && s->cur_frame.f->buf[0]) {
+                 ret = FF_HW_SIMPLE_CALL(avctx, end_frame);
+                 if (ret < 0) {
+@@ -1500,6 +1511,7 @@ static int av1_receive_frame_internal(AV
+                     goto end;
+                 }
+             }
++            s->start_unit = s->nb_unit;
+             raw_tile_group = NULL;
+             s->raw_frame_header = NULL;
+             if (show_frame) {
+@@ -1519,7 +1531,7 @@ end:
+             s->raw_frame_header = NULL;
+         av_packet_unref(s->pkt);
+         ff_cbs_fragment_reset(&s->current_obu);
+-        s->nb_unit = 0;
++        s->nb_unit = s->start_unit = 0;
+     }
+     if (!ret && !frame->buf[0])
+         ret = AVERROR(EAGAIN);
+@@ -1546,7 +1558,7 @@ static int av1_receive_frame(AVCodecCont
+                 return ret;
+             }
+ 
+-            s->nb_unit = 0;
++            s->nb_unit = s->start_unit = 0;
+             av_log(avctx, AV_LOG_DEBUG, "Total OBUs on this packet: %d.\n",
+                    s->current_obu.nb_units);
+         }
+@@ -1567,7 +1579,7 @@ static void av1_decode_flush(AVCodecCont
+ 
+     av1_frame_unref(&s->cur_frame);
+     s->operating_point_idc = 0;
+-    s->nb_unit = 0;
++    s->nb_unit = s->start_unit = 0;
+     s->raw_frame_header = NULL;
+     s->raw_seq = NULL;
+     s->cll = NULL;
+@@ -1633,6 +1645,9 @@ const FFCodec ff_av1_decoder = {
+ #if CONFIG_AV1_VDPAU_HWACCEL
+         HWACCEL_VDPAU(av1),
+ #endif
++#if CONFIG_AV1_VIDEOTOOLBOX_HWACCEL
++        HWACCEL_VIDEOTOOLBOX(av1),
++#endif
+ #if CONFIG_AV1_VULKAN_HWACCEL
+         HWACCEL_VULKAN(av1),
+ #endif
+Index: FFmpeg/libavcodec/hwaccels.h
+===================================================================
+--- FFmpeg.orig/libavcodec/hwaccels.h
++++ FFmpeg/libavcodec/hwaccels.h
+@@ -26,6 +26,7 @@ extern const struct FFHWAccel ff_av1_dxv
+ extern const struct FFHWAccel ff_av1_nvdec_hwaccel;
+ extern const struct FFHWAccel ff_av1_vaapi_hwaccel;
+ extern const struct FFHWAccel ff_av1_vdpau_hwaccel;
++extern const struct FFHWAccel ff_av1_videotoolbox_hwaccel;
+ extern const struct FFHWAccel ff_av1_vulkan_hwaccel;
+ extern const struct FFHWAccel ff_h263_vaapi_hwaccel;
+ extern const struct FFHWAccel ff_h263_videotoolbox_hwaccel;
+Index: FFmpeg/libavcodec/vt_internal.h
+===================================================================
+--- FFmpeg.orig/libavcodec/vt_internal.h
++++ FFmpeg/libavcodec/vt_internal.h
+@@ -56,6 +56,9 @@ int ff_videotoolbox_frame_params(AVCodec
+ int ff_videotoolbox_buffer_copy(VTContext *vtctx,
+                                 const uint8_t *buffer,
+                                 uint32_t size);
++int ff_videotoolbox_buffer_append(VTContext *vtctx,
++                                  const uint8_t *buffer,
++                                  uint32_t size);
+ int ff_videotoolbox_uninit(AVCodecContext *avctx);
+ int ff_videotoolbox_h264_start_frame(AVCodecContext *avctx,
+                                      const uint8_t *buffer,
+@@ -64,6 +67,7 @@ int ff_videotoolbox_h264_decode_slice(AV
+                                       const uint8_t *buffer,
+                                       uint32_t size);
+ int ff_videotoolbox_common_end_frame(AVCodecContext *avctx, AVFrame *frame);
++CFDataRef ff_videotoolbox_av1c_extradata_create(AVCodecContext *avctx);
+ CFDataRef ff_videotoolbox_avcc_extradata_create(AVCodecContext *avctx);
+ CFDataRef ff_videotoolbox_hvcc_extradata_create(AVCodecContext *avctx);
+ CFDataRef ff_videotoolbox_vpcc_extradata_create(AVCodecContext *avctx);
+Index: FFmpeg/libavcodec/videotoolbox_av1.c
+===================================================================
+--- /dev/null
++++ FFmpeg/libavcodec/videotoolbox_av1.c
+@@ -0,0 +1,104 @@
++/*
++ * Videotoolbox hardware acceleration for AV1
++ * Copyright (c) 2023 Jan Ekström
++ * Copyright (c) 2024 Ruslan Chernenko
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "libavutil/mem.h"
++
++#include "av1dec.h"
++#include "hwaccel_internal.h"
++#include "internal.h"
++#include "vt_internal.h"
++
++CFDataRef ff_videotoolbox_av1c_extradata_create(AVCodecContext *avctx)
++{
++    AV1DecContext *s = avctx->priv_data;
++    uint8_t *buf;
++    CFDataRef data;
++    if (!s->raw_seq)
++        return NULL;
++
++    buf = av_malloc(s->seq_data_ref->size + 4);
++    if (!buf)
++        return NULL;
++    buf[0] = 0x81; // version and marker (constant)
++    buf[1] = s->raw_seq->seq_profile << 5 | s->raw_seq->seq_level_idx[0];
++    buf[2] = s->raw_seq->seq_tier[0]                << 7 |
++             s->raw_seq->color_config.high_bitdepth << 6 |
++             s->raw_seq->color_config.twelve_bit    << 5 |
++             s->raw_seq->color_config.mono_chrome   << 4 |
++             s->raw_seq->color_config.subsampling_x << 3 |
++             s->raw_seq->color_config.subsampling_y << 2 |
++             s->raw_seq->color_config.chroma_sample_position;
++
++    if (s->raw_seq->initial_display_delay_present_flag)
++        buf[3] = 0 << 5 |
++                 s->raw_seq->initial_display_delay_present_flag << 4 |
++                 s->raw_seq->initial_display_delay_minus_1[0];
++    else
++        buf[3] = 0x00;
++    memcpy(buf + 4, s->seq_data_ref->data, s->seq_data_ref->size);
++    data = CFDataCreate(kCFAllocatorDefault, buf, s->seq_data_ref->size + 4);
++    av_free(buf);
++    return data;
++};
++
++
++static int videotoolbox_av1_start_frame(AVCodecContext *avctx,
++                                        const uint8_t *buffer,
++                                        uint32_t size)
++{
++    return 0;
++}
++
++static int videotoolbox_av1_decode_slice(AVCodecContext *avctx,
++                                         const uint8_t *buffer,
++                                         uint32_t size)
++{
++    return 0;
++}
++
++static int videotoolbox_av1_end_frame(AVCodecContext *avctx)
++{
++    const AV1DecContext *s = avctx->priv_data;
++    VTContext *vtctx = avctx->internal->hwaccel_priv_data;
++    AVFrame *frame = s->cur_frame.f;
++
++    vtctx->bitstream_size = 0;
++    for (int i = s->start_unit; i < s->nb_unit; i++)
++        ff_videotoolbox_buffer_append(vtctx, s->current_obu.units[i].data,
++                                      s->current_obu.units[i].data_size);
++    return ff_videotoolbox_common_end_frame(avctx, frame);
++}
++
++const FFHWAccel ff_av1_videotoolbox_hwaccel = {
++    .p.name         = "av1_videotoolbox",
++    .p.type         = AVMEDIA_TYPE_VIDEO,
++    .p.id           = AV_CODEC_ID_AV1,
++    .p.pix_fmt      = AV_PIX_FMT_VIDEOTOOLBOX,
++    .alloc_frame    = ff_videotoolbox_alloc_frame,
++    .start_frame    = videotoolbox_av1_start_frame,
++    .decode_slice   = videotoolbox_av1_decode_slice,
++    .end_frame      = videotoolbox_av1_end_frame,
++    .frame_params   = ff_videotoolbox_frame_params,
++    .init           = ff_videotoolbox_common_init,
++    .uninit         = ff_videotoolbox_uninit,
++    .priv_data_size = sizeof(VTContext),
++};
+Index: FFmpeg/libavcodec/av1dec.h
+===================================================================
+--- FFmpeg.orig/libavcodec/av1dec.h
++++ FFmpeg/libavcodec/av1dec.h
+@@ -108,7 +108,8 @@ typedef struct AV1DecContext {
+     AV1Frame ref[AV1_NUM_REF_FRAMES];
+     AV1Frame cur_frame;
+ 
+-    int nb_unit;
++    int nb_unit;           ///< The index of the next OBU to be processed.
++    int start_unit;        ///< The index of the first OBU of the current frame.
+ 
+     // AVOptions
+     int operating_point;
+Index: FFmpeg/configure
+===================================================================
+--- FFmpeg.orig/configure
++++ FFmpeg/configure
+@@ -2463,6 +2463,7 @@ TYPES_LIST="
+     kCMVideoCodecType_HEVC
+     kCMVideoCodecType_HEVCWithAlpha
+     kCMVideoCodecType_VP9
++    kCMVideoCodecType_AV1
+     kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange
+     kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange
+     kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange
+@@ -3159,6 +3160,8 @@ av1_vaapi_hwaccel_deps="vaapi VADecPictu
+ av1_vaapi_hwaccel_select="av1_decoder"
+ av1_vdpau_hwaccel_deps="vdpau VdpPictureInfoAV1"
+ av1_vdpau_hwaccel_select="av1_decoder"
++av1_videotoolbox_hwaccel_deps="videotoolbox"
++av1_videotoolbox_hwaccel_select="av1_decoder"
+ av1_vulkan_hwaccel_deps="vulkan"
+ av1_vulkan_hwaccel_select="av1_decoder"
+ h263_vaapi_hwaccel_deps="vaapi"
+@@ -6707,6 +6710,7 @@ enabled videotoolbox && {
+     check_func_headers CoreMedia/CMFormatDescription.h kCMVideoCodecType_HEVC "-framework CoreMedia"
+     check_func_headers CoreMedia/CMFormatDescription.h kCMVideoCodecType_HEVCWithAlpha "-framework CoreMedia"
+     check_func_headers CoreMedia/CMFormatDescription.h kCMVideoCodecType_VP9 "-framework CoreMedia"
++    check_func_headers CoreMedia/CMFormatDescription.h kCMVideoCodecType_AV1 "-framework CoreMedia"
+     check_func_headers CoreVideo/CVPixelBuffer.h kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange "-framework CoreVideo"
+     check_func_headers CoreVideo/CVPixelBuffer.h kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange "-framework CoreVideo"
+     check_func_headers CoreVideo/CVPixelBuffer.h kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange "-framework CoreVideo"
+Index: FFmpeg/libavcodec/videotoolbox.c
+===================================================================
+--- FFmpeg.orig/libavcodec/videotoolbox.c
++++ FFmpeg/libavcodec/videotoolbox.c
+@@ -55,6 +55,10 @@ enum { kCMVideoCodecType_HEVC = 'hvc1' }
+ enum { kCMVideoCodecType_VP9 = 'vp09' };
+ #endif
+ 
++#if !HAVE_KCMVIDEOCODECTYPE_AV1
++enum { kCMVideoCodecType_AV1 = 'av01' };
++#endif
++
+ #define VIDEOTOOLBOX_ESDS_EXTRADATA_PADDING  12
+ 
+ typedef struct VTHWFrame {
+@@ -91,6 +95,26 @@ int ff_videotoolbox_buffer_copy(VTContex
+     return 0;
+ }
+ 
++int ff_videotoolbox_buffer_append(VTContext *vtctx,
++                                  const uint8_t *buffer,
++                                  uint32_t size)
++{
++    void *tmp;
++
++    tmp = av_fast_realloc(vtctx->bitstream,
++                          &vtctx->allocated_size,
++                          vtctx->bitstream_size + size);
++
++    if (!tmp)
++        return AVERROR(ENOMEM);
++
++    vtctx->bitstream = tmp;
++    memcpy(vtctx->bitstream + vtctx->bitstream_size, buffer, size);
++    vtctx->bitstream_size += (int)size;
++
++    return 0;
++}
++
+ static int videotoolbox_postproc_frame(void *avctx, AVFrame *frame)
+ {
+     int ret;
+@@ -839,6 +863,13 @@ static CFDictionaryRef videotoolbox_deco
+             CFDictionarySetValue(avc_info, CFSTR("vpcC"), data);
+         break;
+ #endif
++#if CONFIG_AV1_VIDEOTOOLBOX_HWACCEL
++    case kCMVideoCodecType_AV1 :
++        data = ff_videotoolbox_av1c_extradata_create(avctx);
++        if (data)
++            CFDictionarySetValue(avc_info, CFSTR("av1C"), data);
++        break;
++#endif
+     default:
+         break;
+     }
+@@ -904,6 +935,9 @@ static int videotoolbox_start(AVCodecCon
+     case AV_CODEC_ID_VP9 :
+         videotoolbox->cm_codec_type = kCMVideoCodecType_VP9;
+         break;
++    case AV_CODEC_ID_AV1 :
++        videotoolbox->cm_codec_type = kCMVideoCodecType_AV1;
++        break;
+     default :
+         break;
+     }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -78,3 +78,4 @@
 0078-fix-atenc-layout-samplerate.patch
 0079-videotoolbox-remove-opengl-compatability.patch
 0080-use-dynamic-pool-for-vpl-qsv-hwupload.patch
+0081-backport-av1-videotoolbox.patch


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This backports AV1 hardware acceleration from upstream and has been tested on the M4 Max. It is important to note that unlike other hardware acceleration provided by VideoToolbox, Apple does not offer any software fallback for AV1. Consequently, the decode will silently fail for all frames when the system lacks AV1 support or when the video utilizes parameters not supported by the decoder (e.g., 4:2:2 and 4:4:4 color). To address this issue, we must implement a server-side workaround to provide graceful software fallback. This is feasible as Apple has a finite set of chips that do not support AV1, while all current chips support AV1 and possess the same decoding capabilities. 

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->