### PR TITLE
builder: use github as libisl mirror for ct-ng

### DIFF
--- a/builder/images/base-linux64/ct-ng-config
+++ b/builder/images/base-linux64/ct-ng-config
@@ -825,7 +825,7 @@ CT_ISL_V_0_26=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.26"
-CT_ISL_MIRRORS="https://libisl.sourceforge.io"
+CT_ISL_MIRRORS="https://github.com/gnattu/isl/releases/download/isl-0.26"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/builder/images/base-linuxarm64/ct-ng-config
+++ b/builder/images/base-linuxarm64/ct-ng-config
@@ -829,7 +829,7 @@ CT_ISL_V_0_26=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.26"
-CT_ISL_MIRRORS="https://libisl.sourceforge.io"
+CT_ISL_MIRRORS="https://github.com/gnattu/isl/releases/download/isl-0.26"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"

--- a/builder/images/base-win64/ct-ng-config
+++ b/builder/images/base-win64/ct-ng-config
@@ -663,7 +663,7 @@ CT_ISL_V_0_26=y
 # CT_ISL_V_0_16 is not set
 # CT_ISL_V_0_15 is not set
 CT_ISL_VERSION="0.26"
-CT_ISL_MIRRORS="https://libisl.sourceforge.io"
+CT_ISL_MIRRORS="https://github.com/gnattu/isl/releases/download/isl-0.26"
 CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
 CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"


### PR DESCRIPTION
The previously used official SourceForge mirror is not reliable as the upstream hosting appears to be IP-blocking some GitHub runners’ IP addresses. Replace it with a self-hosted mirror on GitHub. This mirror is a repository created specifically for this purpose and can be updated if needed.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->