### PR TITLE
avformat/assenc: do not copy null terminator

### DIFF
--- a/debian/patches/0082-fix-ass-incorrect-null-copy.patch
+++ b/debian/patches/0082-fix-ass-incorrect-null-copy.patch
@@ -1,0 +1,14 @@
+Index: FFmpeg/libavformat/assenc.c
+===================================================================
+--- FFmpeg.orig/libavformat/assenc.c
++++ FFmpeg/libavformat/assenc.c
+@@ -67,7 +67,8 @@ static int write_header(AVFormatContext
+                 ass->trailer = trailer;
+         }
+ 
+-        ffio_write_lines(s->pb, par->extradata, header_size, NULL);
++        header_size = av_strnlen(par->extradata, header_size);
++        ffio_write_lines(s->pb, par->extradata, (int)header_size, NULL);
+ 
+         ass->ssa_mode = !strstr(par->extradata, "\n[V4+ Styles]");
+         if (!strstr(par->extradata, "\n[Events]"))

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -79,3 +79,4 @@
 0079-videotoolbox-remove-opengl-compatability.patch
 0080-use-dynamic-pool-for-vpl-qsv-hwupload.patch
 0081-backport-av1-videotoolbox.patch
+0082-fix-ass-incorrect-null-copy.patch


### PR DESCRIPTION
The `par->extradata` buffer filled from some matroska files may be null terminated, and use `ffio_write_lines` using the full buffer length will copy this null character into the output files. This results in a file in which there is a null terminator after the header, but preceeding the actual content of the subtitle file. Treat this buffer as a string and write line with the text length of this buffer to skip the null character.

Regression from 7bf1b9b

Fixes #506 
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->