### PR TITLE
fftools/ffmpeg_mux_init: default to input timebase for streamcopy

### DIFF
--- a/debian/patches/0083-default-to-input-timebase-for-streamcopy.patch
+++ b/debian/patches/0083-default-to-input-timebase-for-streamcopy.patch
@@ -1,0 +1,48 @@
+Index: FFmpeg/fftools/ffmpeg_mux_init.c
+===================================================================
+--- FFmpeg.orig/fftools/ffmpeg_mux_init.c
++++ FFmpeg/fftools/ffmpeg_mux_init.c
+@@ -962,17 +962,12 @@ static int streamcopy_init(const Muxer *
+     else
+         ost->st->avg_frame_rate = ist->st->avg_frame_rate;
+ 
+-    ret = avformat_transfer_internal_stream_timing_info(mux->fc->oformat,
+-                                                        ost->st, ist->st, copy_tb);
+-    if (ret < 0)
+-        goto fail;
+-
+     // copy timebase while removing common factors
+     if (ost->st->time_base.num <= 0 || ost->st->time_base.den <= 0) {
+         if (fr.num)
+             ost->st->time_base = av_inv_q(fr);
+         else
+-            ost->st->time_base = av_add_q(av_stream_get_codec_timebase(ost->st), (AVRational){0, 1});
++            ost->st->time_base = av_add_q(ist->st->time_base, (AVRational){0, 1});
+     }
+ 
+     if (!ms->copy_prior_start) {
+Index: FFmpeg/tests/fate/ffmpeg.mak
+===================================================================
+--- FFmpeg.orig/tests/fate/ffmpeg.mak
++++ FFmpeg/tests/fate/ffmpeg.mak
+@@ -144,7 +144,7 @@ fate-copy-trac236: CMD = transcode mov $
+ 
+ FATE_STREAMCOPY-$(call TRANSCODE, RAWVIDEO MPEG2VIDEO, MXF, MPEGTS_DEMUXER MPEGVIDEO_PARSER MPEGAUDIO_PARSER MP2_DECODER ARESAMPLE_FILTER PCM_S16LE_DECODER) += fate-copy-trac4914
+ fate-copy-trac4914: CMD = transcode mpegts $(TARGET_SAMPLES)/mpeg2/xdcam8mp2-1s_small.ts\
+-                      mxf "-c:a pcm_s16le -af aresample -c:v copy"
++                      mxf "-c:a pcm_s16le -af aresample -c:v copy -time_base 1001/30000"
+ 
+ FATE_STREAMCOPY-$(call TRANSCODE, RAWVIDEO MPEG2VIDEO, AVI, MPEGTS_DEMUXER MPEGVIDEO_PARSER MPEGAUDIO_PARSER EXTRACT_EXTRADATA_BSF MP2_DECODER ARESAMPLE_FILTER) += fate-copy-trac4914-avi
+ fate-copy-trac4914-avi: CMD = transcode mpegts $(TARGET_SAMPLES)/mpeg2/xdcam8mp2-1s_small.ts\
+Index: FFmpeg/tests/ref/fate/copy-trac4914-avi
+===================================================================
+--- FFmpeg.orig/tests/ref/fate/copy-trac4914-avi
++++ FFmpeg/tests/ref/fate/copy-trac4914-avi
+@@ -1,5 +1,5 @@
+-26e4202638bc384b82d2b5eb4d33a5f0 *tests/data/fate/copy-trac4914-avi.avi
+-479494 tests/data/fate/copy-trac4914-avi.avi
++3b6f31b806ef421652a066f239536b0d *tests/data/fate/copy-trac4914-avi.avi
++492046 tests/data/fate/copy-trac4914-avi.avi
+ #tb 0: 1001/30000
+ #media_type 0: video
+ #codec_id 0: rawvideo

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -79,3 +79,4 @@
 0079-videotoolbox-remove-opengl-compatability.patch
 0080-use-dynamic-pool-for-vpl-qsv-hwupload.patch
 0081-backport-av1-videotoolbox.patch
+0083-default-to-input-timebase-for-streamcopy.patch


### PR DESCRIPTION
Stop trying to invent some "framerate-based" timebase when there is no reason to think the stream is CFR at all.

This is a backport of upstream commit [10185e2d4c1e9839bc58a1d6a63c861677b13fd0](https://github.com/FFmpeg/FFmpeg/commit/10185e2d4c1e9839bc58a1d6a63c861677b13fd0#diff-d8c9bbd6e9b0ecf96503d73ed510c90dcb0b97debb3b4474c1466cd88e849881)

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes https://github.com/jellyfin/jellyfin/issues/13052