### PR TITLE
avfilter/tonemapx: add dovi to hdr10 support

### DIFF
--- a/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
@@ -1909,9 +1909,9 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +            g1x8 = vminq_u16(g1x8, vdupq_n_u16(INT16_MAX));
 +            b1x8 = vminq_u16(b1x8, vdupq_n_u16(INT16_MAX));
 +
-+            r0ox8 = r0x8;
-+            g0ox8 = g0x8;
-+            b0ox8 = b0x8;
++            r0ox8 = vreinterpretq_s16_u16(r0x8);
++            g0ox8 = vreinterpretq_s16_u16(g0x8);
++            b0ox8 = vreinterpretq_s16_u16(b0x8);
 +
 +            r0oax4 = vmovl_s16(vget_low_s16(r0ox8));
 +            g0oax4 = vmovl_s16(vget_low_s16(g0ox8));
@@ -1938,9 +1938,9 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +            y0ox8 = vcombine_u16(vqmovun_s32(y0oax4), vqmovun_s32(y0obx4));
 +            vst1q_u16(&dsty[x], y0ox8);
 +
-+            r1ox8 = r1x8;
-+            g1ox8 = g1x8;
-+            b1ox8 = b1x8;
++            r1ox8 = vreinterpretq_s16_u16(r1x8);
++            g1ox8 = vreinterpretq_s16_u16(g1x8);
++            b1ox8 = vreinterpretq_s16_u16(b1x8);
 +
 +            r1oax4 = vmovl_s16(vget_low_s16(r1ox8));
 +            g1oax4 = vmovl_s16(vget_low_s16(g1ox8));

--- a/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
@@ -95,7 +95,7 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
-@@ -0,0 +1,2022 @@
+@@ -0,0 +1,2366 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -1684,6 +1684,350 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +#endif // ENABLE_TONEMAPX_NEON_INTRINSICS
 +}
 +
++void tonemap_frame_dovi_2_420hdr_neon(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
++                                      const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
++                                      const int *dstlinesize, const int *srclinesize,
++                                      int dstdepth, int srcdepth,
++                                      int width, int height,
++                                      const struct TonemapIntParams *params)
++{
++#ifdef ENABLE_TONEMAPX_NEON_INTRINSICS
++    uint16_t *rdsty = dsty;
++    uint16_t *rdstu = dstu;
++    uint16_t *rdstv = dstv;
++    const uint16_t *rsrcy = srcy;
++    const uint16_t *rsrcu = srcu;
++    const uint16_t *rsrcv = srcv;
++    int rheight = height;
++    // not zero when not divisible by 8
++    // intentionally leave last pixel emtpy when input is odd
++    int remainw = width & 6;
++
++    int cry   = (*params->rgb2yuv_coeffs)[0][0][0];
++    int cgy   = (*params->rgb2yuv_coeffs)[0][1][0];
++    int cby   = (*params->rgb2yuv_coeffs)[0][2][0];
++    int cru   = (*params->rgb2yuv_coeffs)[1][0][0];
++    int ocgu  = (*params->rgb2yuv_coeffs)[1][1][0];
++    int cburv = (*params->rgb2yuv_coeffs)[1][2][0];
++    int ocgv  = (*params->rgb2yuv_coeffs)[2][1][0];
++    int cbv   = (*params->rgb2yuv_coeffs)[2][2][0];
++
++    uint16x4_t ux4, vx4;
++    uint16x8_t y0x8, y1x8, ux8, vx8;
++    uint16x8_t r0x8, g0x8, b0x8;
++    uint16x8_t r1x8, g1x8, b1x8;
++
++    int16x8_t r0ox8, g0ox8, b0ox8;
++    uint16x8_t y0ox8;
++    int32x4_t r0oax4, r0obx4, g0oax4, g0obx4, b0oax4, b0obx4;
++    int32x4_t y0oax4, y0obx4;
++
++    int16x8_t r1ox8, g1ox8, b1ox8;
++    uint16x8_t y1ox8;
++    int32x4_t r1oax4, r1obx4, g1oax4, g1obx4, b1oax4, b1obx4;
++    int32x4_t y1oax4, y1obx4;
++    int32x2_t ravgax2, gavgax2, bavgax2, ravgbx2, gavgbx2, bavgbx2;
++    int32x4_t ravgx4, gavgx4, bavgx4, uox4, vox4;
++    int32x4_t out_yuv_offx4 = vdupq_n_s32(params->out_yuv_off);
++    int32x4_t out_rndx4 = vdupq_n_s32(TEN_BIT_ROUNDING);
++    int32x4_t out_uv_offsetx4 = vdupq_n_s32(TEN_BIT_UV_OFFSET);
++    int32x4_t rgb_avg_rndx4 = vdupq_n_s32(CHROMA_AVG_ROUNDING);
++    float32x4_t ipt0, ipt1, ipt2, ipt3;
++    float32x4_t ia1, ib1, ia2, ib2;
++    float32x4_t ix4, px4, tx4;
++    float32x4_t lx4, mx4, sx4;
++    float32x4_t rx4a, gx4a, bx4a, rx4b, gx4b, bx4b;
++    float32x4_t y0x4a, y0x4b, y1x4a, y1x4b, ux4a, ux4b, vx4a, vx4b;
++    for (; height > 1; height -= 2,
++                       dsty += dstlinesize[0], dstu += dstlinesize[1] / 2, dstv += dstlinesize[1] / 2,
++                       srcy += srclinesize[0], srcu += srclinesize[1] / 2, srcv += srclinesize[1] / 2) {
++        for (int xx = 0; xx < width >> 3; xx++) {
++            int x = xx << 3;
++
++            y0x8 = vld1q_u16(srcy + x);
++            y1x8 = vld1q_u16(srcy + (srclinesize[0] / 2 + x));
++            ux4 = vld1_u16(srcu + (x >> 1));
++            vx4 = vld1_u16(srcv + (x >> 1));
++
++            ux8 = vcombine_u16(vzip1_u16(ux4, ux4), vzip2_u16(ux4, ux4));
++            vx8 = vcombine_u16(vzip1_u16(vx4, vx4), vzip2_u16(vx4, vx4));
++
++            y0x4a = vcvtq_f32_u32(vmovl_u16(vget_low_u16(y0x8)));
++            y0x4b = vcvtq_f32_u32(vmovl_u16(vget_high_u16(y0x8)));
++            y1x4a = vcvtq_f32_u32(vmovl_u16(vget_low_u16(y1x8)));
++            y1x4b = vcvtq_f32_u32(vmovl_u16(vget_high_u16(y1x8)));
++
++            ux4a = vcvtq_f32_u32(vmovl_u16(vget_low_u16(ux8)));
++            ux4b = vcvtq_f32_u32(vmovl_u16(vget_high_u16(ux8)));
++            vx4a = vcvtq_f32_u32(vmovl_u16(vget_low_u16(vx8)));
++            vx4b = vcvtq_f32_u32(vmovl_u16(vget_high_u16(vx8)));
++
++            y0x4a = vdivq_f32(y0x4a, vdupq_n_f32(TEN_BIT_SCALE));
++            y0x4b = vdivq_f32(y0x4b, vdupq_n_f32(TEN_BIT_SCALE));
++            y1x4a = vdivq_f32(y1x4a, vdupq_n_f32(TEN_BIT_SCALE));
++            y1x4b = vdivq_f32(y1x4b, vdupq_n_f32(TEN_BIT_SCALE));
++            ux4a = vdivq_f32(ux4a, vdupq_n_f32(TEN_BIT_SCALE));
++            ux4b = vdivq_f32(ux4b, vdupq_n_f32(TEN_BIT_SCALE));
++            vx4a = vdivq_f32(vx4a, vdupq_n_f32(TEN_BIT_SCALE));
++            vx4b = vdivq_f32(vx4b, vdupq_n_f32(TEN_BIT_SCALE));
++
++            // Reshape y0x4a
++            ia1 = vzip1q_f32(y0x4a, ux4a);
++            ia2 = vzip2q_f32(y0x4a, ux4a);
++            ib1 = vzip1q_f32(vx4a, vdupq_n_f32(0.0f));
++            ib2 = vzip2q_f32(vx4a, vdupq_n_f32(0.0f));
++            ipt0 = vcombine_f32(vget_low_f32(ia1), vget_low_f32(ib1));
++            ipt1 = vcombine_f32(vget_high_f32(ia1), vget_high_f32(ib1));
++            ipt2 = vcombine_f32(vget_low_f32(ia2), vget_low_f32(ib2));
++            ipt3 = vcombine_f32(vget_high_f32(ia2), vget_high_f32(ib2));
++
++            ipt0 = reshape_dovi_iptpqc2(ipt0, params);
++            ipt1 = reshape_dovi_iptpqc2(ipt1, params);
++            ipt2 = reshape_dovi_iptpqc2(ipt2, params);
++            ipt3 = reshape_dovi_iptpqc2(ipt3, params);
++
++            ia1 = vtrn1q_f32(ipt0, ipt1);
++            ia2 = vtrn1q_f32(ipt2, ipt3);
++            ib1 = vtrn2q_f32(ipt0, ipt1);
++            ib2 = vtrn2q_f32(ipt2, ipt3);
++
++            ix4 = vcombine_f32(vget_low_f32(ia1), vget_low_f32(ia2));
++            px4 = vcombine_f32(vget_low_f32(ib1), vget_low_f32(ib2));
++            tx4 = vcombine_f32(vget_high_f32(ia1), vget_high_f32(ia2));
++
++            ycc2rgbx4(&lx4, &mx4, &sx4, ix4, px4, tx4, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx4(&rx4a, &gx4a, &bx4a, lx4, mx4, sx4, *params->lms2rgb_matrix);
++
++            rx4a = vmulq_n_f32(rx4a, JPEG_SCALE);
++            gx4a = vmulq_n_f32(gx4a, JPEG_SCALE);
++            bx4a = vmulq_n_f32(bx4a, JPEG_SCALE);
++
++            // Reshape y0x4b
++            ia1 = vzip1q_f32(y0x4b, ux4b);
++            ia2 = vzip2q_f32(y0x4b, ux4b);
++            ib1 = vzip1q_f32(vx4b, vdupq_n_f32(0.0f));
++            ib2 = vzip2q_f32(vx4b, vdupq_n_f32(0.0f));
++            ipt0 = vcombine_f32(vget_low_f32(ia1), vget_low_f32(ib1));
++            ipt1 = vcombine_f32(vget_high_f32(ia1), vget_high_f32(ib1));
++            ipt2 = vcombine_f32(vget_low_f32(ia2), vget_low_f32(ib2));
++            ipt3 = vcombine_f32(vget_high_f32(ia2), vget_high_f32(ib2));
++
++            ipt0 = reshape_dovi_iptpqc2(ipt0, params);
++            ipt1 = reshape_dovi_iptpqc2(ipt1, params);
++            ipt2 = reshape_dovi_iptpqc2(ipt2, params);
++            ipt3 = reshape_dovi_iptpqc2(ipt3, params);
++
++            ia1 = vtrn1q_f32(ipt0, ipt1);
++            ia2 = vtrn1q_f32(ipt2, ipt3);
++            ib1 = vtrn2q_f32(ipt0, ipt1);
++            ib2 = vtrn2q_f32(ipt2, ipt3);
++
++            ix4 = vcombine_f32(vget_low_f32(ia1), vget_low_f32(ia2));
++            px4 = vcombine_f32(vget_low_f32(ib1), vget_low_f32(ib2));
++            tx4 = vcombine_f32(vget_high_f32(ia1), vget_high_f32(ia2));
++
++            ycc2rgbx4(&lx4, &mx4, &sx4, ix4, px4, tx4, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx4(&rx4b, &gx4b, &bx4b, lx4, mx4, sx4, *params->lms2rgb_matrix);
++
++            rx4b = vmulq_n_f32(rx4b, JPEG_SCALE);
++            gx4b = vmulq_n_f32(gx4b, JPEG_SCALE);
++            bx4b = vmulq_n_f32(bx4b, JPEG_SCALE);
++
++            r0x8 = vcombine_u16(vqmovn_u32(vcvtq_u32_f32(rx4a)), vqmovn_u32(vcvtq_u32_f32(rx4b)));
++            g0x8 = vcombine_u16(vqmovn_u32(vcvtq_u32_f32(gx4a)), vqmovn_u32(vcvtq_u32_f32(gx4b)));
++            b0x8 = vcombine_u16(vqmovn_u32(vcvtq_u32_f32(bx4a)), vqmovn_u32(vcvtq_u32_f32(bx4b)));
++            r0x8 = vminq_u16(r0x8, vdupq_n_u16(INT16_MAX));
++            g0x8 = vminq_u16(g0x8, vdupq_n_u16(INT16_MAX));
++            b0x8 = vminq_u16(b0x8, vdupq_n_u16(INT16_MAX));
++
++            // Reshape y1x4a
++            ia1 = vzip1q_f32(y1x4a, ux4a);
++            ia2 = vzip2q_f32(y1x4a, ux4a);
++            ib1 = vzip1q_f32(vx4a, vdupq_n_f32(0.0f));
++            ib2 = vzip2q_f32(vx4a, vdupq_n_f32(0.0f));
++            ipt0 = vcombine_f32(vget_low_f32(ia1), vget_low_f32(ib1));
++            ipt1 = vcombine_f32(vget_high_f32(ia1), vget_high_f32(ib1));
++            ipt2 = vcombine_f32(vget_low_f32(ia2), vget_low_f32(ib2));
++            ipt3 = vcombine_f32(vget_high_f32(ia2), vget_high_f32(ib2));
++
++            ipt0 = reshape_dovi_iptpqc2(ipt0, params);
++            ipt1 = reshape_dovi_iptpqc2(ipt1, params);
++            ipt2 = reshape_dovi_iptpqc2(ipt2, params);
++            ipt3 = reshape_dovi_iptpqc2(ipt3, params);
++
++            ia1 = vtrn1q_f32(ipt0, ipt1);
++            ia2 = vtrn1q_f32(ipt2, ipt3);
++            ib1 = vtrn2q_f32(ipt0, ipt1);
++            ib2 = vtrn2q_f32(ipt2, ipt3);
++
++            ix4 = vcombine_f32(vget_low_f32(ia1), vget_low_f32(ia2));
++            px4 = vcombine_f32(vget_low_f32(ib1), vget_low_f32(ib2));
++            tx4 = vcombine_f32(vget_high_f32(ia1), vget_high_f32(ia2));
++
++            ycc2rgbx4(&lx4, &mx4, &sx4, ix4, px4, tx4, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx4(&rx4a, &gx4a, &bx4a, lx4, mx4, sx4, *params->lms2rgb_matrix);
++
++            rx4a = vmulq_n_f32(rx4a, JPEG_SCALE);
++            gx4a = vmulq_n_f32(gx4a, JPEG_SCALE);
++            bx4a = vmulq_n_f32(bx4a, JPEG_SCALE);
++
++            // Reshape y1x4b
++            ia1 = vzip1q_f32(y1x4b, ux4b);
++            ia2 = vzip2q_f32(y1x4b, ux4b);
++            ib1 = vzip1q_f32(vx4b, vdupq_n_f32(0.0f));
++            ib2 = vzip2q_f32(vx4b, vdupq_n_f32(0.0f));
++            ipt0 = vcombine_f32(vget_low_f32(ia1), vget_low_f32(ib1));
++            ipt1 = vcombine_f32(vget_high_f32(ia1), vget_high_f32(ib1));
++            ipt2 = vcombine_f32(vget_low_f32(ia2), vget_low_f32(ib2));
++            ipt3 = vcombine_f32(vget_high_f32(ia2), vget_high_f32(ib2));
++
++            ipt0 = reshape_dovi_iptpqc2(ipt0, params);
++            ipt1 = reshape_dovi_iptpqc2(ipt1, params);
++            ipt2 = reshape_dovi_iptpqc2(ipt2, params);
++            ipt3 = reshape_dovi_iptpqc2(ipt3, params);
++
++            ia1 = vtrn1q_f32(ipt0, ipt1);
++            ia2 = vtrn1q_f32(ipt2, ipt3);
++            ib1 = vtrn2q_f32(ipt0, ipt1);
++            ib2 = vtrn2q_f32(ipt2, ipt3);
++
++            ix4 = vcombine_f32(vget_low_f32(ia1), vget_low_f32(ia2));
++            px4 = vcombine_f32(vget_low_f32(ib1), vget_low_f32(ib2));
++            tx4 = vcombine_f32(vget_high_f32(ia1), vget_high_f32(ia2));
++
++            ycc2rgbx4(&lx4, &mx4, &sx4, ix4, px4, tx4, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx4(&rx4b, &gx4b, &bx4b, lx4, mx4, sx4, *params->lms2rgb_matrix);
++
++            rx4b = vmulq_n_f32(rx4b, JPEG_SCALE);
++            gx4b = vmulq_n_f32(gx4b, JPEG_SCALE);
++            bx4b = vmulq_n_f32(bx4b, JPEG_SCALE);
++
++            r1x8 = vcombine_u16(vqmovn_u32(vcvtq_u32_f32(rx4a)), vqmovn_u32(vcvtq_u32_f32(rx4b)));
++            g1x8 = vcombine_u16(vqmovn_u32(vcvtq_u32_f32(gx4a)), vqmovn_u32(vcvtq_u32_f32(gx4b)));
++            b1x8 = vcombine_u16(vqmovn_u32(vcvtq_u32_f32(bx4a)), vqmovn_u32(vcvtq_u32_f32(bx4b)));
++            r1x8 = vminq_u16(r1x8, vdupq_n_u16(INT16_MAX));
++            g1x8 = vminq_u16(g1x8, vdupq_n_u16(INT16_MAX));
++            b1x8 = vminq_u16(b1x8, vdupq_n_u16(INT16_MAX));
++
++            r0ox8 = r0x8;
++            g0ox8 = g0x8;
++            b0ox8 = b0x8;
++
++            r0oax4 = vmovl_s16(vget_low_s16(r0ox8));
++            g0oax4 = vmovl_s16(vget_low_s16(g0ox8));
++            b0oax4 = vmovl_s16(vget_low_s16(b0ox8));
++
++            r0obx4 = vmovl_s16(vget_high_s16(r0ox8));
++            g0obx4 = vmovl_s16(vget_high_s16(g0ox8));
++            b0obx4 = vmovl_s16(vget_high_s16(b0ox8));
++
++            y0oax4 = vmulq_n_s32(r0oax4, cry);
++            y0oax4 = vmlaq_n_s32(y0oax4, g0oax4, cgy);
++            y0oax4 = vmlaq_n_s32(y0oax4, b0oax4, cby);
++            y0oax4 = vaddq_s32(y0oax4, out_rndx4);
++            y0oax4 = vshrq_n_s32(y0oax4, TEN_BIT_SCALE_SHIFT);
++            y0oax4 = vaddq_s32(y0oax4, out_yuv_offx4);
++
++            y0obx4 = vmulq_n_s32(r0obx4, cry);
++            y0obx4 = vmlaq_n_s32(y0obx4, g0obx4, cgy);
++            y0obx4 = vmlaq_n_s32(y0obx4, b0obx4, cby);
++            y0obx4 = vaddq_s32(y0obx4, out_rndx4);
++            y0obx4 = vshrq_n_s32(y0obx4, TEN_BIT_SCALE_SHIFT);
++            y0obx4 = vaddq_s32(y0obx4, out_yuv_offx4);
++
++            y0ox8 = vcombine_u16(vqmovun_s32(y0oax4), vqmovun_s32(y0obx4));
++            vst1q_u16(&dsty[x], y0ox8);
++
++            r1ox8 = r1x8;
++            g1ox8 = g1x8;
++            b1ox8 = b1x8;
++
++            r1oax4 = vmovl_s16(vget_low_s16(r1ox8));
++            g1oax4 = vmovl_s16(vget_low_s16(g1ox8));
++            b1oax4 = vmovl_s16(vget_low_s16(b1ox8));
++
++            r1obx4 = vmovl_s16(vget_high_s16(r1ox8));
++            g1obx4 = vmovl_s16(vget_high_s16(g1ox8));
++            b1obx4 = vmovl_s16(vget_high_s16(b1ox8));
++
++            y1oax4 = vmulq_n_s32(r1oax4, cry);
++            y1oax4 = vmlaq_n_s32(y1oax4, g1oax4, cgy);
++            y1oax4 = vmlaq_n_s32(y1oax4, b1oax4, cby);
++            y1oax4 = vaddq_s32(y1oax4, out_rndx4);
++            y1oax4 = vshrq_n_s32(y1oax4, TEN_BIT_SCALE_SHIFT);
++            y1oax4 = vaddq_s32(y1oax4, out_yuv_offx4);
++
++            y1obx4 = vmulq_n_s32(r1obx4, cry);
++            y1obx4 = vmlaq_n_s32(y1obx4, g1obx4, cgy);
++            y1obx4 = vmlaq_n_s32(y1obx4, b1obx4, cby);
++            y1obx4 = vaddq_s32(y1obx4, out_rndx4);
++            y1obx4 = vshrq_n_s32(y1obx4, TEN_BIT_SCALE_SHIFT);
++            y1obx4 = vaddq_s32(y1obx4, out_yuv_offx4);
++
++            y1ox8 = vcombine_u16(vqmovun_s32(y1oax4), vqmovun_s32(y1obx4));
++            vst1q_u16(&dsty[x + dstlinesize[0] / 2], y1ox8);
++
++            ravgax2 = vpadd_s32(vget_low_s32(r0oax4), vget_high_s32(r0oax4));
++            ravgbx2 = vpadd_s32(vget_low_s32(r0obx4), vget_high_s32(r0obx4));
++            ravgx4 = vcombine_s32(ravgax2, ravgbx2);
++            ravgax2 = vpadd_s32(vget_low_s32(r1oax4), vget_high_s32(r1oax4));
++            ravgbx2 = vpadd_s32(vget_low_s32(r1obx4), vget_high_s32(r1obx4));
++            ravgx4 = vaddq_s32(ravgx4, vcombine_s32(ravgax2, ravgbx2));
++            ravgx4 = vaddq_s32(ravgx4, rgb_avg_rndx4);
++            ravgx4 = vshrq_n_s32(ravgx4, CHROMA_AVG_ROUNDING);
++
++            gavgax2 = vpadd_s32(vget_low_s32(g0oax4), vget_high_s32(g0oax4));
++            gavgbx2 = vpadd_s32(vget_low_s32(g0obx4), vget_high_s32(g0obx4));
++            gavgx4 = vcombine_s32(gavgax2, gavgbx2);
++            gavgax2 = vpadd_s32(vget_low_s32(g1oax4), vget_high_s32(g1oax4));
++            gavgbx2 = vpadd_s32(vget_low_s32(g1obx4), vget_high_s32(g1obx4));
++            gavgx4 = vaddq_s32(gavgx4, vcombine_s32(gavgax2, gavgbx2));
++            gavgx4 = vaddq_s32(gavgx4, rgb_avg_rndx4);
++            gavgx4 = vshrq_n_s32(gavgx4, CHROMA_AVG_ROUNDING);
++
++            bavgax2 = vpadd_s32(vget_low_s32(b0oax4), vget_high_s32(b0oax4));
++            bavgbx2 = vpadd_s32(vget_low_s32(b0obx4), vget_high_s32(b0obx4));
++            bavgx4 = vcombine_s32(bavgax2, bavgbx2);
++            bavgax2 = vpadd_s32(vget_low_s32(b1oax4), vget_high_s32(b1oax4));
++            bavgbx2 = vpadd_s32(vget_low_s32(b1obx4), vget_high_s32(b1obx4));
++            bavgx4 = vaddq_s32(bavgx4, vcombine_s32(bavgax2, bavgbx2));
++            bavgx4 = vaddq_s32(bavgx4, rgb_avg_rndx4);
++            bavgx4 = vshrq_n_s32(bavgx4, CHROMA_AVG_ROUNDING);
++
++            uox4 = vmlaq_n_s32(out_rndx4, ravgx4, cru);
++            uox4 = vmlaq_n_s32(uox4, gavgx4, ocgu);
++            uox4 = vmlaq_n_s32(uox4, bavgx4, cburv);
++            uox4 = vshrq_n_s32(uox4, TEN_BIT_SCALE_SHIFT);
++            uox4 = vaddq_s32(uox4, out_uv_offsetx4);
++            vst1_u16(&dstu[x >> 1], vqmovun_s32(uox4));
++
++            vox4 = vmlaq_n_s32(out_rndx4, ravgx4, cburv);
++            vox4 = vmlaq_n_s32(vox4, gavgx4, ocgv);
++            vox4 = vmlaq_n_s32(vox4, bavgx4, cbv);
++            vox4 = vshrq_n_s32(vox4, TEN_BIT_SCALE_SHIFT);
++            vox4 = vaddq_s32(vox4, out_uv_offsetx4);
++            vst1_u16(&dstv[x >> 1], vqmovun_s32(vox4));
++        }
++    }
++
++    // Process remaining pixels cannot fill the full simd register with scalar version
++    if (remainw) {
++        int offset = width & (int)0xfffffff8;
++        rdsty += offset;
++        rdstu += offset >> 1;
++        rdstv += offset >> 1;
++        rsrcy += offset;
++        rsrcu += offset >> 1;
++        rsrcv += offset >> 1;
++        tonemap_frame_dovi_2_420hdr(rdsty, rdstu, rdstv,
++                                    rsrcy, rsrcu, rsrcv,
++                                    dstlinesize, srclinesize,
++                                    dstdepth, srcdepth,
++                                    remainw, rheight, params);
++    }
++#endif // ENABLE_TONEMAPX_NEON_INTRINSICS
++}
++
 +void tonemap_frame_420p10_2_420p10_neon(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
 +                                        const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
 +                                        const int *dstlinesize, const int *srclinesize,
@@ -2122,7 +2466,7 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.h
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,75 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -2170,6 +2514,13 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.h
 +                                    const struct TonemapIntParams *params);
 +
 +void tonemap_frame_dovi_2_420p10_neon(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
++                                      const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
++                                      const int *dstlinesize, const int *srclinesize,
++                                      int dstdepth, int srcdepth,
++                                      int width, int height,
++                                      const struct TonemapIntParams *params);
++
++void tonemap_frame_dovi_2_420hdr_neon(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
 +                                      const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
 +                                      const int *dstlinesize, const int *srclinesize,
 +                                      int dstdepth, int srcdepth,
@@ -2271,7 +2622,7 @@ Index: FFmpeg/libavfilter/colorspace.h
 ===================================================================
 --- FFmpeg.orig/libavfilter/colorspace.h
 +++ FFmpeg/libavfilter/colorspace.h
-@@ -85,4 +85,8 @@ float eotf_arib_b67(float x);
+@@ -109,4 +109,8 @@ float eotf_arib_b67(float x);
  float inverse_eotf_arib_b67(float x);
  float inverse_eotf_bt1886(float x);
  
@@ -2284,7 +2635,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.c
-@@ -0,0 +1,1799 @@
+@@ -0,0 +1,1881 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -3354,6 +3705,67 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    }
 +}
 +
++void tonemap_frame_dovi_2_420hdr(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
++                                 const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
++                                 const int *dstlinesize, const int *srclinesize,
++                                 int dstdepth, int srcdepth,
++                                 int width, int height,
++                                 const struct TonemapIntParams *params)
++{
++    const int in_depth = srcdepth;
++    const int out_depth = dstdepth;
++    const int out_uv_offset = 128 << (out_depth - 8);
++    const int out_sh = 29 - out_depth;
++    const int out_rnd = 1 << (out_sh - 1);
++
++    int cry   = (*params->rgb2yuv_coeffs)[0][0][0];
++    int cgy   = (*params->rgb2yuv_coeffs)[0][1][0];
++    int cby   = (*params->rgb2yuv_coeffs)[0][2][0];
++    int cru   = (*params->rgb2yuv_coeffs)[1][0][0];
++    int ocgu  = (*params->rgb2yuv_coeffs)[1][1][0];
++    int cburv = (*params->rgb2yuv_coeffs)[1][2][0];
++    int ocgv  = (*params->rgb2yuv_coeffs)[2][1][0];
++    int cbv   = (*params->rgb2yuv_coeffs)[2][2][0];
++
++    int r00, g00, b00;
++    int r01, g01, b01;
++    int r10, g10, b10;
++    int r11, g11, b11;
++
++    const float in_rng = (float)((1 << in_depth) - 1);
++
++    int16_t r[4], g[4], b[4];
++    for (; height > 1; height -= 2,
++                       dsty += dstlinesize[0], dstu += dstlinesize[1] / 2, dstv += dstlinesize[1] / 2,
++                       srcy += srclinesize[0], srcu += srclinesize[1] / 2, srcv += srclinesize[1] / 2) {
++        for (int x = 0; x < width; x += 2) {
++            int y00 = (srcy[x]                         );
++            int y01 = (srcy[x + 1]                     );
++            int y10 = (srcy[srclinesize[0] / 2 + x]    );
++            int y11 = (srcy[srclinesize[0] / 2 + x + 1]);
++            int u = (srcu[x >> 1]);
++            int v = (srcv[x >> 1]);
++
++            dovi2rgb(y00, y01, y10, y11, u, v, params, in_rng, r, g, b);
++
++            r00 = r[0], g00 = g[0], b00 = b[0];
++            r01 = r[1], g01 = g[1], b01 = b[1];
++            r10 = r[2], g10 = g[2], b10 = b[2];
++            r11 = r[3], g11 = g[3], b11 = b[3];
++
++            dsty[x]                          = av_clip_uintp2((params->out_yuv_off + ((r00 * cry + g00 * cgy + b00 * cby + out_rnd) >> out_sh)), 10);
++            dsty[x + 1]                      = av_clip_uintp2((params->out_yuv_off + ((r01 * cry + g01 * cgy + b01 * cby + out_rnd) >> out_sh)), 10);
++            dsty[dstlinesize[0] / 2 + x]     = av_clip_uintp2((params->out_yuv_off + ((r10 * cry + g10 * cgy + b10 * cby + out_rnd) >> out_sh)), 10);
++            dsty[dstlinesize[0] / 2 + x + 1] = av_clip_uintp2((params->out_yuv_off + ((r11 * cry + g11 * cgy + b11 * cby + out_rnd) >> out_sh)), 10);
++
++#define AVG(a,b,c,d) (((a) + (b) + (c) + (d) + 2) >> 2)
++            dstu[x >> 1] = av_clip_uintp2((out_uv_offset + ((AVG(r00, r01, r10, r11) * cru + AVG(g00, g01, g10, g11) * ocgu + AVG(b00, b01, b10, b11) * cburv + out_rnd) >> out_sh)), 10);
++            dstv[x >> 1] = av_clip_uintp2((out_uv_offset + ((AVG(r00, r01, r10, r11) * cburv + AVG(g00, g01, g10, g11) * ocgv + AVG(b00, b01, b10, b11) * cbv + out_rnd) >> out_sh)), 10);
++#undef AVG
++        }
++    }
++}
++
 +void tonemap_frame_420p10_2_420p(uint8_t *dsty, uint8_t *dstu, uint8_t *dstv,
 +                                 const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
 +                                 const int *dstlinesize, const int *srclinesize,
@@ -3804,8 +4216,11 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +
 +    av_frame_free(&in);
 +
-+    av_frame_remove_side_data(out, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
-+    av_frame_remove_side_data(out, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
++    if (s->trc !=AVCOL_TRC_SMPTE2084) {
++        av_frame_remove_side_data(out, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
++        av_frame_remove_side_data(out, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
++    }
++
 +    av_frame_remove_side_data(out, AV_FRAME_DATA_DOVI_RPU_BUFFER);
 +    av_frame_remove_side_data(out, AV_FRAME_DATA_DOVI_METADATA);
 +
@@ -3896,6 +4311,23 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    av_log(s, AV_LOG_DEBUG, "Requested output format: %s\n",
 +           s->format_str);
 +
++    if (s->trc == AVCOL_TRC_SMPTE2084) {
++        if (s->spc != AVCOL_SPC_BT2020_NCL) {
++            av_log(s, AV_LOG_ERROR, "HDR passthrough requires BT2020 Non-constant luminance matrix\n");
++            return AVERROR(EINVAL);
++        }
++
++        if (s->pri != AVCOL_PRI_BT2020) {
++            av_log(s, AV_LOG_ERROR, "HDR passthrough requires BT2020 primaries\n");
++            return AVERROR(EINVAL);
++        }
++
++        if (!s->apply_dovi) {
++            av_log(s, AV_LOG_ERROR, "HDR passthrough only works for Dolby Vision inputs at the moment\n");
++            return AVERROR(EINVAL);
++        }
++    }
++
 +#if ARCH_AARCH64
 +#ifdef ENABLE_TONEMAPX_NEON_INTRINSICS
 +    {
@@ -3906,7 +4338,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +            s->tonemap_func_planar8 = tonemap_frame_420p10_2_420p_neon;
 +            s->tonemap_func_planar10 = tonemap_frame_420p10_2_420p10_neon;
 +            s->tonemap_func_dovi8 = tonemap_frame_dovi_2_420p_neon;
-+            s->tonemap_func_dovi10 = tonemap_frame_dovi_2_420p10_neon;
++            s->tonemap_func_dovi10 = s->trc == AVCOL_TRC_SMPTE2084 ? tonemap_frame_dovi_2_420hdr_neon : tonemap_frame_dovi_2_420p10_neon;
 +            active_simd = SIMD_NEON;
 +        }
 +    }
@@ -3923,7 +4355,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +            s->tonemap_func_planar8 = tonemap_frame_420p10_2_420p_sse;
 +            s->tonemap_func_planar10 = tonemap_frame_420p10_2_420p10_sse;
 +            s->tonemap_func_dovi8 = tonemap_frame_dovi_2_420p_sse;
-+            s->tonemap_func_dovi10 = tonemap_frame_dovi_2_420p10_sse;
++            s->tonemap_func_dovi10 = s->trc == AVCOL_TRC_SMPTE2084 ? tonemap_frame_dovi_2_420hdr_sse : tonemap_frame_dovi_2_420p10_sse;
 +            active_simd = SIMD_SSE;
 +        }
 +    }
@@ -3939,7 +4371,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +            s->tonemap_func_planar8 = tonemap_frame_420p10_2_420p_avx;
 +            s->tonemap_func_planar10 = tonemap_frame_420p10_2_420p10_avx;
 +            s->tonemap_func_dovi8 = tonemap_frame_dovi_2_420p_avx;
-+            s->tonemap_func_dovi10 = tonemap_frame_dovi_2_420p10_avx;
++            s->tonemap_func_dovi10 = s->trc == AVCOL_TRC_SMPTE2084 ? tonemap_frame_dovi_2_420hdr_avx : tonemap_frame_dovi_2_420p10_avx;
 +            active_simd = SIMD_AVX;
 +        }
 +    }
@@ -3975,7 +4407,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    }
 +
 +    if (!s->tonemap_func_dovi10) {
-+        s->tonemap_func_dovi10 = tonemap_frame_dovi_2_420p10;
++        s->tonemap_func_dovi10 = s->trc == AVCOL_TRC_SMPTE2084 ? tonemap_frame_dovi_2_420hdr : tonemap_frame_dovi_2_420p10;
 +    }
 +
 +    switch (active_simd) {
@@ -4040,6 +4472,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    { "t",            "set transfer characteristic", OFFSET(trc), AV_OPT_TYPE_INT, {.i64 = AVCOL_TRC_BT709}, -1, INT_MAX, FLAGS, .unit = "transfer" },
 +    {     "bt709",    0, 0, AV_OPT_TYPE_CONST, {.i64 = AVCOL_TRC_BT709},           0, 0, FLAGS, .unit = "transfer" },
 +    {     "bt2020",   0, 0, AV_OPT_TYPE_CONST, {.i64 = AVCOL_TRC_BT2020_10},       0, 0, FLAGS, .unit = "transfer" },
++    {     "smpte2084",0, 0, AV_OPT_TYPE_CONST, {.i64 = AVCOL_TRC_SMPTE2084},       0, 0, FLAGS, .unit = "transfer" },
 +    { "matrix",       "set colorspace matrix", OFFSET(spc), AV_OPT_TYPE_INT, {.i64 = AVCOL_SPC_BT709}, -1, INT_MAX, FLAGS, .unit = "matrix" },
 +    { "m",            "set colorspace matrix", OFFSET(spc), AV_OPT_TYPE_INT, {.i64 = AVCOL_SPC_BT709}, -1, INT_MAX, FLAGS, .unit = "matrix" },
 +    {     "bt709",    0, 0, AV_OPT_TYPE_CONST, {.i64 = AVCOL_SPC_BT709},           0, 0, FLAGS, .unit = "matrix" },
@@ -4088,7 +4521,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.h
-@@ -0,0 +1,137 @@
+@@ -0,0 +1,144 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -4211,6 +4644,13 @@ Index: FFmpeg/libavfilter/vf_tonemapx.h
 +                                 int width, int height,
 +                                 const struct TonemapIntParams *params);
 +
++void tonemap_frame_dovi_2_420hdr(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
++                                 const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
++                                 const int *dstlinesize, const int *srclinesize,
++                                 int dstdepth, int srcdepth,
++                                 int width, int height,
++                                 const struct TonemapIntParams *params);
++
 +void tonemap_frame_420p10_2_420p10(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
 +                                   const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
 +                                   const int *dstlinesize, const int *srclinesize,
@@ -4243,7 +4683,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
-@@ -0,0 +1,2289 @@
+@@ -0,0 +1,2584 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -5323,6 +5763,301 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +        rsrcu += offset >> 1;
 +        rsrcv += offset >> 1;
 +        tonemap_frame_dovi_2_420p10(rdsty, rdstu, rdstv,
++                                    rsrcy, rsrcu, rsrcv,
++                                    dstlinesize, srclinesize,
++                                    dstdepth, srcdepth,
++                                    remainw, rheight, params);
++    }
++#endif // ENABLE_TONEMAPX_AVX_INTRINSICS
++}
++
++X86_64_V3 void tonemap_frame_dovi_2_420hdr_avx(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
++                                               const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
++                                               const int *dstlinesize, const int *srclinesize,
++                                               int dstdepth, int srcdepth,
++                                               int width, int height,
++                                               const struct TonemapIntParams *params)
++{
++#ifdef ENABLE_TONEMAPX_AVX_INTRINSICS
++    uint16_t *rdsty = dsty;
++    uint16_t *rdstu = dstu;
++    uint16_t *rdstv = dstv;
++    const uint16_t *rsrcy = srcy;
++    const uint16_t *rsrcu = srcu;
++    const uint16_t *rsrcv = srcv;
++    int rheight = height;
++    // not zero when not divisible by 8
++    // intentionally leave last pixel emtpy when input is odd
++    int remainw = width & 14;
++
++    const int in_depth = srcdepth;
++    const float in_rng = (float)((1 << in_depth) - 1);
++
++    const int out_depth = dstdepth;
++    const int out_uv_offset = 128 << (out_depth - 8);
++    const int out_sh = 29 - out_depth;
++    const int out_rnd = 1 << (out_sh - 1);
++
++    int cry   = (*params->rgb2yuv_coeffs)[0][0][0];
++    int cgy   = (*params->rgb2yuv_coeffs)[0][1][0];
++    int cby   = (*params->rgb2yuv_coeffs)[0][2][0];
++    int cru   = (*params->rgb2yuv_coeffs)[1][0][0];
++    int ocgu  = (*params->rgb2yuv_coeffs)[1][1][0];
++    int cburv = (*params->rgb2yuv_coeffs)[1][2][0];
++    int ocgv  = (*params->rgb2yuv_coeffs)[2][1][0];
++    int cbv   = (*params->rgb2yuv_coeffs)[2][2][0];
++
++    __m256i ux8, vx8;
++    __m256i y0x16, y1x16;
++    __m256i y0x8a, y0x8b, y1x8a, y1x8b, ux8a, ux8b, vx8a, vx8b;
++    __m256i r0x8a, g0x8a, b0x8a, r0x8b, g0x8b, b0x8b;
++    __m256i r1x8a, g1x8a, b1x8a, r1x8b, g1x8b, b1x8b;
++
++    __m256i y0ox16;
++    __m256i roax8, robx8, goax8, gobx8, boax8, bobx8;
++    __m256i yoax8, yobx8;
++
++    __m256i y1ox16;
++    __m256i r1oax8, r1obx8, g1oax8, g1obx8, b1oax8, b1obx8;
++    __m256i y1oax8, y1obx8;
++    __m256i uox8, vox8, ravgx8, gavgx8, bavgx8;
++
++    __m128 ipt0, ipt1, ipt2, ipt3, ipt4, ipt5, ipt6, ipt7;
++    __m256 ix8, px8, tx8;
++    __m256 lx8, mx8, sx8;
++    __m256 rx8a, gx8a, bx8a, rx8b, gx8b, bx8b;
++    __m256 y0x8af, y0x8bf, y1x8af, y1x8bf, ux8af, ux8bf, vx8af, vx8bf;
++    for (; height > 1; height -= 2,
++                       dsty += dstlinesize[0], dstu += dstlinesize[1] / 2, dstv += dstlinesize[1] / 2,
++                       srcy += srclinesize[0], srcu += srclinesize[1] / 2, srcv += srclinesize[1] / 2) {
++        for (int xx = 0; xx < width >> 4; xx++) {
++            int x = xx << 4;
++
++            y0x16 = _mm256_lddqu_si256((__m256i*)(srcy + x));
++            y1x16 = _mm256_lddqu_si256((__m256i*)(srcy + (srclinesize[0] / 2 + x)));
++            ux8 = _mm256_cvtepi16_epi32(_mm_lddqu_si128((__m128i_u *)(srcu + (x >> 1))));
++            vx8 = _mm256_cvtepi16_epi32(_mm_lddqu_si128((__m128i_u *)(srcv + (x >> 1))));
++
++            y0x8a = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(y0x16, 0));
++            y0x8b = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(y0x16, 1));
++            y1x8a = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(y1x16, 0));
++            y1x8b = _mm256_cvtepi16_epi32(_mm256_extracti128_si256(y1x16, 1));
++
++            ux8a = _mm256_permutevar8x32_epi32(ux8, _mm256_set_epi32(3, 3, 2, 2, 1, 1, 0, 0));
++            ux8b = _mm256_permutevar8x32_epi32(ux8, _mm256_set_epi32(7, 7, 6, 6, 5, 5, 4, 4));
++            vx8a = _mm256_permutevar8x32_epi32(vx8, _mm256_set_epi32(3, 3, 2, 2, 1, 1, 0, 0));
++            vx8b = _mm256_permutevar8x32_epi32(vx8, _mm256_set_epi32(7, 7, 6, 6, 5, 5, 4, 4));
++
++            y0x8af = _mm256_cvtepi32_ps(y0x8a);
++            y0x8bf = _mm256_cvtepi32_ps(y0x8b);
++            y1x8af = _mm256_cvtepi32_ps(y1x8a);
++            y1x8bf = _mm256_cvtepi32_ps(y1x8b);
++            ux8af = _mm256_cvtepi32_ps(ux8a);
++            ux8bf = _mm256_cvtepi32_ps(ux8b);
++            vx8af = _mm256_cvtepi32_ps(vx8a);
++            vx8bf = _mm256_cvtepi32_ps(vx8b);
++
++            y0x8af = _mm256_div_ps(y0x8af, _mm256_set1_ps(in_rng));
++            y0x8bf = _mm256_div_ps(y0x8bf, _mm256_set1_ps(in_rng));
++            y1x8af = _mm256_div_ps(y1x8af, _mm256_set1_ps(in_rng));
++            y1x8bf = _mm256_div_ps(y1x8bf, _mm256_set1_ps(in_rng));
++            ux8af = _mm256_div_ps(ux8af, _mm256_set1_ps(in_rng));
++            ux8bf = _mm256_div_ps(ux8bf, _mm256_set1_ps(in_rng));
++            vx8af = _mm256_div_ps(vx8af, _mm256_set1_ps(in_rng));
++            vx8bf = _mm256_div_ps(vx8bf, _mm256_set1_ps(in_rng));
++
++            // Reshape y0x8a
++            reshapeiptx8(&ipt0, &ipt1, &ipt2, &ipt3,
++                         &ipt4, &ipt5, &ipt6, &ipt7,
++                         y0x8af, ux8af, vx8af, params);
++
++            transpose_ipt8x4(ipt0, ipt1, ipt2, ipt3,
++                             ipt4, ipt5, ipt6, ipt7,
++                             &ix8, &px8, &tx8);
++
++            ycc2rgbx8(&lx8, &mx8, &sx8, ix8, px8, tx8, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx8(&rx8a, &gx8a, &bx8a, lx8, mx8, sx8, *params->lms2rgb_matrix);
++
++            rx8a = _mm256_mul_ps(rx8a, _mm256_set1_ps(JPEG_SCALE));
++            gx8a = _mm256_mul_ps(gx8a, _mm256_set1_ps(JPEG_SCALE));
++            bx8a = _mm256_mul_ps(bx8a, _mm256_set1_ps(JPEG_SCALE));
++
++            r0x8a = _mm256_cvtps_epi32(rx8a);
++            r0x8a = av_clip_int16_avx(r0x8a);
++            g0x8a = _mm256_cvtps_epi32(gx8a);
++            g0x8a = av_clip_int16_avx(g0x8a);
++            b0x8a = _mm256_cvtps_epi32(bx8a);
++            b0x8a = av_clip_int16_avx(b0x8a);
++
++            // Reshape y1x8a
++            reshapeiptx8(&ipt0, &ipt1, &ipt2, &ipt3,
++                         &ipt4, &ipt5, &ipt6, &ipt7,
++                         y1x8af, ux8af, vx8af, params);
++
++            transpose_ipt8x4(ipt0, ipt1, ipt2, ipt3,
++                             ipt4, ipt5, ipt6, ipt7,
++                             &ix8, &px8, &tx8);
++
++            ycc2rgbx8(&lx8, &mx8, &sx8, ix8, px8, tx8, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx8(&rx8a, &gx8a, &bx8a, lx8, mx8, sx8, *params->lms2rgb_matrix);
++
++            rx8a = _mm256_mul_ps(rx8a, _mm256_set1_ps(JPEG_SCALE));
++            gx8a = _mm256_mul_ps(gx8a, _mm256_set1_ps(JPEG_SCALE));
++            bx8a = _mm256_mul_ps(bx8a, _mm256_set1_ps(JPEG_SCALE));
++
++            r1x8a = _mm256_cvtps_epi32(rx8a);
++            r1x8a = av_clip_int16_avx(r1x8a);
++            g1x8a = _mm256_cvtps_epi32(gx8a);
++            g1x8a = av_clip_int16_avx(g1x8a);
++            b1x8a = _mm256_cvtps_epi32(bx8a);
++            b1x8a = av_clip_int16_avx(b1x8a);
++
++            // Reshape y0x8b
++            reshapeiptx8(&ipt0, &ipt1, &ipt2, &ipt3,
++                         &ipt4, &ipt5, &ipt6, &ipt7,
++                         y0x8bf, ux8bf, vx8bf, params);
++
++            transpose_ipt8x4(ipt0, ipt1, ipt2, ipt3,
++                             ipt4, ipt5, ipt6, ipt7,
++                             &ix8, &px8, &tx8);
++
++            ycc2rgbx8(&lx8, &mx8, &sx8, ix8, px8, tx8, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx8(&rx8b, &gx8b, &bx8b, lx8, mx8, sx8, *params->lms2rgb_matrix);
++
++            rx8b = _mm256_mul_ps(rx8b, _mm256_set1_ps(JPEG_SCALE));
++            gx8b = _mm256_mul_ps(gx8b, _mm256_set1_ps(JPEG_SCALE));
++            bx8b = _mm256_mul_ps(bx8b, _mm256_set1_ps(JPEG_SCALE));
++
++            r0x8b = _mm256_cvtps_epi32(rx8b);
++            r0x8b = av_clip_int16_avx(r0x8b);
++            g0x8b = _mm256_cvtps_epi32(gx8b);
++            g0x8b = av_clip_int16_avx(g0x8b);
++            b0x8b = _mm256_cvtps_epi32(bx8b);
++            b0x8b = av_clip_int16_avx(b0x8b);
++
++            // Reshape y1x8b
++            reshapeiptx8(&ipt0, &ipt1, &ipt2, &ipt3,
++                         &ipt4, &ipt5, &ipt6, &ipt7,
++                         y1x8bf, ux8bf, vx8bf, params);
++
++            transpose_ipt8x4(ipt0, ipt1, ipt2, ipt3,
++                             ipt4, ipt5, ipt6, ipt7,
++                             &ix8, &px8, &tx8);
++
++            ycc2rgbx8(&lx8, &mx8, &sx8, ix8, px8, tx8, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx8(&rx8b, &gx8b, &bx8b, lx8, mx8, sx8, *params->lms2rgb_matrix);
++
++            rx8b = _mm256_mul_ps(rx8b, _mm256_set1_ps(JPEG_SCALE));
++            gx8b = _mm256_mul_ps(gx8b, _mm256_set1_ps(JPEG_SCALE));
++            bx8b = _mm256_mul_ps(bx8b, _mm256_set1_ps(JPEG_SCALE));
++
++            r1x8b = _mm256_cvtps_epi32(rx8b);
++            r1x8b = av_clip_int16_avx(r1x8b);
++            g1x8b = _mm256_cvtps_epi32(gx8b);
++            g1x8b = av_clip_int16_avx(g1x8b);
++            b1x8b = _mm256_cvtps_epi32(bx8b);
++            b1x8b = av_clip_int16_avx(b1x8b);
++
++            roax8 = r0x8a;
++            goax8 = g0x8a;
++            boax8 = b0x8a;
++
++            robx8 = r0x8b;
++            gobx8 = g0x8b;
++            bobx8 = b0x8b;
++
++            yoax8 = _mm256_mullo_epi32(roax8, _mm256_set1_epi32(cry));
++            yoax8 = _mm256_add_epi32(yoax8, _mm256_mullo_epi32(goax8, _mm256_set1_epi32(cgy)));
++            yoax8 = _mm256_add_epi32(yoax8, _mm256_mullo_epi32(boax8, _mm256_set1_epi32(cby)));
++            yoax8 = _mm256_add_epi32(yoax8, _mm256_set1_epi32(out_rnd));
++            yoax8 = _mm256_srai_epi32(yoax8, out_sh);
++            yoax8 = _mm256_add_epi32(yoax8, _mm256_set1_epi32(params->out_yuv_off));
++
++            yobx8 = _mm256_mullo_epi32(robx8, _mm256_set1_epi32(cry));
++            yobx8 = _mm256_add_epi32(yobx8, _mm256_mullo_epi32(gobx8, _mm256_set1_epi32(cgy)));
++            yobx8 = _mm256_add_epi32(yobx8, _mm256_mullo_epi32(bobx8, _mm256_set1_epi32(cby)));
++            yobx8 = _mm256_add_epi32(yobx8, _mm256_set1_epi32(out_rnd));
++            yobx8 = _mm256_srai_epi32(yobx8, out_sh);
++            yobx8 = _mm256_add_epi32(yobx8, _mm256_set1_epi32(params->out_yuv_off));
++
++            y0ox16 = _mm256_packus_epi32(yoax8, yobx8);
++            y0ox16 = _mm256_permute4x64_epi64(y0ox16, _MM_SHUFFLE(3, 1, 2, 0));
++            _mm256_storeu_si256((__m256i_u *) &dsty[x], y0ox16);
++
++            r1oax8 = r1x8a;
++            g1oax8 = g1x8a;
++            b1oax8 = b1x8a;
++
++            r1obx8 = r1x8b;
++            g1obx8 = g1x8b;
++            b1obx8 = b1x8b;
++
++            y1oax8 = _mm256_mullo_epi32(r1oax8, _mm256_set1_epi32(cry));
++            y1oax8 = _mm256_add_epi32(y1oax8, _mm256_mullo_epi32(g1oax8, _mm256_set1_epi32(cgy)));
++            y1oax8 = _mm256_add_epi32(y1oax8, _mm256_mullo_epi32(b1oax8, _mm256_set1_epi32(cby)));
++            y1oax8 = _mm256_add_epi32(y1oax8, _mm256_set1_epi32(out_rnd));
++            y1oax8 = _mm256_srai_epi32(y1oax8, out_sh);
++            y1oax8 = _mm256_add_epi32(y1oax8, _mm256_set1_epi32(params->out_yuv_off));
++
++            y1obx8 = _mm256_mullo_epi32(r1obx8, _mm256_set1_epi32(cry));
++            y1obx8 = _mm256_add_epi32(y1obx8, _mm256_mullo_epi32(g1obx8, _mm256_set1_epi32(cgy)));
++            y1obx8 = _mm256_add_epi32(y1obx8, _mm256_mullo_epi32(b1obx8, _mm256_set1_epi32(cby)));
++            y1obx8 = _mm256_add_epi32(y1obx8, _mm256_set1_epi32(out_rnd));
++            y1obx8 = _mm256_srai_epi32(y1obx8, out_sh);
++            y1obx8 = _mm256_add_epi32(y1obx8, _mm256_set1_epi32(params->out_yuv_off));
++
++            y1ox16 = _mm256_packus_epi32(y1oax8, y1obx8);
++            y1ox16 = _mm256_permute4x64_epi64(y1ox16, _MM_SHUFFLE(3, 1, 2, 0));
++            _mm256_storeu_si256((__m256i_u *) &dsty[x + dstlinesize[0] / 2], y1ox16);
++
++            ravgx8 = _mm256_hadd_epi32(roax8, robx8);
++            ravgx8 = _mm256_add_epi32(ravgx8, _mm256_hadd_epi32(r1oax8, r1obx8));
++            ravgx8 = _mm256_permute4x64_epi64(ravgx8, _MM_SHUFFLE(3, 1, 2, 0));
++            ravgx8 = _mm256_add_epi32(ravgx8, _mm256_set1_epi32(2));
++            ravgx8 = _mm256_srai_epi32(ravgx8, 2);
++
++            gavgx8 = _mm256_hadd_epi32(goax8, gobx8);
++            gavgx8 = _mm256_add_epi32(gavgx8, _mm256_hadd_epi32(g1oax8, g1obx8));
++            gavgx8 = _mm256_permute4x64_epi64(gavgx8, _MM_SHUFFLE(3, 1, 2, 0));
++            gavgx8 = _mm256_add_epi32(gavgx8, _mm256_set1_epi32(2));
++            gavgx8 = _mm256_srai_epi32(gavgx8, 2);
++
++            bavgx8 = _mm256_hadd_epi32(boax8, bobx8);
++            bavgx8 = _mm256_add_epi32(bavgx8, _mm256_hadd_epi32(b1oax8, b1obx8));
++            bavgx8 = _mm256_permute4x64_epi64(bavgx8, _MM_SHUFFLE(3, 1, 2, 0));
++            bavgx8 = _mm256_add_epi32(bavgx8, _mm256_set1_epi32(2));
++            bavgx8 = _mm256_srai_epi32(bavgx8, 2);
++
++            uox8 = _mm256_add_epi32(_mm256_set1_epi32(out_rnd), _mm256_mullo_epi32(ravgx8, _mm256_set1_epi32(cru)));
++            uox8 = _mm256_add_epi32(uox8, _mm256_mullo_epi32(gavgx8, _mm256_set1_epi32(ocgu)));
++            uox8 = _mm256_add_epi32(uox8, _mm256_mullo_epi32(bavgx8, _mm256_set1_epi32(cburv)));
++            uox8 = _mm256_srai_epi32(uox8, out_sh);
++            uox8 = _mm256_add_epi32(uox8, _mm256_set1_epi32(out_uv_offset));
++            uox8 = _mm256_packus_epi32(uox8, _mm256_setzero_si256());
++            uox8 = _mm256_permute4x64_epi64(uox8, _MM_SHUFFLE(3, 1, 2, 0));
++            _mm_storeu_si128((__m128i_u *) &dstu[x >> 1], _mm256_castsi256_si128(uox8));
++
++            vox8 = _mm256_add_epi32(_mm256_set1_epi32(out_rnd), _mm256_mullo_epi32(ravgx8, _mm256_set1_epi32(cburv)));
++            vox8 = _mm256_add_epi32(vox8, _mm256_mullo_epi32(gavgx8, _mm256_set1_epi32(ocgv)));
++            vox8 = _mm256_add_epi32(vox8, _mm256_mullo_epi32(bavgx8, _mm256_set1_epi32(cbv)));
++            vox8 = _mm256_srai_epi32(vox8, out_sh);
++            vox8 = _mm256_add_epi32(vox8, _mm256_set1_epi32(out_uv_offset));
++            vox8 = _mm256_packus_epi32(vox8, _mm256_setzero_si256());
++            vox8 = _mm256_permute4x64_epi64(vox8, _MM_SHUFFLE(3, 1, 2, 0));
++            _mm_storeu_si128((__m128i_u *) &dstv[x >> 1], _mm256_castsi256_si128(vox8));
++        }
++    }
++
++    // Process remaining pixels cannot fill the full simd register with scalar version
++    if (remainw) {
++        int offset = width & (int)0xfffffff0;
++        rdsty += offset;
++        rdstu += offset >> 1;
++        rdstv += offset >> 1;
++        rsrcy += offset;
++        rsrcu += offset >> 1;
++        rsrcv += offset >> 1;
++        tonemap_frame_dovi_2_420hdr(rdsty, rdstu, rdstv,
 +                                    rsrcy, rsrcu, rsrcv,
 +                                    dstlinesize, srclinesize,
 +                                    dstdepth, srcdepth,
@@ -6537,7 +7272,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.h
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,75 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -6577,6 +7312,13 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.h
 +                                               int width, int height,
 +                                               const struct TonemapIntParams *params);
 +
++X86_64_V3 void tonemap_frame_dovi_2_420hdr_avx(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
++                                               const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
++                                               const int *dstlinesize, const int *srclinesize,
++                                               int dstdepth, int srcdepth,
++                                               int width, int height,
++                                               const struct TonemapIntParams *params);
++
 +X86_64_V3 void tonemap_frame_420p10_2_420p_avx(uint8_t *dsty, uint8_t *dstu, uint8_t *dstv,
 +                                               const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
 +                                               const int *dstlinesize, const int *srclinesize,
@@ -6610,7 +7352,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
-@@ -0,0 +1,2370 @@
+@@ -0,0 +1,2740 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -7790,6 +8532,376 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +        rsrcu += offset >> 1;
 +        rsrcv += offset >> 1;
 +        tonemap_frame_dovi_2_420p10(rdsty, rdstu, rdstv,
++                                      rsrcy, rsrcu, rsrcv,
++                                      dstlinesize, srclinesize,
++                                      dstdepth, srcdepth,
++                                      remainw, rheight, params);
++    }
++#endif // ENABLE_TONEMAPX_SSE_INTRINSICS
++}
++
++X86_64_V2 void tonemap_frame_dovi_2_420hdr_sse(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
++                                               const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
++                                               const int *dstlinesize, const int *srclinesize,
++                                               int dstdepth, int srcdepth,
++                                               int width, int height,
++                                               const struct TonemapIntParams *params)
++{
++#ifdef ENABLE_TONEMAPX_SSE_INTRINSICS
++    uint16_t *rdsty = dsty;
++    uint16_t *rdstu = dstu;
++    uint16_t *rdstv = dstv;
++    const uint16_t *rsrcy = srcy;
++    const uint16_t *rsrcu = srcu;
++    const uint16_t *rsrcv = srcv;
++    int rheight = height;
++    // not zero when not divisible by 8
++    // intentionally leave last pixel emtpy when input is odd
++    int remainw = width & 6;
++
++    const int in_depth = srcdepth;
++    const float in_rng = (float)((1 << in_depth) - 1);
++
++    const int out_depth = dstdepth;
++    const int out_uv_offset = 128 << (out_depth - 8);
++    const int out_sh = 29 - out_depth;
++    const int out_rnd = 1 << (out_sh - 1);
++
++    int cry   = (*params->rgb2yuv_coeffs)[0][0][0];
++    int cgy   = (*params->rgb2yuv_coeffs)[0][1][0];
++    int cby   = (*params->rgb2yuv_coeffs)[0][2][0];
++    int cru   = (*params->rgb2yuv_coeffs)[1][0][0];
++    int ocgu  = (*params->rgb2yuv_coeffs)[1][1][0];
++    int cburv = (*params->rgb2yuv_coeffs)[1][2][0];
++    int ocgv  = (*params->rgb2yuv_coeffs)[2][1][0];
++    int cbv   = (*params->rgb2yuv_coeffs)[2][2][0];
++
++    __m128i zero128 = _mm_setzero_si128();
++    __m128i ux4, vx4;
++    __m128i y0x8, y1x8;
++    __m128i y0x4a, y0x4b, y1x4a, y1x4b, ux4a, ux4b, vx4a, vx4b;
++    __m128i r0x4a, g0x4a, b0x4a, r0x4b, g0x4b, b0x4b;
++    __m128i r1x4a, g1x4a, b1x4a, r1x4b, g1x4b, b1x4b;
++
++    __m128i y0ox8;
++    __m128i roax4, robx4, goax4, gobx4, boax4, bobx4;
++    __m128i yoax4, yobx4;
++
++    __m128i y1ox8;
++    __m128i r1oax4, r1obx4, g1oax4, g1obx4, b1oax4, b1obx4;
++    __m128i y1oax4, y1obx4;
++    __m128i uox4, vox4, ravgx4, gavgx4, bavgx4;
++
++    __m128 ipt0, ipt1, ipt2, ipt3;
++    __m128 ia1, ib1, ia2, ib2;
++    __m128 ix4, px4, tx4;
++    __m128 lx4, mx4, sx4;
++    __m128 rx4a, gx4a, bx4a, rx4b, gx4b, bx4b;
++    __m128 y0x4af, y0x4bf, y1x4af, y1x4bf, ux4af, ux4bf, vx4af, vx4bf;
++    for (; height > 1; height -= 2,
++                       dsty += dstlinesize[0], dstu += dstlinesize[1] / 2, dstv += dstlinesize[1] / 2,
++                       srcy += srclinesize[0], srcu += srclinesize[1] / 2, srcv += srclinesize[1] / 2) {
++        for (int xx = 0; xx < width >> 3; xx++) {
++            int x = xx << 3;
++
++            y0x8 = _mm_lddqu_si128((__m128i*)(srcy + x));
++            y1x8 = _mm_lddqu_si128((__m128i*)(srcy + (srclinesize[0] / 2 + x)));
++            ux4 = _mm_loadu_si64((__m128i*)(srcu + (x >> 1)));
++            vx4 = _mm_loadu_si64((__m128i*)(srcv + (x >> 1)));
++
++            y0x4a = _mm_cvtepu16_epi32(y0x8);
++            y0x4b = _mm_unpackhi_epi16(y0x8, zero128);
++            y1x4a = _mm_cvtepu16_epi32(y1x8);
++            y1x4b = _mm_unpackhi_epi16(y1x8, zero128);
++            ux4 = _mm_cvtepu16_epi32(ux4);
++            vx4 = _mm_cvtepu16_epi32(vx4);
++
++            ux4a = _mm_unpacklo_epi32(ux4, ux4);
++            ux4b = _mm_unpackhi_epi32(ux4, ux4);
++            vx4a = _mm_unpacklo_epi32(vx4, vx4);
++            vx4b = _mm_unpackhi_epi32(vx4, vx4);
++
++            y0x4af = _mm_cvtepi32_ps(y0x4a);
++            y0x4bf = _mm_cvtepi32_ps(y0x4b);
++            y1x4af = _mm_cvtepi32_ps(y1x4a);
++            y1x4bf = _mm_cvtepi32_ps(y1x4b);
++            ux4af = _mm_cvtepi32_ps(ux4a);
++            ux4bf = _mm_cvtepi32_ps(ux4b);
++            vx4af = _mm_cvtepi32_ps(vx4a);
++            vx4bf = _mm_cvtepi32_ps(vx4b);
++
++            y0x4af = _mm_div_ps(y0x4af, _mm_set1_ps(in_rng));
++            y0x4bf = _mm_div_ps(y0x4bf, _mm_set1_ps(in_rng));
++            y1x4af = _mm_div_ps(y1x4af, _mm_set1_ps(in_rng));
++            y1x4bf = _mm_div_ps(y1x4bf, _mm_set1_ps(in_rng));
++            ux4af = _mm_div_ps(ux4af, _mm_set1_ps(in_rng));
++            ux4bf = _mm_div_ps(ux4bf, _mm_set1_ps(in_rng));
++            vx4af = _mm_div_ps(vx4af, _mm_set1_ps(in_rng));
++            vx4bf = _mm_div_ps(vx4bf, _mm_set1_ps(in_rng));
++
++            // Reshape y0x4a
++            ia1 = _mm_unpacklo_ps(y0x4af, ux4af);
++            ia2 = _mm_unpackhi_ps(y0x4af, ux4af);
++            ib1 = _mm_unpacklo_ps(vx4af, _mm_setzero_ps());
++            ib2 = _mm_unpackhi_ps(vx4af, _mm_setzero_ps());
++            ipt0 = _mm_shuffle_ps(ia1, ib1, _MM_SHUFFLE(1, 0, 1, 0));
++            ipt1 = _mm_shuffle_ps(ia1, ib1, _MM_SHUFFLE(3, 2, 3, 2));
++            ipt2 = _mm_shuffle_ps(ia2, ib2, _MM_SHUFFLE(1, 0, 1, 0));
++            ipt3 = _mm_shuffle_ps(ia2, ib2, _MM_SHUFFLE(3, 2, 3, 2));
++
++            ipt0 = reshape_dovi_iptpqc2(ipt0, params);
++            ipt1 = reshape_dovi_iptpqc2(ipt1, params);
++            ipt2 = reshape_dovi_iptpqc2(ipt2, params);
++            ipt3 = reshape_dovi_iptpqc2(ipt3, params);
++
++            ipt0 = _mm_shuffle_ps(ipt0, ipt0, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt1 = _mm_shuffle_ps(ipt1, ipt1, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt2 = _mm_shuffle_ps(ipt2, ipt2, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt3 = _mm_shuffle_ps(ipt3, ipt3, _MM_SHUFFLE(3, 1, 2, 0));
++
++            ia1 = _mm_unpacklo_ps(ipt0, ipt1);
++            ia2 = _mm_unpacklo_ps(ipt2, ipt3);
++            ib1 = _mm_unpackhi_ps(ipt0, ipt1);
++            ib2 = _mm_unpackhi_ps(ipt2, ipt3);
++
++            ix4 = _mm_shuffle_ps(ia1, ia2, _MM_SHUFFLE(1, 0, 1, 0));
++            px4 = _mm_shuffle_ps(ib1, ib2, _MM_SHUFFLE(1, 0, 1, 0));
++            tx4 = _mm_shuffle_ps(ia1, ia2, _MM_SHUFFLE(3, 2, 3, 2));
++
++            ycc2rgbx4(&lx4, &mx4, &sx4, ix4, px4, tx4, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx4(&rx4a, &gx4a, &bx4a, lx4, mx4, sx4, *params->lms2rgb_matrix);
++
++            rx4a = _mm_mul_ps(rx4a, _mm_set1_ps(JPEG_SCALE));
++            gx4a = _mm_mul_ps(gx4a, _mm_set1_ps(JPEG_SCALE));
++            bx4a = _mm_mul_ps(bx4a, _mm_set1_ps(JPEG_SCALE));
++
++            r0x4a = _mm_cvtps_epi32(rx4a);
++            r0x4a = av_clip_int16_sse(r0x4a);
++            g0x4a = _mm_cvtps_epi32(gx4a);
++            g0x4a = av_clip_int16_sse(g0x4a);
++            b0x4a = _mm_cvtps_epi32(bx4a);
++            b0x4a = av_clip_int16_sse(b0x4a);
++
++            // Reshape y1x4a
++            ia1 = _mm_unpacklo_ps(y1x4af, ux4af);
++            ia2 = _mm_unpackhi_ps(y1x4af, ux4af);
++            ib1 = _mm_unpacklo_ps(vx4af, _mm_setzero_ps());
++            ib2 = _mm_unpackhi_ps(vx4af, _mm_setzero_ps());
++            ipt0 = _mm_shuffle_ps(ia1, ib1, _MM_SHUFFLE(1, 0, 1, 0));
++            ipt1 = _mm_shuffle_ps(ia1, ib1, _MM_SHUFFLE(3, 2, 3, 2));
++            ipt2 = _mm_shuffle_ps(ia2, ib2, _MM_SHUFFLE(1, 0, 1, 0));
++            ipt3 = _mm_shuffle_ps(ia2, ib2, _MM_SHUFFLE(3, 2, 3, 2));
++
++            ipt0 = reshape_dovi_iptpqc2(ipt0, params);
++            ipt1 = reshape_dovi_iptpqc2(ipt1, params);
++            ipt2 = reshape_dovi_iptpqc2(ipt2, params);
++            ipt3 = reshape_dovi_iptpqc2(ipt3, params);
++
++            ipt0 = _mm_shuffle_ps(ipt0, ipt0, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt1 = _mm_shuffle_ps(ipt1, ipt1, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt2 = _mm_shuffle_ps(ipt2, ipt2, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt3 = _mm_shuffle_ps(ipt3, ipt3, _MM_SHUFFLE(3, 1, 2, 0));
++
++            ia1 = _mm_unpacklo_ps(ipt0, ipt1);
++            ia2 = _mm_unpacklo_ps(ipt2, ipt3);
++            ib1 = _mm_unpackhi_ps(ipt0, ipt1);
++            ib2 = _mm_unpackhi_ps(ipt2, ipt3);
++
++            ix4 = _mm_shuffle_ps(ia1, ia2, _MM_SHUFFLE(1, 0, 1, 0));
++            px4 = _mm_shuffle_ps(ib1, ib2, _MM_SHUFFLE(1, 0, 1, 0));
++            tx4 = _mm_shuffle_ps(ia1, ia2, _MM_SHUFFLE(3, 2, 3, 2));
++
++            ycc2rgbx4(&lx4, &mx4, &sx4, ix4, px4, tx4, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx4(&rx4a, &gx4a, &bx4a, lx4, mx4, sx4, *params->lms2rgb_matrix);
++
++            rx4a = _mm_mul_ps(rx4a, _mm_set1_ps(JPEG_SCALE));
++            gx4a = _mm_mul_ps(gx4a, _mm_set1_ps(JPEG_SCALE));
++            bx4a = _mm_mul_ps(bx4a, _mm_set1_ps(JPEG_SCALE));
++
++            r1x4a = _mm_cvtps_epi32(rx4a);
++            r1x4a = av_clip_int16_sse(r1x4a);
++            g1x4a = _mm_cvtps_epi32(gx4a);
++            g1x4a = av_clip_int16_sse(g1x4a);
++            b1x4a = _mm_cvtps_epi32(bx4a);
++            b1x4a = av_clip_int16_sse(b1x4a);
++
++            // Reshape y0x4b
++            ia1 = _mm_unpacklo_ps(y0x4bf, ux4bf);
++            ia2 = _mm_unpackhi_ps(y0x4bf, ux4bf);
++            ib1 = _mm_unpacklo_ps(vx4bf, _mm_setzero_ps());
++            ib2 = _mm_unpackhi_ps(vx4bf, _mm_setzero_ps());
++            ipt0 = _mm_shuffle_ps(ia1, ib1, _MM_SHUFFLE(1, 0, 1, 0));
++            ipt1 = _mm_shuffle_ps(ia1, ib1, _MM_SHUFFLE(3, 2, 3, 2));
++            ipt2 = _mm_shuffle_ps(ia2, ib2, _MM_SHUFFLE(1, 0, 1, 0));
++            ipt3 = _mm_shuffle_ps(ia2, ib2, _MM_SHUFFLE(3, 2, 3, 2));
++
++            ipt0 = reshape_dovi_iptpqc2(ipt0, params);
++            ipt1 = reshape_dovi_iptpqc2(ipt1, params);
++            ipt2 = reshape_dovi_iptpqc2(ipt2, params);
++            ipt3 = reshape_dovi_iptpqc2(ipt3, params);
++
++            ipt0 = _mm_shuffle_ps(ipt0, ipt0, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt1 = _mm_shuffle_ps(ipt1, ipt1, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt2 = _mm_shuffle_ps(ipt2, ipt2, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt3 = _mm_shuffle_ps(ipt3, ipt3, _MM_SHUFFLE(3, 1, 2, 0));
++
++            ia1 = _mm_unpacklo_ps(ipt0, ipt1);
++            ia2 = _mm_unpacklo_ps(ipt2, ipt3);
++            ib1 = _mm_unpackhi_ps(ipt0, ipt1);
++            ib2 = _mm_unpackhi_ps(ipt2, ipt3);
++
++            ix4 = _mm_shuffle_ps(ia1, ia2, _MM_SHUFFLE(1, 0, 1, 0));
++            px4 = _mm_shuffle_ps(ib1, ib2, _MM_SHUFFLE(1, 0, 1, 0));
++            tx4 = _mm_shuffle_ps(ia1, ia2, _MM_SHUFFLE(3, 2, 3, 2));
++
++            ycc2rgbx4(&lx4, &mx4, &sx4, ix4, px4, tx4, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx4(&rx4b, &gx4b, &bx4b, lx4, mx4, sx4, *params->lms2rgb_matrix);
++
++            rx4b = _mm_mul_ps(rx4b, _mm_set1_ps(JPEG_SCALE));
++            gx4b = _mm_mul_ps(gx4b, _mm_set1_ps(JPEG_SCALE));
++            bx4b = _mm_mul_ps(bx4b, _mm_set1_ps(JPEG_SCALE));
++
++            r0x4b = _mm_cvtps_epi32(rx4b);
++            r0x4b = av_clip_int16_sse(r0x4b);
++            g0x4b = _mm_cvtps_epi32(gx4b);
++            g0x4b = av_clip_int16_sse(g0x4b);
++            b0x4b = _mm_cvtps_epi32(bx4b);
++            b0x4b = av_clip_int16_sse(b0x4b);
++
++            // Reshape y1x4b
++            ia1 = _mm_unpacklo_ps(y1x4bf, ux4bf);
++            ia2 = _mm_unpackhi_ps(y1x4bf, ux4bf);
++            ib1 = _mm_unpacklo_ps(vx4bf, _mm_setzero_ps());
++            ib2 = _mm_unpackhi_ps(vx4bf, _mm_setzero_ps());
++            ipt0 = _mm_shuffle_ps(ia1, ib1, _MM_SHUFFLE(1, 0, 1, 0));
++            ipt1 = _mm_shuffle_ps(ia1, ib1, _MM_SHUFFLE(3, 2, 3, 2));
++            ipt2 = _mm_shuffle_ps(ia2, ib2, _MM_SHUFFLE(1, 0, 1, 0));
++            ipt3 = _mm_shuffle_ps(ia2, ib2, _MM_SHUFFLE(3, 2, 3, 2));
++
++            ipt0 = reshape_dovi_iptpqc2(ipt0, params);
++            ipt1 = reshape_dovi_iptpqc2(ipt1, params);
++            ipt2 = reshape_dovi_iptpqc2(ipt2, params);
++            ipt3 = reshape_dovi_iptpqc2(ipt3, params);
++
++            ipt0 = _mm_shuffle_ps(ipt0, ipt0, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt1 = _mm_shuffle_ps(ipt1, ipt1, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt2 = _mm_shuffle_ps(ipt2, ipt2, _MM_SHUFFLE(3, 1, 2, 0));
++            ipt3 = _mm_shuffle_ps(ipt3, ipt3, _MM_SHUFFLE(3, 1, 2, 0));
++
++            ia1 = _mm_unpacklo_ps(ipt0, ipt1);
++            ia2 = _mm_unpacklo_ps(ipt2, ipt3);
++            ib1 = _mm_unpackhi_ps(ipt0, ipt1);
++            ib2 = _mm_unpackhi_ps(ipt2, ipt3);
++
++            ix4 = _mm_shuffle_ps(ia1, ia2, _MM_SHUFFLE(1, 0, 1, 0));
++            px4 = _mm_shuffle_ps(ib1, ib2, _MM_SHUFFLE(1, 0, 1, 0));
++            tx4 = _mm_shuffle_ps(ia1, ia2, _MM_SHUFFLE(3, 2, 3, 2));
++
++            ycc2rgbx4(&lx4, &mx4, &sx4, ix4, px4, tx4, params->dovi->nonlinear, *params->ycc_offset);
++            lms2rgbx4(&rx4b, &gx4b, &bx4b, lx4, mx4, sx4, *params->lms2rgb_matrix);
++
++            rx4b = _mm_mul_ps(rx4b, _mm_set1_ps(JPEG_SCALE));
++            gx4b = _mm_mul_ps(gx4b, _mm_set1_ps(JPEG_SCALE));
++            bx4b = _mm_mul_ps(bx4b, _mm_set1_ps(JPEG_SCALE));
++
++            r1x4b = _mm_cvtps_epi32(rx4b);
++            r1x4b = av_clip_int16_sse(r1x4b);
++            g1x4b = _mm_cvtps_epi32(gx4b);
++            g1x4b = av_clip_int16_sse(g1x4b);
++            b1x4b = _mm_cvtps_epi32(bx4b);
++            b1x4b = av_clip_int16_sse(b1x4b);
++
++            roax4 = r0x4a;
++            goax4 = g0x4a;
++            boax4 = b0x4a;
++
++            robx4 = r0x4b;
++            gobx4 = g0x4b;
++            bobx4 = b0x4b;
++
++            yoax4 = _mm_mullo_epi32(roax4, _mm_set1_epi32(cry));
++            yoax4 = _mm_add_epi32(yoax4, _mm_mullo_epi32(goax4, _mm_set1_epi32(cgy)));
++            yoax4 = _mm_add_epi32(yoax4, _mm_mullo_epi32(boax4, _mm_set1_epi32(cby)));
++            yoax4 = _mm_add_epi32(yoax4, _mm_set1_epi32(out_rnd));
++            yoax4 = _mm_srai_epi32(yoax4, out_sh);
++            yoax4 = _mm_add_epi32(yoax4, _mm_set1_epi32(params->out_yuv_off));
++
++            yobx4 = _mm_mullo_epi32(robx4, _mm_set1_epi32(cry));
++            yobx4 = _mm_add_epi32(yobx4, _mm_mullo_epi32(gobx4, _mm_set1_epi32(cgy)));
++            yobx4 = _mm_add_epi32(yobx4, _mm_mullo_epi32(bobx4, _mm_set1_epi32(cby)));
++            yobx4 = _mm_add_epi32(yobx4, _mm_set1_epi32(out_rnd));
++            yobx4 = _mm_srai_epi32(yobx4, out_sh);
++            yobx4 = _mm_add_epi32(yobx4, _mm_set1_epi32(params->out_yuv_off));
++
++            y0ox8 = _mm_packus_epi32(yoax4, yobx4);
++            _mm_storeu_si128((__m128i_u *) &dsty[x], y0ox8);
++
++            r1oax4 = r1x4a;
++            g1oax4 = g1x4a;
++            b1oax4 = b1x4a;
++
++            r1obx4 = r1x4b;
++            g1obx4 = g1x4b;
++            b1obx4 = b1x4b;
++
++            y1oax4 = _mm_mullo_epi32(r1oax4, _mm_set1_epi32(cry));
++            y1oax4 = _mm_add_epi32(y1oax4, _mm_mullo_epi32(g1oax4, _mm_set1_epi32(cgy)));
++            y1oax4 = _mm_add_epi32(y1oax4, _mm_mullo_epi32(b1oax4, _mm_set1_epi32(cby)));
++            y1oax4 = _mm_add_epi32(y1oax4, _mm_set1_epi32(out_rnd));
++            y1oax4 = _mm_srai_epi32(y1oax4, out_sh);
++            y1oax4 = _mm_add_epi32(y1oax4, _mm_set1_epi32(params->out_yuv_off));
++
++            y1obx4 = _mm_mullo_epi32(r1obx4, _mm_set1_epi32(cry));
++            y1obx4 = _mm_add_epi32(y1obx4, _mm_mullo_epi32(g1obx4, _mm_set1_epi32(cgy)));
++            y1obx4 = _mm_add_epi32(y1obx4, _mm_mullo_epi32(b1obx4, _mm_set1_epi32(cby)));
++            y1obx4 = _mm_add_epi32(y1obx4, _mm_set1_epi32(out_rnd));
++            y1obx4 = _mm_srai_epi32(y1obx4, out_sh);
++            y1obx4 = _mm_add_epi32(y1obx4, _mm_set1_epi32(params->out_yuv_off));
++
++            y1ox8 = _mm_packus_epi32(y1oax4, y1obx4);
++            _mm_storeu_si128((__m128i_u *) &dsty[x + dstlinesize[0] / 2], y1ox8);
++
++            ravgx4 = _mm_hadd_epi32(roax4, robx4);
++            ravgx4 = _mm_add_epi32(ravgx4, _mm_hadd_epi32(r1oax4, r1obx4));
++            ravgx4 = _mm_add_epi32(ravgx4, _mm_set1_epi32(2));
++            ravgx4 = _mm_srai_epi32(ravgx4, 2);
++
++            gavgx4 = _mm_hadd_epi32(goax4, gobx4);
++            gavgx4 = _mm_add_epi32(gavgx4, _mm_hadd_epi32(g1oax4, g1obx4));
++            gavgx4 = _mm_add_epi32(gavgx4, _mm_set1_epi32(2));
++            gavgx4 = _mm_srai_epi32(gavgx4, 2);
++
++            bavgx4 = _mm_hadd_epi32(boax4, bobx4);
++            bavgx4 = _mm_add_epi32(bavgx4, _mm_hadd_epi32(b1oax4, b1obx4));
++            bavgx4 = _mm_add_epi32(bavgx4, _mm_set1_epi32(2));
++            bavgx4 = _mm_srai_epi32(bavgx4, 2);
++
++            uox4 = _mm_add_epi32(_mm_set1_epi32(out_rnd), _mm_mullo_epi32(ravgx4, _mm_set1_epi32(cru)));
++            uox4 = _mm_add_epi32(uox4, _mm_mullo_epi32(gavgx4, _mm_set1_epi32(ocgu)));
++            uox4 = _mm_add_epi32(uox4, _mm_mullo_epi32(bavgx4, _mm_set1_epi32(cburv)));
++            uox4 = _mm_srai_epi32(uox4, out_sh);
++            uox4 = _mm_add_epi32(uox4, _mm_set1_epi32(out_uv_offset));
++            _mm_storeu_si64((__m128i_u *) &dstu[x >> 1], _mm_packus_epi32(uox4, zero128));
++
++            vox4 = _mm_add_epi32(_mm_set1_epi32(out_rnd), _mm_mullo_epi32(ravgx4, _mm_set1_epi32(cburv)));
++            vox4 = _mm_add_epi32(vox4, _mm_mullo_epi32(gavgx4, _mm_set1_epi32(ocgv)));
++            vox4 = _mm_add_epi32(vox4, _mm_mullo_epi32(bavgx4, _mm_set1_epi32(cbv)));
++            vox4 = _mm_srai_epi32(vox4, out_sh);
++            vox4 = _mm_add_epi32(vox4, _mm_set1_epi32(out_uv_offset));
++            _mm_storeu_si64((__m128i_u *) &dstv[x >> 1], _mm_packus_epi32(vox4, zero128));
++        }
++    }
++
++    // Process remaining pixels cannot fill the full simd register with scalar version
++    if (remainw) {
++        int offset = width & (int)0xfffffff8;
++        rdsty += offset;
++        rdstu += offset >> 1;
++        rdstv += offset >> 1;
++        rsrcy += offset;
++        rsrcu += offset >> 1;
++        rsrcv += offset >> 1;
++        tonemap_frame_dovi_2_420hdr(rdsty, rdstu, rdstv,
 +                                      rsrcy, rsrcu, rsrcv,
 +                                      dstlinesize, srclinesize,
 +                                      dstdepth, srcdepth,
@@ -8985,7 +10097,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.h
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,75 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -9019,6 +10131,13 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.h
 +                                             const struct TonemapIntParams *params);
 +
 +X86_64_V2 void tonemap_frame_dovi_2_420p10_sse(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
++                                               const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
++                                               const int *dstlinesize, const int *srclinesize,
++                                               int dstdepth, int srcdepth,
++                                               int width, int height,
++                                               const struct TonemapIntParams *params);
++
++X86_64_V2 void tonemap_frame_dovi_2_420hdr_sse(uint16_t *dsty, uint16_t *dstu, uint16_t *dstv,
 +                                               const uint16_t *srcy, const uint16_t *srcu, const uint16_t *srcv,
 +                                               const int *dstlinesize, const int *srclinesize,
 +                                               int dstdepth, int srcdepth,

--- a/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0060-add-simd-optimized-tonemapx-filter.patch
@@ -2635,7 +2635,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.c
-@@ -0,0 +1,1881 @@
+@@ -0,0 +1,1886 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -4079,6 +4079,11 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    if (!desc || !odesc) {
 +        av_frame_free(&in);
 +        return AVERROR_BUG;
++    }
++
++    if (s->trc == AVCOL_TRC_SMPTE2084 && odesc->comp[0].depth == 8) {
++        av_log(s, AV_LOG_ERROR, "HDR passthrough requires 10 bit output format depth\n");
++        av_assert0(0);
 +    }
 +
 +    switch (odesc->comp[2].plane) {


### PR DESCRIPTION
This adds a reshape-only mode for Dolby Vision videos without a compatibility layer. In this mode, only Dolby Vision reshaping will be performed, and the output will still be in SMPTE 2084 transfer.

The GPU-based filters already support this mode. This will be useful in the future when we implement HDR transcoding.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->