### PR TITLE
Add NE10 to enable more neon optimization for libopus

### DIFF
--- a/builder/scripts.d/45-libNE10.sh
+++ b/builder/scripts.d/45-libNE10.sh
@@ -30,6 +30,7 @@ ffbuild_dockerbuild() {
         return -1
     fi
 
+    export NE10_LINUX_TARGET_ARCH=aarch64
     cmake .. "${myconf[@]}"
     make -j$(nproc)
     # NE10 does not have install method, we have to copy files with shell command

--- a/builder/scripts.d/45-libNE10.sh
+++ b/builder/scripts.d/45-libNE10.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-SCRIPT_REPO="https://github.com/projectNe10/Ne10.git"
-SCRIPT_COMMIT="1f059a764d0e1bc2481c0055c0e71538470baa83"
+SCRIPT_REPO="https://github.com/gnattu/Ne10.git"
+SCRIPT_COMMIT="545f4f18014cdbf9fb5fb1a9f5d24000200dfa8b"
 
 ffbuild_enabled() {
     [[ $TARGET == win* ]] && return -1

--- a/builder/scripts.d/45-libNE10.sh
+++ b/builder/scripts.d/45-libNE10.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+SCRIPT_REPO="https://github.com/projectNe10/Ne10.git"
+SCRIPT_COMMIT="1f059a764d0e1bc2481c0055c0e71538470baa83"
+
+ffbuild_enabled() {
+    [[ $TARGET == win* ]] && return -1
+    [[ $TARGET == *arm64 ]] && return 0
+    return -1
+}
+
+ffbuild_dockerbuild() {
+    git-mini-clone "$SCRIPT_REPO" "$SCRIPT_COMMIT" Ne10
+    cd Ne10
+
+    mkdir -p build && cd build
+
+    local myconf=(
+        -DGNULINUX_PLATFORM=ON # macOS is also "GNU Linux". This target means all unix-like target
+    )
+
+    if [[ $TARGET == linux* ]]; then
+        myconf+=(
+            -DCMAKE_TOOLCHAIN_FILE="$FFBUILD_CMAKE_TOOLCHAIN"
+        )
+    elif [[ $TARGET == mac* ]]; then
+        :
+    else
+        echo "Unknown target"
+        return -1
+    fi
+
+    cmake .. "${myconf[@]}"
+    make -j$(nproc)
+    # NE10 does not have install method, we have to copy files with shell command
+    cp modules/libNE10.a "$FFBUILD_PREFIX"/lib/libNE10.a
+    cp -R ../inc "$FFBUILD_PREFIX"/include/libNE10
+}

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -43,10 +43,10 @@ ffbuild_dockerbuild() {
 
     # For some reason libopus will not add optimization flag, we have to set it ourselves
     if [[ $TARGET == mac* ]]; then
-          export CFLAGS="-O3"
-      else
-          export CFLAGS="-O3 -fPIC -DPIC"
-      fi
+        export CFLAGS="-O3"
+    else
+        export CFLAGS="-O3 -fPIC -DPIC"
+    fi
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -40,7 +40,13 @@ ffbuild_dockerbuild() {
 
     # reset CLFAGS because libopus may give up optimization if current CFLAGS contains value
     CFLAGS_BACKUP="$CFLAGS"
-    export CFLAGS="-O3" # For some reason libopus will not add optimization flag, we have to set it ourselves
+
+    # For some reason libopus will not add optimization flag, we have to set it ourselves
+    if [[ $TARGET == mac* ]]; then
+          export CFLAGS="-O3"
+      else
+          export CFLAGS="-O3 -fPIC -DPIC"
+      fi
 
     ./configure "${myconf[@]}"
     make -j$(nproc)

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -38,21 +38,10 @@ ffbuild_dockerbuild() {
         )
     fi
 
-    # reset CLFAGS because libopus may give up optimization if current CFLAGS contains value
-    CFLAGS_BACKUP="$CFLAGS"
-
-    # For some reason libopus will not add optimization flag, we have to set it ourselves
-    if [[ $TARGET == mac* ]]; then
-        export CFLAGS="-O3"
-    else
-        export CFLAGS="-O3 -fPIC -DPIC"
-    fi
-
-    ./configure "${myconf[@]}"
+     # Override previously set -O(n) option and the CC's default optimization options.
+    CFLAGS="$CFLAGS -O3" ./configure "${myconf[@]}"
     make -j$(nproc)
     make install
-
-    export CFLAGS="$CFLAGS_BACKUP"
 
     if [[ $TARGET == *arm64 ]]; then
         if [[ $TARGET == mac* ]]; then

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -38,9 +38,15 @@ ffbuild_dockerbuild() {
         )
     fi
 
+    # reset CLFAGS because libopus may give up optimization if current CFLAGS contains value
+    CFLAGS_BACKUP="$CFLAGS"
+    export CFLAGS="-O3" # For some reason libopus will not add optimization flag, we have to set it ourselves
+
     ./configure "${myconf[@]}"
     make -j$(nproc)
     make install
+
+    export CFLAGS="$CFLAGS_BACKUP"
 
     if [[ $TARGET == *arm64 ]]; then
         if [[ $TARGET == mac* ]]; then

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -38,19 +38,19 @@ ffbuild_dockerbuild() {
         )
     fi
 
-     # Override previously set -O(n) option and the CC's default optimization options.
+    # Override previously set -O(n) option and the CC's default optimization options.
     CFLAGS="$CFLAGS -O3" ./configure "${myconf[@]}"
     make -j$(nproc)
     make install
 
     if [[ $TARGET == *arm64 ]]; then
         if [[ $TARGET == mac* ]]; then
-          gsed -i 's/-lopus/-lopus -lNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
-          gsed -i 's/-I${includedir}\/opus/-I${includedir}\/opus -I${includedir}\/libNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
-      else
-          sed -i 's/-lopus/-lopus -lNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
-          sed -i 's/-I${includedir}\/opus/-I${includedir}\/opus -I${includedir}\/libNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
-      fi
+            gsed -i 's/-lopus/-lopus -lNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
+            gsed -i 's/-I${includedir}\/opus/-I${includedir}\/opus -I${includedir}\/libNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
+        else
+            sed -i 's/-lopus/-lopus -lNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
+            sed -i 's/-I${includedir}\/opus/-I${includedir}\/opus -I${includedir}\/libNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
+        fi
     fi
 }
 

--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -31,9 +31,26 @@ ffbuild_dockerbuild() {
         return -1
     fi
 
+    if [[ $TARGET == linux* || $TARGET == mac* ]] && [[ $TARGET == *arm64 ]]; then
+        myconf+=(
+            --with-NE10-libraries="$FFBUILD_PREFIX"/lib
+            --with-NE10-includes="$FFBUILD_PREFIX"/include/libNE10
+        )
+    fi
+
     ./configure "${myconf[@]}"
     make -j$(nproc)
     make install
+
+    if [[ $TARGET == *arm64 ]]; then
+        if [[ $TARGET == mac* ]]; then
+          gsed -i 's/-lopus/-lopus -lNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
+          gsed -i 's/-I${includedir}\/opus/-I${includedir}\/opus -I${includedir}\/libNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
+      else
+          sed -i 's/-lopus/-lopus -lNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
+          sed -i 's/-I${includedir}\/opus/-I${includedir}\/opus -I${includedir}\/libNE10/' "$FFBUILD_PREFIX"/lib/pkgconfig/opus.pc
+      fi
+    fi
 }
 
 ffbuild_configure() {


### PR DESCRIPTION
Unlike on x86, where libopus provides inline assembly, most of the performance optimizations for ARM Neon are implemented in the NE10 library. We need to build it separately for optimal performance on arm64 targets.

The performance improved significantly on M4 Max using test command:

```
./ffmpeg -f lavfi -i "anoisesrc=d=1000" -c:a libopus -b:a 128k -benchmark -f null -
```

#### Before:

```
[out#0/null @ 0x6000004a8300] video:0KiB audio:14175KiB subtitle:0KiB other streams:0KiB global headers:0KiB muxing overhead: unknown
size=N/A time=00:16:40.00 bitrate=N/A speed=61.7x
bench: utime=16.488s stime=0.590s rtime=16.202s
bench: maxrss=12926976KiB
```

#### After:

```
[out#0/null @ 0x6000035e8000] video:0KiB audio:14171KiB subtitle:0KiB other streams:0KiB global headers:0KiB muxing overhead: unknown
size=N/A time=00:16:40.00 bitrate=N/A speed= 343x    
bench: utime=3.277s stime=0.492s rtime=2.916s
bench: maxrss=11796480KiB
```

It is more than 5 times as fast. Would be more useful on CPU constrained devices like RK3588 based boards.
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->