### PR TITLE
fftools/ffprobe: add only_first_vframe option to show first video frame info

### DIFF
--- a/debian/patches/0085-add-first-vframe-only-to-ffprobe.patch
+++ b/debian/patches/0085-add-first-vframe-only-to-ffprobe.patch
@@ -1,0 +1,44 @@
+Index: FFmpeg/fftools/ffprobe.c
+===================================================================
+--- FFmpeg.orig/fftools/ffprobe.c
++++ FFmpeg/fftools/ffprobe.c
+@@ -146,6 +146,8 @@ static int show_private_data
+ #define SHOW_OPTIONAL_FIELDS_ALWAYS      1
+ static int show_optional_fields = SHOW_OPTIONAL_FIELDS_AUTO;
+ 
++static int only_show_first_video_frame = 0;
++
+ static char *output_format;
+ static char *stream_specifier;
+ static char *show_data_hash;
+@@ -3159,6 +3161,14 @@ static int read_interval_packets(WriterC
+             }
+ 
+             frame_count++;
++
++            if (only_show_first_video_frame) {
++                AVCodecParameters *par = ifile->streams[pkt->stream_index].st->codecpar;
++                if (par->codec_type != AVMEDIA_TYPE_VIDEO) {
++                    continue;
++                }
++            }
++
+             if (do_read_packets) {
+                 if (do_show_packets)
+                     show_packet(w, ifile, pkt, i++);
+@@ -3179,6 +3189,7 @@ static int read_interval_packets(WriterC
+ 
+                 while (process_frame(w, ifile, frame, pkt, &packet_new) > 0);
+             }
++            if (only_show_first_video_frame) break;
+         }
+         av_packet_unref(pkt);
+     }
+@@ -4587,6 +4598,7 @@ static const OptionDef real_options[] =
+     { "print_filename",        OPT_TYPE_FUNC, OPT_FUNC_ARG, {.func_arg = opt_print_filename}, "override the printed input filename", "print_file"},
+     { "find_stream_info",      OPT_TYPE_BOOL, OPT_INPUT | OPT_EXPERT, { &find_stream_info },
+         "read and decode the streams to fill missing information with heuristics" },
++    { "only_first_vframe",     OPT_TYPE_BOOL,        0, { &only_show_first_video_frame }, "only show first video frame when show_frames is used" },
+     { NULL, },
+ };
+ 

--- a/debian/patches/0085-add-first-vframe-only-to-ffprobe.patch
+++ b/debian/patches/0085-add-first-vframe-only-to-ffprobe.patch
@@ -11,30 +11,112 @@ Index: FFmpeg/fftools/ffprobe.c
  static char *output_format;
  static char *stream_specifier;
  static char *show_data_hash;
-@@ -3159,6 +3161,14 @@ static int read_interval_packets(WriterC
+@@ -3086,9 +3088,10 @@ static int read_interval_packets(WriterC
+     AVFormatContext *fmt_ctx = ifile->fmt_ctx;
+     AVPacket *pkt = NULL;
+     AVFrame *frame = NULL;
+-    int ret = 0, i = 0, frame_count = 0;
++    int ret = 0, i = 0, frame_count = 0, nb_video_streams = 0;
+     int64_t start = -INT64_MAX, end = interval->end;
+     int has_start = 0, has_end = interval->has_end && !interval->end_is_offset;
++    unsigned char *checked_stream = NULL;
+ 
+     av_log(NULL, AV_LOG_VERBOSE, "Processing read interval ");
+     log_read_interval(interval, NULL, AV_LOG_VERBOSE);
+@@ -3127,12 +3130,51 @@ static int read_interval_packets(WriterC
+         ret = AVERROR(ENOMEM);
+         goto end;
+     }
++
++    if (only_show_first_video_frame) {
++        int si = 0;
++        checked_stream = av_calloc(nb_streams, sizeof(unsigned char));
++        if (!checked_stream) {
++            ret = AVERROR(ENOMEM);
++            goto end;
++        }
++        for (si = 0; si < nb_streams; si ++) {
++            AVCodecParameters *par = ifile->streams[si].st->codecpar;
++            if (par->codec_type == AVMEDIA_TYPE_VIDEO) {
++                nb_video_streams++;
++                selected_streams[si] = 1;
++            }
++        }
++    }
+     while (!av_read_frame(fmt_ctx, pkt)) {
+         if (fmt_ctx->nb_streams > nb_streams) {
+             REALLOCZ_ARRAY_STREAM(nb_streams_frames,  nb_streams, fmt_ctx->nb_streams);
+             REALLOCZ_ARRAY_STREAM(nb_streams_packets, nb_streams, fmt_ctx->nb_streams);
+             REALLOCZ_ARRAY_STREAM(selected_streams,   nb_streams, fmt_ctx->nb_streams);
+-            nb_streams = fmt_ctx->nb_streams;
++
++            if (checked_stream) {
++                unsigned char *checked_stream_extended = NULL;
++                int si = 0;
++                checked_stream_extended = av_calloc(fmt_ctx->nb_streams, sizeof(unsigned char));
++                if (!checked_stream) {
++                    ret = AVERROR(ENOMEM);
++                    goto end;
++                }
++
++                memcpy(checked_stream_extended, checked_stream, nb_streams * sizeof(unsigned char));
++                av_freep(&checked_stream);
++                checked_stream = checked_stream_extended;
++
++                nb_video_streams = 0;
++                for (si = 0; si < fmt_ctx->nb_streams; si ++) {
++                    AVCodecParameters *par = ifile->streams[si].st->codecpar;
++                    if (par->codec_type == AVMEDIA_TYPE_VIDEO) {
++                        nb_video_streams++;
++                        selected_streams[si] = 1;
++                    }
++                }
++            }
++            nb_streams = (int)fmt_ctx->nb_streams;
+         }
+         if (selected_streams[pkt->stream_index]) {
+             AVRational tb = ifile->streams[pkt->stream_index].st->time_base;
+@@ -3159,6 +3201,12 @@ static int read_interval_packets(WriterC
              }
  
              frame_count++;
 +
 +            if (only_show_first_video_frame) {
 +                AVCodecParameters *par = ifile->streams[pkt->stream_index].st->codecpar;
-+                if (par->codec_type != AVMEDIA_TYPE_VIDEO) {
-+                    continue;
-+                }
++                if (par->codec_type != AVMEDIA_TYPE_VIDEO) continue;
 +            }
 +
              if (do_read_packets) {
                  if (do_show_packets)
                      show_packet(w, ifile, pkt, i++);
-@@ -3179,6 +3189,7 @@ static int read_interval_packets(WriterC
+@@ -3179,6 +3227,16 @@ static int read_interval_packets(WriterC
  
                  while (process_frame(w, ifile, frame, pkt, &packet_new) > 0);
              }
-+            if (only_show_first_video_frame) break;
++            if (only_show_first_video_frame) {
++                int nb_checked_streams = 0, si = 0;
++                checked_stream[pkt->stream_index] = 1;
++                for (si = 0; si < nb_streams; si ++) {
++                    nb_checked_streams += checked_stream[si];
++                }
++                if (nb_checked_streams >= nb_video_streams) {
++                    break;
++                }
++            }
          }
          av_packet_unref(pkt);
      }
-@@ -4587,6 +4598,7 @@ static const OptionDef real_options[] =
+@@ -3196,6 +3254,9 @@ static int read_interval_packets(WriterC
+ end:
+     av_frame_free(&frame);
+     av_packet_free(&pkt);
++    if (checked_stream) {
++        av_freep(&checked_stream);
++    }
+     if (ret < 0) {
+         av_log(NULL, AV_LOG_ERROR, "Could not read packets in interval ");
+         log_read_interval(interval, NULL, AV_LOG_ERROR);
+@@ -4587,6 +4648,7 @@ static const OptionDef real_options[] =
      { "print_filename",        OPT_TYPE_FUNC, OPT_FUNC_ARG, {.func_arg = opt_print_filename}, "override the printed input filename", "print_file"},
      { "find_stream_info",      OPT_TYPE_BOOL, OPT_INPUT | OPT_EXPERT, { &find_stream_info },
          "read and decode the streams to fill missing information with heuristics" },

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -82,3 +82,4 @@
 0082-fix-ass-incorrect-null-copy.patch
 0083-default-to-input-timebase-for-streamcopy.patch
 0084-fix-a-race-condition-in-vaapi-csc-to-yuv420p.patch
+0085-add-first-vframe-only-to-ffprobe.patch


### PR DESCRIPTION
Currently, ffprobe can only read frames at a specific interval, and users have no options to select only video frames without explicitly selecting a stream. This option instructs show_frames to pick the first video frame and prints its information. This will be useful for extracting tricky metadata, such as the HDR10plus ST2094 metadata.

~~One potential edge case is that the video file contains multiple video streams and this will only show info for one of the stream. But our prober does not really handle this case anyway.~~

~~Another potential edge case is that the video contains embedded images and such image becomes the first frame, but I have failed to generate such files. Maybe the image itself has to be the stream 0?~~

Now all video streams will be printed if possible, the only question would be performance if there are a lot of streams in a single file, but that should be an extremely rare case.

The output would look like this which is easier for us to detect HDR10+ videos and some potentially problematic files:

<details>
  <summary>JSON output of ffprobe</summary>
  
  ```json
{
    "frames": [
        {
            "media_type": "video",
            "stream_index": 0,
            "key_frame": 1,
            "pts": 6144,
            "pts_time": "0.400000",
            "best_effort_timestamp": 6144,
            "best_effort_timestamp_time": "0.400000",
            "duration": 256,
            "duration_time": "0.016667",
            "pkt_pos": "17082",
            "pkt_size": "196722",
            "width": 3840,
            "height": 2160,
            "crop_top": 0,
            "crop_bottom": 0,
            "crop_left": 0,
            "crop_right": 0,
            "pix_fmt": "yuv420p10le",
            "sample_aspect_ratio": "1:1",
            "pict_type": "I",
            "interlaced_frame": 0,
            "top_field_first": 0,
            "repeat_pict": 0,
            "color_range": "tv",
            "color_space": "bt2020nc",
            "color_primaries": "bt2020",
            "color_transfer": "smpte2084",
            "chroma_location": "topleft",
            "side_data_list": [
                {
                    "side_data_type": "Mastering display metadata",
                    "red_x": "34000/50000",
                    "red_y": "16000/50000",
                    "green_x": "13250/50000",
                    "green_y": "34500/50000",
                    "blue_x": "7500/50000",
                    "blue_y": "3000/50000",
                    "white_point_x": "15635/50000",
                    "white_point_y": "16450/50000",
                    "min_luminance": "1/10000",
                    "max_luminance": "10000000/10000"
                },
                {
                    "side_data_type": "Content light level metadata",
                    "max_content": 1000,
                    "max_average": 400
                },
                {
                    "side_data_type": "HDR Dynamic Metadata SMPTE2094-40 (HDR10+)",
                    "application version": 1,
                    "num_windows": 1,
                    "targeted_system_display_maximum_luminance": "300/1",
                    "maxscl": "3956/100000",
                    "maxscl": "2063/100000",
                    "maxscl": "2047/100000",
                    "average_maxrgb": "93/100000",
                    "num_distribution_maxrgb_percentiles": 9,
                    "distribution_maxrgb_percentage": 1,
                    "distribution_maxrgb_percentile": "0/100000",
                    "distribution_maxrgb_percentage": 5,
                    "distribution_maxrgb_percentile": "2094/100000",
                    "distribution_maxrgb_percentage": 10,
                    "distribution_maxrgb_percentile": "96/100000",
                    "distribution_maxrgb_percentage": 25,
                    "distribution_maxrgb_percentile": "3/100000",
                    "distribution_maxrgb_percentage": 50,
                    "distribution_maxrgb_percentile": "4/100000",
                    "distribution_maxrgb_percentage": 75,
                    "distribution_maxrgb_percentile": "5/100000",
                    "distribution_maxrgb_percentage": 90,
                    "distribution_maxrgb_percentile": "88/100000",
                    "distribution_maxrgb_percentage": 95,
                    "distribution_maxrgb_percentile": "720/100000",
                    "distribution_maxrgb_percentage": 99,
                    "distribution_maxrgb_percentile": "2888/100000",
                    "fraction_bright_pixels": "0/1000",
                    "knee_point_x": "0/4095",
                    "knee_point_y": "0/4095",
                    "num_bezier_curve_anchors": 9,
                    "bezier_curve_anchors": "102/1023",
                    "bezier_curve_anchors": "205/1023",
                    "bezier_curve_anchors": "307/1023",
                    "bezier_curve_anchors": "410/1023",
                    "bezier_curve_anchors": "512/1023",
                    "bezier_curve_anchors": "614/1023",
                    "bezier_curve_anchors": "717/1023",
                    "bezier_curve_anchors": "819/1023",
                    "bezier_curve_anchors": "922/1023"
                }
            ]
        }
    ],
    "streams": [
        {
            "index": 0,
            "codec_name": "hevc",
            "codec_long_name": "H.265 / HEVC (High Efficiency Video Coding)",
            "profile": "Main 10",
            "codec_type": "video",
            "codec_tag_string": "hvc1",
            "codec_tag": "0x31637668",
            "width": 3840,
            "height": 2160,
            "coded_width": 3840,
            "coded_height": 2160,
            "closed_captions": 0,
            "film_grain": 0,
            "has_b_frames": 2,
            "sample_aspect_ratio": "1:1",
            "display_aspect_ratio": "16:9",
            "pix_fmt": "yuv420p10le",
            "level": 153,
            "color_range": "tv",
            "color_space": "bt2020nc",
            "color_transfer": "smpte2084",
            "color_primaries": "bt2020",
            "chroma_location": "topleft",
            "refs": 1,
            "id": "0x1",
            "r_frame_rate": "60/1",
            "avg_frame_rate": "60/1",
            "time_base": "1/15360",
            "start_pts": 6144,
            "start_time": "0.400000",
            "duration_ts": 913408,
            "duration": "59.466667",
            "bit_rate": "70248435",
            "nb_frames": "3568",
            "nb_read_frames": "1",
            "extradata_size": 184,
            "disposition": {
                "default": 1,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "non_diegetic": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0
            },
            "tags": {
                "language": "und",
                "handler_name": "VideoHandler",
                "vendor_id": "[0][0][0][0]"
            }
        },
        {
            "index": 1,
            "codec_name": "aac",
            "codec_long_name": "AAC (Advanced Audio Coding)",
            "profile": "LC",
            "codec_type": "audio",
            "codec_tag_string": "mp4a",
            "codec_tag": "0x6134706d",
            "sample_fmt": "fltp",
            "sample_rate": "48000",
            "channels": 2,
            "channel_layout": "stereo",
            "bits_per_sample": 0,
            "initial_padding": 0,
            "id": "0x2",
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "1/48000",
            "start_pts": 0,
            "start_time": "0.000000",
            "duration_ts": 2872320,
            "duration": "59.840000",
            "bit_rate": "320118",
            "nb_frames": "2808",
            "extradata_size": 2,
            "disposition": {
                "default": 1,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0,
                "non_diegetic": 0,
                "captions": 0,
                "descriptions": 0,
                "metadata": 0,
                "dependent": 0,
                "still_image": 0
            },
            "tags": {
                "language": "und",
                "handler_name": "SoundHandler",
                "vendor_id": "[0][0][0][0]"
            }
        }
    ],
    "format": {
        "filename": "/Volumes/ex/HDR Samles/HDR10Plus_test.mp4",
        "nb_streams": 2,
        "nb_programs": 0,
        "nb_stream_groups": 0,
        "format_name": "mov,mp4,m4a,3gp,3g2,mj2",
        "format_long_name": "QuickTime / MOV",
        "start_time": "0.000000",
        "duration": "59.866667",
        "size": "524677055",
        "bit_rate": "70112746",
        "probe_score": 100,
        "tags": {
            "major_brand": "isom",
            "minor_version": "512",
            "compatible_brands": "isomiso2mp41",
            "encoder": "Lavf61.1.100"
        }
    }
}
```
  
</details>

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->