### PR TITLE
Fix Opus AVX2 auto detection and DG1 upstream support

### DIFF
--- a/builder/scripts.d/50-libopus.sh
+++ b/builder/scripts.d/50-libopus.sh
@@ -11,6 +11,9 @@ ffbuild_dockerbuild() {
     git-mini-clone "$SCRIPT_REPO" "$SCRIPT_COMMIT" opus
     cd opus
 
+    # Fix AVX2 auto detction
+    wget -q -O - https://github.com/xiph/opus/commit/9ec11c1.patch | git apply
+
     ./autogen.sh
 
     local myconf=(

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -455,8 +455,10 @@ prepare_extra_amd64() {
     pushd ${SOURCE_DIR}
     git clone -b intel-media-24.4.2 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
-    # enable vc1 decode on dg2 (note that mtl+ is not supported)
+    # Enable VC1 decode on DG2 (note that MTL+ is not supported)
     wget -q -O - https://github.com/intel/media-driver/commit/d5dd47b.patch | git apply
+    # Fix DG1 support in upstream i915 KMD (prod DKMS is not required)
+    wget -q -O - https://github.com/intel/media-driver/commit/620a0b7.patch | git apply
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
           -DENABLE_KERNELS=ON \


### PR DESCRIPTION
**Changes**
- Fix AVX2 auto detection in libopus (Ref: https://github.com/xiph/opus/issues/361)
- Fix DG1 support in upstream i915 KMD (requires drm-tip or linux ~6.14+)