### PR TITLE
Enable ffnvcodec for Linux/Arm64 builds

### DIFF
--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="40ff2a12515e60853fb11da67ab04cdb5a08dea5"
+SCRIPT_COMMIT="42b2b24fb8819f1ed3643aa9cf2a62f03868e3aa"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-ffnvcodec.sh
+++ b/builder/scripts.d/50-ffnvcodec.sh
@@ -5,7 +5,6 @@ SCRIPT_COMMIT="451da99614412a7f9526ef301a5ee0c7a6f9ad76"
 
 ffbuild_enabled() {
     [[ $TARGET == mac* ]] && return -1
-    [[ $TARGET == *arm64 ]] && return -1
     return 0
 }
 

--- a/builder/scripts.d/50-rkrga.sh
+++ b/builder/scripts.d/50-rkrga.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/nyanmisaka/rk-mirrors.git"
-SCRIPT_COMMIT="e97e327662d1c0867d4cbcc01d5caf15250fc4e7"
+SCRIPT_COMMIT="c30fdd20ed8bfae438d2b1ea9b8d1dd64c9481bc"
 SCRIPT_BRANCH="jellyfin-rga"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-vulkan/45-vulkan.sh
+++ b/builder/scripts.d/50-vulkan/45-vulkan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/Vulkan-Headers.git"
-SCRIPT_COMMIT="v1.4.305"
+SCRIPT_COMMIT="v1.4.307"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/debian/control
+++ b/debian/control
@@ -42,11 +42,11 @@ Build-Depends:
 # --enable-libzvbi
  libzvbi-dev,
 # --enable-cuda-llvm
- clang [!armhf !arm64],
+ clang:amd64 [!armhf],
 # --enable-opencl
  ocl-icd-opencl-dev,
 # used to detect libraries
- pkg-config,
+ pkg-config | pkgconf,
 # HTML documentation
  texinfo,
 # assembler optimizations

--- a/debian/patches/0047-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0047-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -37,22 +37,18 @@ Index: FFmpeg/configure
  h264_amf_encoder_deps="amf"
  h264_cuvid_decoder_deps="cuvid"
  h264_cuvid_decoder_select="h264_mp4toannexb_bsf"
-@@ -3329,7 +3334,8 @@ h264_omx_encoder_deps="omx"
- h264_qsv_decoder_select="h264_mp4toannexb_bsf qsvdec"
+@@ -3330,6 +3335,7 @@ h264_qsv_decoder_select="h264_mp4toannex
  h264_qsv_encoder_select="atsc_a53 qsvenc"
  h264_rkmpp_decoder_deps="rkmpp"
--h264_rkmpp_decoder_select="h264_mp4toannexb_bsf"
-+h264_rkmpp_decoder_select="h264_mp4toannexb_bsf dump_extradata_bsf"
+ h264_rkmpp_decoder_select="h264_mp4toannexb_bsf"
 +h264_rkmpp_encoder_deps="rkmpp"
  h264_vaapi_encoder_select="atsc_a53 cbs_h264 vaapi_encode"
  h264_v4l2m2m_decoder_deps="v4l2_m2m h264_v4l2_m2m"
  h264_v4l2m2m_decoder_select="h264_mp4toannexb_bsf"
-@@ -3347,7 +3353,8 @@ hevc_nvenc_encoder_select="atsc_a53"
- hevc_qsv_decoder_select="hevc_mp4toannexb_bsf qsvdec"
+@@ -3348,6 +3354,7 @@ hevc_qsv_decoder_select="hevc_mp4toannex
  hevc_qsv_encoder_select="hevcparse qsvenc"
  hevc_rkmpp_decoder_deps="rkmpp"
--hevc_rkmpp_decoder_select="hevc_mp4toannexb_bsf"
-+hevc_rkmpp_decoder_select="hevc_mp4toannexb_bsf dump_extradata_bsf"
+ hevc_rkmpp_decoder_select="hevc_mp4toannexb_bsf"
 +hevc_rkmpp_encoder_deps="rkmpp"
  hevc_vaapi_encoder_deps="VAEncPictureParameterBufferHEVC"
  hevc_vaapi_encoder_select="atsc_a53 cbs_h265 vaapi_encode"
@@ -295,7 +291,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
   *
   * This file is part of FFmpeg.
   *
-@@ -19,569 +20,1028 @@
+@@ -19,569 +20,1025 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
  
@@ -523,7 +519,6 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    r->eof = 0;
 +    r->draining = 0;
 +    r->info_change = 0;
-+    r->errinfo_cnt = 0;
 +    r->got_frame = 0;
 +    r->use_rfbc = 0;
 +
@@ -1298,7 +1293,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    }
 +    if (mpp_frame_get_errinfo(mpp_frame)) {
 +        av_log(avctx, AV_LOG_DEBUG, "Received a 'errinfo' frame\n");
-+        ret = (r->errinfo_cnt++ > MAX_ERRINFO_COUNT) ? AVERROR_EXTERNAL : AVERROR(EAGAIN);
++        ret = AVERROR(EAGAIN);
 +        goto exit;
 +    }
 +
@@ -1431,7 +1426,6 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        goto exit;
 +    } else {
 +        av_log(avctx, AV_LOG_DEBUG, "Received a frame\n");
-+        r->errinfo_cnt = 0;
 +        r->got_frame = 1;
 +
 +        switch (avctx->pix_fmt) {
@@ -1681,7 +1675,6 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        r->eof = 0;
 +        r->draining = 0;
 +        r->info_change = 0;
-+        r->errinfo_cnt = 0;
 +        r->got_frame = 0;
  
 -    ret = decoder->mpi->reset(decoder->ctx);
@@ -1732,10 +1725,10 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +DEFINE_RKMPP_DECODER(h263, H263, NULL)
 +#endif
 +#if CONFIG_H264_RKMPP_DECODER
-+DEFINE_RKMPP_DECODER(h264, H264, "h264_mp4toannexb,dump_extra")
++DEFINE_RKMPP_DECODER(h264, H264, "h264_mp4toannexb")
 +#endif
 +#if CONFIG_HEVC_RKMPP_DECODER
-+DEFINE_RKMPP_DECODER(hevc, HEVC, "hevc_mp4toannexb,dump_extra")
++DEFINE_RKMPP_DECODER(hevc, HEVC, "hevc_mp4toannexb")
 +#endif
 +#if CONFIG_VP8_RKMPP_DECODER
 +DEFINE_RKMPP_DECODER(vp8, VP8, NULL)
@@ -1759,7 +1752,7 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppdec.h
-@@ -0,0 +1,147 @@
+@@ -0,0 +1,145 @@
 +/*
 + * Copyright (c) 2017 Lionel CHAZALLON
 + * Copyright (c) 2023 Huseyin BIYIK
@@ -1803,7 +1796,6 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 +#include "libavutil/opt.h"
 +#include "libavutil/pixdesc.h"
 +
-+#define MAX_ERRINFO_COUNT   100
 +#define MAX_SOC_NAME_LENGTH 128
 +
 +typedef struct RKMPPDecContext {
@@ -1820,7 +1812,6 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 +    int            eof;
 +    int            draining;
 +    int            info_change;
-+    int            errinfo_cnt;
 +    int            got_frame;
 +    int            use_rfbc;
 +

--- a/debian/rules
+++ b/debian/rules
@@ -77,6 +77,12 @@ CONFIG_ARM := --arch=armhf \
 CONFIG_ARM64 := --arch=arm64 \
 	--cross-prefix=/usr/bin/aarch64-linux-gnu- \
 	${CONFIG_ARM_COMMON} \
+	--enable-ffnvcodec \
+	--enable-cuda \
+	--enable-cuda-llvm \
+	--enable-cuvid \
+	--enable-nvdec \
+	--enable-nvenc \
 
 HOST_ARCH := $(shell arch)
 BUILD_ARCH := ${DEB_HOST_MULTIARCH}

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -475,7 +475,7 @@ popd
 popd
 
 # DAV1D
-git clone -b 1.5.0 --depth=1 https://code.videolan.org/videolan/dav1d.git
+git clone -b 1.5.1 --depth=1 https://code.videolan.org/videolan/dav1d.git
 meson setup dav1d dav1d_build \
     --prefix=${FF_DEPS_PREFIX} \
     --cross-file=${FF_MESON_TOOLCHAIN} \
@@ -548,7 +548,7 @@ popd
 # AMF
 mkdir amf-headers
 pushd amf-headers
-amf_ver="1.4.35"
+amf_ver="1.4.36"
 amf_link="https://github.com/GPUOpen-LibrariesAndSDKs/AMF/releases/download/v${amf_ver}/AMF-headers-v${amf_ver}.tar.gz"
 wget ${amf_link} -O amf.tar.gz
 tar xaf amf.tar.gz

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -47,10 +47,10 @@ popd
 popd
 
 # LIBXML2
-git clone --depth=1 https://github.com/GNOME/libxml2.git
+git clone -b v2.13.5 --depth=1 https://github.com/GNOME/libxml2.git
 pushd libxml2
 # Fallback to internal entropy when system native method failed
-git apply ${SOURCE_DIR}/builder/patches/libxml2/master/0001-dict-Fallback-to-internal-entropy-master.patch
+git apply ${SOURCE_DIR}/builder/patches/libxml2/v2.13.5/0001-dict-Fallback-to-internal-entropy.patch
 ./autogen.sh \
     --prefix=${FF_DEPS_PREFIX} \
     --host=${FF_TOOLCHAIN} \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -285,18 +285,18 @@ prepare_extra_common() {
     echo "fdk-aac-stripped${TARGET_DIR}/lib/libfdk-aac.so* usr/lib/jellyfin-ffmpeg/lib" >> ${DPKG_INSTALL_LIST}
     popd
     popd
-}
 
-# Prepare extra headers, libs and drivers for x86_64-linux-gnu
-prepare_extra_amd64() {
     # FFNVCODEC
     pushd ${SOURCE_DIR}
     git clone -b n12.0.16.1 --depth=1 https://github.com/FFmpeg/nv-codec-headers.git
     pushd nv-codec-headers
-    make && make install
+    make PREFIX=${TARGET_DIR} install
     popd
     popd
+}
 
+# Prepare extra headers, libs and drivers for x86_64-linux-gnu
+prepare_extra_amd64() {
     # AMF
     # https://www.ffmpeg.org/general.html#AMD-AMF_002fVCE
     pushd ${SOURCE_DIR}

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -240,7 +240,7 @@ prepare_extra_common() {
 
     # DAV1D
     pushd ${SOURCE_DIR}
-    git clone -b 1.5.0 --depth=1 https://code.videolan.org/videolan/dav1d.git
+    git clone -b 1.5.1 --depth=1 https://code.videolan.org/videolan/dav1d.git
     meson setup dav1d dav1d_build \
         ${MESON_CROSS_OPT} \
         --prefix=${TARGET_DIR} \
@@ -302,7 +302,7 @@ prepare_extra_amd64() {
     pushd ${SOURCE_DIR}
     mkdir amf-headers
     pushd amf-headers
-    amf_ver="1.4.35"
+    amf_ver="1.4.36"
     amf_link="https://github.com/GPUOpen-LibrariesAndSDKs/AMF/releases/download/v${amf_ver}/AMF-headers-v${amf_ver}.tar.gz"
     wget ${amf_link} -O amf.tar.gz
     tar xaf amf.tar.gz
@@ -437,7 +437,7 @@ prepare_extra_amd64() {
     # VPL-GPU-RT (RT only)
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-25.1.0 --depth=1 https://github.com/intel/vpl-gpu-rt.git
+    git clone -b intel-onevpl-25.1.1 --depth=1 https://github.com/intel/vpl-gpu-rt.git
     pushd vpl-gpu-rt
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} \
@@ -457,7 +457,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-25.1.0 --depth=1 https://github.com/intel/media-driver.git
+    git clone -b intel-media-25.1.1 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
     # Enable VC1 decode on DG2 (note that MTL+ is not supported)
     wget -q -O - https://github.com/intel/media-driver/commit/d5dd47b.patch | git apply
@@ -480,7 +480,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.4.305 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
+    git clone -b v1.4.307 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -493,7 +493,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.4.305 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
+    git clone -b v1.4.307 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \

--- a/msys2/PKGBUILD/40-mingw-w64-dav1d/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-dav1d/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=dav1d
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}")
-pkgver=1.5.0
+pkgver=1.5.1
 pkgrel=1
 pkgdesc="AV1 cross-platform decoder focused on speed and correctness (mingw-w64)"
 arch=('any')
@@ -23,7 +23,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-pkgconf"
              "${MINGW_PACKAGE_PREFIX}-xxhash")
 source=("https://downloads.videolan.org/pub/videolan/dav1d/${pkgver}/dav1d-${pkgver}.tar.xz"{,.asc}
         "0001-dll-version.patch")
-sha256sums=('14bd6f5157808ed9aedcafbe50df689d304fd4810ac20be6eec1ab037436afd6'
+sha256sums=('401813f1f89fa8fd4295805aa5284d9aed9bc7fc1fdbe554af4292f64cbabe21'
             'SKIP'
             '7fc584e69c156d7d9805b38912f07f417ccd1cce5fe4ee457761e8bea9128d04')
 validpgpkeys=('65F7C6B4206BD057A7EB73787180713BE58D1ADC') # VideoLAN Release Signing Key

--- a/msys2/PKGBUILD/50-mingw-w64-amf-headers/PKGBUILD
+++ b/msys2/PKGBUILD/50-mingw-w64-amf-headers/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=amf-headers
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}"
-pkgver=1.4.35
+pkgver=1.4.36
 pkgrel=1
 pkgdesc='Header files for AMD Advanced Media Framework'
 arch=('any')


### PR DESCRIPTION
**Changes**
- Enable ffnvcodec for Linux/Arm64 builds
- Sync fixes from ffmpeg-rockchip

**Issues**
- Fixes #533
- Fixes #534