### PR TITLE
Disable x265 Neon_Dotprod+ ASM on Linux/Arm64 for now

### DIFF
--- a/builder/images/base-linuxarm64/Dockerfile
+++ b/builder/images/base-linuxarm64/Dockerfile
@@ -43,7 +43,7 @@ RUN git clone --filter=blob:none --depth=1 https://github.com/yugr/Implib.so /op
 
 ENV FFBUILD_TOOLCHAIN=aarch64-ffbuild-linux-gnu
 ENV PATH="/opt/ct-ng/bin:${PATH}" \
-    FFBUILD_TARGET_FLAGS="--pkg-config=pkg-config --pkg-config-flags=--static --cross-prefix=${FFBUILD_TOOLCHAIN}- --arch=aarch64 --target-os=linux" \
+    FFBUILD_TARGET_FLAGS="--pkg-config=pkg-config --pkg-config-flags=--static --cross-prefix=${FFBUILD_TOOLCHAIN}- --arch=aarch64 --cpu=armv8-a --target-os=linux" \
     FFBUILD_CROSS_PREFIX="${FFBUILD_TOOLCHAIN}-" \
     FFBUILD_RUST_TARGET="aarch64-unknown-linux-gnu" \
     FFBUILD_PREFIX=/opt/ffbuild \
@@ -56,8 +56,8 @@ ENV PATH="/opt/ct-ng/bin:${PATH}" \
     AR="${FFBUILD_TOOLCHAIN}-gcc-ar" \
     RANLIB="${FFBUILD_TOOLCHAIN}-gcc-ranlib" \
     NM="${FFBUILD_TOOLCHAIN}-gcc-nm" \
-    CFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -pthread" \
-    CXXFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -pthread" \
-    LDFLAGS="-static-libgcc -static-libstdc++ -L/opt/ffbuild/lib -O2 -pipe -fstack-protector-strong -Wl,-z,relro,-z,now -pthread -lm" \
+    CFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -march=armv8-a -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -pthread" \
+    CXXFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -march=armv8-a -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -pthread" \
+    LDFLAGS="-static-libgcc -static-libstdc++ -L/opt/ffbuild/lib -O2 -pipe -march=armv8-a -fstack-protector-strong -Wl,-z,relro,-z,now -pthread -lm" \
     STAGE_CFLAGS="-fvisibility=hidden -fno-semantic-interposition" \
     STAGE_CXXFLAGS="-fvisibility=hidden -fno-semantic-interposition"

--- a/builder/scripts.d/50-x265.sh
+++ b/builder/scripts.d/50-x265.sh
@@ -28,6 +28,17 @@ ffbuild_dockerbuild() {
         )
     fi
 
+    # Wa for https://bitbucket.org/multicoreware/x265_git/issues/984/illegal-instruction-neon_dotprod-crashes
+    if [[ $TARGET == linuxarm64 ]]; then
+        common_config+=(
+            -DENABLE_NEON=ON
+            -DENABLE_NEON_DOTPROD=OFF
+            -DENABLE_NEON_I8MM=OFF
+            -DENABLE_SVE=OFF
+            -DENABLE_SVE2=OFF
+        )
+    fi
+
     if [[ $TARGET != *32 ]]; then
         mkdir 8bit 10bit 12bit
         cmake "${common_config[@]}" -DHIGH_BIT_DEPTH=ON -DEXPORT_C_API=OFF -DENABLE_HDR10_PLUS=ON -DMAIN12=ON -S source -B 12bit &


### PR DESCRIPTION
**Changes**
- Disable x265 Neon_Dotprod+ ASM on Linux/Arm64 for now

  This caused crashes on Cortex-A76/A55 CPUs with armv8.2-dotprod support.
  Ref: https://bitbucket.org/multicoreware/x265_git/issues/984/illegal-instruction-neon_dotprod-crashes

- Target armv8-a for Linux/Arm64 portable builds build