### PR TITLE
Fix value range and lost params for GPU tonemap filters

### DIFF
--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -1813,7 +1813,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_cuda.c
-@@ -0,0 +1,1173 @@
+@@ -0,0 +1,1174 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -1937,6 +1937,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +{
 +    TonemapCUDAContext *s = ctx->priv;
 +    s->final_param = NAN;
++    return 0;
 +}
 +
 +static av_cold int init(AVFilterContext *ctx)

--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -1086,7 +1086,7 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/cuda/tonemap.cu
-@@ -0,0 +1,579 @@
+@@ -0,0 +1,583 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -1210,7 +1210,8 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +
 +static __inline__ __device__
 +float bt2390(float s, float peak, float dst_peak) {
-+    float s_pq = inverse_eotf_st2084(s);
++    float s_clipped = min(s, peak);
++    float s_pq = inverse_eotf_st2084(s_clipped);
 +    return eotf_st2084(bt2390_common(s_pq, peak, dst_peak));
 +}
 +
@@ -1324,8 +1325,11 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +
 +static __inline__ __device__
 +float3 map_one_pixel_itp_mode(float3 rgb, const FFCUDAFrame& src, const FFCUDAFrame& dst) {
-+    float3 ictcp = lrgb2ictcp(rgb.x, rgb.y, rgb.z);
 +    float peak = src.peak;
++    float r = mix(rgb.x, min(rgb.x, peak), tonemap_func == TONEMAP_BT2390);
++    float g = mix(rgb.x, min(rgb.y, peak), tonemap_func == TONEMAP_BT2390);
++    float b = mix(rgb.x, min(rgb.z, peak), tonemap_func == TONEMAP_BT2390);
++    float3 ictcp = lrgb2ictcp(r, g, b);
 +    float dst_peak = 1.0f;
 +    ictcp.x = max(ictcp.x, FLOAT_EPS);
 +    float i_o = ictcp.x;

--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -1813,7 +1813,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_cuda.c
-@@ -0,0 +1,1165 @@
+@@ -0,0 +1,1167 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -1924,6 +1924,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    int tradeoff;
 +    int init_with_dovi;
 +    double param;
++    double final_param;
 +    double desat_param;
 +    double peak;
 +    double dst_peak;
@@ -1935,6 +1936,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +static av_cold int init(AVFilterContext *ctx)
 +{
 +    TonemapCUDAContext *s = ctx->priv;
++    s->final_param = NAN;
 +
 +    if (!strcmp(s->format_str, "same")) {
 +        s->format = AV_PIX_FMT_NONE;
@@ -2347,26 +2349,26 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    switch(s->tonemap) {
 +    case TONEMAP_GAMMA:
 +        if (isnan(s->param))
-+            s->param = 1.8f;
++            s->final_param = 1.8f;
 +        break;
 +    case TONEMAP_REINHARD:
 +        if (!isnan(s->param))
-+            s->param = (1.0f - s->param) / s->param;
++            s->final_param = (1.0f - s->param) / s->param;
 +        break;
 +    case TONEMAP_MOBIUS:
 +        if (isnan(s->param))
-+            s->param = 0.3f;
++            s->final_param = 0.3f;
 +        break;
 +    case TONEMAP_BT2390:
 +        if (isnan(s->param))
-+            s->param = 1.0f; // diff from the spec-defined 0.5f
++            s->final_param = 1.0f; // diff from the spec-defined 0.5f
 +        else
-+            s->param = FFMIN(FFMAX(s->param, 0.5f), 2.0f);
++            s->final_param = FFMIN(FFMAX(s->param, 0.5f), 2.0f);
 +        break;
 +    }
 +
-+    if (isnan(s->param))
-+        s->param = 1.0f;
++    if (isnan(s->final_param))
++        s->final_param = 1.0f;
 +
 +    if (s->peak)
 +        s->peak = FFMAX(s->peak / 10.0f, 1.1f);

--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -1327,8 +1327,8 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +float3 map_one_pixel_itp_mode(float3 rgb, const FFCUDAFrame& src, const FFCUDAFrame& dst) {
 +    float peak = src.peak;
 +    float r = mix(rgb.x, min(rgb.x, peak), tonemap_func == TONEMAP_BT2390);
-+    float g = mix(rgb.x, min(rgb.y, peak), tonemap_func == TONEMAP_BT2390);
-+    float b = mix(rgb.x, min(rgb.z, peak), tonemap_func == TONEMAP_BT2390);
++    float g = mix(rgb.y, min(rgb.y, peak), tonemap_func == TONEMAP_BT2390);
++    float b = mix(rgb.z, min(rgb.z, peak), tonemap_func == TONEMAP_BT2390);
 +    float3 ictcp = lrgb2ictcp(r, g, b);
 +    float dst_peak = 1.0f;
 +    ictcp.x = max(ictcp.x, FLOAT_EPS);

--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -1813,7 +1813,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_cuda.c
-@@ -0,0 +1,1167 @@
+@@ -0,0 +1,1173 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -1933,10 +1933,15 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    const AVPixFmtDescriptor *in_desc, *out_desc;
 +} TonemapCUDAContext;
 +
-+static av_cold int init(AVFilterContext *ctx)
++static av_cold int preinit(AVFilterContext *ctx)
 +{
 +    TonemapCUDAContext *s = ctx->priv;
 +    s->final_param = NAN;
++}
++
++static av_cold int init(AVFilterContext *ctx)
++{
++    TonemapCUDAContext *s = ctx->priv;
 +
 +    if (!strcmp(s->format_str, "same")) {
 +        s->format = AV_PIX_FMT_NONE;
@@ -2497,7 +2502,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    CONSTANT(".f32 dither_size         = %.1f", (float)ff_fruit_dither_size);
 +    CONSTANT(".f32 dither_quantization = %.1f", (float)((1 << s->out_desc->comp[0].depth) - 1));
 +    CONSTANT(".f32 ref_white           = %.4f", REFERENCE_WHITE_ALT);
-+    CONSTANT(".f32 tone_param          = %.4f", s->param);
++    CONSTANT(".f32 tone_param          = %.4f", s->final_param);
 +    CONSTANT(".f32 desat_param         = %.4f", s->desat_param);
 +    CONSTANT(".f32 pq_max_lum_div_ref_white = %.13lf", (float)(ST2084_MAX_LUMINANCE / REFERENCE_WHITE_ALT));
 +    CONSTANT(".f32 ref_white_div_pq_max_lum = %.13lf", (float)(REFERENCE_WHITE_ALT / ST2084_MAX_LUMINANCE));
@@ -2968,6 +2973,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    .name           = "tonemap_cuda",
 +    .description    = NULL_IF_CONFIG_SMALL("GPU accelerated HDR to SDR tonemapping"),
 +
++    .preinit        = preinit,
 +    .init           = init,
 +    .uninit         = uninit,
 +

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -2080,11 +2080,11 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    ctx->initialised = 0;
 +}
 +
-+ static av_cold int tonemap_opencl_pre_init(AVFilterContext *avctx)
++ static av_cold int tonemap_opencl_preinit(AVFilterContext *avctx)
 + {
 +     TonemapOpenCLContext *ctx = avctx->priv;
 +     ctx->final_param = NAN;
-+     return ff_opencl_filter_init(avctx);
++     return 0;
 + }
 +
 +static int format_is_supported(enum AVPixelFormat fmt)
@@ -2481,12 +2481,11 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      { NULL }
  };
  
-@@ -541,7 +1092,7 @@ const AVFilter ff_vf_tonemap_opencl = {
+@@ -541,6 +1092,7 @@ const AVFilter ff_vf_tonemap_opencl = {
      .description    = NULL_IF_CONFIG_SMALL("Perform HDR to SDR conversion with tonemapping."),
      .priv_size      = sizeof(TonemapOpenCLContext),
      .priv_class     = &tonemap_opencl_class,
--    .init           = &ff_opencl_filter_init,
-+    .init           = &tonemap_opencl_pre_init,
++    .preinit        = &tonemap_opencl_preinit,
+     .init           = &ff_opencl_filter_init,
      .uninit         = &tonemap_opencl_uninit,
      FILTER_INPUTS(tonemap_opencl_inputs),
-     FILTER_OUTPUTS(tonemap_opencl_outputs),

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -1371,7 +1371,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  };
  
  typedef struct TonemapOpenCLContext {
-@@ -56,23 +77,43 @@ typedef struct TonemapOpenCLContext {
+@@ -56,23 +77,44 @@ typedef struct TonemapOpenCLContext {
      enum AVColorPrimaries primaries, primaries_in, primaries_out;
      enum AVColorRange range, range_in, range_out;
      enum AVChromaLocation chroma_loc;
@@ -1397,6 +1397,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      double                peak;
 +    double                target_peak;
      double                param;
++    double                final_param;
      double                desat_param;
 -    double                target_peak;
      double                scene_threshold;
@@ -1419,7 +1420,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  };
  
  static const char *const delinearize_funcs[AVCOL_TRC_NB] = {
-@@ -80,7 +121,7 @@ static const char *const delinearize_fun
+@@ -80,7 +122,7 @@ static const char *const delinearize_fun
      [AVCOL_TRC_BT2020_10] = "inverse_eotf_bt1886",
  };
  
@@ -1428,7 +1429,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      [TONEMAP_NONE]     = "direct",
      [TONEMAP_LINEAR]   = "linear",
      [TONEMAP_GAMMA]    = "gamma",
-@@ -88,8 +129,18 @@ static const char *const tonemap_func[TO
+@@ -88,8 +130,18 @@ static const char *const tonemap_func[TO
      [TONEMAP_REINHARD] = "reinhard",
      [TONEMAP_HABLE]    = "hable",
      [TONEMAP_MOBIUS]   = "mobius",
@@ -1447,7 +1448,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  static int get_rgb2rgb_matrix(enum AVColorPrimaries in, enum AVColorPrimaries out,
                                double rgb2rgb[3][3]) {
      double rgb2xyz[3][3], xyz2rgb[3][3];
-@@ -108,23 +159,150 @@ static int get_rgb2rgb_matrix(enum AVCol
+@@ -108,90 +160,361 @@ static int get_rgb2rgb_matrix(enum AVCol
      return 0;
  }
  
@@ -1607,24 +1608,36 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      switch(ctx->tonemap) {
      case TONEMAP_GAMMA:
-@@ -139,59 +317,203 @@ static int tonemap_opencl_init(AVFilterC
          if (isnan(ctx->param))
-             ctx->param = 0.3f;
+-            ctx->param = 1.8f;
++            ctx->final_param = 1.8f;
          break;
+     case TONEMAP_REINHARD:
+         if (!isnan(ctx->param))
+-            ctx->param = (1.0f - ctx->param) / ctx->param;
++            ctx->final_param = (1.0f - ctx->param) / ctx->param;
+         break;
+     case TONEMAP_MOBIUS:
+         if (isnan(ctx->param))
+-            ctx->param = 0.3f;
++            ctx->final_param = 0.3f;
++        break;
 +    case TONEMAP_BT2390:
 +        if (isnan(ctx->param))
-+            ctx->param = 1.0f; // diff from the spec-defined 0.5f
++            ctx->final_param = 1.0f; // diff from the spec-defined 0.5f
 +        else
-+            ctx->param = FFMIN(FFMAX(ctx->param, 0.5f), 2.0f);
-+        break;
++            ctx->final_param = FFMIN(FFMAX(ctx->param, 0.5f), 2.0f);
+         break;
      }
  
-     if (isnan(ctx->param))
-         ctx->param = 1.0f;
- 
+-    if (isnan(ctx->param))
+-        ctx->param = 1.0f;
++    if (isnan(ctx->final_param))
++        ctx->final_param = 1.0f;
++
 +    if (ctx->peak)
 +        ctx->peak = FFMAX(ctx->peak / 10.0f, 1.1f);
-+
+ 
      // SDR peak is 1.0f
      ctx->target_peak = 1.0f;
 -    av_log(ctx, AV_LOG_DEBUG, "tone mapping transfer from %s to %s\n",
@@ -1726,6 +1739,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
                 ctx->primaries_in == AVCOL_PRI_BT709);
  
 -    av_bprintf(&header, "__constant const float tone_param = %.4ff;\n",
+-               ctx->param);
+-    av_bprintf(&header, "__constant const float desat_param = %.4ff;\n",
 +    if (ctx->trc_out == AVCOL_TRC_SMPTE2084) {
 +        int is_10_or_16b_out = ctx->out_desc->comp[0].depth == 10 ||
 +                               ctx->out_desc->comp[0].depth == 16;
@@ -1743,8 +1758,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    av_bprintf(&header, "__constant float ref_white = %.4ff;\n",
 +               REFERENCE_WHITE_ALT);
 +    av_bprintf(&header, "__constant float tone_param = %.4ff;\n",
-                ctx->param);
--    av_bprintf(&header, "__constant const float desat_param = %.4ff;\n",
++               ctx->final_param);
 +    av_bprintf(&header, "__constant float desat_param = %.4ff;\n",
                 ctx->desat_param);
 -    av_bprintf(&header, "__constant const float target_peak = %.4ff;\n",
@@ -1826,7 +1840,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_bprintf(&header, "#define chroma_loc %d\n", (int)ctx->chroma_loc);
  
      if (rgb2rgb_passthrough)
-@@ -199,19 +521,41 @@ static int tonemap_opencl_init(AVFilterC
+@@ -199,19 +522,41 @@ static int tonemap_opencl_init(AVFilterC
      else
          ff_opencl_print_const_matrix_3x3(&header, "rgb2rgb", rgb2rgb);
  
@@ -1875,7 +1889,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
                 ctx->colorspace_out, av_color_space_name(ctx->colorspace_out));
          goto fail;
      }
-@@ -219,24 +563,13 @@ static int tonemap_opencl_init(AVFilterC
+@@ -219,24 +564,13 @@ static int tonemap_opencl_init(AVFilterC
      ff_fill_rgb2yuv_table(luma_dst, rgb2yuv);
      ff_opencl_print_const_matrix_3x3(&header, "yuv_matrix", rgb2yuv);
  
@@ -1905,7 +1919,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
      opencl_sources[0] = header.str;
-@@ -254,46 +587,206 @@ static int tonemap_opencl_init(AVFilterC
+@@ -254,46 +588,213 @@ static int tonemap_opencl_init(AVFilterC
      CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create OpenCL "
                       "command queue %d.\n", cle);
  
@@ -1945,7 +1959,12 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        cle = clWaitForEvents(1, &event);
 +        CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to wait for event completion: %d.\n", cle);
 +    }
-+
+ 
+-    ctx->util_mem =
+-        clCreateBuffer(ctx->ocf.hwctx->context, 0,
+-                       (2 * DETECTION_FRAMES + 7) * sizeof(unsigned),
+-                       NULL, &cle);
+-    CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create util buffer: %d.\n", cle);
 +    if (ctx->tradeoff) {
 +        size_t lut_size = LUT_SIZE;
 +        size_t lut_buffer_size = lut_size * sizeof(cl_float3);
@@ -1970,12 +1989,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        ctx->kernel = clCreateKernel(ctx->ocf.program, "tonemap", &cle);
 +        CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create kernel %d.\n", cle);
 +    }
- 
--    ctx->util_mem =
--        clCreateBuffer(ctx->ocf.hwctx->context, 0,
--                       (2 * DETECTION_FRAMES + 7) * sizeof(unsigned),
--                       NULL, &cle);
--    CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create util buffer: %d.\n", cle);
++
 +    if (ctx->dovi) {
 +        CL_CREATE_BUFFER_FLAGS(ctx, dovi_buf, dovi_buf_flags,
 +                               3*(params_sz+pivots_sz+coeffs_sz+mmr_sz), NULL);
@@ -2066,6 +2080,13 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    ctx->initialised = 0;
 +}
 +
++ static av_cold int tonemap_opencl_pre_init(AVFilterContext *avctx)
++ {
++     TonemapOpenCLContext *ctx = avctx->priv;
++     ctx->final_param = NAN;
++     return ff_opencl_filter_init(avctx);
++ }
++
 +static int format_is_supported(enum AVPixelFormat fmt)
 +{
 +    for (int i = 0; i < FF_ARRAY_ELEMS(supported_formats); i++)
@@ -2108,12 +2129,12 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported input format: %s\n",
 +               av_get_pix_fmt_name(in_format));
 +        return AVERROR(ENOSYS);
-     }
++    }
 +    if (!format_is_supported(out_format)) {
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported output format: %s\n",
 +               av_get_pix_fmt_name(out_format));
 +        return AVERROR(ENOSYS);
-+    }
+     }
 +    if (in_desc->comp[0].depth != 10 && in_desc->comp[0].depth != 16) {
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported input format depth: %d\n",
 +               in_desc->comp[0].depth);
@@ -2132,12 +2153,18 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      ret = ff_opencl_filter_config_output(outlink);
      if (ret < 0)
          return ret;
-@@ -308,13 +801,49 @@ static int launch_kernel(AVFilterContext
+@@ -308,13 +809,49 @@ static int launch_kernel(AVFilterContext
      size_t global_work[2];
      size_t local_work[2];
      cl_int cle;
 +    int idx_arg;
-+
+ 
+-    CL_SET_KERNEL_ARG(kernel, 0, cl_mem, &output->data[0]);
+-    CL_SET_KERNEL_ARG(kernel, 1, cl_mem, &input->data[0]);
+-    CL_SET_KERNEL_ARG(kernel, 2, cl_mem, &output->data[1]);
+-    CL_SET_KERNEL_ARG(kernel, 3, cl_mem, &input->data[1]);
+-    CL_SET_KERNEL_ARG(kernel, 4, cl_mem, &ctx->util_mem);
+-    CL_SET_KERNEL_ARG(kernel, 5, cl_float, &peak);
 +    if (!output->data[0] || !input->data[0] || !output->data[1] || !input->data[1]) {
 +        err = AVERROR(EIO);
 +        goto fail;
@@ -2165,13 +2192,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    if (ctx->out_planes > 2) {
 +        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &output->data[2]);
 +    }
- 
--    CL_SET_KERNEL_ARG(kernel, 0, cl_mem, &output->data[0]);
--    CL_SET_KERNEL_ARG(kernel, 1, cl_mem, &input->data[0]);
--    CL_SET_KERNEL_ARG(kernel, 2, cl_mem, &output->data[1]);
--    CL_SET_KERNEL_ARG(kernel, 3, cl_mem, &input->data[1]);
--    CL_SET_KERNEL_ARG(kernel, 4, cl_mem, &ctx->util_mem);
--    CL_SET_KERNEL_ARG(kernel, 5, cl_float, &peak);
++
 +    if (ctx->in_planes > 2) {
 +        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &input->data[2]);
 +    }
@@ -2188,7 +2209,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      local_work[0]  = 16;
      local_work[1]  = 16;
-@@ -338,13 +867,10 @@ static int tonemap_opencl_filter_frame(A
+@@ -338,13 +875,10 @@ static int tonemap_opencl_filter_frame(A
      AVFilterContext    *avctx = inlink->dst;
      AVFilterLink     *outlink = avctx->outputs[0];
      TonemapOpenCLContext *ctx = avctx->priv;
@@ -2203,7 +2224,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(input->format),
-@@ -363,8 +889,49 @@ static int tonemap_opencl_filter_frame(A
+@@ -363,8 +897,49 @@ static int tonemap_opencl_filter_frame(A
      if (err < 0)
          goto fail;
  
@@ -2255,7 +2276,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      if (ctx->trc != -1)
          output->color_trc = ctx->trc;
-@@ -385,72 +952,50 @@ static int tonemap_opencl_filter_frame(A
+@@ -385,72 +960,50 @@ static int tonemap_opencl_filter_frame(A
      ctx->range_out = output->color_range;
      ctx->chroma_loc = output->chroma_location;
  
@@ -2311,11 +2332,11 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_frame_remove_side_data(output, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
 +        av_frame_remove_side_data(output, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
 +    }
- 
--    av_log(ctx, AV_LOG_DEBUG, "Tone-mapping output: %s, %ux%u (%"PRId64").\n",
++
 +    av_frame_remove_side_data(output, AV_FRAME_DATA_DOVI_RPU_BUFFER);
 +    av_frame_remove_side_data(output, AV_FRAME_DATA_DOVI_METADATA);
-+
+ 
+-    av_log(ctx, AV_LOG_DEBUG, "Tone-mapping output: %s, %ux%u (%"PRId64").\n",
 +    av_log(ctx, AV_LOG_DEBUG, "Tonemapping output: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(output->format),
             output->width, output->height, output->pts);
@@ -2351,7 +2372,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_frame_free(&input);
      av_frame_free(&output);
      return err;
-@@ -458,24 +1003,9 @@ fail:
+@@ -458,24 +1011,9 @@ fail:
  
  static av_cold void tonemap_opencl_uninit(AVFilterContext *avctx)
  {
@@ -2378,7 +2399,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      ff_opencl_filter_uninit(avctx);
  }
-@@ -483,37 +1013,50 @@ static av_cold void tonemap_opencl_unini
+@@ -483,37 +1021,50 @@ static av_cold void tonemap_opencl_unini
  #define OFFSET(x) offsetof(TonemapOpenCLContext, x)
  #define FLAGS (AV_OPT_FLAG_FILTERING_PARAM | AV_OPT_FLAG_VIDEO_PARAM)
  static const AVOption tonemap_opencl_options[] = {
@@ -2460,3 +2481,12 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      { NULL }
  };
  
+@@ -541,7 +1092,7 @@ const AVFilter ff_vf_tonemap_opencl = {
+     .description    = NULL_IF_CONFIG_SMALL("Perform HDR to SDR conversion with tonemapping."),
+     .priv_size      = sizeof(TonemapOpenCLContext),
+     .priv_class     = &tonemap_opencl_class,
+-    .init           = &ff_opencl_filter_init,
++    .init           = &tonemap_opencl_pre_init,
+     .uninit         = &tonemap_opencl_uninit,
+     FILTER_INPUTS(tonemap_opencl_inputs),
+     FILTER_OUTPUTS(tonemap_opencl_outputs),

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -526,7 +526,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      float j = tone_param;
      float a, b;
  
-@@ -71,202 +85,606 @@ float mobius(float s, float peak) {
+@@ -71,202 +85,611 @@ float mobius(float s, float peak) {
          return s;
  
      a = -j * j * (peak - 1.0f) / (j * j - 2.0f * j + peak);
@@ -681,9 +681,9 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    float src_peak_delin_pq = inverse_eotf_st2084(peak);
 +    float dst_peak_delin_pq = inverse_eotf_st2084(1.0f);
 +  #ifdef TONE_MODE_RGB
-+    sig_r = inverse_eotf_st2084x4(sig_r);
-+    sig_g = inverse_eotf_st2084x4(sig_g);
-+    sig_b = inverse_eotf_st2084x4(sig_b);
++    sig_r = inverse_eotf_st2084x4(fmin(sig_r, peak));
++    sig_g = inverse_eotf_st2084x4(fmin(sig_g, peak));
++    sig_b = inverse_eotf_st2084x4(fmin(sig_b, peak));
 +    MAP_FOUR_PIXELS(sig_r, src_peak_delin_pq, dst_peak_delin_pq)
 +    MAP_FOUR_PIXELS(sig_g, src_peak_delin_pq, dst_peak_delin_pq)
 +    MAP_FOUR_PIXELS(sig_b, src_peak_delin_pq, dst_peak_delin_pq)
@@ -691,7 +691,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    sig_g = eotf_st2084x4(sig_g);
 +    sig_b = eotf_st2084x4(sig_b);
 +  #else
-+    sig = inverse_eotf_st2084x4(sig);
++    sig = inverse_eotf_st2084x4(fmin(sig, peak));
 +    MAP_FOUR_PIXELS(sig, src_peak_delin_pq, dst_peak_delin_pq)
 +    sig = eotf_st2084x4(sig);
 +  #endif
@@ -728,6 +728,11 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +#ifdef TONE_MODE_ITP
 +void map_four_pixels_itp(float4 *r4, float4 *g4, float4 *b4, float peak) {
 +    float4 i4_o, i4, ct4 , cp4;
++#ifdef TONE_FUNC_BT2390
++    *r4 = fmin(*r4, peak);
++    *g4 = fmin(*g4, peak);
++    *b4 = fmin(*b4, peak);
++#endif
 +    lrgb2ictcp(*r4, *g4, *b4, &i4, &ct4, &cp4);
 +    i4 = fmax(i4, FLOAT_EPS);
 +    i4_o = i4;

--- a/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
+++ b/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
@@ -1237,7 +1237,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    }
 +}
 +
-+static av_cold int tonemap_videotoolbox_pre_init(AVFilterContext *avctx)
++static av_cold int tonemap_videotoolbox_preinit(AVFilterContext *avctx)
 +{
 +    TonemapVideoToolboxContext *ctx = avctx->priv;
 +    ctx->final_param = NAN;
@@ -2119,7 +2119,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    .description    = NULL_IF_CONFIG_SMALL("Perform HDR to SDR conversion with Metal."),
 +    .priv_size      = sizeof(TonemapVideoToolboxContext),
 +    .priv_class     = &tonemap_videotoolbox_class,
-+    .init           = tonemap_videotoolbox_pre_init,
++    .preinit        = tonemap_videotoolbox_preinit,
 +    .uninit         = tonemap_videotoolbox_uninit,
 +    FILTER_INPUTS(tonemap_videotoolbox_inputs),
 +    FILTER_OUTPUTS(tonemap_videotoolbox_outputs),

--- a/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
+++ b/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
@@ -40,7 +40,7 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
-@@ -0,0 +1,916 @@
+@@ -0,0 +1,921 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -628,6 +628,11 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +        *b4 *= factor_b;
 +    } else if (is_tone_mode_itp) {
 +        float4 i4_o, i4, ct4 , cp4;
++        if (is_tone_func_bt2390) {
++            *r4 = fmin(*r4, peak);
++            *g4 = fmin(*g4, peak);
++            *b4 = fmin(*b4, peak);
++        }
 +        lrgb2ictcp(*r4, *g4, *b4, &i4, &ct4, &cp4);
 +        i4 = fmax(i4, FLOAT_EPS);
 +        i4_o = i4;

--- a/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
+++ b/debian/patches/0052-add-vf-tonemap-videotoolbox-filter.patch
@@ -966,7 +966,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
-@@ -0,0 +1,1157 @@
+@@ -0,0 +1,1159 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -1059,6 +1059,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    double                      peak;
 +    double                      target_peak;
 +    double                      param;
++    double                      final_param;
 +    double                      desat_param;
 +    double                      scene_threshold;
 +    int                         initialised;
@@ -1238,7 +1239,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +
 +static av_cold int tonemap_videotoolbox_pre_init(AVFilterContext *avctx)
 +{
-+    //TonemapVideoToolboxContext *ctx = avctx->priv;
++    TonemapVideoToolboxContext *ctx = avctx->priv;
++    ctx->final_param = NAN;
 +    return 0;
 +}
 +
@@ -1329,26 +1331,26 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    switch(ctx->tonemap) {
 +        case TONEMAP_GAMMA:
 +            if (isnan(ctx->param))
-+                ctx->param = 1.8f;
++                ctx->final_param = 1.8f;
 +            break;
 +        case TONEMAP_REINHARD:
 +            if (!isnan(ctx->param))
-+                ctx->param = (1.0f - ctx->param) / ctx->param;
++                ctx->final_param = (1.0f - ctx->param) / ctx->param;
 +            break;
 +        case TONEMAP_MOBIUS:
 +            if (isnan(ctx->param))
-+                ctx->param = 0.3f;
++                ctx->final_param = 0.3f;
 +            break;
 +        case TONEMAP_BT2390:
 +            if (isnan(ctx->param))
-+                ctx->param = 1.0f; // diff from the spec-defined 0.5f
++                ctx->final_param = 1.0f; // diff from the spec-defined 0.5f
 +            else
-+                ctx->param = FFMIN(FFMAX(ctx->param, 0.5f), 2.0f);
++                ctx->final_param = FFMIN(FFMAX(ctx->param, 0.5f), 2.0f);
 +            break;
 +    }
 +
-+    if (isnan(ctx->param))
-+        ctx->param = 1.0f;
++    if (isnan(ctx->final_param))
++        ctx->final_param = 1.0f;
 +
 +    if (ctx->peak)
 +        ctx->peak = FFMAX(ctx->peak / 10.0f, 1.1f);
@@ -1434,7 +1436,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +        goto fail;
 +    }
 +
-+    tone_param = (float)ctx->param;
++    tone_param = (float)ctx->final_param;
 +    desat_param = (float)ctx->desat_param;
 +    target_peak = (float)ctx->target_peak;
 +    scene_threshold = (float)ctx->scene_threshold;


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

For BT.2390 EETF, the mapped output might get overflowed due to the input signal has a too high value. For this tone mapping operator, the input signal exceeds the input peak should be clipped to the specified input peak value to prevent artifacts due to overflowing.

For ICtCp tone mapper, this means the input RGB color channels has to be clipped to the input peak before color conversion.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #552