### PR TITLE
lavc/huffyuvdsp: disable gcc vectorization

### DIFF
--- a/debian/patches/0033-enable-gcc-vectorization-and-fix-cpuflags.patch
+++ b/debian/patches/0033-enable-gcc-vectorization-and-fix-cpuflags.patch
@@ -36,3 +36,39 @@ Index: FFmpeg/libavcodec/x86/cabac.h
  int get_cabac_inline_x86(CABACContext *c, uint8_t *const state)
  {
      int bit, tmp;
+Index: FFmpeg/libavcodec/huffyuvdsp.c
+===================================================================
+--- FFmpeg.orig/libavcodec/huffyuvdsp.c
++++ FFmpeg/libavcodec/huffyuvdsp.c
+@@ -16,6 +16,13 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
++// GCC Vectorize with AVX will break huffyuv unit tests.
++#if defined(__GNUC__) && !defined(__clang__)
++    #if (__GNUC__ > 6)
++        #pragma GCC optimize ("no-tree-vectorize")
++    #endif
++#endif
++
+ #include <stdint.h>
+ 
+ #include "config.h"
+Index: FFmpeg/libavcodec/huffyuvenc.c
+===================================================================
+--- FFmpeg.orig/libavcodec/huffyuvenc.c
++++ FFmpeg/libavcodec/huffyuvenc.c
+@@ -28,6 +28,13 @@
+  * huffyuv encoder
+  */
+ 
++ // GCC Vectorize with AVX will break huffyuv unit tests.
++#if defined(__GNUC__) && !defined(__clang__)
++    #if (__GNUC__ > 6)
++        #pragma GCC optimize ("no-tree-vectorize")
++    #endif
++#endif
++
+ #include "config_components.h"
+ 
+ #include "avcodec.h"


### PR DESCRIPTION
GCC vectorization with avx will break unit tests for this dsp and its corresponding encoder.

We are not using this encoder anyway, so just make it potentially slower to make the FATE test happy.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #556