### PR TITLE
Add FP16 tradeoff for DOVI reshaping

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.1.1-2"
+version: "7.1.1-3"
 packages:
   - bullseye-amd64
   - bullseye-armhf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+jellyfin-ffmpeg (7.1.1-3) unstable; urgency=medium
+
+  * avfilter/tonemap_opencl: reduce compute and memory load of 3dlut
+  * avfilter/tonemap_opencl: always use eotf for lms2rgb
+  * Add FP16 tradeoff for DOVI reshaping
+  * Fix VUI full range flag in RKMPP encoded videos
+  * Increase default frame pool size for D3D11VA AV1/VP9
+  * Handle NOPTS and no extradata in RKMPP decoders
+
+ -- nyanmisaka <nst799610810@gmail.com>  Tue, 6 May 2025 21:12:22 +0800
+
 jellyfin-ffmpeg (7.1.1-2) unstable; urgency=medium
 
   * Fix VPP tonemap without having HDR10 metadata

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -499,11 +499,32 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 ===================================================================
 --- FFmpeg.orig/libavfilter/opencl/tonemap.cl
 +++ FFmpeg/libavfilter/opencl/tonemap.cl
-@@ -16,54 +16,68 @@
+@@ -16,54 +16,89 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
  
 -#define REFERENCE_WHITE 100.0f
++#ifdef DOVI_RESHAPE
++  #undef typedef_vecs
++  #undef M_ZERO_VEC
++  #define typedef_vecs(base, new) \
++    typedef base     new;    \
++    typedef base##2  new##2; \
++    typedef base##3  new##3; \
++    typedef base##4  new##4; \
++    typedef base##8  new##8; \
++    typedef base##16 new##16;
++  #ifdef DOVI_PERF_FP16
++    #pragma OPENCL EXTENSION cl_khr_fp16 : enable
++    #define M_ZERO_VEC 0.0h
++    typedef_vecs(half,  vec)
++  #else
++    #define M_ZERO_VEC 0.0f
++    typedef_vecs(float, vec)
++  #endif
++  #undef typedef_vecs
++#endif
++
 +#define FLOAT_EPS 1e-6f
 +#define LUT_SIZE 65
 +
@@ -589,7 +610,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      float j = tone_param;
      float a, b;
  
-@@ -71,202 +85,612 @@ float mobius(float s, float peak) {
+@@ -71,202 +106,632 @@ float mobius(float s, float peak) {
          return s;
  
      a = -j * j * (peak - 1.0f) / (j * j - 2.0f * j + peak);
@@ -851,7 +872,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -float3 map_one_pixel_rgb(float3 rgb, float peak, float average) {
 -    float sig = max(max(rgb.x, max(rgb.y, rgb.z)), 1e-6f);
 +#ifdef DOVI_RESHAPE
-+float reshape_poly(float s, float4 coeffs) {
++vec reshape_poly(vec s, vec4 coeffs) {
 +    return (coeffs.z * s + coeffs.y) * s + coeffs.x;
 +}
  
@@ -861,27 +882,28 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -    if (target_peak > 1.0f) {
 -        sig *= 1.0f / target_peak;
 -        peak *= 1.0f / target_peak;
-+float reshape_mmr(float3 sig,
-+                  float4 coeffs,
-+                  __global float4 *dovi_mmr,
-+                  int dovi_mmr_single,
-+                  int dovi_min_order,
-+                  int dovi_max_order)
++vec reshape_mmr(vec3 sig,
++                vec4 coeffs,
++                __global const vec4 *dovi_mmr,
++                uchar dovi_mmr_single,
++                uchar dovi_min_order,
++                uchar dovi_max_order)
 +{
-+    int mmr_idx = dovi_mmr_single ? 0 : (int)coeffs.y;
-+    int order = (int)coeffs.w;
-+    float4 sigX;
++    uchar mmr_idx = dovi_mmr_single ? 0 : (uchar)coeffs.y;
++    uchar order = (uchar)coeffs.w;
++    vec4 sigX;
++    bool t;
 +
-+    float s = coeffs.x;
++    vec s = coeffs.x;
 +    sigX.xyz = sig.xxy * sig.yzz;
 +    sigX.w = sigX.x * sig.z;
 +    s += dot(dovi_mmr[mmr_idx + 0].xyz, sig);
 +    s += dot(dovi_mmr[mmr_idx + 1], sigX);
 +
-+    int t = dovi_max_order >= 2 && (dovi_min_order >= 2 || order >= 2);
++    t = dovi_max_order >= 2 && (dovi_min_order >= 2 || order >= 2);
 +    if (t) {
-+        float3 sig2 = sig * sig;
-+        float4 sigX2 = sigX * sigX;
++        vec3 sig2 = sig * sig;
++        vec4 sigX2 = sigX * sigX;
 +        s += dot(dovi_mmr[mmr_idx + 2].xyz, sig2);
 +        s += dot(dovi_mmr[mmr_idx + 3], sigX2);
 +        t = dovi_max_order == 3 && (dovi_min_order == 3 || order >= 3);
@@ -892,32 +914,45 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      }
  
 -    float sig_old = sig;
-+    return s;
-+}
- 
+-
 -    // Scale the signal to compensate for differences in the average brightness
 -    float slope = min(1.0f, sdr_avg / average);
 -    sig *= slope;
 -    peak *= slope;
-+float3 reshape_dovi_yuv(float3 yuv,
-+                        __global float *src_dovi_params,
-+                        __global float *src_dovi_pivots,
-+                        __global float4 *src_dovi_coeffs,
-+                        __global float4 *src_dovi_mmr)
++    return s;
++}
+ 
+-    // Desaturate the color using a coefficient dependent on the signal level
+-    if (desat_param > 0.0f) {
+-        float luma = get_luma_dst(rgb);
+-        float coeff = max(sig - 0.18f, 1e-6f) / max(sig, 1e-6f);
+-        coeff = native_powr(coeff, 10.0f / desat_param);
+-        rgb = mix(rgb, (float3)luma, (float3)coeff);
+-        sig = mix(sig, luma * slope, coeff);
+-    }
++void reshape_dovi_yuv(float3 *yuv,
++                      __global const vec *src_dovi_params,
++                      __global const vec *src_dovi_pivots,
++                      __global const vec4 *src_dovi_coeffs,
++                      __global const vec4 *src_dovi_mmr)
 +{
-+    int i;
-+    float s;
-+    float3 sig = clamp(yuv.xyz, 0.0f, 1.0f);
-+    float sig_arr[3] = {sig.x, sig.y, sig.z};
-+    float4 coeffs;
-+    int dovi_num_pivots, dovi_has_mmr, dovi_has_poly;
-+    int dovi_mmr_single, dovi_min_order, dovi_max_order;
-+    float dovi_lo, dovi_hi;
-+    __global float *dovi_params;
-+    __global float *dovi_pivots;
-+    __global float4 *dovi_coeffs, *dovi_mmr;
++    uchar i;
++    bool t, has_mmr_poly;
++  #ifdef DOVI_PERF_FP16
++    vec3 sig = convert_half3(clamp((*yuv).xyz, 0.0f, 1.0f));
++  #else
++    vec3 sig = clamp((*yuv).xyz, 0.0f, 1.0f);
++  #endif
++    vec s;
++    vec4 coeffs;
++    uchar dovi_num_pivots, dovi_has_mmr, dovi_has_poly;
++    uchar dovi_mmr_single, dovi_min_order, dovi_max_order;
++    vec dovi_lo, dovi_hi;
++    __global const vec *dovi_params;
++    __global const vec *dovi_pivots;
++    __global const vec4 *dovi_coeffs, *dovi_mmr;
 +
-+#pragma unroll
++  #pragma unroll
 +    for (i = 0; i < 3; i++) {
 +        dovi_params = src_dovi_params + i*8;
 +        dovi_pivots = src_dovi_pivots + i*8;
@@ -932,35 +967,37 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +        dovi_lo = dovi_params[6];
 +        dovi_hi = dovi_params[7];
 +
-+        s = sig_arr[i];
++        s = ((vec *)(&sig))[i];
 +        coeffs = dovi_coeffs[0];
 +
 +        if (i == 0 && dovi_num_pivots > 2) {
-+            coeffs = mix(mix(mix(dovi_coeffs[0], dovi_coeffs[1], (float4)(s >= dovi_pivots[0])),
-+                             mix(dovi_coeffs[2], dovi_coeffs[3], (float4)(s >= dovi_pivots[2])),
-+                             (float4)(s >= dovi_pivots[1])),
-+                         mix(mix(dovi_coeffs[4], dovi_coeffs[5], (float4)(s >= dovi_pivots[4])),
-+                             mix(dovi_coeffs[6], dovi_coeffs[7], (float4)(s >= dovi_pivots[6])),
-+                             (float4)(s >= dovi_pivots[5])),
-+                         (float4)(s >= dovi_pivots[3]));
++  #ifdef DOVI_PERF_FP16
++            const vec8 pivots0 = vload8(0, (__global const vec *)dovi_pivots);
++            const vec8 coeffs0 = vload8(0, (__global const vec *)dovi_coeffs);
++            const vec8 coeffs1 = vload8(1, (__global const vec *)dovi_coeffs);
++            const vec8 coeffs2 = vload8(2, (__global const vec *)dovi_coeffs);
++            const vec8 coeffs3 = vload8(3, (__global const vec *)dovi_coeffs);
++
++            const vec *pivots = (const vec *)&pivots0;
++  #else
++            __global const vec *pivots = dovi_pivots;
++            const vec8 coeffs0 = (vec8)(dovi_coeffs[0], dovi_coeffs[1]);
++            const vec8 coeffs1 = (vec8)(dovi_coeffs[2], dovi_coeffs[3]);
++            const vec8 coeffs2 = (vec8)(dovi_coeffs[4], dovi_coeffs[5]);
++            const vec8 coeffs3 = (vec8)(dovi_coeffs[6], dovi_coeffs[7]);
++  #endif
++            coeffs = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(s >= pivots[0])),
++                             mix(coeffs1.lo, coeffs1.hi, (vec4)(s >= pivots[2])),
++                             (vec4)(s >= pivots[1])),
++                         mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(s >= pivots[4])),
++                             mix(coeffs3.lo, coeffs3.hi, (vec4)(s >= pivots[6])),
++                             (vec4)(s >= pivots[5])),
++                         (vec4)(s >= pivots[3]));
 +        }
  
--    // Desaturate the color using a coefficient dependent on the signal level
--    if (desat_param > 0.0f) {
--        float luma = get_luma_dst(rgb);
--        float coeff = max(sig - 0.18f, 1e-6f) / max(sig, 1e-6f);
--        coeff = native_powr(coeff, 10.0f / desat_param);
--        rgb = mix(rgb, (float3)luma, (float3)coeff);
--        sig = mix(sig, luma * slope, coeff);
--    }
-+        int has_mmr_poly = dovi_has_mmr && dovi_has_poly;
- 
 -    sig = TONE_FUNC(sig, peak);
-+        if ((has_mmr_poly && coeffs.w == 0.0f) || (!has_mmr_poly && dovi_has_poly))
-+            s = reshape_poly(s, coeffs);
-+        else
-+            s = reshape_mmr(sig, coeffs, dovi_mmr,
-+                            dovi_mmr_single, dovi_min_order, dovi_max_order);
++        has_mmr_poly = dovi_has_mmr && dovi_has_poly;
++        t = (has_mmr_poly && coeffs.w == M_ZERO_VEC) || (!has_mmr_poly && dovi_has_poly);
  
 -    sig = min(sig, 1.0f);
 -    rgb *= (sig/sig_old);
@@ -972,10 +1009,15 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -    c = ootf(c, peak);
 -    c = lrgb2lrgb(c);
 -    return c;
-+        sig_arr[i] = clamp(s, dovi_lo, dovi_hi);
++        s = t ? reshape_poly(s, coeffs)
++              : reshape_mmr(sig, coeffs, dovi_mmr,
++                            dovi_mmr_single, dovi_min_order, dovi_max_order);
++  #ifdef DOVI_PERF_FP16
++        ((float *)yuv)[i] = convert_float(clamp(s, dovi_lo, dovi_hi));
++  #else
++        ((float *)yuv)[i] = clamp(s, dovi_lo, dovi_hi);
++  #endif
 +    }
-+
-+    return (float3)(sig_arr[0], sig_arr[1], sig_arr[2]);
  }
 +#endif
 +
@@ -1008,7 +1050,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +                      __read_only  image2d_t dither,
 +#endif
 +#ifdef DOVI_RESHAPE
-+                      __global float *dovi_buf,
++                      __global const vec *dovi_buf,
 +#endif
 +                      float peak)
  {
@@ -1019,43 +1061,11 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      int xi = get_global_id(0);
      int yi = get_global_id(1);
      // each work item process four pixels
-     int x = 2 * xi;
-     int y = 2 * yi;
- 
--    float y0 = read_imagef(src1, sampler, (int2)(x,     y)).x;
--    float y1 = read_imagef(src1, sampler, (int2)(x + 1, y)).x;
--    float y2 = read_imagef(src1, sampler, (int2)(x,     y + 1)).x;
--    float y3 = read_imagef(src1, sampler, (int2)(x + 1, y + 1)).x;
--    float2 uv = read_imagef(src2, sampler, (int2)(xi,     yi)).xy;
--
--    float3 c0 = map_to_dst_space_from_yuv((float3)(y0, uv.x, uv.y), peak);
--    float3 c1 = map_to_dst_space_from_yuv((float3)(y1, uv.x, uv.y), peak);
--    float3 c2 = map_to_dst_space_from_yuv((float3)(y2, uv.x, uv.y), peak);
--    float3 c3 = map_to_dst_space_from_yuv((float3)(y3, uv.x, uv.y), peak);
--
--    float sig0 = max(c0.x, max(c0.y, c0.z));
--    float sig1 = max(c1.x, max(c1.y, c1.z));
--    float sig2 = max(c2.x, max(c2.y, c2.z));
--    float sig3 = max(c3.x, max(c3.y, c3.z));
--    float sig = max(sig0, max(sig1, max(sig2, sig3)));
--
--    struct detection_result r = detect_peak_avg(util_buf, &sum_wg, sig, peak);
--
--    float3 c0_old = c0, c1_old = c1, c2_old = c2;
--    c0 = map_one_pixel_rgb(c0, r.peak, r.average);
--    c1 = map_one_pixel_rgb(c1, r.peak, r.average);
--    c2 = map_one_pixel_rgb(c2, r.peak, r.average);
--    c3 = map_one_pixel_rgb(c3, r.peak, r.average);
--
--    c0 = inverse_ootf(c0, target_peak);
--    c1 = inverse_ootf(c1, target_peak);
--    c2 = inverse_ootf(c2, target_peak);
--    c3 = inverse_ootf(c3, target_peak);
--
--    y0 = lrgb2y(c0);
--    y1 = lrgb2y(c1);
--    y2 = lrgb2y(c2);
--    y3 = lrgb2y(c3);
+-    int x = 2 * xi;
+-    int y = 2 * yi;
++    int x = xi << 1;
++    int y = yi << 1;
++
 +    int2 src1_sz = get_image_dim(src1);
 +    int2 dst2_sz = get_image_dim(dst2);
 +
@@ -1092,14 +1102,14 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +#endif
 +
 +#ifdef DOVI_RESHAPE
-+    __global float *dovi_params = dovi_buf;
-+    __global float *dovi_pivots = dovi_buf + 24;
-+    __global float4 *dovi_coeffs = (__global float4 *)(dovi_buf + 48);
-+    __global float4 *dovi_mmr = (__global float4 *)(dovi_buf + 144);
-+    yuv0 = reshape_dovi_yuv(yuv0, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    yuv1 = reshape_dovi_yuv(yuv1, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    yuv2 = reshape_dovi_yuv(yuv2, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    yuv3 = reshape_dovi_yuv(yuv3, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    __global const vec *dovi_params = dovi_buf;
++    __global const vec *dovi_pivots = dovi_buf + 24;
++    __global const vec4 *dovi_coeffs = (__global const vec4 *)(dovi_buf + 48);
++    __global const vec4 *dovi_mmr = (__global const vec4 *)(dovi_buf + 144);
++    reshape_dovi_yuv(&yuv0, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    reshape_dovi_yuv(&yuv1, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    reshape_dovi_yuv(&yuv2, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    reshape_dovi_yuv(&yuv3, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
 +#endif
 +
 +    float3 c0, c1, c2, c3;
@@ -1160,7 +1170,41 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    y0 = get_dithered_y(y0, d), y1 = get_dithered_y(y1, d);
 +    y2 = get_dithered_y(y2, d), y3 = get_dithered_y(y3, d);
 +#endif
-+
+ 
+-    float y0 = read_imagef(src1, sampler, (int2)(x,     y)).x;
+-    float y1 = read_imagef(src1, sampler, (int2)(x + 1, y)).x;
+-    float y2 = read_imagef(src1, sampler, (int2)(x,     y + 1)).x;
+-    float y3 = read_imagef(src1, sampler, (int2)(x + 1, y + 1)).x;
+-    float2 uv = read_imagef(src2, sampler, (int2)(xi,     yi)).xy;
+-
+-    float3 c0 = map_to_dst_space_from_yuv((float3)(y0, uv.x, uv.y), peak);
+-    float3 c1 = map_to_dst_space_from_yuv((float3)(y1, uv.x, uv.y), peak);
+-    float3 c2 = map_to_dst_space_from_yuv((float3)(y2, uv.x, uv.y), peak);
+-    float3 c3 = map_to_dst_space_from_yuv((float3)(y3, uv.x, uv.y), peak);
+-
+-    float sig0 = max(c0.x, max(c0.y, c0.z));
+-    float sig1 = max(c1.x, max(c1.y, c1.z));
+-    float sig2 = max(c2.x, max(c2.y, c2.z));
+-    float sig3 = max(c3.x, max(c3.y, c3.z));
+-    float sig = max(sig0, max(sig1, max(sig2, sig3)));
+-
+-    struct detection_result r = detect_peak_avg(util_buf, &sum_wg, sig, peak);
+-
+-    float3 c0_old = c0, c1_old = c1, c2_old = c2;
+-    c0 = map_one_pixel_rgb(c0, r.peak, r.average);
+-    c1 = map_one_pixel_rgb(c1, r.peak, r.average);
+-    c2 = map_one_pixel_rgb(c2, r.peak, r.average);
+-    c3 = map_one_pixel_rgb(c3, r.peak, r.average);
+-
+-    c0 = inverse_ootf(c0, target_peak);
+-    c1 = inverse_ootf(c1, target_peak);
+-    c2 = inverse_ootf(c2, target_peak);
+-    c3 = inverse_ootf(c3, target_peak);
+-
+-    y0 = lrgb2y(c0);
+-    y1 = lrgb2y(c1);
+-    y2 = lrgb2y(c2);
+-    y3 = lrgb2y(c3);
      float3 chroma_c = get_chroma_sample(c0, c1, c2, c3);
      float3 chroma = lrgb2yuv(chroma_c);
  
@@ -1199,12 +1243,12 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    // Compute the base linear index.
 +    uint base_idx = base.x + base.y * LUT_SIZE + base.z * LUT_SIZE * LUT_SIZE;
 +
-+#define LUT_IDX_MAX (LUT_SIZE * LUT_SIZE * LUT_SIZE - 1)
-+
 +    // Sort the fraction offsets, so that we always have a>=b>=c
 +    float a = fmax(f.x, fmax(f.y, f.z));
 +    float c = fmin(f.x, fmin(f.y, f.z));
 +    float b = f.x + f.y + f.z - a - c;
++
++#define LUT_IDX_MAX (LUT_SIZE * LUT_SIZE * LUT_SIZE - 1)
 +
 +    // The initial and the last corner values of current cube will always be fetched
 +    float3 c000 = lut[min(base_idx, (uint)LUT_IDX_MAX)];
@@ -1236,7 +1280,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    return clamp(result, 0.0f, 1.0f);
 +}
 +
-+__kernel void tonemap_lut(__global float3 *lut,
++__kernel void tonemap_lut(__global const float3 *restrict lut,
 +                          __write_only image2d_t dst1,
 +                          __read_only  image2d_t src1,
 +                          __write_only image2d_t dst2,
@@ -1251,15 +1295,15 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +                          __read_only  image2d_t dither,
 +#endif
 +#ifdef DOVI_RESHAPE
-+                          __global float *dovi_buf,
++                          __global const vec *restrict dovi_buf,
 +#endif
 +                          float peak)
 +{
 +    int xi = get_global_id(0);
 +    int yi = get_global_id(1);
 +    // each work item process four pixels
-+    int x = 2 * xi;
-+    int y = 2 * yi;
++    int x = xi << 1;
++    int y = yi << 1;
 +
 +    int2 src1_sz = get_image_dim(src1);
 +    int2 dst2_sz = get_image_dim(dst2);
@@ -1297,14 +1341,14 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +#endif
 +
 +#ifdef DOVI_RESHAPE
-+    __global float *dovi_params = dovi_buf;
-+    __global float *dovi_pivots = dovi_buf + 24;
-+    __global float4 *dovi_coeffs = (__global float4 *)(dovi_buf + 48);
-+    __global float4 *dovi_mmr = (__global float4 *)(dovi_buf + 144);
-+    yuv0 = reshape_dovi_yuv(yuv0, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    yuv1 = reshape_dovi_yuv(yuv1, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    yuv2 = reshape_dovi_yuv(yuv2, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    yuv3 = reshape_dovi_yuv(yuv3, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    __global const vec *dovi_params = dovi_buf;
++    __global const vec *dovi_pivots = dovi_buf + 24;
++    __global const vec4 *dovi_coeffs = (__global const vec4 *)(dovi_buf + 48);
++    __global const vec4 *dovi_mmr = (__global const vec4 *)(dovi_buf + 144);
++    reshape_dovi_yuv(&yuv0, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    reshape_dovi_yuv(&yuv1, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    reshape_dovi_yuv(&yuv2, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    reshape_dovi_yuv(&yuv3, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
 +#endif
 +
 +    float3 c0, c1, c2, c3;
@@ -1449,7 +1493,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  };
  
  typedef struct TonemapOpenCLContext {
-@@ -56,23 +85,45 @@ typedef struct TonemapOpenCLContext {
+@@ -56,23 +85,46 @@ typedef struct TonemapOpenCLContext {
      enum AVColorPrimaries primaries, primaries_in, primaries_out;
      enum AVColorRange range, range_in, range_out;
      enum AVChromaLocation chroma_loc;
@@ -1461,13 +1505,14 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +#define pivots_cnt (7+1)
 +#define coeffs_cnt 8*4
 +#define mmr_cnt 8*6*4
-+#define params_sz params_cnt*sizeof(float)
-+#define pivots_sz pivots_cnt*sizeof(float)
-+#define coeffs_sz coeffs_cnt*sizeof(float)
-+#define mmr_sz mmr_cnt*sizeof(float)
++#define params_sz params_cnt*sizeof(cl_float)
++#define pivots_sz pivots_cnt*sizeof(cl_float)
++#define coeffs_sz coeffs_cnt*sizeof(cl_float)
++#define mmr_sz mmr_cnt*sizeof(cl_float)
 +    struct DoviMetadata *dovi;
 +    cl_mem dovi_buf;
-+    int is_pure_dovi;
++    unsigned dovi_use_fp16;
++    unsigned is_pure_dovi;
  
      enum TonemapAlgorithm tonemap;
 +    enum TonemapMode      tonemap_mode;
@@ -1499,7 +1544,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  };
  
  static const char *const delinearize_funcs[AVCOL_TRC_NB] = {
-@@ -80,7 +131,7 @@ static const char *const delinearize_fun
+@@ -80,7 +132,7 @@ static const char *const delinearize_fun
      [AVCOL_TRC_BT2020_10] = "inverse_eotf_bt1886",
  };
  
@@ -1508,7 +1553,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      [TONEMAP_NONE]     = "direct",
      [TONEMAP_LINEAR]   = "linear",
      [TONEMAP_GAMMA]    = "gamma",
-@@ -88,8 +139,18 @@ static const char *const tonemap_func[TO
+@@ -88,8 +140,18 @@ static const char *const tonemap_func[TO
      [TONEMAP_REINHARD] = "reinhard",
      [TONEMAP_HABLE]    = "hable",
      [TONEMAP_MOBIUS]   = "mobius",
@@ -1527,7 +1572,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  static int get_rgb2rgb_matrix(enum AVColorPrimaries in, enum AVColorPrimaries out,
                                double rgb2rgb[3][3]) {
      double rgb2xyz[3][3], xyz2rgb[3][3];
-@@ -108,90 +169,368 @@ static int get_rgb2rgb_matrix(enum AVCol
+@@ -108,90 +170,438 @@ static int get_rgb2rgb_matrix(enum AVCol
      return 0;
  }
  
@@ -1535,19 +1580,45 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 -// Average light level for SDR signals. This is equal to a signal level of 0.5
 -// under a typical presentation gamma of about 2.0.
 -static const float sdr_avg = 0.25f;
++static unsigned as_unsigned(const float x) {
++    const float *px = &x;
++    return *(unsigned*)px;
++}
++
++// IEEE-754 16-bit floating-point format (without infinity):
++// 1-5-10, exp-15, +-131008.0, +-6.1035156E-5, +-5.9604645E-8, 3.311 digits
++static cl_half cl_float2half(const cl_float x) {
++    // round-to-nearest-even: add last bit after truncated mantissa
++    const unsigned b = as_unsigned(x)+0x00001000;
++    // exponent
++    const unsigned e = (b&0x7F800000)>>23;
++    // mantissa; in line below:
++    // 0x007FF000 = 0x00800000-0x00001000 = decimal indicator flag - initial rounding
++    const unsigned m = b&0x007FFFFF;
++
++    // sign : normalized : denormalized : saturate
++    return (b&0x80000000)>>16                                   |
++           (e>112)*((((e-112)<<10)&0x7C00)|m>>13)               |
++           ((e<113)&(e>101))*((((0x007FF000+m)>>(125-e))+1)>>1) |
++           (e>143)*0x7FFF;
++}
++
 +static int tonemap_opencl_update_dovi_buf(AVFilterContext *avctx)
 +{
 +    TonemapOpenCLContext *ctx = avctx->priv;
-+    float *pbuf = NULL;
-+    float coeffs_data[8][4] = {0};
-+    float mmr_packed_data[8*6][4] = {0};
++    const unsigned fp16 = !!ctx->dovi_use_fp16;
++    const size_t buf_sz = 3*(params_sz+pivots_sz+coeffs_sz+mmr_sz) >> fp16;
++    void *pbuf = NULL;
++    cl_float coeffs_dataf[8][4] = {0};
++    cl_float mmr_packed_dataf[8*6][4] = {0};
++    cl_half coeffs_datah[8][4] = {0};
++    cl_half mmr_packed_datah[8*6][4] = {0};
 +    int c, i, j, k, err;
 +    cl_int cle;
 +
-+    pbuf = (float *)clEnqueueMapBuffer(ctx->command_queue, ctx->dovi_buf,
-+                                       CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION, 0,
-+                                       3*(params_sz+pivots_sz+coeffs_sz+mmr_sz),
-+                                       0, NULL, NULL, &cle);
++    pbuf = clEnqueueMapBuffer(ctx->command_queue, ctx->dovi_buf,
++                              CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION, 0,
++                              buf_sz, 0, NULL, NULL, &cle);
 +    CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to map dovi buf: %d.\n", cle);
 +
 +    av_assert0(pbuf);
@@ -1560,26 +1631,26 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +            continue;
 +        av_assert0(comp->num_pivots >= 2 && comp->num_pivots <= 9);
 +
-+        memset(coeffs_data, 0, sizeof(coeffs_data));
++        memset(coeffs_dataf, 0, sizeof(coeffs_dataf));
 +        for (i = 0; i < comp->num_pivots - 1; i++) {
 +            switch (comp->method[i]) {
 +            case 0: // polynomial
 +                has_poly = 1;
-+                coeffs_data[i][3] = 0.0f; // order=0 signals polynomial
++                coeffs_dataf[i][3] = 0.0f; // order=0 signals polynomial
 +                for (k = 0; k < 3; k++)
-+                    coeffs_data[i][k] = comp->poly_coeffs[i][k];
++                    coeffs_dataf[i][k] = comp->poly_coeffs[i][k];
 +                break;
 +            case 1:
 +                min_order = FFMIN(min_order, comp->mmr_order[i]);
 +                max_order = FFMAX(max_order, comp->mmr_order[i]);
 +                mmr_single = !has_mmr;
 +                has_mmr = 1;
-+                coeffs_data[i][3] = (float)comp->mmr_order[i];
-+                coeffs_data[i][0] = comp->mmr_constant[i];
-+                coeffs_data[i][1] = (float)mmr_idx;
++                coeffs_dataf[i][3] = (float)comp->mmr_order[i];
++                coeffs_dataf[i][0] = comp->mmr_constant[i];
++                coeffs_dataf[i][1] = (float)mmr_idx;
 +                for (j = 0; j < comp->mmr_order[i]; j++) {
 +                    // store weights per order as two packed vec4s
-+                    float *mmr = &mmr_packed_data[mmr_idx][0];
++                    cl_float *mmr = &mmr_packed_dataf[mmr_idx][0];
 +                    mmr[0] = comp->mmr_coeffs[i][j][0];
 +                    mmr[1] = comp->mmr_coeffs[i][j][1];
 +                    mmr[2] = comp->mmr_coeffs[i][j][2];
@@ -1601,34 +1672,67 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        if (has_mmr)
 +            av_assert0(min_order <= max_order);
 +
++        if (fp16) {
++            for (i = 0; i < 8; i++)
++                for (j = 0; j < 4; j++)
++                    coeffs_datah[i][j] = cl_float2half(coeffs_dataf[i][j]);
++
++            for (i = 0; i < 8*6; i++)
++                for (j = 0; j < 4; j++)
++                    mmr_packed_datah[i][j] = cl_float2half(mmr_packed_dataf[i][j]);
++        }
++
 +        // dovi_params
 +        {
-+            float params[8] = {
++            const cl_float paramsf[8] = {
 +                comp->num_pivots, !!has_mmr, !!has_poly,
 +                mmr_single, min_order, max_order,
 +                comp->pivots[0], comp->pivots[comp->num_pivots - 1]
 +            };
-+            memcpy(pbuf + c*params_cnt, params, params_sz);
++
++            if (fp16) {
++                cl_half paramsh[8] = {0};
++                for (i = 0; i < 8; i++)
++                    paramsh[i] = cl_float2half(paramsf[i]);
++
++                memcpy((cl_half*)pbuf + c*params_cnt, paramsh, params_sz>>1);
++            } else
++                memcpy((cl_float*)pbuf + c*params_cnt, paramsf, params_sz);
 +        }
 +
 +        // dovi_pivots
 +        if (c == 0 && comp->num_pivots > 2) {
 +            // Skip the (irrelevant) lower and upper bounds
-+            float pivots_data[7+1] = {0};
-+            memcpy(pivots_data, comp->pivots + 1,
-+                   (comp->num_pivots - 2) * sizeof(pivots_data[0]));
++            cl_float pivots_dataf[7+1] = {0};
++            memcpy(pivots_dataf, comp->pivots + 1,
++                   (comp->num_pivots - 2) * sizeof(pivots_dataf[0]));
 +            // Fill the remainder with a quasi-infinite sentinel pivot
-+            for (i = comp->num_pivots - 2; i < FF_ARRAY_ELEMS(pivots_data); i++)
-+                pivots_data[i] = 1e9f;
-+            memcpy(pbuf + 3*params_cnt + c*pivots_cnt, pivots_data, pivots_sz);
++            for (i = comp->num_pivots - 2; i < FF_ARRAY_ELEMS(pivots_dataf); i++)
++                pivots_dataf[i] = 1e9f;
++
++            if (fp16) {
++                cl_half pivots_datah[7+1] = {0};
++                for (i = 0; i < 7+1; i++)
++                    pivots_datah[i] = cl_float2half(pivots_dataf[i]);
++
++                memcpy((cl_half*)pbuf + 3*params_cnt + c*pivots_cnt, pivots_datah, pivots_sz>>1);
++            } else
++                memcpy((cl_float*)pbuf + 3*params_cnt + c*pivots_cnt, pivots_dataf, pivots_sz);
 +        }
 +
 +        // dovi_coeffs
-+        memcpy(pbuf + 3*(params_cnt+pivots_cnt) + c*coeffs_cnt, &coeffs_data[0], coeffs_sz);
++        if (fp16)
++            memcpy((cl_half*)pbuf + 3*(params_cnt+pivots_cnt) + c*coeffs_cnt, &coeffs_datah[0], coeffs_sz>>1);
++        else
++            memcpy((cl_float*)pbuf + 3*(params_cnt+pivots_cnt) + c*coeffs_cnt, &coeffs_dataf[0], coeffs_sz);
 +
 +        // dovi_mmr
-+        if (has_mmr)
-+            memcpy(pbuf + 3*(params_cnt+pivots_cnt+coeffs_cnt) + c*mmr_cnt, &mmr_packed_data[0], mmr_sz);
++        if (has_mmr) {
++            if (fp16)
++                memcpy((cl_half*)pbuf + 3*(params_cnt+pivots_cnt+coeffs_cnt) + c*mmr_cnt, &mmr_packed_datah[0], mmr_sz>>1);
++            else
++                memcpy((cl_float*)pbuf + 3*(params_cnt+pivots_cnt+coeffs_cnt) + c*mmr_cnt, &mmr_packed_dataf[0], mmr_sz);
++        }
 +    }
 +
 +    cle = clEnqueueUnmapMemObject(ctx->command_queue, ctx->dovi_buf, pbuf, 0, NULL, NULL);
@@ -1677,13 +1781,16 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 -    int err;
 -    AVBPrint header;
 -    const char *opencl_sources[OPENCL_SOURCE_NB];
--
--    av_bprint_init(&header, 1024, AV_BPRINT_SIZE_AUTOMATIC);
 +    cl_mem_flags dovi_buf_flags = CL_MEM_ALLOC_HOST_PTR | CL_MEM_HOST_WRITE_ONLY | CL_MEM_READ_ONLY;
 +    char *device_vendor = NULL;
 +    char *device_name = NULL;
 +    char *device_exts = NULL;
 +    int i, j, err;
+ 
+-    av_bprint_init(&header, 1024, AV_BPRINT_SIZE_AUTOMATIC);
++    if (ctx->tonemap_mode == TONEMAP_MODE_AUTO) {
++        ctx->tonemap_mode = TONEMAP_MODE_ITP;
++    }
  
      switch(ctx->tonemap) {
      case TONEMAP_GAMMA:
@@ -1727,18 +1834,6 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to check OpenCL "
 +                     "device vendor id %d.\n", cle);
 +
-+#ifndef CL_MEM_FORCE_HOST_MEMORY_INTEL
-+  #define CL_MEM_FORCE_HOST_MEMORY_INTEL (1 << 20)
-+#endif
-+    // zero-copy buffer requires this extension on Intel dGPUs
-+    if (device_vendor_id == 0x8086) {
-+        device_exts = check_opencl_device_str(ctx->ocf.hwctx->device_id, CL_DEVICE_EXTENSIONS);
-+        if (device_exts && strstr(device_exts, "cl_intel_mem_force_host_memory"))
-+            dovi_buf_flags |= CL_MEM_FORCE_HOST_MEMORY_INTEL;
-+        if (device_exts)
-+            av_free(device_exts);
-+    }
-+
 +    if (ctx->tradeoff == -1) {
 +        ctx->tradeoff = 1;
 +        cle = clGetDeviceInfo(ctx->ocf.hwctx->device_id, CL_DEVICE_HOST_UNIFIED_MEMORY,
@@ -1780,16 +1875,35 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +            av_log(avctx, AV_LOG_DEBUG, "Disabled tradeoffs on high performance device.\n");
 +    }
 +
-+    if (ctx->tonemap_mode == TONEMAP_MODE_AUTO) {
-+        ctx->tonemap_mode = TONEMAP_MODE_ITP;
-+    }
-+
 +    // for low perf device, only do reshaping for pure dovi
 +    if (ctx->tradeoff && ctx->dovi && !ctx->is_pure_dovi) {
 +        av_freep(&ctx->dovi);
 +        ctx->dovi = NULL;
 +        ctx->apply_dovi = 0;
 +    }
++
++    device_exts = check_opencl_device_str(ctx->ocf.hwctx->device_id, CL_DEVICE_EXTENSIONS);
++
++    // use FP16 for dovi reshaping only when tradeoff is enabled and it's supported
++    ctx->dovi_use_fp16 = 0;
++    if (ctx->tradeoff && ctx->dovi) {
++        if (device_exts && strstr(device_exts, "cl_khr_fp16")) {
++            ctx->dovi_use_fp16 = 1;
++            av_log(avctx, AV_LOG_DEBUG, "FP16 is enabled for DOVI reshaping.\n");
++        }
++    }
++
++#ifndef CL_MEM_FORCE_HOST_MEMORY_INTEL
++  #define CL_MEM_FORCE_HOST_MEMORY_INTEL (1 << 20)
++#endif
++    // zero-copy buffer requires this extension on Intel dGPUs
++    if (device_vendor_id == 0x8086) {
++        if (device_exts && strstr(device_exts, "cl_intel_mem_force_host_memory"))
++            dovi_buf_flags |= CL_MEM_FORCE_HOST_MEMORY_INTEL;
++    }
++
++    if (device_exts)
++        av_free(device_exts);
 +
 +    av_log(ctx, AV_LOG_DEBUG, "Tonemapping transfer from %s to %s\n",
             av_color_transfer_name(ctx->trc_in),
@@ -1926,7 +2040,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_bprintf(&header, "#define chroma_loc %d\n", (int)ctx->chroma_loc);
  
      if (rgb2rgb_passthrough)
-@@ -199,19 +538,41 @@ static int tonemap_opencl_init(AVFilterC
+@@ -199,19 +609,41 @@ static int tonemap_opencl_init(AVFilterC
      else
          ff_opencl_print_const_matrix_3x3(&header, "rgb2rgb", rgb2rgb);
  
@@ -1943,8 +2057,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        double ycc2rgb_offset[3] = {0};
 +        double lms2rgb[3][3];
 +        av_bprintf(&header, "#define DOVI_RESHAPE\n");
-+        if (ctx->tradeoff)
-+            av_bprintf(&header, "#define DOVI_PERF_TRADEOFF\n");
++        if (ctx->dovi_use_fp16)
++            av_bprintf(&header, "#define DOVI_PERF_FP16\n");
 +        for (i = 0; i < 3; i++) {
 +            for (j = 0; j < 3; j++)
 +                ycc2rgb_offset[i] -= ctx->dovi->nonlinear[i][j] * ctx->dovi->nonlinear_offset[j];
@@ -1975,7 +2089,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
                 ctx->colorspace_out, av_color_space_name(ctx->colorspace_out));
          goto fail;
      }
-@@ -219,24 +580,13 @@ static int tonemap_opencl_init(AVFilterC
+@@ -219,24 +651,13 @@ static int tonemap_opencl_init(AVFilterC
      ff_fill_rgb2yuv_table(luma_dst, rgb2yuv);
      ff_opencl_print_const_matrix_3x3(&header, "yuv_matrix", rgb2yuv);
  
@@ -2005,7 +2119,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
      opencl_sources[0] = header.str;
-@@ -254,46 +604,216 @@ static int tonemap_opencl_init(AVFilterC
+@@ -254,46 +675,216 @@ static int tonemap_opencl_init(AVFilterC
      CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create OpenCL "
                       "command queue %d.\n", cle);
  
@@ -2045,15 +2159,10 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        cle = clWaitForEvents(1, &event);
 +        CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to wait for event completion: %d.\n", cle);
 +    }
- 
--    ctx->util_mem =
--        clCreateBuffer(ctx->ocf.hwctx->context, 0,
--                       (2 * DETECTION_FRAMES + 7) * sizeof(unsigned),
--                       NULL, &cle);
--    CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create util buffer: %d.\n", cle);
++
 +    if (ctx->tradeoff) {
-+        size_t lut_size = LUT_SIZE;
-+        size_t lut_buffer_size = lut_size * sizeof(cl_float3);
++        const size_t lut_size = LUT_SIZE;
++        const size_t lut_buffer_size = lut_size * sizeof(cl_float3);
 +        float peak = (float)ctx->peak;
 +
 +        ctx->lut_generation_kernel = clCreateKernel(ctx->ocf.program, "build_lut", &cle);
@@ -2077,10 +2186,15 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        ctx->kernel = clCreateKernel(ctx->ocf.program, "tonemap", &cle);
 +        CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create kernel %d.\n", cle);
 +    }
-+
+ 
+-    ctx->util_mem =
+-        clCreateBuffer(ctx->ocf.hwctx->context, 0,
+-                       (2 * DETECTION_FRAMES + 7) * sizeof(unsigned),
+-                       NULL, &cle);
+-    CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create util buffer: %d.\n", cle);
 +    if (ctx->dovi) {
-+        CL_CREATE_BUFFER_FLAGS(ctx, dovi_buf, dovi_buf_flags,
-+                               3*(params_sz+pivots_sz+coeffs_sz+mmr_sz), NULL);
++        const size_t buf_sz = 3*(params_sz+pivots_sz+coeffs_sz+mmr_sz) >> !!ctx->dovi_use_fp16;
++        CL_CREATE_BUFFER_FLAGS(ctx, dovi_buf, dovi_buf_flags, buf_sz, NULL);
 +    }
  
      ctx->initialised = 1;
@@ -2223,14 +2337,13 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported output format: %s\n",
 +               av_get_pix_fmt_name(out_format));
 +        return AVERROR(ENOSYS);
-+    }
+     }
 +    if (in_desc->comp[0].depth != 10 && in_desc->comp[0].depth != 16) {
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported input format depth: %d\n",
 +               in_desc->comp[0].depth);
 +        return AVERROR(ENOSYS);
-     }
- 
--    s->ocf.output_format = s->format == AV_PIX_FMT_NONE ? AV_PIX_FMT_NV12 : s->format;
++    }
++
 +    ctx->in_fmt     = in_format;
 +    ctx->out_fmt    = out_format;
 +    ctx->in_desc    = in_desc;
@@ -2238,11 +2351,12 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    ctx->in_planes  = av_pix_fmt_count_planes(in_format);
 +    ctx->out_planes = av_pix_fmt_count_planes(out_format);
 +    ctx->ocf.output_format = out_format;
-+
+ 
+-    s->ocf.output_format = s->format == AV_PIX_FMT_NONE ? AV_PIX_FMT_NV12 : s->format;
      ret = ff_opencl_filter_config_output(outlink);
      if (ret < 0)
          return ret;
-@@ -308,13 +828,49 @@ static int launch_kernel(AVFilterContext
+@@ -308,13 +899,49 @@ static int launch_kernel(AVFilterContext
      size_t global_work[2];
      size_t local_work[2];
      cl_int cle;
@@ -2257,7 +2371,13 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        err = AVERROR(EIO);
 +        goto fail;
 +    }
-+
+ 
+-    CL_SET_KERNEL_ARG(kernel, 0, cl_mem, &output->data[0]);
+-    CL_SET_KERNEL_ARG(kernel, 1, cl_mem, &input->data[0]);
+-    CL_SET_KERNEL_ARG(kernel, 2, cl_mem, &output->data[1]);
+-    CL_SET_KERNEL_ARG(kernel, 3, cl_mem, &input->data[1]);
+-    CL_SET_KERNEL_ARG(kernel, 4, cl_mem, &ctx->util_mem);
+-    CL_SET_KERNEL_ARG(kernel, 5, cl_float, &peak);
 +    if (ctx->in_planes > 2 && !input->data[2]) {
 +        err = AVERROR(EIO);
 +        goto fail;
@@ -2287,18 +2407,12 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    if (ctx->dovi_buf) {
 +        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &ctx->dovi_buf);
 +    }
- 
--    CL_SET_KERNEL_ARG(kernel, 0, cl_mem, &output->data[0]);
--    CL_SET_KERNEL_ARG(kernel, 1, cl_mem, &input->data[0]);
--    CL_SET_KERNEL_ARG(kernel, 2, cl_mem, &output->data[1]);
--    CL_SET_KERNEL_ARG(kernel, 3, cl_mem, &input->data[1]);
--    CL_SET_KERNEL_ARG(kernel, 4, cl_mem, &ctx->util_mem);
--    CL_SET_KERNEL_ARG(kernel, 5, cl_float, &peak);
++
 +    CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_float, &peak);
  
      local_work[0]  = 16;
      local_work[1]  = 16;
-@@ -338,12 +894,10 @@ static int tonemap_opencl_filter_frame(A
+@@ -338,12 +965,10 @@ static int tonemap_opencl_filter_frame(A
      AVFilterContext    *avctx = inlink->dst;
      AVFilterLink     *outlink = avctx->outputs[0];
      TonemapOpenCLContext *ctx = avctx->priv;
@@ -2312,7 +2426,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(input->format),
-@@ -351,7 +905,6 @@ static int tonemap_opencl_filter_frame(A
+@@ -351,7 +976,6 @@ static int tonemap_opencl_filter_frame(A
  
      if (!input->hw_frames_ctx)
          return AVERROR(EINVAL);
@@ -2320,7 +2434,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      output = ff_get_video_buffer(outlink, outlink->w, outlink->h);
      if (!output) {
-@@ -363,17 +916,59 @@ static int tonemap_opencl_filter_frame(A
+@@ -363,17 +987,59 @@ static int tonemap_opencl_filter_frame(A
      if (err < 0)
          goto fail;
  
@@ -2386,7 +2500,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      ctx->trc_in = input->color_trc;
      ctx->trc_out = output->color_trc;
-@@ -385,72 +980,50 @@ static int tonemap_opencl_filter_frame(A
+@@ -385,72 +1051,50 @@ static int tonemap_opencl_filter_frame(A
      ctx->range_out = output->color_range;
      ctx->chroma_loc = output->chroma_location;
  
@@ -2482,7 +2596,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_frame_free(&input);
      av_frame_free(&output);
      return err;
-@@ -458,62 +1031,101 @@ fail:
+@@ -458,62 +1102,101 @@ fail:
  
  static av_cold void tonemap_opencl_uninit(AVFilterContext *avctx)
  {
@@ -2631,7 +2745,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      { NULL }
  };
  
-@@ -541,11 +1153,12 @@ const AVFilter ff_vf_tonemap_opencl = {
+@@ -541,11 +1224,12 @@ const AVFilter ff_vf_tonemap_opencl = {
      .description    = NULL_IF_CONFIG_SMALL("Perform HDR to SDR conversion with tonemapping."),
      .priv_size      = sizeof(TonemapOpenCLContext),
      .priv_class     = &tonemap_opencl_class,

--- a/debian/patches/0033-tune-dxva-align-for-intel-to-avoid-copy-on-qsv.patch
+++ b/debian/patches/0033-tune-dxva-align-for-intel-to-avoid-copy-on-qsv.patch
@@ -19,9 +19,12 @@ Index: FFmpeg/libavcodec/dxva2.c
      /* 1 base work surface */
      num_surfaces = 1;
  
-@@ -625,7 +635,7 @@ int ff_dxva2_common_frame_params(AVCodec
+@@ -623,9 +633,9 @@ int ff_dxva2_common_frame_params(AVCodec
+     if (avctx->codec_id == AV_CODEC_ID_H264 || avctx->codec_id == AV_CODEC_ID_HEVC)
+         num_surfaces += 16;
      else if (avctx->codec_id == AV_CODEC_ID_VP9 || avctx->codec_id == AV_CODEC_ID_AV1)
-         num_surfaces += 8;
+-        num_surfaces += 8;
++        num_surfaces += 8 + 4; /* 4 base work surface in vpp async */
      else
 -        num_surfaces += 2;
 +        num_surfaces += 2 + 4; /* 4 base work surface in vpp async */

--- a/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -37,10 +37,12 @@ Index: FFmpeg/configure
  h264_amf_encoder_deps="amf"
  h264_cuvid_decoder_deps="cuvid"
  h264_cuvid_decoder_select="h264_mp4toannexb_bsf"
-@@ -3363,6 +3368,7 @@ h264_qsv_decoder_select="h264_mp4toannex
+@@ -3362,7 +3367,8 @@ h264_omx_encoder_deps="omx"
+ h264_qsv_decoder_select="h264_mp4toannexb_bsf qsvdec"
  h264_qsv_encoder_select="atsc_a53 qsvenc"
  h264_rkmpp_decoder_deps="rkmpp"
- h264_rkmpp_decoder_select="h264_mp4toannexb_bsf"
+-h264_rkmpp_decoder_select="h264_mp4toannexb_bsf"
++h264_rkmpp_decoder_select="h264_mp4toannexb_bsf dump_extradata_bsf"
 +h264_rkmpp_encoder_deps="rkmpp"
  h264_vaapi_encoder_select="atsc_a53 cbs_h264 vaapi_encode"
  h264_vulkan_encoder_select="cbs_h264 vulkan_encode"
@@ -50,7 +52,7 @@ Index: FFmpeg/configure
  hevc_qsv_encoder_select="hevcparse qsvenc"
  hevc_rkmpp_decoder_deps="rkmpp"
 -hevc_rkmpp_decoder_select="hevc_mp4toannexb_bsf"
-+hevc_rkmpp_decoder_select="dovi_rpudec hevcparse hevc_mp4toannexb_bsf"
++hevc_rkmpp_decoder_select="hevc_mp4toannexb_bsf dump_extradata_bsf dovi_rpudec hevcparse"
 +hevc_rkmpp_encoder_deps="rkmpp"
  hevc_vaapi_encoder_deps="VAEncPictureParameterBufferHEVC"
  hevc_vaapi_encoder_select="atsc_a53 cbs_h265 vaapi_encode"
@@ -294,7 +296,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
   *
   * This file is part of FFmpeg.
   *
-@@ -19,551 +20,1276 @@
+@@ -19,551 +20,1301 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
  
@@ -515,12 +517,14 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    }
 +
 +    return NULL;
-+}
-+
+ }
+ 
+-static void rkmpp_release_decoder(FFRefStructOpaque unused, void *obj)
 +static void clear_unused_sd_frames(SideDataFrame *list,
 +                                   int64_t in_pts,
 +                                   int64_t out_pts)
-+{
+ {
+-    RKMPPDecoder *decoder = obj;
 +    while (list) {
 +        if (list->queued == 1) {
 +            AVFrame *frame = list->frame;
@@ -535,7 +539,11 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        list = list->next;
 +    }
 +}
-+
+ 
+-    if (decoder->mpi) {
+-        decoder->mpi->reset(decoder->ctx);
+-        mpp_destroy(decoder->ctx);
+-        decoder->ctx = NULL;
 +static void clear_sd_frame_list(SideDataFrame **list)
 +{
 +    while (*list) {
@@ -546,18 +554,12 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        av_frame_free(&sd_frame->frame);
 +        av_freep(&sd_frame);
 +    }
- }
- 
--static void rkmpp_release_decoder(FFRefStructOpaque unused, void *obj)
++}
++
 +static SideDataFrame *get_free_sd_frame(SideDataFrame **list)
- {
--    RKMPPDecoder *decoder = obj;
++{
 +    SideDataFrame *out = *list;
- 
--    if (decoder->mpi) {
--        decoder->mpi->reset(decoder->ctx);
--        mpp_destroy(decoder->ctx);
--        decoder->ctx = NULL;
++
 +    for (; out; out = out->next) {
 +        if (!out->queued) {
 +            out->queued = 1;
@@ -597,6 +599,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    RKMPPDecContext *r = avctx->priv_data;
  
 -    avctx->pix_fmt = AV_PIX_FMT_DRM_PRIME;
++    r->last_pts = AV_NOPTS_VALUE;
 +    r->eof = 0;
 +    r->draining = 0;
 +    r->info_change = 0;
@@ -606,7 +609,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +#if CONFIG_HEVC_RKMPP_DECODER
 +    if (avctx->codec_id == AV_CODEC_ID_HEVC) {
 +        r->parsed_extradata = 0;
-+        r->last_pts_in = AV_NOPTS_VALUE;
++        r->last_pts_dovi = AV_NOPTS_VALUE;
 +        ff_dovi_ctx_unref(&r->dovi_ctx);
 +        av_buffer_unref(&r->rpu_buf);
 +        ff_h2645_packet_uninit(&r->h2645_pkt);
@@ -804,12 +807,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +#if CONFIG_RKRGA
 +        }
 +#endif
-     }
- 
--    ret = decoder->mpi->control(decoder->ctx, MPP_DEC_SET_EXT_BUF_GROUP, decoder->frame_group);
--    if (ret) {
--        av_log(avctx, AV_LOG_ERROR, "Failed to assign buffer group (code = %d)\n", ret);
--        ret = AVERROR_UNKNOWN;
++    }
++
 +    if (r->afbc) {
 +        MppFrameFormat afbc_fmt = MPP_FRAME_FBC_AFBC_V2;
 +
@@ -845,8 +844,12 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            goto fail;
 +        }
 +        av_log(avctx, AV_LOG_VERBOSE, "Created a RKMPP hardware device\n");
-+    }
-+
+     }
+ 
+-    ret = decoder->mpi->control(decoder->ctx, MPP_DEC_SET_EXT_BUF_GROUP, decoder->frame_group);
+-    if (ret) {
+-        av_log(avctx, AV_LOG_ERROR, "Failed to assign buffer group (code = %d)\n", ret);
+-        ret = AVERROR_UNKNOWN;
 +#if CONFIG_HEVC_RKMPP_DECODER
 +    /* prepare for parsing dovi rpu for HEVC */
 +    r->dovi_ctx.logctx = avctx;
@@ -1037,23 +1040,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            break;
 +        default:
 +            return 0;
-+    }
-+
-+    sd = av_frame_get_side_data(frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
-+    if (sd)
-+        mastering = (AVMasteringDisplayMetadata *)sd->data;
-+    else
-+        mastering = av_mastering_display_metadata_create_side_data(frame);
-+    if (!mastering)
-+        return AVERROR(ENOMEM);
-+
-+    for (i = 0; i < 3; i++) {
-+        const int j = mapping[i];
-+        mastering->display_primaries[i][0] = av_make_q(mpp_mastering.display_primaries[j][0], chroma_den);
-+        mastering->display_primaries[i][1] = av_make_q(mpp_mastering.display_primaries[j][1], chroma_den);
      }
-+    mastering->white_point[0] = av_make_q(mpp_mastering.white_point[0], chroma_den);
-+    mastering->white_point[1] = av_make_q(mpp_mastering.white_point[1], chroma_den);
  
 -    // on first packet, send extradata
 -    if (decoder->first_packet) {
@@ -1073,10 +1060,26 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    ret = rkmpp_write_data(avctx, avpkt->data, avpkt->size, avpkt->pts);
 -    if (ret && ret!=AVERROR(EAGAIN))
 -        av_log(avctx, AV_LOG_ERROR, "Failed to write data to decoder (code = %d)\n", ret);
-+    mastering->max_luminance = av_make_q(mpp_mastering.max_luminance, max_luma_den);
-+    mastering->min_luminance = av_make_q(mpp_mastering.min_luminance, min_luma_den);
++    sd = av_frame_get_side_data(frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
++    if (sd)
++        mastering = (AVMasteringDisplayMetadata *)sd->data;
++    else
++        mastering = av_mastering_display_metadata_create_side_data(frame);
++    if (!mastering)
++        return AVERROR(ENOMEM);
++
++    for (i = 0; i < 3; i++) {
++        const int j = mapping[i];
++        mastering->display_primaries[i][0] = av_make_q(mpp_mastering.display_primaries[j][0], chroma_den);
++        mastering->display_primaries[i][1] = av_make_q(mpp_mastering.display_primaries[j][1], chroma_den);
++    }
++    mastering->white_point[0] = av_make_q(mpp_mastering.white_point[0], chroma_den);
++    mastering->white_point[1] = av_make_q(mpp_mastering.white_point[1], chroma_den);
  
 -    return ret;
++    mastering->max_luminance = av_make_q(mpp_mastering.max_luminance, max_luma_den);
++    mastering->min_luminance = av_make_q(mpp_mastering.min_luminance, min_luma_den);
++
 +    mastering->has_luminance = 1;
 +    mastering->has_primaries = 1;
 +
@@ -1222,34 +1225,34 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    if ((ret = frame_create_buf(frame, mpp_frame, mpp_frame_get_buf_size(mpp_frame),
 +                                rkmpp_free_mpp_frame, mpp_frame, AV_BUFFER_FLAG_READONLY)) < 0)
 +        return ret;
-+
-+    if ((ret = frame_create_buf(frame, (uint8_t *)desc, sizeof(*desc),
-+                                rkmpp_free_drm_desc, desc, AV_BUFFER_FLAG_READONLY)) < 0)
-+        return ret;
  
 -            av_log(avctx, AV_LOG_INFO, "Decoder noticed an info change (%dx%d), format=%d\n",
 -                                        (int)mpp_frame_get_width(mppframe), (int)mpp_frame_get_height(mppframe),
 -                                        (int)mpp_frame_get_fmt(mppframe));
-+    frame->data[0] = (uint8_t *)desc;
++    if ((ret = frame_create_buf(frame, (uint8_t *)desc, sizeof(*desc),
++                                rkmpp_free_drm_desc, desc, AV_BUFFER_FLAG_READONLY)) < 0)
++        return ret;
  
 -            avctx->width = mpp_frame_get_width(mppframe);
 -            avctx->height = mpp_frame_get_height(mppframe);
++    frame->data[0] = (uint8_t *)desc;
+ 
+-            decoder->mpi->control(decoder->ctx, MPP_DEC_SET_INFO_CHANGE_READY, NULL);
 +    frame->hw_frames_ctx = av_buffer_ref(r->hwframe);
 +    if (!frame->hw_frames_ctx)
 +        return AVERROR(ENOMEM);
  
--            decoder->mpi->control(decoder->ctx, MPP_DEC_SET_INFO_CHANGE_READY, NULL);
+-            av_buffer_unref(&decoder->frames_ref);
 +    if ((ret = ff_decode_frame_props(avctx, frame)) < 0)
 +        return ret;
- 
--            av_buffer_unref(&decoder->frames_ref);
-+    frame->width  = avctx->width;
-+    frame->height = avctx->height;
  
 -            decoder->frames_ref = av_hwframe_ctx_alloc(decoder->device_ref);
 -            if (!decoder->frames_ref) {
 -                ret = AVERROR(ENOMEM);
 -                goto fail;
++    frame->width  = avctx->width;
++    frame->height = avctx->height;
++
 +    mpp_frame_pts = mpp_frame_get_pts(mpp_frame);
 +    frame->pts    = MPP_PTS_TO_PTS(mpp_frame_pts, avctx->pkt_timebase);
 +
@@ -1296,7 +1299,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                memcpy(sd_dst->data, sd_src->data, sd_src->size);
              }
 +        }
-+        clear_unused_sd_frames(r->sd_frame_list, r->last_pts_in, mpp_frame_pts); /* display order */
++        clear_unused_sd_frames(r->sd_frame_list, r->last_pts_dovi, mpp_frame_pts); /* display order */
 +    }
 +#endif
  
@@ -1659,11 +1662,18 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -        if (ret != MPP_OK) {
 -            av_log(avctx, AV_LOG_ERROR, "Failed to get decoder used slots (code = %d).\n", ret);
 -            return ret;
+-        }
 +    RKMPPDecContext *r = avctx->priv_data;
 +    MppPacket mpp_pkt = NULL;
 +    int64_t mpp_pkt_pts = PTS_TO_MPP_PTS(pkt->pts, avctx->pkt_timebase);
++    int64_t last_pts = r->last_pts;
 +    int ret;
-+
+ 
+-        freeslots = INPUT_MAX_PACKETS - usedslots;
+-        if (freeslots > 0) {
+-            ret = ff_decode_get_packet(avctx, &pkt);
+-            if (ret < 0 && ret != AVERROR_EOF) {
+-                return ret;
 +    /* avoid sending new data after EOS */
 +    if (r->draining)
 +        return AVERROR(EOF);
@@ -1677,6 +1687,27 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        return 0;
 +    }
 +
++    /* make up some pts if it's not available from pkt */
++    if (pkt->pts == AV_NOPTS_VALUE) {
++        int64_t pts_diff = 1;
++        AVRational framerate = { avctx->framerate.num,
++                                 avctx->framerate.den };
++
++        if (avctx->pkt_timebase.num && avctx->pkt_timebase.den) {
++            if (!(framerate.num && framerate.den)) {
++                framerate.num = 25;
++                framerate.den = 1;
+             }
++            pts_diff = (avctx->pkt_timebase.den * framerate.den) /
++                       (avctx->pkt_timebase.num * framerate.num);
++        }
++        last_pts += pts_diff;
+ 
+-            ret = rkmpp_send_packet(avctx, &pkt);
+-            av_packet_unref(&pkt);
++        mpp_pkt_pts = PTS_TO_MPP_PTS(last_pts, avctx->pkt_timebase);
++    }
+ 
 +    if ((ret = mpp_packet_init(&mpp_pkt, pkt->data, pkt->size)) != MPP_OK) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to init packet: %d\n", ret);
 +        return AVERROR_EXTERNAL;
@@ -1688,6 +1719,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        mpp_packet_deinit(&mpp_pkt);
 +        return AVERROR(EAGAIN);
 +    }
++    /* update the last pts */
++    r->last_pts = pkt->pts == AV_NOPTS_VALUE ? last_pts : pkt->pts;
++
 +    av_log(avctx, AV_LOG_DEBUG, "Wrote %d bytes to decoder\n", pkt->size);
 +
 +#if CONFIG_HEVC_RKMPP_DECODER
@@ -1695,9 +1729,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    if (avctx->codec_id == AV_CODEC_ID_HEVC) {
 +        const AVPixFmtDescriptor *pix_desc, *pix_desc_sw;
 +        int split_flags;
-+        uint8_t *sd;
++        uint8_t *sd = NULL;
 +        size_t sd_size;
-+        SideDataFrame *sd_frame;
 +
 +        pix_desc = av_pix_fmt_desc_get(avctx->pix_fmt);
 +        if (!pix_desc)
@@ -1724,15 +1757,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                goto exit;
 +
 +            r->parsed_extradata = 1;
-         }
++        }
 +        split_flags = (H2645_FLAG_IS_NALFF * !!r->is_nalff) | H2645_FLAG_SMALL_PADDING;
- 
--        freeslots = INPUT_MAX_PACKETS - usedslots;
--        if (freeslots > 0) {
--            ret = ff_decode_get_packet(avctx, &pkt);
--            if (ret < 0 && ret != AVERROR_EOF) {
--                return ret;
--            }
++
 +        /* prepare dovi config for dovi ctx */
 +        sd = av_packet_get_side_data(pkt, AV_PKT_DATA_DOVI_CONF, &sd_size);
 +        if (sd && sd_size >= sizeof(r->dovi_ctx.cfg)) {
@@ -1752,9 +1779,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                   "Error splitting the input into NAL units\n");
 +            goto exit;
 +        }
- 
--            ret = rkmpp_send_packet(avctx, &pkt);
--            av_packet_unref(&pkt);
++
 +        /* check for RPU delimiter - unregistered NALs of type 62 */
 +        if (r->h2645_pkt.nb_nals > 1 && r->h2645_pkt.nals[r->h2645_pkt.nb_nals - 1].type == HEVC_NAL_UNSPEC62 &&
 +            r->h2645_pkt.nals[r->h2645_pkt.nb_nals - 1].size > 2 && !r->h2645_pkt.nals[r->h2645_pkt.nb_nals - 1].nuh_layer_id
@@ -1767,7 +1792,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            if (!r->rpu_buf)
 +                goto exit;
 +            memcpy(r->rpu_buf->data, nal->raw_data + 2, nal->raw_size - 2);
- 
++
 +            ret = ff_dovi_rpu_parse(&r->dovi_ctx, nal->data + 2, nal->size - 2,
 +                                    avctx->err_recognition);
              if (ret < 0) {
@@ -1776,19 +1801,18 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                av_buffer_unref(&r->rpu_buf);
 +                av_log(avctx, AV_LOG_DEBUG, "Error parsing DOVI NAL unit\n");
 +                goto exit;
-             }
-         }
- 
--        // make sure we keep decoder full
--        if (freeslots > 1)
--            return AVERROR(EAGAIN);
++            }
++        }
++
 +        /* queue dovi sidedata to the list */
 +        {
++            SideDataFrame *sd_frame = NULL;
 +            AVFrame *tmp_frame = av_frame_alloc();
++
 +            if (!tmp_frame)
 +                goto exit;
 +
-+            tmp_frame->pts = r->last_pts_in = mpp_pkt_pts;
++            tmp_frame->pts = r->last_pts_dovi = mpp_pkt_pts;
 +
 +            if (r->rpu_buf) {
 +                AVFrameSideData *rpu;
@@ -1811,14 +1835,13 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            if (!sd_frame) {
 +                av_frame_free(&tmp_frame);
 +                goto exit;
-+            }
+             }
 +
 +            sd_frame->frame = tmp_frame;
-+        }
-     }
+         }
++    }
 +#endif
- 
--    return rkmpp_retrieve_frame(avctx, frame);
++
 +exit:
 +    mpp_packet_deinit(&mpp_pkt);
 +    return 0;
@@ -1836,7 +1859,10 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    /* no more frames after EOS */
 +    if (r->eof)
 +        return AVERROR_EOF;
-+
+ 
+-        // make sure we keep decoder full
+-        if (freeslots > 1)
+-            return AVERROR(EAGAIN);
 +    /* drain remain frames */
 +    if (r->draining) {
 +        ret = rkmpp_get_frame(avctx, frame, MPP_TIMEOUT_BLOCK);
@@ -1876,8 +1902,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                pkt->size = 0;
 +            }
 +        }
-+    }
-+
+     }
+ 
+-    return rkmpp_retrieve_frame(avctx, frame);
 +exit:
 +    if (r->draining &&
 +        ret == AVERROR(EAGAIN))
@@ -1906,7 +1933,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +#if CONFIG_HEVC_RKMPP_DECODER
 +        if (avctx->codec_id == AV_CODEC_ID_HEVC) {
 +            r->parsed_extradata = 0;
-+            r->last_pts_in = AV_NOPTS_VALUE;
++            r->last_pts_dovi = AV_NOPTS_VALUE;
 +            ff_dovi_ctx_flush(&r->dovi_ctx);
 +            av_buffer_unref(&r->rpu_buf);
 +            clear_sd_frame_list(&r->sd_frame_list);
@@ -1961,10 +1988,10 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +DEFINE_RKMPP_DECODER(h263, H263, NULL)
 +#endif
 +#if CONFIG_H264_RKMPP_DECODER
-+DEFINE_RKMPP_DECODER(h264, H264, "h264_mp4toannexb")
++DEFINE_RKMPP_DECODER(h264, H264, "h264_mp4toannexb,dump_extra")
 +#endif
 +#if CONFIG_HEVC_RKMPP_DECODER
-+DEFINE_RKMPP_DECODER(hevc, HEVC, "hevc_mp4toannexb")
++DEFINE_RKMPP_DECODER(hevc, HEVC, "hevc_mp4toannexb,dump_extra")
 +#endif
 +#if CONFIG_VP8_RKMPP_DECODER
 +DEFINE_RKMPP_DECODER(vp8, VP8, NULL)
@@ -1988,7 +2015,7 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppdec.h
-@@ -0,0 +1,176 @@
+@@ -0,0 +1,177 @@
 +/*
 + * Copyright (c) 2017 Lionel CHAZALLON
 + * Copyright (c) 2023 Huseyin BIYIK
@@ -2072,9 +2099,10 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 +    DOVIContext    dovi_ctx;
 +    AVBufferRef   *rpu_buf;
 +    SideDataFrame *sd_frame_list;
-+    int64_t        last_pts_in;
++    int64_t        last_pts_dovi;
 +#endif
 +
++    int64_t        last_pts;
 +    AVPacket       last_pkt;
 +    int            eof;
 +    int            draining;

--- a/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -2169,7 +2169,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppenc.c
-@@ -0,0 +1,1209 @@
+@@ -0,0 +1,1220 @@
 +/*
 + * Copyright (c) 2023 Huseyin BIYIK
 + * Copyright (c) 2023 NyanMisaka
@@ -2528,6 +2528,17 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    mpp_enc_cfg_set_s32(cfg, "prep:mirroring", 0);
 +    mpp_enc_cfg_set_s32(cfg, "prep:rotation", 0);
 +    mpp_enc_cfg_set_s32(cfg, "prep:flip", 0);
++
++    mpp_enc_cfg_set_s32(cfg, "prep:colorspace", avctx->colorspace);
++    mpp_enc_cfg_set_s32(cfg, "prep:colorprim", avctx->color_primaries);
++    mpp_enc_cfg_set_s32(cfg, "prep:colortrc", avctx->color_trc);
++
++    mpp_enc_cfg_set_s32(cfg, "prep:colorrange", avctx->color_range);
++    if (r->pix_fmt == AV_PIX_FMT_YUVJ420P ||
++        r->pix_fmt == AV_PIX_FMT_YUVJ422P ||
++        r->pix_fmt == AV_PIX_FMT_YUVJ444P) {
++        mpp_enc_cfg_set_s32(cfg, "prep:colorrange", AVCOL_RANGE_JPEG);
++    }
 +
 +    if (avctx->framerate.den > 0 && avctx->framerate.num > 0)
 +        av_reduce(&fps_num, &fps_den, avctx->framerate.num, avctx->framerate.den, 65535);


### PR DESCRIPTION
**Changes**
- Add FP16 tradeoff for DOVI reshaping
- Fix VUI full range flag in RKMPP encoded videos
- Increase default frame pool size for D3D11VA AV1/VP9
- Handle NOPTS and no extradata in RKMPP decoders
- Bump version to 7.1.1-3

TODO:
- [x] Should it be enabled selectively based on tradeoff and fp16_hw_caps?
- [x] Test in various clips to avoid regressions (visible visual degradation)

![image](https://github.com/user-attachments/assets/586376d7-0dd2-4cca-b603-c4063c66815d)
