### PR TITLE
Defer DX11 to OCL mapping for low startup latency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ jellyfin-ffmpeg (7.1.1-3) unstable; urgency=medium
   * Fix VUI full range flag in RKMPP encoded videos
   * Increase default frame pool size for D3D11VA AV1/VP9
   * Handle NOPTS and no extradata in RKMPP decoders
+  * Defer DX11 to OCL mapping for low startup latency
 
  -- nyanmisaka <nst799610810@gmail.com>  Tue, 6 May 2025 21:12:22 +0800
 

--- a/debian/patches/0009-add-d3d11-opencl-interop-for-amd.patch
+++ b/debian/patches/0009-add-d3d11-opencl-interop-for-amd.patch
@@ -159,7 +159,20 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
                  0,
              };
              OpenCLDeviceSelector selector = {
-@@ -2461,8 +2504,9 @@ static int opencl_frames_derive_from_dxv
+@@ -1742,9 +1785,11 @@ static void opencl_frames_uninit(AVHWFra
+ 
+ #if HAVE_OPENCL_DXVA2 || HAVE_OPENCL_D3D11
+     int i, p;
+-    for (i = 0; i < priv->nb_mapped_frames; i++) {
++    for (i = 0; i < priv->nb_mapped_frames && priv->mapped_frames; i++) {
+         AVOpenCLFrameDescriptor *desc = &priv->mapped_frames[i];
+         for (p = 0; p < desc->nb_planes; p++) {
++            if (!desc->planes[p])
++                continue;
+             cle = clReleaseMemObject(desc->planes[p]);
+             if (cle != CL_SUCCESS) {
+                 av_log(hwfc, AV_LOG_ERROR, "Failed to release mapped "
+@@ -2461,8 +2506,9 @@ static int opencl_frames_derive_from_dxv
      cl_int cle;
      int err, i, p, nb_planes;
  
@@ -171,7 +184,7 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
                 "for DXVA2 to OpenCL mapping.\n");
          return AVERROR(EINVAL);
      }
-@@ -2536,12 +2580,22 @@ static void opencl_unmap_from_d3d11(AVHW
+@@ -2536,12 +2582,22 @@ static void opencl_unmap_from_d3d11(AVHW
      OpenCLFramesContext *frames_priv = dst_fc->hwctx;
      cl_event event;
      cl_int cle;
@@ -196,35 +209,170 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
                 "handle: %d.\n", cle);
      }
  
-@@ -2556,7 +2610,9 @@ static int opencl_map_from_d3d11(AVHWFra
+@@ -2553,37 +2609,175 @@ static int opencl_map_from_d3d11(AVHWFra
+ {
+     OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->hwctx;
+     OpenCLFramesContext  *frames_priv = dst_fc->hwctx;
++    AVOpenCLDeviceContext    *dst_dev = &device_priv->p;
      AVOpenCLFrameDescriptor *desc;
++    int index = (intptr_t)src->data[1];
++    ID3D11Texture2D *tex = (ID3D11Texture2D *)src->data[0];
      cl_event event;
++    cl_mem_flags cl_flags;
      cl_int cle;
 -    int err, index, i;
++    cl_mem plane_uint;
 +    const cl_mem *mem_objs;
 +    cl_uint num_objs;
-+    int err, index, i, nb_planes;
++    int err, i, p, nb_planes = 2;
  
-     index = (intptr_t)src->data[1];
-     if (index >= frames_priv->nb_mapped_frames) {
-@@ -2565,16 +2621,25 @@ static int opencl_map_from_d3d11(AVHWFra
-         return AVERROR(EINVAL);
-     }
- 
-+    if (!(device_priv->d3d11_map_amd ||
-+          device_priv->d3d11_map_intel))
+-    index = (intptr_t)src->data[1];
+-    if (index >= frames_priv->nb_mapped_frames) {
++    cl_flags = opencl_mem_flags_for_mapping(flags);
++    if (!cl_flags)
++        return AVERROR(EINVAL);
++
++    // both AMD and Intel supports NV12 and P01X,
++    // but Intel requires D3D11_RESOURCE_MISC_SHARED.
++    if (device_priv->d3d11_map_amd ||
++        device_priv->d3d11_map_intel) {
++        if (src_fc->sw_format != AV_PIX_FMT_NV12 &&
++            src_fc->sw_format != AV_PIX_FMT_P010 &&
++            src_fc->sw_format != AV_PIX_FMT_P012) {
++            av_log(dst_fc, AV_LOG_ERROR, "Only NV12, P010 and P012 textures are "
++                   "supported with AMD and Intel for D3D11 to OpenCL mapping.\n");
++            return AVERROR(EINVAL);
++        }
++    } else
 +        return AVERROR(ENOSYS);
 +
-     av_log(dst_fc, AV_LOG_DEBUG, "Map D3D11 texture %d to OpenCL.\n",
-            index);
++    if (src_fc->initial_pool_size == 0) {
++        av_log(dst_fc, AV_LOG_ERROR, "Only fixed-size pools are supported "
++               "for D3D11 to OpenCL mapping.\n");
++        return AVERROR(EINVAL);
++    }
++    if (index >= src_fc->initial_pool_size) {
+         av_log(dst_fc, AV_LOG_ERROR, "Texture array index out of range for "
+-               "mapping: %d >= %d.\n", index, frames_priv->nb_mapped_frames);
++               "mapping: %d >= %d.\n", index, src_fc->initial_pool_size);
+         return AVERROR(EINVAL);
+     }
++    av_log(dst_fc, AV_LOG_DEBUG, "Map D3D11 texture %d to OpenCL.\n", index);
+ 
+-    av_log(dst_fc, AV_LOG_DEBUG, "Map D3D11 texture %d to OpenCL.\n",
+-           index);
++    if (!frames_priv->mapped_frames) {
++        frames_priv->nb_mapped_frames = src_fc->initial_pool_size;
++
++        frames_priv->mapped_frames =
++            av_calloc(frames_priv->nb_mapped_frames,
++                      sizeof(*frames_priv->mapped_frames));
++        if (!frames_priv->mapped_frames)
++            return AVERROR(ENOMEM);
++
++        for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
++            desc = &frames_priv->mapped_frames[i];
++            desc->nb_planes = nb_planes + !!device_priv->d3d11_map_amd;
++        }
++    }
  
      desc = &frames_priv->mapped_frames[index];
-+    nb_planes = device_priv->d3d11_map_amd ? (desc->nb_planes - 1)
-+                                           : desc->nb_planes;
-+    num_objs = device_priv->d3d11_map_amd ? 1 : desc->nb_planes;
-+    mem_objs = device_priv->d3d11_map_amd ? &desc->planes[nb_planes]
-+                                          : desc->planes;
  
++    // deferred clCreateFromD3D11Texture2DKHR() for low startup latency.
++    if (device_priv->d3d11_map_intel) {
++        for (p = 0; p < desc->nb_planes; p++) {
++            UINT subresource = 2 * index + p;
++
++            if (desc->planes[p])
++                continue;
++
++            desc->planes[p] =
++                device_priv->clCreateFromD3D11Texture2DKHR(
++                    dst_dev->context, cl_flags, tex,
++                    subresource, &cle);
++            if (!desc->planes[p]) {
++                av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL "
++                       "image from plane %d of D3D11 texture "
++                       "index %d (subresource %u): %d.\n",
++                       p, index, (unsigned)subresource, cle);
++                err = AVERROR(EIO);
++                goto fail2;
++            }
++        }
++    } else if (device_priv->d3d11_map_amd) {
++        if (!desc->planes[desc->nb_planes - 1]) {
++            // put the multiple-plane AMD shared image at the end.
++            desc->planes[desc->nb_planes - 1] = device_priv->clCreateFromD3D11Texture2DKHR(
++                dst_dev->context, cl_flags, tex, index, &cle);
++            if (!desc->planes[desc->nb_planes - 1]) {
++                av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL image "
++                       "from D3D11 texture index %d: %d.\n", index, cle);
++                err = AVERROR(EIO);
++                goto fail2;
++            }
++
++            for (p = 0; p < desc->nb_planes - 1; p++) {
++                cl_image_format image_fmt;
++
++                if (desc->planes[p])
++                    continue;
++
++                // get plane from AMD in CL_UNSIGNED_INT8|16 type.
++                plane_uint = device_priv->clGetPlaneFromImageAMD(
++                    dst_dev->context, desc->planes[desc->nb_planes - 1], p, &cle);
++                if (!plane_uint) {
++                    av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL image "
++                           "from plane %d of image created from D3D11 "
++                           "texture index %d: %d.\n", p, index, cle);
++                    err = AVERROR(EIO);
++                    goto fail2;
++                }
++
++                cle = clGetImageInfo(
++                    plane_uint, CL_IMAGE_FORMAT, sizeof(cl_image_format), &image_fmt, NULL);
++                if (cle != CL_SUCCESS) {
++                    av_log(dst_fc, AV_LOG_ERROR, "Failed to query image format of CL image "
++                           "from plane %d of image created from D3D11 "
++                           "texture index %d: %d.\n", p, index, cle);
++                    err = AVERROR_UNKNOWN;
++                    goto fail2;
++                }
++
++                switch (image_fmt.image_channel_data_type) {
++                case CL_UNSIGNED_INT8:
++                    image_fmt.image_channel_data_type = CL_UNORM_INT8; break;
++                case CL_UNSIGNED_INT16:
++                    image_fmt.image_channel_data_type = CL_UNORM_INT16; break;
++                default:
++                    av_log(dst_fc, AV_LOG_ERROR, "The data type of CL image "
++                           "from plane %d of image created from D3D11 texture index %d "
++                           "isn't a CL_UNSIGNED_INT8|16 type.\n", p, index);
++                    err = AVERROR(EIO);
++                    goto fail2;
++                }
++
++                // convert plane from CL_UNSIGNED_INT8|16 to CL_UNORM_INT8|16.
++                desc->planes[p] = device_priv->clConvertImageAMD(
++                    dst_dev->context, plane_uint, &image_fmt, &cle);
++                if (!desc->planes[p]) {
++                    av_log(dst_fc, AV_LOG_ERROR, "Failed to convert data type of CL image "
++                           "from plane %d of image created from D3D11 texture index %d "
++                           "to CL_UNORM_INT8|16 type: %d.\n", p, index, cle);
++                    err = AVERROR(EIO);
++                    goto fail2;
++                }
++
++                clReleaseMemObject(plane_uint);
++            }
++        }
++    } else {
++        err = AVERROR(ENOSYS);
++        goto fail2;
++    }
++
++    num_objs = device_priv->d3d11_map_amd ? 1 : desc->nb_planes;
++    mem_objs = device_priv->d3d11_map_amd ? &desc->planes[desc->nb_planes - 1]
++                                          : desc->planes;
      cle = device_priv->clEnqueueAcquireD3D11ObjectsKHR(
 -        frames_priv->command_queue, desc->nb_planes, desc->planes,
 +        frames_priv->command_queue, num_objs, mem_objs,
@@ -233,9 +381,12 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
 -        av_log(dst_fc, AV_LOG_ERROR, "Failed to acquire surface "
 +        av_log(dst_fc, AV_LOG_ERROR, "Failed to acquire texture "
                 "handle: %d.\n", cle);
-         return AVERROR(EIO);
+-        return AVERROR(EIO);
++        err = AVERROR(EIO);
++        goto fail;
      }
-@@ -2583,7 +2648,7 @@ static int opencl_map_from_d3d11(AVHWFra
+ 
+     err = opencl_wait_events(dst_fc, &event, 1);
      if (err < 0)
          goto fail;
  
@@ -244,7 +395,7 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
          dst->data[i] = (uint8_t*)desc->planes[i];
  
      err = ff_hwframe_map_create(dst->hw_frames_ctx, dst, src,
-@@ -2598,7 +2663,7 @@ static int opencl_map_from_d3d11(AVHWFra
+@@ -2598,76 +2792,13 @@ static int opencl_map_from_d3d11(AVHWFra
  
  fail:
      cle = device_priv->clEnqueueReleaseD3D11ObjectsKHR(
@@ -253,41 +404,49 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
          0, NULL, &event);
      if (cle == CL_SUCCESS)
          opencl_wait_events(dst_fc, &event, 1);
-@@ -2613,16 +2678,25 @@ static int opencl_frames_derive_from_d3d
-     OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->hwctx;
-     AVOpenCLDeviceContext    *dst_dev = &device_priv->p;
-     OpenCLFramesContext  *frames_priv = dst_fc->hwctx;
-+    cl_mem plane_uint;
-     cl_mem_flags cl_flags;
-     cl_int cle;
-     int err, i, p, nb_planes;
- 
+-    memset(dst->data, 0, sizeof(dst->data));
+-    return err;
+-}
+-
+-static int opencl_frames_derive_from_d3d11(AVHWFramesContext *dst_fc,
+-                                           AVHWFramesContext *src_fc, int flags)
+-{
+-    AVD3D11VAFramesContext *src_hwctx = src_fc->hwctx;
+-    OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->hwctx;
+-    AVOpenCLDeviceContext    *dst_dev = &device_priv->p;
+-    OpenCLFramesContext  *frames_priv = dst_fc->hwctx;
+-    cl_mem_flags cl_flags;
+-    cl_int cle;
+-    int err, i, p, nb_planes;
+-
 -    if (src_fc->sw_format != AV_PIX_FMT_NV12) {
 -        av_log(dst_fc, AV_LOG_ERROR, "Only NV12 textures are supported "
 -               "for D3D11 to OpenCL mapping.\n");
 -        return AVERROR(EINVAL);
-+    // both AMD and Intel supports NV12 and P010,
-+    // but Intel requires D3D11_RESOURCE_MISC_SHARED.
-+    if (device_priv->d3d11_map_amd ||
-+        device_priv->d3d11_map_intel) {
-+        if (src_fc->sw_format != AV_PIX_FMT_NV12 &&
-+            src_fc->sw_format != AV_PIX_FMT_P010) {
-+            av_log(dst_fc, AV_LOG_ERROR, "Only NV12 and P010 textures are "
-+                   "supported with AMD and Intel for D3D11 to OpenCL mapping.\n");
-+            return AVERROR(EINVAL);
-+        }
-+    } else {
-+        return AVERROR(ENOSYS);
-     }
+-    }
 -    nb_planes = 2;
-+    nb_planes = device_priv->d3d11_map_amd ? 3 : 2;
- 
-     if (src_fc->initial_pool_size == 0) {
-         av_log(dst_fc, AV_LOG_ERROR, "Only fixed-size pools are supported "
-@@ -2645,27 +2719,94 @@ static int opencl_frames_derive_from_d3d
-     for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
-         AVOpenCLFrameDescriptor *desc = &frames_priv->mapped_frames[i];
-         desc->nb_planes = nb_planes;
+-
+-    if (src_fc->initial_pool_size == 0) {
+-        av_log(dst_fc, AV_LOG_ERROR, "Only fixed-size pools are supported "
+-               "for D3D11 to OpenCL mapping.\n");
+-        return AVERROR(EINVAL);
+-    }
+-
+-    cl_flags = opencl_mem_flags_for_mapping(flags);
+-    if (!cl_flags)
+-        return AVERROR(EINVAL);
+-
+-    frames_priv->nb_mapped_frames = src_fc->initial_pool_size;
+-
+-    frames_priv->mapped_frames =
+-        av_calloc(frames_priv->nb_mapped_frames,
+-                  sizeof(*frames_priv->mapped_frames));
+-    if (!frames_priv->mapped_frames)
+-        return AVERROR(ENOMEM);
+-
+-    for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
+-        AVOpenCLFrameDescriptor *desc = &frames_priv->mapped_frames[i];
+-        desc->nb_planes = nb_planes;
 -        for (p = 0; p < nb_planes; p++) {
 -            UINT subresource = 2 * i + p;
 -
@@ -300,94 +459,42 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
 -                       "image from plane %d of D3D texture "
 -                       "index %d (subresource %u): %d.\n",
 -                       p, i, (unsigned int)subresource, cle);
-+        if (device_priv->d3d11_map_amd) {
-+            // put the multiple-plane AMD shared image at the end.
-+            desc->planes[nb_planes - 1] = device_priv->clCreateFromD3D11Texture2DKHR(
-+                dst_dev->context, cl_flags, src_hwctx->texture, i, &cle);
-+            if (!desc->planes[nb_planes - 1]) {
-+                av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL image "
-+                       "from D3D11 texture index %d: %d.\n", i, cle);
-                 err = AVERROR(EIO);
-                 goto fail;
-             }
-+
-+            for (p = 0; p < nb_planes - 1; p++) {
-+                cl_image_format image_fmt;
-+
-+                // get plane from AMD in CL_UNSIGNED_INT8|16 type.
-+                plane_uint = device_priv->clGetPlaneFromImageAMD(
-+                    dst_dev->context, desc->planes[nb_planes - 1], p, &cle);
-+                if (!plane_uint) {
-+                    av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL image "
-+                           "from plane %d of image created from D3D11 "
-+                           "texture index %d: %d.\n", p, i, cle);
-+                    err = AVERROR(EIO);
-+                    goto fail;
-+                }
-+
-+                cle = clGetImageInfo(
-+                    plane_uint, CL_IMAGE_FORMAT, sizeof(cl_image_format), &image_fmt, NULL);
-+                if (cle != CL_SUCCESS) {
-+                    av_log(dst_fc, AV_LOG_ERROR, "Failed to query image format of CL image "
-+                           "from plane %d of image created from D3D11 "
-+                           "texture index %d: %d.\n", p, i, cle);
-+                    err = AVERROR_UNKNOWN;
-+                    goto fail;
-+                }
-+
-+                switch (image_fmt.image_channel_data_type) {
-+                case CL_UNSIGNED_INT8:
-+                    image_fmt.image_channel_data_type = CL_UNORM_INT8; break;
-+                case CL_UNSIGNED_INT16:
-+                    image_fmt.image_channel_data_type = CL_UNORM_INT16; break;
-+                default:
-+                    av_log(dst_fc, AV_LOG_ERROR, "The data type of CL image "
-+                           "from plane %d of image created from D3D11 texture index %d "
-+                           "isn't a CL_UNSIGNED_INT8|16 type.\n", p, i);
-+                    err = AVERROR(EIO);
-+                    goto fail;
-+                }
-+
-+                // convert plane from CL_UNSIGNED_INT8|16 to CL_UNORM_INT8|16.
-+                desc->planes[p] = device_priv->clConvertImageAMD(
-+                    dst_dev->context, plane_uint, &image_fmt, &cle);
-+                if (!desc->planes[p]) {
-+                    av_log(dst_fc, AV_LOG_ERROR, "Failed to convert data type of CL image "
-+                           "from plane %d of image created from D3D11 texture index %d "
-+                           "to CL_UNORM_INT8|16 type: %d.\n", p, i, cle);
-+                    err = AVERROR(EIO);
-+                    goto fail;
-+                }
-+
-+                clReleaseMemObject(plane_uint);
-+            }
-+        } else if (device_priv->d3d11_map_intel) {
-+            for (p = 0; p < nb_planes; p++) {
-+                UINT subresource = 2 * i + p;
-+
-+                desc->planes[p] =
-+                    device_priv->clCreateFromD3D11Texture2DKHR(
-+                        dst_dev->context, cl_flags, src_hwctx->texture,
-+                        subresource, &cle);
-+                if (!desc->planes[p]) {
-+                    av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL "
-+                           "image from plane %d of D3D11 texture "
-+                           "index %d (subresource %u): %d.\n",
-+                           p, i, (unsigned int)subresource, cle);
-+                    err = AVERROR(EIO);
-+                    goto fail;
-+                }
-+            }
-+        } else {
-+            return AVERROR(ENOSYS);
-         }
+-                err = AVERROR(EIO);
+-                goto fail;
+-            }
+-        }
+-    }
+-
+-    return 0;
+-
+-fail:
++fail2:
+     for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
+-        AVOpenCLFrameDescriptor *desc = &frames_priv->mapped_frames[i];
++        desc = &frames_priv->mapped_frames[i];
+         for (p = 0; p < desc->nb_planes; p++) {
+             if (desc->planes[p])
+                 clReleaseMemObject(desc->planes[p]);
+@@ -2675,6 +2806,9 @@ fail:
      }
- 
-     return 0;
- 
- fail:
+     av_freep(&frames_priv->mapped_frames);
+     frames_priv->nb_mapped_frames = 0;
 +    if (plane_uint)
 +        clReleaseMemObject(plane_uint);
-     for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
-         AVOpenCLFrameDescriptor *desc = &frames_priv->mapped_frames[i];
-         for (p = 0; p < desc->nb_planes; p++) {
++    memset(dst->data, 0, sizeof(dst->data));
+     return err;
+ }
+ 
+@@ -3012,12 +3146,6 @@ static int opencl_frames_derive_to(AVHWF
+     case AV_HWDEVICE_TYPE_D3D11VA:
+         if (!priv->d3d11_mapping_usable)
+             return AVERROR(ENOSYS);
+-        {
+-            int err;
+-            err = opencl_frames_derive_from_d3d11(dst_fc, src_fc, flags);
+-            if (err < 0)
+-                return err;
+-        }
+         break;
+ #endif
+ #if HAVE_OPENCL_DRM_ARM

--- a/debian/patches/0012-add-d3d11-opencl-interop-for-qsv.patch
+++ b/debian/patches/0012-add-d3d11-opencl-interop-for-qsv.patch
@@ -32,37 +32,7 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
          }
      }
  #endif
-@@ -1785,18 +1794,20 @@ static void opencl_frames_uninit(AVHWFra
- 
- #if HAVE_OPENCL_DXVA2 || HAVE_OPENCL_D3D11
-     int i, p;
--    for (i = 0; i < priv->nb_mapped_frames; i++) {
--        AVOpenCLFrameDescriptor *desc = &priv->mapped_frames[i];
--        for (p = 0; p < desc->nb_planes; p++) {
--            cle = clReleaseMemObject(desc->planes[p]);
--            if (cle != CL_SUCCESS) {
--                av_log(hwfc, AV_LOG_ERROR, "Failed to release mapped "
--                       "frame object (frame %d plane %d): %d.\n",
--                       i, p, cle);
-+    if (priv->nb_mapped_frames && priv->mapped_frames) {
-+        for (i = 0; i < priv->nb_mapped_frames; i++) {
-+            AVOpenCLFrameDescriptor *desc = &priv->mapped_frames[i];
-+            for (p = 0; p < desc->nb_planes; p++) {
-+                cle = clReleaseMemObject(desc->planes[p]);
-+                if (cle != CL_SUCCESS) {
-+                    av_log(hwfc, AV_LOG_ERROR, "Failed to release mapped "
-+                           "frame object (frame %d plane %d): %d.\n",
-+                           i, p, cle);
-+                }
-             }
-         }
-+        av_freep(&priv->mapped_frames);
-     }
--    av_freep(&priv->mapped_frames);
- #endif
- 
-     if (priv->command_queue) {
-@@ -2572,6 +2583,233 @@ fail:
+@@ -2574,6 +2583,196 @@ fail:
  
  #if HAVE_OPENCL_D3D11
  
@@ -110,51 +80,92 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
 +    OpenCLFramesContext  *frames_priv = dst_fc->hwctx;
 +    AVOpenCLDeviceContext    *dst_dev = &device_priv->p;
 +    mfxFrameSurface1 *mfx_surface = (mfxFrameSurface1*)src->data[3];
-+    mfxHDLPair *pair = (mfxHDLPair*)mfx_surface->Data.MemId;
-+    ID3D11Texture2D *tex = (ID3D11Texture2D*)pair->first;
++    mfxHDLPair *pair = (mfxHDLPair *)mfx_surface->Data.MemId;
++    int index = (intptr_t)pair->second;
++    ID3D11Texture2D *tex = (ID3D11Texture2D *)pair->first;
 +    AVOpenCLFrameDescriptor *desc;
 +    cl_mem_flags cl_flags;
 +    cl_event event;
 +    cl_int cle;
-+    int err, p, index, derived_frames;
++    int err, i, p, derived_frames = 0, nb_planes = 2;
 +
 +    cl_flags = opencl_mem_flags_for_mapping(flags);
 +    if (!cl_flags)
 +        return AVERROR(EINVAL);
 +
-+    av_log(dst_fc, AV_LOG_DEBUG, "Map QSV surface %#llx to OpenCL.\n", (uintptr_t)pair);
++    if (src_fc->sw_format != AV_PIX_FMT_NV12 &&
++        src_fc->sw_format != AV_PIX_FMT_P010 &&
++        src_fc->sw_format != AV_PIX_FMT_P012) {
++        av_log(dst_fc, AV_LOG_ERROR, "Only NV12, P010 and P012 textures "
++               "are supported for QSV with D3D11 to OpenCL mapping.\n");
++        return AVERROR(EINVAL);
++    }
 +
-+    index = (intptr_t)pair->second;
-+    derived_frames = frames_priv->nb_mapped_frames > 0;
-+    if (derived_frames) {
-+        av_assert0(index >= 0 && index != MFX_INFINITE);
-+        if (index >= frames_priv->nb_mapped_frames) {
-+            av_log(dst_fc, AV_LOG_ERROR, "Texture array index out of range for "
-+                   "mapping: %d >= %d.\n", index, frames_priv->nb_mapped_frames);
-+            return AVERROR(EINVAL);
-+        }
++    if (src_fc->initial_pool_size > 0) {
++        av_log(dst_fc, AV_LOG_DEBUG, "Fixed-size pools input for QSV "
++               "with D3D11 to OpenCL mapping.\n");
++        derived_frames = 1;
++    }
++    if ((src_hwctx->frame_type & MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET) ||
++        (src_hwctx->frame_type & MFX_MEMTYPE_FROM_VPPOUT)) {
++        av_log(dst_fc, AV_LOG_DEBUG, "MFX memtype VPP input for QSV "
++               "with D3D11 to OpenCL mapping.\n");
++        derived_frames = 0;
 +    }
 +
 +    if (derived_frames) {
-+        desc = &frames_priv->mapped_frames[index];
-+    } else {
-+        desc = av_mallocz(sizeof(*desc));
-+        if (!desc)
++        av_assert0(index >= 0 && index != MFX_INFINITE);
++        if (index >= src_fc->initial_pool_size) {
++            av_log(dst_fc, AV_LOG_ERROR, "Texture array index out of range for "
++                   "mapping: %d >= %d.\n", index, src_fc->initial_pool_size);
++            return AVERROR(EINVAL);
++        }
++    }
++    av_log(dst_fc, AV_LOG_DEBUG, "Map QSV surface %#llx to OpenCL.\n", (uintptr_t)pair);
++
++    if (derived_frames && !frames_priv->mapped_frames) {
++        frames_priv->nb_mapped_frames = src_fc->initial_pool_size;
++
++        frames_priv->mapped_frames =
++            av_calloc(frames_priv->nb_mapped_frames,
++                      sizeof(*frames_priv->mapped_frames));
++        if (!frames_priv->mapped_frames)
 +            return AVERROR(ENOMEM);
 +
-+        desc->nb_planes = 2;
-+        for (p = 0; p < desc->nb_planes; p++) {
-+            desc->planes[p] =
-+                device_priv->clCreateFromD3D11Texture2DKHR(
-+                    dst_dev->context, cl_flags, tex,
-+                    p, &cle);
-+            if (!desc->planes[p]) {
-+                av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL "
-+                       "image from plane %d of D3D11 texture: %d.\n",
-+                       p, cle);
-+                err = AVERROR(EIO);
-+                goto fail2;
-+            }
++        for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
++            desc = &frames_priv->mapped_frames[i];
++            desc->nb_planes = nb_planes;
++        }
++    }
++
++    if (derived_frames)
++        desc = &frames_priv->mapped_frames[index];
++    else {
++        desc = av_mallocz(sizeof(*desc));
++        if (!desc) {
++            err = AVERROR(ENOMEM);
++            goto fail2;
++        }
++        desc->nb_planes = nb_planes;
++    }
++    // deferred clCreateFromD3D11Texture2DKHR() for low startup latency.
++    for (p = 0; p < desc->nb_planes; p++) {
++        UINT subresource = derived_frames ? (2 * index + p) : p;
++
++        if (desc->planes[p])
++            continue;
++
++        desc->planes[p] =
++            device_priv->clCreateFromD3D11Texture2DKHR(
++                dst_dev->context, cl_flags, tex,
++                subresource, &cle);
++        if (!desc->planes[p]) {
++            av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL "
++                   "image from plane %d of D3D11 texture "
++                   "index %d (subresource %u): %d.\n",
++                   p, index, (unsigned)subresource, cle);
++            err = AVERROR(EIO);
++            goto fail2;
 +        }
 +    }
 +
@@ -192,7 +203,17 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
 +    if (cle == CL_SUCCESS)
 +        opencl_wait_events(dst_fc, &event, 1);
 +fail2:
-+    if (!derived_frames) {
++    if (derived_frames) {
++        for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
++            desc = &frames_priv->mapped_frames[i];
++            for (p = 0; p < desc->nb_planes; p++) {
++                if (desc->planes[p])
++                    clReleaseMemObject(desc->planes[p]);
++            }
++        }
++        av_freep(&frames_priv->mapped_frames);
++        frames_priv->nb_mapped_frames = 0;
++    } else {
 +        for (p = 0; p < desc->nb_planes; p++) {
 +            if (desc->planes[p])
 +                clReleaseMemObject(desc->planes[p]);
@@ -203,100 +224,12 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
 +    return err;
 +}
 +
-+static int opencl_frames_derive_from_d3d11_qsv(AVHWFramesContext *dst_fc,
-+                                               AVHWFramesContext *src_fc, int flags)
-+{
-+    AVQSVFramesContext     *src_hwctx = src_fc->hwctx;
-+    OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->hwctx;
-+    AVOpenCLDeviceContext    *dst_dev = &device_priv->p;
-+    OpenCLFramesContext  *frames_priv = dst_fc->hwctx;
-+    cl_mem_flags cl_flags;
-+    cl_int cle;
-+    int err, i, p, nb_planes = 2;
-+    mfxHDLPair *pair = NULL;
-+    ID3D11Texture2D *tex = NULL;
-+
-+    if (src_fc->sw_format != AV_PIX_FMT_NV12 &&
-+        src_fc->sw_format != AV_PIX_FMT_P010) {
-+        av_log(dst_fc, AV_LOG_ERROR, "Only NV12 and P010 textures are "
-+               "supported for QSV with D3D11 to OpenCL mapping.\n");
-+        return AVERROR(EINVAL);
-+    }
-+
-+    if (src_fc->initial_pool_size == 0) {
-+        av_log(dst_fc, AV_LOG_DEBUG, "Non fixed-size pools input for QSV "
-+               "with D3D11 to OpenCL mapping.\n");
-+        return 0;
-+    }
-+
-+    if ((src_hwctx->frame_type & MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET) ||
-+        (src_hwctx->frame_type & MFX_MEMTYPE_FROM_VPPOUT)) {
-+        av_log(dst_fc, AV_LOG_DEBUG, "MFX memtype VPP input for QSV "
-+               "with D3D11 to OpenCL mapping.\n");
-+        return 0;
-+    }
-+
-+    if (!src_hwctx->surfaces)
-+        return AVERROR(ENOMEM);
-+    pair = (mfxHDLPair*)src_hwctx->surfaces[0].Data.MemId;
-+    if (!pair)
-+        return AVERROR(ENOMEM);
-+    tex = (ID3D11Texture2D*)pair->first;
-+
-+    cl_flags = opencl_mem_flags_for_mapping(flags);
-+    if (!cl_flags)
-+        return AVERROR(EINVAL);
-+
-+    frames_priv->nb_mapped_frames = src_fc->initial_pool_size;
-+
-+    frames_priv->mapped_frames =
-+        av_calloc(frames_priv->nb_mapped_frames,
-+                  sizeof(*frames_priv->mapped_frames));
-+    if (!frames_priv->mapped_frames)
-+        return AVERROR(ENOMEM);
-+
-+    for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
-+        AVOpenCLFrameDescriptor *desc = &frames_priv->mapped_frames[i];
-+        desc->nb_planes = nb_planes;
-+
-+        for (p = 0; p < nb_planes; p++) {
-+            UINT subresource = 2 * i + p;
-+            desc->planes[p] =
-+                device_priv->clCreateFromD3D11Texture2DKHR(
-+                    dst_dev->context, cl_flags, tex,
-+                    subresource, &cle);
-+            if (!desc->planes[p]) {
-+                av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL "
-+                       "image from plane %d of D3D11 texture "
-+                       "index %d (subresource %u): %d.\n",
-+                       p, i, (unsigned int)subresource, cle);
-+                err = AVERROR(EIO);
-+                goto fail;
-+            }
-+        }
-+    }
-+
-+    return 0;
-+
-+fail:
-+    for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
-+        AVOpenCLFrameDescriptor *desc = &frames_priv->mapped_frames[i];
-+        for (p = 0; p < desc->nb_planes; p++) {
-+            if (desc->planes[p])
-+                clReleaseMemObject(desc->planes[p]);
-+        }
-+    }
-+    av_freep(&frames_priv->mapped_frames);
-+    frames_priv->nb_mapped_frames = 0;
-+    return err;
-+}
-+
 +#endif
 +
  static void opencl_unmap_from_d3d11(AVHWFramesContext *dst_fc,
                                      HWMapDescriptor *hwmap)
  {
-@@ -3096,6 +3334,11 @@ static int opencl_map_to(AVHWFramesConte
+@@ -3089,6 +3288,11 @@ static int opencl_map_to(AVHWFramesConte
              return opencl_map_from_dxva2(hwfc, dst, src, flags);
  #endif
  #if HAVE_OPENCL_D3D11
@@ -308,7 +241,7 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
      case AV_PIX_FMT_D3D11:
          if (priv->d3d11_mapping_usable)
              return opencl_map_from_d3d11(hwfc, dst, src, flags);
-@@ -3150,6 +3393,18 @@ static int opencl_frames_derive_to(AVHWF
+@@ -3143,6 +3347,12 @@ static int opencl_frames_derive_to(AVHWF
          break;
  #endif
  #if HAVE_OPENCL_D3D11
@@ -316,12 +249,6 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
 +    case AV_HWDEVICE_TYPE_QSV:
 +        if (!priv->d3d11_qsv_mapping_usable)
 +            return AVERROR(ENOSYS);
-+        {
-+            int err;
-+            err = opencl_frames_derive_from_d3d11_qsv(dst_fc, src_fc, flags);
-+            if (err < 0)
-+                return err;
-+        }
 +        break;
 +#endif
      case AV_HWDEVICE_TYPE_D3D11VA:

--- a/debian/patches/0043-sync-intel-d3d11va-textures-before-mapping-to-opencl.patch
+++ b/debian/patches/0043-sync-intel-d3d11va-textures-before-mapping-to-opencl.patch
@@ -59,8 +59,8 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
  
  
 @@ -1809,7 +1813,16 @@ static void opencl_frames_uninit(AVHWFra
-         av_freep(&priv->mapped_frames);
      }
+     av_freep(&priv->mapped_frames);
  #endif
 -
 +#if HAVE_OPENCL_D3D11
@@ -190,29 +190,27 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
      OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->hwctx;
      OpenCLFramesContext  *frames_priv = dst_fc->hwctx;
      AVOpenCLDeviceContext    *dst_dev = &device_priv->p;
-@@ -2652,6 +2765,21 @@ static int opencl_map_from_d3d11_qsv(AVH
+@@ -2685,6 +2798,19 @@ static int opencl_map_from_d3d11_qsv(AVH
          }
      }
  
 +    if (src_hwctx->require_sync) {
-+        err = opencl_init_d3d11_sync_point(frames_priv,
-+                                           device_hwctx,
++        err = opencl_init_d3d11_sync_point(frames_priv, device_hwctx,
 +                                           tex, dst_fc);
 +        if (err < 0)
-+            return err;
++            goto fail2;
 +
 +        if (frames_priv->sync_point || frames_priv->sync_tex_2x2) {
-+            opencl_sync_d3d11_texture(frames_priv,
-+                                      device_hwctx,
++            opencl_sync_d3d11_texture(frames_priv, device_hwctx,
 +                                      tex, (derived_frames ? index : 0),
 +                                      dst_fc);
 +        }
 +    }
 +
-     if (derived_frames) {
+     if (derived_frames)
          desc = &frames_priv->mapped_frames[index];
-     } else {
-@@ -2843,6 +2971,10 @@ static void opencl_unmap_from_d3d11(AVHW
+     else {
+@@ -2806,6 +2932,10 @@ static void opencl_unmap_from_d3d11(AVHW
  static int opencl_map_from_d3d11(AVHWFramesContext *dst_fc, AVFrame *dst,
                                   const AVFrame *src, int flags)
  {
@@ -222,50 +220,31 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
 +    AVD3D11VADeviceContext *device_hwctx = src_fc->device_ctx->hwctx;
      OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->hwctx;
      OpenCLFramesContext  *frames_priv = dst_fc->hwctx;
-     AVOpenCLFrameDescriptor *desc;
-@@ -2873,6 +3005,14 @@ static int opencl_map_from_d3d11(AVHWFra
-     mem_objs = device_priv->d3d11_map_amd ? &desc->planes[nb_planes]
-                                           : desc->planes;
- 
-+    if (src_hwctx->require_sync &&
-+        frames_priv->sync_point && frames_priv->sync_tex_2x2) {
-+        opencl_sync_d3d11_texture(frames_priv,
-+                                  device_hwctx,
-+                                  (ID3D11Texture2D*)src->data[0], index,
-+                                  dst_fc);
-+    }
-+
-     cle = device_priv->clEnqueueAcquireD3D11ObjectsKHR(
-         frames_priv->command_queue, num_objs, mem_objs,
-         0, NULL, &event);
-@@ -2912,6 +3052,7 @@ fail:
- static int opencl_frames_derive_from_d3d11(AVHWFramesContext *dst_fc,
-                                            AVHWFramesContext *src_fc, int flags)
- {
-+    AVD3D11VADeviceContext *device_hwctx = src_fc->device_ctx->hwctx;
-     AVD3D11VAFramesContext *src_hwctx = src_fc->hwctx;
-     OpenCLDeviceContext  *device_priv = dst_fc->device_ctx->hwctx;
      AVOpenCLDeviceContext    *dst_dev = &device_priv->p;
-@@ -2954,6 +3095,14 @@ static int opencl_frames_derive_from_d3d
-     if (!frames_priv->mapped_frames)
-         return AVERROR(ENOMEM);
+@@ -2865,6 +2995,18 @@ static int opencl_map_from_d3d11(AVHWFra
+         }
+     }
  
 +    if (src_hwctx->require_sync) {
-+        err = opencl_init_d3d11_sync_point(frames_priv,
-+                                           device_hwctx,
-+                                           src_hwctx->texture, dst_fc);
++        err = opencl_init_d3d11_sync_point(frames_priv, device_hwctx,
++                                           tex, dst_fc);
 +        if (err < 0)
-+            return err;
++            goto fail2;
++
++        if (frames_priv->sync_point || frames_priv->sync_tex_2x2) {
++            opencl_sync_d3d11_texture(frames_priv, device_hwctx,
++                                      tex, index, dst_fc);
++        }
 +    }
 +
-     for (i = 0; i < frames_priv->nb_mapped_frames; i++) {
-         AVOpenCLFrameDescriptor *desc = &frames_priv->mapped_frames[i];
-         desc->nb_planes = nb_planes;
+     desc = &frames_priv->mapped_frames[index];
+ 
+     // deferred clCreateFromD3D11Texture2DKHR() for low startup latency.
 Index: FFmpeg/libavutil/hwcontext_qsv.c
 ===================================================================
 --- FFmpeg.orig/libavutil/hwcontext_qsv.c
 +++ FFmpeg/libavutil/hwcontext_qsv.c
-@@ -2016,6 +2016,7 @@ static int qsv_dynamic_frames_derive_to(
+@@ -2064,6 +2064,7 @@ static int qsv_dynamic_frames_derive_to(
          } else {
              dst_hwctx->frame_type |= MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET;
          }
@@ -273,7 +252,7 @@ Index: FFmpeg/libavutil/hwcontext_qsv.c
      }
      break;
  #endif
-@@ -2091,6 +2092,7 @@ static int qsv_fixed_frames_derive_to(AV
+@@ -2139,6 +2140,7 @@ static int qsv_fixed_frames_derive_to(AV
              } else {
                  dst_hwctx->frame_type |= MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET;
              }


### PR DESCRIPTION
**Changes**
- Defer DX11 to OCL mapping for low startup latency

**Issues**
- D3D11VA and MSDK QSV decoders still only support fixed-size frame pools. However, deriving OpenCL images from these arrayed DX11 textures takes a long time on Gen12.0 GFX. Defer mapping these images until the decoder outputs it. This significantly reduces startup latency - from 5s to 1s for a 4K transcoding w/ tonemap.