### PR TITLE
ffprobe: always use ifile->nb_streams for first vframe option

### DIFF
--- a/debian/patches/0079-add-first-vframe-only-to-ffprobe.patch
+++ b/debian/patches/0079-add-first-vframe-only-to-ffprobe.patch
@@ -23,19 +23,19 @@ Index: FFmpeg/fftools/ffprobe.c
  
      av_log(NULL, AV_LOG_VERBOSE, "Processing read interval ");
      log_read_interval(interval, NULL, AV_LOG_VERBOSE);
-@@ -3149,12 +3152,51 @@ static int read_interval_packets(WriterC
+@@ -3149,6 +3152,22 @@ static int read_interval_packets(WriterC
          ret = AVERROR(ENOMEM);
          goto end;
      }
 +
 +    if (only_show_first_video_frame) {
 +        int si = 0;
-+        checked_stream = av_calloc(nb_streams, sizeof(unsigned char));
++        checked_stream = av_calloc(ifile->nb_streams, sizeof(unsigned char));
 +        if (!checked_stream) {
 +            ret = AVERROR(ENOMEM);
 +            goto end;
 +        }
-+        for (si = 0; si < nb_streams; si ++) {
++        for (si = 0; si < ifile->nb_streams; si ++) {
 +            AVCodecParameters *par = ifile->streams[si].st->codecpar;
 +            if (par->codec_type == AVMEDIA_TYPE_VIDEO) {
 +                nb_video_streams++;
@@ -46,37 +46,7 @@ Index: FFmpeg/fftools/ffprobe.c
      while (!av_read_frame(fmt_ctx, pkt)) {
          if (fmt_ctx->nb_streams > nb_streams) {
              REALLOCZ_ARRAY_STREAM(nb_streams_frames,  nb_streams, fmt_ctx->nb_streams);
-             REALLOCZ_ARRAY_STREAM(nb_streams_packets, nb_streams, fmt_ctx->nb_streams);
-             REALLOCZ_ARRAY_STREAM(selected_streams,   nb_streams, fmt_ctx->nb_streams);
--            nb_streams = fmt_ctx->nb_streams;
-+
-+            if (checked_stream) {
-+                unsigned char *checked_stream_extended = NULL;
-+                int si = 0;
-+                checked_stream_extended = av_calloc(fmt_ctx->nb_streams, sizeof(unsigned char));
-+                if (!checked_stream) {
-+                    ret = AVERROR(ENOMEM);
-+                    goto end;
-+                }
-+
-+                memcpy(checked_stream_extended, checked_stream, nb_streams * sizeof(unsigned char));
-+                av_freep(&checked_stream);
-+                checked_stream = checked_stream_extended;
-+
-+                nb_video_streams = 0;
-+                for (si = 0; si < fmt_ctx->nb_streams; si ++) {
-+                    AVCodecParameters *par = ifile->streams[si].st->codecpar;
-+                    if (par->codec_type == AVMEDIA_TYPE_VIDEO) {
-+                        nb_video_streams++;
-+                        selected_streams[si] = 1;
-+                    }
-+                }
-+            }
-+            nb_streams = (int)fmt_ctx->nb_streams;
-         }
-         if (selected_streams[pkt->stream_index]) {
-             AVRational tb = ifile->streams[pkt->stream_index].st->time_base;
-@@ -3181,6 +3223,12 @@ static int read_interval_packets(WriterC
+@@ -3181,6 +3200,12 @@ static int read_interval_packets(WriterC
              }
  
              frame_count++;
@@ -89,14 +59,14 @@ Index: FFmpeg/fftools/ffprobe.c
              if (do_read_packets) {
                  if (do_show_packets)
                      show_packet(w, ifile, pkt, i++);
-@@ -3201,6 +3249,16 @@ static int read_interval_packets(WriterC
+@@ -3201,6 +3226,16 @@ static int read_interval_packets(WriterC
  
                  while (process_frame(w, ifile, frame, pkt, &packet_new) > 0);
              }
 +            if (only_show_first_video_frame) {
 +                int nb_checked_streams = 0, si = 0;
 +                checked_stream[pkt->stream_index] = 1;
-+                for (si = 0; si < nb_streams; si ++) {
++                for (si = 0; si < ifile->nb_streams; si ++) {
 +                    nb_checked_streams += checked_stream[si];
 +                }
 +                if (nb_checked_streams >= nb_video_streams) {
@@ -106,7 +76,7 @@ Index: FFmpeg/fftools/ffprobe.c
          }
          av_packet_unref(pkt);
      }
-@@ -3218,6 +3276,9 @@ static int read_interval_packets(WriterC
+@@ -3218,6 +3253,9 @@ static int read_interval_packets(WriterC
  end:
      av_frame_free(&frame);
      av_packet_free(&pkt);
@@ -116,7 +86,7 @@ Index: FFmpeg/fftools/ffprobe.c
      if (ret < 0) {
          av_log(NULL, AV_LOG_ERROR, "Could not read packets in interval ");
          log_read_interval(interval, NULL, AV_LOG_ERROR);
-@@ -4609,6 +4670,7 @@ static const OptionDef real_options[] =
+@@ -4609,6 +4647,7 @@ static const OptionDef real_options[] =
      { "print_filename",        OPT_TYPE_FUNC, OPT_FUNC_ARG, {.func_arg = opt_print_filename}, "override the printed input filename", "print_file"},
      { "find_stream_info",      OPT_TYPE_BOOL, OPT_INPUT | OPT_EXPERT, { &find_stream_info },
          "read and decode the streams to fill missing information with heuristics" },


### PR DESCRIPTION
The global static nb_streams is dynamic and can be extended to a number that would cause out of bounds access. Always use the nb_streams from the input file structure and stop rescaling our checking bitmask with the dynamic nb_streams. This should still work for all video files.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes https://github.com/jellyfin/jellyfin/issues/14074