### PR TITLE
Add intel-opencl-icd to control/Suggests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -7,6 +7,10 @@ jellyfin-ffmpeg (7.1.1-3) unstable; urgency=medium
   * Increase default frame pool size for D3D11VA AV1/VP9
   * Handle NOPTS and no extradata in RKMPP decoders
   * Defer DX11 to OCL mapping for low startup latency
+  * avfilter/tonemapx: use cpu friendly conditional assignments
+  * Remove all armhf build configs
+  * ffprobe: always use ifile->nb_streams for first vframe option
+  * Add intel-opencl-icd{,-legacy} to control/Suggests
 
  -- nyanmisaka <nst799610810@gmail.com>  Tue, 6 May 2025 21:12:22 +0800
 

--- a/debian/control
+++ b/debian/control
@@ -60,6 +60,9 @@ Conflicts: jellyfin-ffmpeg, jellyfin-ffmpeg5, jellyfin-ffmpeg6
 Depends:
  ${shlibs:Depends},
  ${misc:Depends}
+Suggests:
+ intel-opencl-icd [amd64],
+ intel-opencl-icd-legacy [amd64]
 Description: Tools for transcoding, streaming and playing of multimedia files
  FFmpeg is the leading multimedia framework, able to decode, encode, transcode,
  mux, demux, stream, filter and play pretty much anything that humans and

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -376,7 +376,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.7.1 --depth=1 https://github.com/intel/gmmlib.git
+    git clone -b intel-gmmlib-22.7.2 --depth=1 https://github.com/intel/gmmlib.git
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -562,6 +562,8 @@ prepare_extra_amd64() {
         tar xaf mesa.tar.gz
         # Cherry-pick fixes targeting mesa-stable
         wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/ee4d7e98.patch | git -C mesa-${mesa_ver} apply
+        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/8aadce68.patch | git -C mesa-${mesa_ver} apply
+        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/cb9ae704.patch | git -C mesa-${mesa_ver} apply
         meson setup mesa-${mesa_ver} mesa_build \
             --prefix=${TARGET_DIR} \
             --libdir=lib \


### PR DESCRIPTION
**Changes**
- Add `intel-opencl-icd{,-legacy}` to control/Suggests

  So that users can install Intel OpenCL runtime more conveniently by adding `--install-suggests` to `apt-get`.