### PR TITLE
Vectorize dovi reshaping

### DIFF
--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -953,7 +953,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +                      uchar dovi_min_order,
 +                      uchar dovi_max_order)
 +{
-+    uint mmr_idx = dovi_mmr_single ? 0 : (uint)coeffs.y;
++    uchar mmr_idx = dovi_mmr_single ? 0 : (uchar)coeffs.y;
 +  #ifdef DOVI_PERF_FP16
 +    const vec8 mmr_order1 = vload8(0, (__global const vec *)&dovi_mmr[mmr_idx]);
 +  #else
@@ -982,11 +982,11 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    // Branching is free for PT channels as the condition t is same for all threads.
 +    t = dovi_max_order >= 2 && (dovi_min_order >= 2 || order >= 2);
 +    if (t) {
-+      #ifdef DOVI_PERF_FP16
++  #ifdef DOVI_PERF_FP16
 +        const vec8 mmr_order2 = vload8(1, (__global const vec *)&dovi_mmr[mmr_idx]);
-+      #else
++  #else
 +        const vec8 mmr_order2 = (vec8)(dovi_mmr[mmr_idx + 2], dovi_mmr[mmr_idx + 3]);
-+      #endif
++  #endif
 +        vec4 sig2_i4 = sig_i4 * sig_i4;
 +        vec4 sig2_p4 = sig_p4 * sig_p4;
 +        vec4 sig2_t4 = sig_t4 * sig_t4;
@@ -999,11 +999,11 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +
 +        t = dovi_max_order == 3 && (dovi_min_order == 3 || order >= 3);
 +        if (t) {
-+          #ifdef DOVI_PERF_FP16
++  #ifdef DOVI_PERF_FP16
 +            const vec8 mmr_order3 = vload8(2, (__global const vec *)&dovi_mmr[mmr_idx]);
-+          #else
++  #else
 +            const vec8 mmr_order3 = (vec8)(dovi_mmr[mmr_idx + 4], dovi_mmr[mmr_idx + 5]);
-+          #endif
++  #endif
 +            DOT_MMR(sig2_i4 * sig_i4, sig2_p4 * sig_p4, sig2_t4 * sig_t4,
 +                    sigX2x * sigXx, sigX2y * sigXy, sigX2z * sigXz, sigX2w * sigXw,
 +                    mmr_order3);
@@ -1152,7 +1152,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +  #ifdef DOVI_PERF_FP16
 +    coeffw_is_zero = convert_half4(coeffsw == (vec4)M_ZERO_VEC);
 +  #else
-+    coeffw_is_zero = coeffsw == (vec4)M_ZERO_VEC;
++    coeffw_is_zero = convert_float4(coeffsw == (vec4)M_ZERO_VEC);
 +  #endif
 +    do_poly = has_mmr_poly
 +              ? coeffw_is_zero
@@ -1182,11 +1182,11 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    EXTRACT_COEFFS()
 +
 +  #define RESHAPE_P_T(sig_x4) \
-+    has_mmr_poly = dovi_has_mmr && dovi_has_poly;                            \
-+    t = has_mmr_poly ? coeffs.w == M_ZERO_VEC : dovi_has_poly != M_ZERO_VEC; \
-+    sx4 = t ? reshape_polyx4(sig_x4, coeffsx, coeffsy, coeffsz)              \
-+            : reshape_mmr_ptx4(sig_i4, sig_p4, sig_t4,                       \
-+                               coeffs, dovi_mmr,                             \
++    has_mmr_poly = dovi_has_mmr && dovi_has_poly;                               \
++    t = has_mmr_poly ? coeffs.w == M_ZERO_VEC : dovi_has_poly != M_ZERO_VEC;    \
++    sx4 = t ? reshape_polyx4(sig_x4, coeffsx, coeffsy, coeffsz)                 \
++            : reshape_mmr_ptx4(sig_i4, sig_p4, sig_t4,                          \
++                               coeffs, dovi_mmr,                                \
 +                               dovi_mmr_single, dovi_min_order, dovi_max_order);
 +
 +    RESHAPE_P_T(sig_p4)

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -610,7 +610,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      float j = tone_param;
      float a, b;
  
-@@ -71,202 +106,790 @@ float mobius(float s, float peak) {
+@@ -71,202 +106,755 @@ float mobius(float s, float peak) {
          return s;
  
      a = -j * j * (peak - 1.0f) / (j * j - 2.0f * j + peak);
@@ -914,21 +914,13 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      }
  
 -    float sig_old = sig;
--
++    return s;
++}
+ 
 -    // Scale the signal to compensate for differences in the average brightness
 -    float slope = min(1.0f, sdr_avg / average);
 -    sig *= slope;
 -    peak *= slope;
-+    return s;
-+}
- 
--    // Desaturate the color using a coefficient dependent on the signal level
--    if (desat_param > 0.0f) {
--        float luma = get_luma_dst(rgb);
--        float coeff = max(sig - 0.18f, 1e-6f) / max(sig, 1e-6f);
--        coeff = native_powr(coeff, 10.0f / desat_param);
--        rgb = mix(rgb, (float3)luma, (float3)coeff);
--        sig = mix(sig, luma * slope, coeff);
 +vec4 reshape_mmrx4(vec4 sig_i4,
 +                   vec4 sig_p4,
 +                   vec4 sig_t4,
@@ -987,28 +979,33 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    vec4 sig_t4 = clamp((vec4)((*ipt0).z,(*ipt1).z,(*ipt2).z,(*ipt3).z), 0.0f, 1.0f);
 +  #endif
 +
-+    // Reshape I
-+    dovi_params = src_dovi_params;
-+    dovi_pivots = src_dovi_pivots;
-+    dovi_coeffs = src_dovi_coeffs;
-+    dovi_mmr = src_dovi_mmr;
-+    dovi_num_pivots = dovi_params[0];
-+    dovi_has_mmr = dovi_params[1];
-+    dovi_has_poly = dovi_params[2];
-+    dovi_mmr_single = dovi_params[3];
-+    dovi_min_order = dovi_params[4];
-+    dovi_max_order = dovi_params[5];
-+    dovi_lo = dovi_params[6];
++  #define SETUP_DOVI_PARAMS(channel_offset) \
++    dovi_params = src_dovi_params + (channel_offset)*8; \
++    dovi_pivots = src_dovi_pivots + (channel_offset)*8; \
++    dovi_coeffs = src_dovi_coeffs + (channel_offset)*8; \
++    dovi_mmr = src_dovi_mmr + (channel_offset)*48; \
++    dovi_num_pivots = dovi_params[0]; \
++    dovi_has_mmr = dovi_params[1]; \
++    dovi_has_poly = dovi_params[2]; \
++    dovi_mmr_single = dovi_params[3]; \
++    dovi_min_order = dovi_params[4]; \
++    dovi_max_order = dovi_params[5]; \
++    dovi_lo = dovi_params[6]; \
 +    dovi_hi = dovi_params[7];
 +
-+    coeffs = dovi_coeffs[0];
-+    coeffsx = (vec4)coeffs.x;
-+    coeffsy = (vec4)coeffs.y;
-+    coeffsz = (vec4)coeffs.z;
++  #define EXTRACT_COEFFS() \
++    coeffs = dovi_coeffs[0]; \
++    coeffsx = (vec4)coeffs.x; \
++    coeffsy = (vec4)coeffs.y; \
++    coeffsz = (vec4)coeffs.z; \
 +    coeffsw = (vec4)coeffs.w;
 +
++    // Reshape I
++    SETUP_DOVI_PARAMS(0)
++    EXTRACT_COEFFS()
++
 +    if (dovi_num_pivots > 2) {
-+  #ifdef DOVI_PERF_FP16
++      #ifdef DOVI_PERF_FP16
 +        const vec8 pivots0 = vload8(0, (__global const vec *)dovi_pivots);
 +        const vec8 coeffs0 = vload8(0, (__global const vec *)dovi_coeffs);
 +        const vec8 coeffs1 = vload8(1, (__global const vec *)dovi_coeffs);
@@ -1016,64 +1013,56 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +        const vec8 coeffs3 = vload8(3, (__global const vec *)dovi_coeffs);
 +
 +        const vec *pivots = (const vec *)&pivots0;
-+  #else
++      #else
 +        __global const vec *pivots = dovi_pivots;
 +        const vec8 coeffs0 = (vec8)(dovi_coeffs[0], dovi_coeffs[1]);
 +        const vec8 coeffs1 = (vec8)(dovi_coeffs[2], dovi_coeffs[3]);
 +        const vec8 coeffs2 = (vec8)(dovi_coeffs[4], dovi_coeffs[5]);
 +        const vec8 coeffs3 = (vec8)(dovi_coeffs[6], dovi_coeffs[7]);
-+  #endif
-+        vec4 coeffs_temp = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(sig_i4.x >= pivots[0])),
-+                               mix(coeffs1.lo, coeffs1.hi, (vec4)(sig_i4.x >= pivots[2])),
-+                               (vec4)(sig_i4.x >= pivots[1])),
-+                           mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(sig_i4.x >= pivots[4])),
-+                               mix(coeffs3.lo, coeffs3.hi, (vec4)(sig_i4.x >= pivots[6])),
-+                               (vec4)(sig_i4.x >= pivots[5])),
-+                           (vec4)(sig_i4.x >= pivots[3]));
-+        coeffsx.x = coeffs_temp.x;
-+        coeffsy.x = coeffs_temp.y;
-+        coeffsz.x = coeffs_temp.z;
-+        coeffsw.x = coeffs_temp.w;
++      #endif
 +
-+        coeffs_temp = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(sig_i4.y >= pivots[0])),
-+                               mix(coeffs1.lo, coeffs1.hi, (vec4)(sig_i4.y >= pivots[2])),
-+                               (vec4)(sig_i4.y >= pivots[1])),
-+                           mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(sig_i4.y >= pivots[4])),
-+                               mix(coeffs3.lo, coeffs3.hi, (vec4)(sig_i4.y >= pivots[6])),
-+                               (vec4)(sig_i4.y >= pivots[5])),
-+                           (vec4)(sig_i4.y >= pivots[3]));
-+        coeffsx.y = coeffs_temp.x;
-+        coeffsy.y = coeffs_temp.y;
-+        coeffsz.y = coeffs_temp.z;
-+        coeffsw.y = coeffs_temp.w;
++      #define PICK_COEFF_FOR(LANE)                                                           \
++         mix(                                                                                \
++           mix(                                                                              \
++             mix(coeffs0.lo, coeffs0.hi, (vec4)((LANE) >= pivots[0])),                       \
++             mix(coeffs1.lo, coeffs1.hi, (vec4)((LANE) >= pivots[2])),                       \
++             (vec4)((LANE) >= pivots[1])                                                     \
++           ),                                                                                \
++           mix(                                                                              \
++             mix(coeffs2.lo, coeffs2.hi, (vec4)((LANE) >= pivots[4])),                       \
++             mix(coeffs3.lo, coeffs3.hi, (vec4)((LANE) >= pivots[6])),                       \
++             (vec4)((LANE) >= pivots[5])                                                     \
++           ),                                                                                \
++           (vec4)((LANE) >= pivots[3])                                                       \
++         )
 +
-+        coeffs_temp = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(sig_i4.z >= pivots[0])),
-+                               mix(coeffs1.lo, coeffs1.hi, (vec4)(sig_i4.z >= pivots[2])),
-+                               (vec4)(sig_i4.z >= pivots[1])),
-+                           mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(sig_i4.z >= pivots[4])),
-+                               mix(coeffs3.lo, coeffs3.hi, (vec4)(sig_i4.z >= pivots[6])),
-+                               (vec4)(sig_i4.z >= pivots[5])),
-+                           (vec4)(sig_i4.z >= pivots[3]));
-+        coeffsx.z = coeffs_temp.x;
-+        coeffsy.z = coeffs_temp.y;
-+        coeffsz.z = coeffs_temp.z;
-+        coeffsw.z = coeffs_temp.w;
++      #define PACK_COEFFS(LANE)         \
++        coeffsx.LANE = coeffs_temp.x;   \
++        coeffsy.LANE = coeffs_temp.y;   \
++        coeffsz.LANE = coeffs_temp.z;   \
++        coeffsw.LANE = coeffs_temp.w;
 +
-+        coeffs_temp = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(sig_i4.w >= pivots[0])),
-+                               mix(coeffs1.lo, coeffs1.hi, (vec4)(sig_i4.w >= pivots[2])),
-+                               (vec4)(sig_i4.w >= pivots[1])),
-+                           mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(sig_i4.w >= pivots[4])),
-+                               mix(coeffs3.lo, coeffs3.hi, (vec4)(sig_i4.w >= pivots[6])),
-+                               (vec4)(sig_i4.w >= pivots[5])),
-+                           (vec4)(sig_i4.w >= pivots[3]));
-+        coeffsx.w = coeffs_temp.x;
-+        coeffsy.w = coeffs_temp.y;
-+        coeffsz.w = coeffs_temp.z;
-+        coeffsw.w = coeffs_temp.w;
-     }
++        vec4 coeffs_temp = PICK_COEFF_FOR(sig_i4.x);
++        PACK_COEFFS(x)
++
++        coeffs_temp = PICK_COEFF_FOR(sig_i4.y);;
++        PACK_COEFFS(y)
+ 
+-    // Desaturate the color using a coefficient dependent on the signal level
+-    if (desat_param > 0.0f) {
+-        float luma = get_luma_dst(rgb);
+-        float coeff = max(sig - 0.18f, 1e-6f) / max(sig, 1e-6f);
+-        coeff = native_powr(coeff, 10.0f / desat_param);
+-        rgb = mix(rgb, (float3)luma, (float3)coeff);
+-        sig = mix(sig, luma * slope, coeff);
+-    }
++        coeffs_temp = PICK_COEFF_FOR(sig_i4.z);;
++        PACK_COEFFS(z)
  
 -    sig = TONE_FUNC(sig, peak);
--
++        coeffs_temp = PICK_COEFF_FOR(sig_i4.w);;
++        PACK_COEFFS(w)
+ 
 -    sig = min(sig, 1.0f);
 -    rgb *= (sig/sig_old);
 -    return rgb;
@@ -1085,6 +1074,10 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -    c = lrgb2lrgb(c);
 -    return c;
 -}
++      #undef PICK_COEFF_FOR
++      #undef PACK_COEFFS
++    }
++
 +    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
 +    #ifdef DOVI_PERF_FP16
 +      coeffw_is_zero = convert_half4(coeffsw == (vec4)M_ZERO_VEC);
@@ -1111,24 +1104,8 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    (*ipt3).x = result.w;
 +
 +    // Reshape P
-+    dovi_params = src_dovi_params + 1*8;
-+    dovi_pivots = src_dovi_pivots + 1*8;
-+    dovi_coeffs = src_dovi_coeffs + 1*8;
-+    dovi_mmr = src_dovi_mmr + 1*48;
-+    dovi_num_pivots = dovi_params[0];
-+    dovi_has_mmr = dovi_params[1];
-+    dovi_has_poly = dovi_params[2];
-+    dovi_mmr_single = dovi_params[3];
-+    dovi_min_order = dovi_params[4];
-+    dovi_max_order = dovi_params[5];
-+    dovi_lo = dovi_params[6];
-+    dovi_hi = dovi_params[7];
-+
-+    coeffs = dovi_coeffs[0];
-+    coeffsx = (vec4)coeffs.x;
-+    coeffsy = (vec4)coeffs.y;
-+    coeffsz = (vec4)coeffs.z;
-+    coeffsw = (vec4)coeffs.w;
++    SETUP_DOVI_PARAMS(1)
++    EXTRACT_COEFFS()
 +
 +    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
 +    t = has_mmr_poly ? coeffs.w == M_ZERO_VEC : dovi_has_poly != M_ZERO_VEC;
@@ -1137,35 +1114,19 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +            : reshape_mmrx4(sig_i4, sig_p4, sig_t4,
 +                            coeffsx, coeffsy, coeffsz, coeffsw, dovi_mmr,
 +                            dovi_mmr_single, dovi_min_order, dovi_max_order);
-+#ifdef DOVI_PERF_FP16
++  #ifdef DOVI_PERF_FP16
 +    result = convert_float4(clamp(sx4, dovi_lo, dovi_hi));
-+#else
++  #else
 +    result = clamp(sx4, dovi_lo, dovi_hi);
-+#endif
++  #endif
 +    (*ipt0).y = result.x;
 +    (*ipt1).y = result.y;
 +    (*ipt2).y = result.z;
 +    (*ipt3).y = result.w;
 +
 +    // Reshape T
-+    dovi_params = src_dovi_params + 2*8;
-+    dovi_pivots = src_dovi_pivots + 2*8;
-+    dovi_coeffs = src_dovi_coeffs + 2*8;
-+    dovi_mmr = src_dovi_mmr + 2*48;
-+    dovi_num_pivots = dovi_params[0];
-+    dovi_has_mmr = dovi_params[1];
-+    dovi_has_poly = dovi_params[2];
-+    dovi_mmr_single = dovi_params[3];
-+    dovi_min_order = dovi_params[4];
-+    dovi_max_order = dovi_params[5];
-+    dovi_lo = dovi_params[6];
-+    dovi_hi = dovi_params[7];
-+
-+    coeffs = dovi_coeffs[0];
-+    coeffsx = (vec4)coeffs.x;
-+    coeffsy = (vec4)coeffs.y;
-+    coeffsz = (vec4)coeffs.z;
-+    coeffsw = (vec4)coeffs.w;
++    SETUP_DOVI_PARAMS(2)
++    EXTRACT_COEFFS()
 +
 +    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
 +    t = has_mmr_poly ? coeffs.w == M_ZERO_VEC : dovi_has_poly != M_ZERO_VEC;
@@ -1183,6 +1144,9 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    (*ipt1).z = result.y;
 +    (*ipt2).z = result.z;
 +    (*ipt3).z = result.w;
++
++  #undef SETUP_DOVI_PARAMS
++  #undef EXTRACT_COEFFS
 +}
 +#endif
 +

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -610,7 +610,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      float j = tone_param;
      float a, b;
  
-@@ -71,202 +106,687 @@ float mobius(float s, float peak) {
+@@ -71,202 +106,790 @@ float mobius(float s, float peak) {
          return s;
  
      a = -j * j * (peak - 1.0f) / (j * j - 2.0f * j + peak);
@@ -853,10 +853,8 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    float3 c = yuv2lrgb(yuv);
 +#endif
 +    return c;
- }
- 
--float3 map_one_pixel_rgb(float3 rgb, float peak, float average) {
--    float sig = max(max(rgb.x, max(rgb.y, rgb.z)), 1e-6f);
++}
++
 +// Map from source space YUV to destination space RGB
 +float3 map_to_dst_space_from_yuv(float3 yuv) {
 +#ifdef DOVI_RESHAPE
@@ -869,6 +867,13 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    c = lrgb2lrgb(c);
 +#endif
 +    return c;
+ }
+ 
+-float3 map_one_pixel_rgb(float3 rgb, float peak, float average) {
+-    float sig = max(max(rgb.x, max(rgb.y, rgb.z)), 1e-6f);
++#ifdef DOVI_RESHAPE
++vec4 reshape_polyx4(vec4 s, vec4 coeffsx, vec4 coeffsy, vec4 coeffsz) {
++    return (coeffsz * s + coeffsy) * s + coeffsx;
 +}
  
 -    // Rescale the variables in order to bring it into a representation where
@@ -877,13 +882,6 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -    if (target_peak > 1.0f) {
 -        sig *= 1.0f / target_peak;
 -        peak *= 1.0f / target_peak;
--    }
-+#ifdef DOVI_RESHAPE
-+vec reshape_poly(vec s, vec4 coeffs) {
-+    return (coeffs.z * s + coeffs.y) * s + coeffs.x;
-+}
- 
--    float sig_old = sig;
 +vec reshape_mmr(vec3 sig,
 +                vec4 coeffs,
 +                __global const vec4 *dovi_mmr,
@@ -913,8 +911,10 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +            s += dot(dovi_mmr[mmr_idx + 4].xyz, sig2 * sig);
 +            s += dot(dovi_mmr[mmr_idx + 5], sigX2 * sigX);
 +        }
-+    }
+     }
  
+-    float sig_old = sig;
+-
 -    // Scale the signal to compensate for differences in the average brightness
 -    float slope = min(1.0f, sdr_avg / average);
 -    sig *= slope;
@@ -929,26 +929,63 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -        coeff = native_powr(coeff, 10.0f / desat_param);
 -        rgb = mix(rgb, (float3)luma, (float3)coeff);
 -        sig = mix(sig, luma * slope, coeff);
-+void reshape_dovi_yuv(float3 *yuv,
-+                      __global const vec *src_dovi_params,
-+                      __global const vec *src_dovi_pivots,
-+                      __global const vec4 *src_dovi_coeffs,
-+                      __global const vec4 *src_dovi_mmr)
++vec4 reshape_mmrx4(vec4 sig_i4,
++                   vec4 sig_p4,
++                   vec4 sig_t4,
++                   vec4 coeffsx,
++                   vec4 coeffsy,
++                   vec4 coeffsz,
++                   vec4 coeffsw,
++                   __global const vec4 *dovi_mmr,
++                   uchar dovi_mmr_single,
++                   uchar dovi_min_order,
++                   uchar dovi_max_order)
 +{
-+    bool t, has_mmr_poly;
-+  #ifdef DOVI_PERF_FP16
-+    vec3 sig = convert_half3(clamp((*yuv).xyz, 0.0f, 1.0f));
-+  #else
-+    vec3 sig = clamp((*yuv).xyz, 0.0f, 1.0f);
-+  #endif
-+    vec s;
-+    vec4 coeffs;
++    vec4 coeffs = (vec4)(coeffsx.x, coeffsy.x, coeffsz.x, coeffsw.x);
++    vec4 result = (vec4)M_ZERO_VEC;
++    result.x = reshape_mmr((vec3)(sig_i4.x, sig_p4.x, sig_t4.x), coeffs, dovi_mmr,
++                           dovi_mmr_single, dovi_min_order, dovi_max_order);
++    coeffs = (vec4)(coeffsx.y, coeffsy.y, coeffsz.y, coeffsw.y);
++    result.y = reshape_mmr((vec3)(sig_i4.y, sig_p4.y, sig_t4.y), coeffs, dovi_mmr,
++                           dovi_mmr_single, dovi_min_order, dovi_max_order);
++    coeffs = (vec4)(coeffsx.z, coeffsy.z, coeffsz.z, coeffsw.z);
++    result.z = reshape_mmr((vec3)(sig_i4.z, sig_p4.z, sig_t4.z), coeffs, dovi_mmr,
++                           dovi_mmr_single, dovi_min_order, dovi_max_order);
++    coeffs = (vec4)(coeffsx.w, coeffsy.w, coeffsz.w, coeffsw.w);
++    result.w = reshape_mmr((vec3)(sig_i4.w, sig_p4.w, sig_t4.w), coeffs, dovi_mmr,
++                           dovi_mmr_single, dovi_min_order, dovi_max_order);
++    return result;
++}
++
++void reshape_dovi_iptx4(float3 *ipt0,
++                        float3 *ipt1,
++                        float3 *ipt2,
++                        float3 *ipt3,
++                        __global const vec *src_dovi_params,
++                        __global const vec *src_dovi_pivots,
++                        __global const vec4 *src_dovi_coeffs,
++                        __global const vec4 *src_dovi_mmr)
++{
++    bool has_mmr_poly, t;
++    vec4 do_poly, coeffw_is_zero;
++    vec4 coeffs, coeffsx, coeffsy, coeffsz, coeffsw, sx4;
++    float4 result;
 +    uchar dovi_num_pivots, dovi_has_mmr, dovi_has_poly;
 +    uchar dovi_mmr_single, dovi_min_order, dovi_max_order;
-+    vec dovi_lo, dovi_hi;
 +    __global const vec *dovi_params;
 +    __global const vec *dovi_pivots;
 +    __global const vec4 *dovi_coeffs, *dovi_mmr;
++    vec dovi_lo, dovi_hi;
++
++  #ifdef DOVI_PERF_FP16
++    vec4 sig_i4 = convert_half4(clamp((vec4)((*ipt0).x,(*ipt1).x,(*ipt2).x,(*ipt3).x), 0.0f, 1.0f));
++    vec4 sig_p4 = convert_half4(clamp((vec4)((*ipt0).y,(*ipt1).y,(*ipt2).y,(*ipt3).y), 0.0f, 1.0f));
++    vec4 sig_t4 = convert_half4(clamp((vec4)((*ipt0).z,(*ipt1).z,(*ipt2).z,(*ipt3).z), 0.0f, 1.0f));
++  #else
++    vec4 sig_i4 = clamp((vec4)((*ipt0).x,(*ipt1).x,(*ipt2).x,(*ipt3).x), 0.0f, 1.0f);
++    vec4 sig_p4 = clamp((vec4)((*ipt0).y,(*ipt1).y,(*ipt2).y,(*ipt3).y), 0.0f, 1.0f);
++    vec4 sig_t4 = clamp((vec4)((*ipt0).z,(*ipt1).z,(*ipt2).z,(*ipt3).z), 0.0f, 1.0f);
++  #endif
 +
 +    // Reshape I
 +    dovi_params = src_dovi_params;
@@ -964,8 +1001,11 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    dovi_lo = dovi_params[6];
 +    dovi_hi = dovi_params[7];
 +
-+    s = sig.x;
 +    coeffs = dovi_coeffs[0];
++    coeffsx = (vec4)coeffs.x;
++    coeffsy = (vec4)coeffs.y;
++    coeffsz = (vec4)coeffs.z;
++    coeffsw = (vec4)coeffs.w;
 +
 +    if (dovi_num_pivots > 2) {
 +  #ifdef DOVI_PERF_FP16
@@ -983,19 +1023,57 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +        const vec8 coeffs2 = (vec8)(dovi_coeffs[4], dovi_coeffs[5]);
 +        const vec8 coeffs3 = (vec8)(dovi_coeffs[6], dovi_coeffs[7]);
 +  #endif
-+        coeffs = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(s >= pivots[0])),
-+                         mix(coeffs1.lo, coeffs1.hi, (vec4)(s >= pivots[2])),
-+                         (vec4)(s >= pivots[1])),
-+                     mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(s >= pivots[4])),
-+                         mix(coeffs3.lo, coeffs3.hi, (vec4)(s >= pivots[6])),
-+                         (vec4)(s >= pivots[5])),
-+                     (vec4)(s >= pivots[3]));
++        vec4 coeffs_temp = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(sig_i4.x >= pivots[0])),
++                               mix(coeffs1.lo, coeffs1.hi, (vec4)(sig_i4.x >= pivots[2])),
++                               (vec4)(sig_i4.x >= pivots[1])),
++                           mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(sig_i4.x >= pivots[4])),
++                               mix(coeffs3.lo, coeffs3.hi, (vec4)(sig_i4.x >= pivots[6])),
++                               (vec4)(sig_i4.x >= pivots[5])),
++                           (vec4)(sig_i4.x >= pivots[3]));
++        coeffsx.x = coeffs_temp.x;
++        coeffsy.x = coeffs_temp.y;
++        coeffsz.x = coeffs_temp.z;
++        coeffsw.x = coeffs_temp.w;
++
++        coeffs_temp = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(sig_i4.y >= pivots[0])),
++                               mix(coeffs1.lo, coeffs1.hi, (vec4)(sig_i4.y >= pivots[2])),
++                               (vec4)(sig_i4.y >= pivots[1])),
++                           mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(sig_i4.y >= pivots[4])),
++                               mix(coeffs3.lo, coeffs3.hi, (vec4)(sig_i4.y >= pivots[6])),
++                               (vec4)(sig_i4.y >= pivots[5])),
++                           (vec4)(sig_i4.y >= pivots[3]));
++        coeffsx.y = coeffs_temp.x;
++        coeffsy.y = coeffs_temp.y;
++        coeffsz.y = coeffs_temp.z;
++        coeffsw.y = coeffs_temp.w;
++
++        coeffs_temp = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(sig_i4.z >= pivots[0])),
++                               mix(coeffs1.lo, coeffs1.hi, (vec4)(sig_i4.z >= pivots[2])),
++                               (vec4)(sig_i4.z >= pivots[1])),
++                           mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(sig_i4.z >= pivots[4])),
++                               mix(coeffs3.lo, coeffs3.hi, (vec4)(sig_i4.z >= pivots[6])),
++                               (vec4)(sig_i4.z >= pivots[5])),
++                           (vec4)(sig_i4.z >= pivots[3]));
++        coeffsx.z = coeffs_temp.x;
++        coeffsy.z = coeffs_temp.y;
++        coeffsz.z = coeffs_temp.z;
++        coeffsw.z = coeffs_temp.w;
++
++        coeffs_temp = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(sig_i4.w >= pivots[0])),
++                               mix(coeffs1.lo, coeffs1.hi, (vec4)(sig_i4.w >= pivots[2])),
++                               (vec4)(sig_i4.w >= pivots[1])),
++                           mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(sig_i4.w >= pivots[4])),
++                               mix(coeffs3.lo, coeffs3.hi, (vec4)(sig_i4.w >= pivots[6])),
++                               (vec4)(sig_i4.w >= pivots[5])),
++                           (vec4)(sig_i4.w >= pivots[3]));
++        coeffsx.w = coeffs_temp.x;
++        coeffsy.w = coeffs_temp.y;
++        coeffsz.w = coeffs_temp.z;
++        coeffsw.w = coeffs_temp.w;
      }
  
 -    sig = TONE_FUNC(sig, peak);
-+    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
-+    t = (has_mmr_poly && coeffs.w == M_ZERO_VEC) || (!has_mmr_poly && dovi_has_poly);
- 
+-
 -    sig = min(sig, 1.0f);
 -    rgb *= (sig/sig_old);
 -    return rgb;
@@ -1007,14 +1085,30 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -    c = lrgb2lrgb(c);
 -    return c;
 -}
-+    s = t ? reshape_poly(s, coeffs)
-+          : reshape_mmr(sig, coeffs, dovi_mmr,
-+                        dovi_mmr_single, dovi_min_order, dovi_max_order);
++    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
++    #ifdef DOVI_PERF_FP16
++      coeffw_is_zero = convert_half4(coeffsw == (vec4)M_ZERO_VEC);
++    #else
++      coeffw_is_zero = coeffsw == (vec4)M_ZERO_VEC;
++    #endif
++    do_poly = has_mmr_poly
++              ? coeffw_is_zero
++              : (vec4)(dovi_has_poly != M_ZERO_VEC);
++
++    sx4 = mix(reshape_mmrx4(sig_i4, sig_p4, sig_t4,
++                            coeffsx, coeffsy, coeffsz, coeffsw, dovi_mmr,
++                            dovi_mmr_single, dovi_min_order, dovi_max_order),
++                 reshape_polyx4(sig_i4, coeffsx, coeffsy, coeffsz),
++                 do_poly);
 +  #ifdef DOVI_PERF_FP16
-+    (*yuv).x = convert_float(clamp(s, dovi_lo, dovi_hi));
++    result = convert_float4(clamp(sx4, dovi_lo, dovi_hi));
 +  #else
-+    (*yuv).x = clamp(s, dovi_lo, dovi_hi);
++    result = clamp(sx4, dovi_lo, dovi_hi);
 +  #endif
++    (*ipt0).x = result.x;
++    (*ipt1).x = result.y;
++    (*ipt2).x = result.z;
++    (*ipt3).x = result.w;
 +
 +    // Reshape P
 +    dovi_params = src_dovi_params + 1*8;
@@ -1030,20 +1124,28 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    dovi_lo = dovi_params[6];
 +    dovi_hi = dovi_params[7];
 +
-+    s = sig.y;
 +    coeffs = dovi_coeffs[0];
++    coeffsx = (vec4)coeffs.x;
++    coeffsy = (vec4)coeffs.y;
++    coeffsz = (vec4)coeffs.z;
++    coeffsw = (vec4)coeffs.w;
 +
 +    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
-+    t = (has_mmr_poly && coeffs.w == M_ZERO_VEC) || (!has_mmr_poly && dovi_has_poly);
++    t = has_mmr_poly ? coeffs.w == M_ZERO_VEC : dovi_has_poly != M_ZERO_VEC;
 +
-+    s = t ? reshape_poly(s, coeffs)
-+          : reshape_mmr(sig, coeffs, dovi_mmr,
-+                        dovi_mmr_single, dovi_min_order, dovi_max_order);
-+  #ifdef DOVI_PERF_FP16
-+    (*yuv).y = convert_float(clamp(s, dovi_lo, dovi_hi));
-+  #else
-+    (*yuv).y = clamp(s, dovi_lo, dovi_hi);
-+  #endif
++    sx4 = t ? reshape_polyx4(sig_p4, coeffsx, coeffsy, coeffsz)
++            : reshape_mmrx4(sig_i4, sig_p4, sig_t4,
++                            coeffsx, coeffsy, coeffsz, coeffsw, dovi_mmr,
++                            dovi_mmr_single, dovi_min_order, dovi_max_order);
++#ifdef DOVI_PERF_FP16
++    result = convert_float4(clamp(sx4, dovi_lo, dovi_hi));
++#else
++    result = clamp(sx4, dovi_lo, dovi_hi);
++#endif
++    (*ipt0).y = result.x;
++    (*ipt1).y = result.y;
++    (*ipt2).y = result.z;
++    (*ipt3).y = result.w;
 +
 +    // Reshape T
 +    dovi_params = src_dovi_params + 2*8;
@@ -1059,20 +1161,28 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    dovi_lo = dovi_params[6];
 +    dovi_hi = dovi_params[7];
 +
-+    s = sig.z;
 +    coeffs = dovi_coeffs[0];
++    coeffsx = (vec4)coeffs.x;
++    coeffsy = (vec4)coeffs.y;
++    coeffsz = (vec4)coeffs.z;
++    coeffsw = (vec4)coeffs.w;
 +
 +    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
-+    t = (has_mmr_poly && coeffs.w == M_ZERO_VEC) || (!has_mmr_poly && dovi_has_poly);
++    t = has_mmr_poly ? coeffs.w == M_ZERO_VEC : dovi_has_poly != M_ZERO_VEC;
 +
-+    s = t ? reshape_poly(s, coeffs)
-+          : reshape_mmr(sig, coeffs, dovi_mmr,
-+                        dovi_mmr_single, dovi_min_order, dovi_max_order);
++    sx4 = t ? reshape_polyx4(sig_t4, coeffsx, coeffsy, coeffsz)
++            : reshape_mmrx4(sig_i4, sig_p4, sig_t4,
++                            coeffsx, coeffsy, coeffsz, coeffsw, dovi_mmr,
++                            dovi_mmr_single, dovi_min_order, dovi_max_order);
 +  #ifdef DOVI_PERF_FP16
-+    (*yuv).z = convert_float(clamp(s, dovi_lo, dovi_hi));
++    result = convert_float4(clamp(sx4, dovi_lo, dovi_hi));
 +  #else
-+    (*yuv).z = clamp(s, dovi_lo, dovi_hi);
++    result = clamp(sx4, dovi_lo, dovi_hi);
 +  #endif
++    (*ipt0).z = result.x;
++    (*ipt1).z = result.y;
++    (*ipt2).z = result.z;
++    (*ipt3).z = result.w;
 +}
 +#endif
 +
@@ -1161,10 +1271,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    __global const vec *dovi_pivots = dovi_buf + 24;
 +    __global const vec4 *dovi_coeffs = (__global const vec4 *)(dovi_buf + 48);
 +    __global const vec4 *dovi_mmr = (__global const vec4 *)(dovi_buf + 144);
-+    reshape_dovi_yuv(&yuv0, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    reshape_dovi_yuv(&yuv1, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    reshape_dovi_yuv(&yuv2, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    reshape_dovi_yuv(&yuv3, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    reshape_dovi_iptx4(&yuv0, &yuv1, &yuv2, &yuv3, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
 +#endif
 +
 +    float3 c0, c1, c2, c3;
@@ -1400,10 +1507,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    __global const vec *dovi_pivots = dovi_buf + 24;
 +    __global const vec4 *dovi_coeffs = (__global const vec4 *)(dovi_buf + 48);
 +    __global const vec4 *dovi_mmr = (__global const vec4 *)(dovi_buf + 144);
-+    reshape_dovi_yuv(&yuv0, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    reshape_dovi_yuv(&yuv1, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    reshape_dovi_yuv(&yuv2, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
-+    reshape_dovi_yuv(&yuv3, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
++    reshape_dovi_iptx4(&yuv0, &yuv1, &yuv2, &yuv3, dovi_params, dovi_pivots, dovi_coeffs, dovi_mmr);
 +#endif
 +
 +    float3 c0, c1, c2, c3;

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -610,7 +610,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      float j = tone_param;
      float a, b;
  
-@@ -71,202 +106,632 @@ float mobius(float s, float peak) {
+@@ -71,202 +106,687 @@ float mobius(float s, float peak) {
          return s;
  
      a = -j * j * (peak - 1.0f) / (j * j - 2.0f * j + peak);
@@ -853,8 +853,10 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    float3 c = yuv2lrgb(yuv);
 +#endif
 +    return c;
-+}
-+
+ }
+ 
+-float3 map_one_pixel_rgb(float3 rgb, float peak, float average) {
+-    float sig = max(max(rgb.x, max(rgb.y, rgb.z)), 1e-6f);
 +// Map from source space YUV to destination space RGB
 +float3 map_to_dst_space_from_yuv(float3 yuv) {
 +#ifdef DOVI_RESHAPE
@@ -867,13 +869,6 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    c = lrgb2lrgb(c);
 +#endif
 +    return c;
- }
- 
--float3 map_one_pixel_rgb(float3 rgb, float peak, float average) {
--    float sig = max(max(rgb.x, max(rgb.y, rgb.z)), 1e-6f);
-+#ifdef DOVI_RESHAPE
-+vec reshape_poly(vec s, vec4 coeffs) {
-+    return (coeffs.z * s + coeffs.y) * s + coeffs.x;
 +}
  
 -    // Rescale the variables in order to bring it into a representation where
@@ -882,6 +877,13 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -    if (target_peak > 1.0f) {
 -        sig *= 1.0f / target_peak;
 -        peak *= 1.0f / target_peak;
+-    }
++#ifdef DOVI_RESHAPE
++vec reshape_poly(vec s, vec4 coeffs) {
++    return (coeffs.z * s + coeffs.y) * s + coeffs.x;
++}
+ 
+-    float sig_old = sig;
 +vec reshape_mmr(vec3 sig,
 +                vec4 coeffs,
 +                __global const vec4 *dovi_mmr,
@@ -911,10 +913,8 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +            s += dot(dovi_mmr[mmr_idx + 4].xyz, sig2 * sig);
 +            s += dot(dovi_mmr[mmr_idx + 5], sigX2 * sigX);
 +        }
-     }
++    }
  
--    float sig_old = sig;
--
 -    // Scale the signal to compensate for differences in the average brightness
 -    float slope = min(1.0f, sdr_avg / average);
 -    sig *= slope;
@@ -929,14 +929,12 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -        coeff = native_powr(coeff, 10.0f / desat_param);
 -        rgb = mix(rgb, (float3)luma, (float3)coeff);
 -        sig = mix(sig, luma * slope, coeff);
--    }
 +void reshape_dovi_yuv(float3 *yuv,
 +                      __global const vec *src_dovi_params,
 +                      __global const vec *src_dovi_pivots,
 +                      __global const vec4 *src_dovi_coeffs,
 +                      __global const vec4 *src_dovi_mmr)
 +{
-+    uchar i;
 +    bool t, has_mmr_poly;
 +  #ifdef DOVI_PERF_FP16
 +    vec3 sig = convert_half3(clamp((*yuv).xyz, 0.0f, 1.0f));
@@ -952,52 +950,51 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    __global const vec *dovi_pivots;
 +    __global const vec4 *dovi_coeffs, *dovi_mmr;
 +
-+  #pragma unroll
-+    for (i = 0; i < 3; i++) {
-+        dovi_params = src_dovi_params + i*8;
-+        dovi_pivots = src_dovi_pivots + i*8;
-+        dovi_coeffs = src_dovi_coeffs + i*8;
-+        dovi_mmr = src_dovi_mmr + i*48;
-+        dovi_num_pivots = dovi_params[0];
-+        dovi_has_mmr = dovi_params[1];
-+        dovi_has_poly = dovi_params[2];
-+        dovi_mmr_single = dovi_params[3];
-+        dovi_min_order = dovi_params[4];
-+        dovi_max_order = dovi_params[5];
-+        dovi_lo = dovi_params[6];
-+        dovi_hi = dovi_params[7];
++    // Reshape I
++    dovi_params = src_dovi_params;
++    dovi_pivots = src_dovi_pivots;
++    dovi_coeffs = src_dovi_coeffs;
++    dovi_mmr = src_dovi_mmr;
++    dovi_num_pivots = dovi_params[0];
++    dovi_has_mmr = dovi_params[1];
++    dovi_has_poly = dovi_params[2];
++    dovi_mmr_single = dovi_params[3];
++    dovi_min_order = dovi_params[4];
++    dovi_max_order = dovi_params[5];
++    dovi_lo = dovi_params[6];
++    dovi_hi = dovi_params[7];
 +
-+        s = ((vec *)(&sig))[i];
-+        coeffs = dovi_coeffs[0];
++    s = sig.x;
++    coeffs = dovi_coeffs[0];
 +
-+        if (i == 0 && dovi_num_pivots > 2) {
++    if (dovi_num_pivots > 2) {
 +  #ifdef DOVI_PERF_FP16
-+            const vec8 pivots0 = vload8(0, (__global const vec *)dovi_pivots);
-+            const vec8 coeffs0 = vload8(0, (__global const vec *)dovi_coeffs);
-+            const vec8 coeffs1 = vload8(1, (__global const vec *)dovi_coeffs);
-+            const vec8 coeffs2 = vload8(2, (__global const vec *)dovi_coeffs);
-+            const vec8 coeffs3 = vload8(3, (__global const vec *)dovi_coeffs);
++        const vec8 pivots0 = vload8(0, (__global const vec *)dovi_pivots);
++        const vec8 coeffs0 = vload8(0, (__global const vec *)dovi_coeffs);
++        const vec8 coeffs1 = vload8(1, (__global const vec *)dovi_coeffs);
++        const vec8 coeffs2 = vload8(2, (__global const vec *)dovi_coeffs);
++        const vec8 coeffs3 = vload8(3, (__global const vec *)dovi_coeffs);
 +
-+            const vec *pivots = (const vec *)&pivots0;
++        const vec *pivots = (const vec *)&pivots0;
 +  #else
-+            __global const vec *pivots = dovi_pivots;
-+            const vec8 coeffs0 = (vec8)(dovi_coeffs[0], dovi_coeffs[1]);
-+            const vec8 coeffs1 = (vec8)(dovi_coeffs[2], dovi_coeffs[3]);
-+            const vec8 coeffs2 = (vec8)(dovi_coeffs[4], dovi_coeffs[5]);
-+            const vec8 coeffs3 = (vec8)(dovi_coeffs[6], dovi_coeffs[7]);
++        __global const vec *pivots = dovi_pivots;
++        const vec8 coeffs0 = (vec8)(dovi_coeffs[0], dovi_coeffs[1]);
++        const vec8 coeffs1 = (vec8)(dovi_coeffs[2], dovi_coeffs[3]);
++        const vec8 coeffs2 = (vec8)(dovi_coeffs[4], dovi_coeffs[5]);
++        const vec8 coeffs3 = (vec8)(dovi_coeffs[6], dovi_coeffs[7]);
 +  #endif
-+            coeffs = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(s >= pivots[0])),
-+                             mix(coeffs1.lo, coeffs1.hi, (vec4)(s >= pivots[2])),
-+                             (vec4)(s >= pivots[1])),
-+                         mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(s >= pivots[4])),
-+                             mix(coeffs3.lo, coeffs3.hi, (vec4)(s >= pivots[6])),
-+                             (vec4)(s >= pivots[5])),
-+                         (vec4)(s >= pivots[3]));
-+        }
++        coeffs = mix(mix(mix(coeffs0.lo, coeffs0.hi, (vec4)(s >= pivots[0])),
++                         mix(coeffs1.lo, coeffs1.hi, (vec4)(s >= pivots[2])),
++                         (vec4)(s >= pivots[1])),
++                     mix(mix(coeffs2.lo, coeffs2.hi, (vec4)(s >= pivots[4])),
++                         mix(coeffs3.lo, coeffs3.hi, (vec4)(s >= pivots[6])),
++                         (vec4)(s >= pivots[5])),
++                     (vec4)(s >= pivots[3]));
+     }
  
 -    sig = TONE_FUNC(sig, peak);
-+        has_mmr_poly = dovi_has_mmr && dovi_has_poly;
-+        t = (has_mmr_poly && coeffs.w == M_ZERO_VEC) || (!has_mmr_poly && dovi_has_poly);
++    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
++    t = (has_mmr_poly && coeffs.w == M_ZERO_VEC) || (!has_mmr_poly && dovi_has_poly);
  
 -    sig = min(sig, 1.0f);
 -    rgb *= (sig/sig_old);
@@ -1009,16 +1006,74 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -    c = ootf(c, peak);
 -    c = lrgb2lrgb(c);
 -    return c;
-+        s = t ? reshape_poly(s, coeffs)
-+              : reshape_mmr(sig, coeffs, dovi_mmr,
-+                            dovi_mmr_single, dovi_min_order, dovi_max_order);
+-}
++    s = t ? reshape_poly(s, coeffs)
++          : reshape_mmr(sig, coeffs, dovi_mmr,
++                        dovi_mmr_single, dovi_min_order, dovi_max_order);
 +  #ifdef DOVI_PERF_FP16
-+        ((float *)yuv)[i] = convert_float(clamp(s, dovi_lo, dovi_hi));
++    (*yuv).x = convert_float(clamp(s, dovi_lo, dovi_hi));
 +  #else
-+        ((float *)yuv)[i] = clamp(s, dovi_lo, dovi_hi);
++    (*yuv).x = clamp(s, dovi_lo, dovi_hi);
 +  #endif
-+    }
- }
++
++    // Reshape P
++    dovi_params = src_dovi_params + 1*8;
++    dovi_pivots = src_dovi_pivots + 1*8;
++    dovi_coeffs = src_dovi_coeffs + 1*8;
++    dovi_mmr = src_dovi_mmr + 1*48;
++    dovi_num_pivots = dovi_params[0];
++    dovi_has_mmr = dovi_params[1];
++    dovi_has_poly = dovi_params[2];
++    dovi_mmr_single = dovi_params[3];
++    dovi_min_order = dovi_params[4];
++    dovi_max_order = dovi_params[5];
++    dovi_lo = dovi_params[6];
++    dovi_hi = dovi_params[7];
++
++    s = sig.y;
++    coeffs = dovi_coeffs[0];
++
++    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
++    t = (has_mmr_poly && coeffs.w == M_ZERO_VEC) || (!has_mmr_poly && dovi_has_poly);
++
++    s = t ? reshape_poly(s, coeffs)
++          : reshape_mmr(sig, coeffs, dovi_mmr,
++                        dovi_mmr_single, dovi_min_order, dovi_max_order);
++  #ifdef DOVI_PERF_FP16
++    (*yuv).y = convert_float(clamp(s, dovi_lo, dovi_hi));
++  #else
++    (*yuv).y = clamp(s, dovi_lo, dovi_hi);
++  #endif
++
++    // Reshape T
++    dovi_params = src_dovi_params + 2*8;
++    dovi_pivots = src_dovi_pivots + 2*8;
++    dovi_coeffs = src_dovi_coeffs + 2*8;
++    dovi_mmr = src_dovi_mmr + 2*48;
++    dovi_num_pivots = dovi_params[0];
++    dovi_has_mmr = dovi_params[1];
++    dovi_has_poly = dovi_params[2];
++    dovi_mmr_single = dovi_params[3];
++    dovi_min_order = dovi_params[4];
++    dovi_max_order = dovi_params[5];
++    dovi_lo = dovi_params[6];
++    dovi_hi = dovi_params[7];
++
++    s = sig.z;
++    coeffs = dovi_coeffs[0];
++
++    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
++    t = (has_mmr_poly && coeffs.w == M_ZERO_VEC) || (!has_mmr_poly && dovi_has_poly);
++
++    s = t ? reshape_poly(s, coeffs)
++          : reshape_mmr(sig, coeffs, dovi_mmr,
++                        dovi_mmr_single, dovi_min_order, dovi_max_order);
++  #ifdef DOVI_PERF_FP16
++    (*yuv).z = convert_float(clamp(s, dovi_lo, dovi_hi));
++  #else
++    (*yuv).z = clamp(s, dovi_lo, dovi_hi);
++  #endif
++}
 +#endif
 +
 +__constant sampler_t sampler = (CLK_NORMALIZED_COORDS_FALSE |

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -610,7 +610,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      float j = tone_param;
      float a, b;
  
-@@ -71,202 +106,755 @@ float mobius(float s, float peak) {
+@@ -71,202 +106,822 @@ float mobius(float s, float peak) {
          return s;
  
      a = -j * j * (peak - 1.0f) / (j * j - 2.0f * j + peak);
@@ -667,7 +667,6 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -        uint avg_wg = *sum_wg / (lsizex * lsizey);
 -        atomic_max(&peak_buf[frame_idx], avg_wg);
 -        atomic_add(&avg_buf[frame_idx], avg_wg);
--    }
 +float bt2390(float s, float peak_inv_pq, float target_peak_inv_pq) {
 +    float peak_pq = peak_inv_pq;
 +    float scale = peak_pq > 0.0f ? (1.0f / peak_pq) : 1.0f;
@@ -709,12 +708,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +  #endif
 +    float4 sig_o = sig;
 +#endif
- 
--    if (scene_frame_num > 0) {
--        float peak = (float)*max_total_p / (REFERENCE_WHITE * scene_frame_num);
--        float avg = (float)*avg_total_p / (REFERENCE_WHITE * scene_frame_num);
--        r.peak = max(1.0f, peak);
--        r.average = max(0.25f, avg);
++
 +    // Desaturate the color using a coefficient dependent on the signal level
 +    if (desat_param > 0.0f) {
 +#ifdef TONE_MODE_RGB
@@ -732,35 +726,11 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +        *b4 = mix(*b4, luma, coeff);
      }
  
--    if (lidx == 0 && lidy == 0 && atomic_add(counter_wg_p, 1) == num_wg - 1) {
--        *counter_wg_p = 0;
--        avg_buf[frame_idx] /= num_wg;
--
--        if (scene_threshold > 0.0f) {
--            uint cur_max = peak_buf[frame_idx];
--            uint cur_avg = avg_buf[frame_idx];
--            int diff = (int)(scene_frame_num * cur_avg) - (int)*avg_total_p;
--
--            if (abs(diff) > scene_frame_num * scene_threshold * REFERENCE_WHITE) {
--                for (uint i = 0; i < DETECTION_FRAMES + 1; i++)
--                  avg_buf[i] = 0;
--                for (uint i = 0; i < DETECTION_FRAMES + 1; i++)
--                  peak_buf[i] = 0;
--                *avg_total_p = *max_total_p = 0;
--                *scene_frame_num_p = 0;
--                avg_buf[frame_idx] = cur_avg;
--                peak_buf[frame_idx] = cur_max;
--            }
--        }
--        uint next = (frame_idx + 1) % (DETECTION_FRAMES + 1);
--        // add current frame, subtract next frame
--        *max_total_p += peak_buf[frame_idx] - peak_buf[next];
--        *avg_total_p += avg_buf[frame_idx] - avg_buf[next];
--        // reset next frame
--        peak_buf[next] = avg_buf[next] = 0;
--        *frame_idx_p = next;
--        *scene_frame_num_p = min(*scene_frame_num_p + 1,
--                                 (uint)DETECTION_FRAMES);
+-    if (scene_frame_num > 0) {
+-        float peak = (float)*max_total_p / (REFERENCE_WHITE * scene_frame_num);
+-        float avg = (float)*avg_total_p / (REFERENCE_WHITE * scene_frame_num);
+-        r.peak = max(1.0f, peak);
+-        r.average = max(0.25f, avg);
 +#ifdef TONE_FUNC_BT2390
 +    float src_peak_delin_pq = inverse_eotf_st2084(peak);
 +    float dst_peak_delin_pq = inverse_eotf_st2084(1.0f);
@@ -825,7 +795,6 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +        ct4 *= coeff;
 +        cp4 *= coeff;
      }
--    return r;
 +#ifdef TONE_FUNC_BT2390
 +    float src_peak_delin_pq = inverse_eotf_st2084(peak);
 +    float dst_peak_delin_pq = inverse_eotf_st2084(1.0f);
@@ -867,21 +836,32 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    c = lrgb2lrgb(c);
 +#endif
 +    return c;
- }
- 
--float3 map_one_pixel_rgb(float3 rgb, float peak, float average) {
--    float sig = max(max(rgb.x, max(rgb.y, rgb.z)), 1e-6f);
++}
++
 +#ifdef DOVI_RESHAPE
 +vec4 reshape_polyx4(vec4 s, vec4 coeffsx, vec4 coeffsy, vec4 coeffsz) {
-+    return (coeffsz * s + coeffsy) * s + coeffsx;
++    return mad(mad(coeffsz, s, coeffsy), s, coeffsx);
 +}
  
--    // Rescale the variables in order to bring it into a representation where
--    // 1.0 represents the dst_peak. This is because all of the tone mapping
--    // algorithms are defined in such a way that they map to the range [0.0, 1.0].
--    if (target_peak > 1.0f) {
--        sig *= 1.0f / target_peak;
--        peak *= 1.0f / target_peak;
+-    if (lidx == 0 && lidy == 0 && atomic_add(counter_wg_p, 1) == num_wg - 1) {
+-        *counter_wg_p = 0;
+-        avg_buf[frame_idx] /= num_wg;
+-
+-        if (scene_threshold > 0.0f) {
+-            uint cur_max = peak_buf[frame_idx];
+-            uint cur_avg = avg_buf[frame_idx];
+-            int diff = (int)(scene_frame_num * cur_avg) - (int)*avg_total_p;
+-
+-            if (abs(diff) > scene_frame_num * scene_threshold * REFERENCE_WHITE) {
+-                for (uint i = 0; i < DETECTION_FRAMES + 1; i++)
+-                  avg_buf[i] = 0;
+-                for (uint i = 0; i < DETECTION_FRAMES + 1; i++)
+-                  peak_buf[i] = 0;
+-                *avg_total_p = *max_total_p = 0;
+-                *scene_frame_num_p = 0;
+-                avg_buf[frame_idx] = cur_avg;
+-                peak_buf[frame_idx] = cur_max;
+-            }
 +vec reshape_mmr(vec3 sig,
 +                vec4 coeffs,
 +                __global const vec4 *dovi_mmr,
@@ -900,6 +880,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    s += dot(dovi_mmr[mmr_idx + 0].xyz, sig);
 +    s += dot(dovi_mmr[mmr_idx + 1], sigX);
 +
++    // Branching here is faster from testing, divergence rate for I channel seems to be low
 +    t = dovi_max_order >= 2 && (dovi_min_order >= 2 || order >= 2);
 +    if (t) {
 +        vec3 sig2 = sig * sig;
@@ -910,17 +891,31 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +        if (t) {
 +            s += dot(dovi_mmr[mmr_idx + 4].xyz, sig2 * sig);
 +            s += dot(dovi_mmr[mmr_idx + 5], sigX2 * sigX);
-+        }
+         }
+-        uint next = (frame_idx + 1) % (DETECTION_FRAMES + 1);
+-        // add current frame, subtract next frame
+-        *max_total_p += peak_buf[frame_idx] - peak_buf[next];
+-        *avg_total_p += avg_buf[frame_idx] - avg_buf[next];
+-        // reset next frame
+-        peak_buf[next] = avg_buf[next] = 0;
+-        *frame_idx_p = next;
+-        *scene_frame_num_p = min(*scene_frame_num_p + 1,
+-                                 (uint)DETECTION_FRAMES);
      }
+-    return r;
+-}
  
--    float sig_old = sig;
+-float3 map_one_pixel_rgb(float3 rgb, float peak, float average) {
+-    float sig = max(max(rgb.x, max(rgb.y, rgb.z)), 1e-6f);
 +    return s;
 +}
  
--    // Scale the signal to compensate for differences in the average brightness
--    float slope = min(1.0f, sdr_avg / average);
--    sig *= slope;
--    peak *= slope;
+-    // Rescale the variables in order to bring it into a representation where
+-    // 1.0 represents the dst_peak. This is because all of the tone mapping
+-    // algorithms are defined in such a way that they map to the range [0.0, 1.0].
+-    if (target_peak > 1.0f) {
+-        sig *= 1.0f / target_peak;
+-        peak *= 1.0f / target_peak;
 +vec4 reshape_mmrx4(vec4 sig_i4,
 +                   vec4 sig_p4,
 +                   vec4 sig_t4,
@@ -949,6 +944,81 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    return result;
 +}
 +
++vec4 reshape_mmr_ptx4(vec4 sig_i4,
++                      vec4 sig_p4,
++                      vec4 sig_t4,
++                      vec4 coeffs,
++                      __global const vec4 *dovi_mmr,
++                      uchar dovi_mmr_single,
++                      uchar dovi_min_order,
++                      uchar dovi_max_order)
++{
++    uint mmr_idx = dovi_mmr_single ? 0 : (uint)coeffs.y;
++  #ifdef DOVI_PERF_FP16
++    const vec8 mmr_order1 = vload8(0, (__global const vec *)&dovi_mmr[mmr_idx]);
++  #else
++    const vec8 mmr_order1 = (vec8)(dovi_mmr[mmr_idx + 0], dovi_mmr[mmr_idx + 1]);
++  #endif
++    uchar order = (uchar)coeffs.w;
++    bool t;
++    vec4 sigXx, sigXy, sigXz, sigXw;
++    vec4 sx4 = (vec4)coeffs.x;
++    sigXx = sig_i4 * sig_p4;
++    sigXy = sig_i4 * sig_t4;
++    sigXz = sig_p4 * sig_t4;
++    sigXw = sigXx * sig_t4;
++
++  #define DOT_MMR(A, B, C, D, E, F, G, ORD)  \
++    sx4 = mad((A), (vec4)(ORD.lo.x), sx4);   \
++    sx4 = mad((B), (vec4)(ORD.lo.y), sx4);   \
++    sx4 = mad((C), (vec4)(ORD.lo.z), sx4);   \
++    sx4 = mad((D), (vec4)(ORD.hi.x), sx4);   \
++    sx4 = mad((E), (vec4)(ORD.hi.y), sx4);   \
++    sx4 = mad((F), (vec4)(ORD.hi.z), sx4);   \
++    sx4 = mad((G), (vec4)(ORD.hi.w), sx4);   \
++
++    DOT_MMR(sig_i4, sig_p4, sig_t4, sigXx, sigXy, sigXz, sigXw, mmr_order1)
++
++    // Branching is free for PT channels as the condition t is same for all threads.
++    t = dovi_max_order >= 2 && (dovi_min_order >= 2 || order >= 2);
++    if (t) {
++      #ifdef DOVI_PERF_FP16
++        const vec8 mmr_order2 = vload8(1, (__global const vec *)&dovi_mmr[mmr_idx]);
++      #else
++        const vec8 mmr_order2 = (vec8)(dovi_mmr[mmr_idx + 2], dovi_mmr[mmr_idx + 3]);
++      #endif
++        vec4 sig2_i4 = sig_i4 * sig_i4;
++        vec4 sig2_p4 = sig_p4 * sig_p4;
++        vec4 sig2_t4 = sig_t4 * sig_t4;
++        vec4 sigX2x = sigXx * sigXx;
++        vec4 sigX2y = sigXy * sigXy;
++        vec4 sigX2z = sigXz * sigXz;
++        vec4 sigX2w = sigXw * sigXw;
++
++        DOT_MMR(sig2_i4, sig2_p4, sig2_t4, sigX2x, sigX2y, sigX2z, sigX2w, mmr_order2);
++
++        t = dovi_max_order == 3 && (dovi_min_order == 3 || order >= 3);
++        if (t) {
++          #ifdef DOVI_PERF_FP16
++            const vec8 mmr_order3 = vload8(2, (__global const vec *)&dovi_mmr[mmr_idx]);
++          #else
++            const vec8 mmr_order3 = (vec8)(dovi_mmr[mmr_idx + 4], dovi_mmr[mmr_idx + 5]);
++          #endif
++            DOT_MMR(sig2_i4 * sig_i4, sig2_p4 * sig_p4, sig2_t4 * sig_t4,
++                    sigX2x * sigXx, sigX2y * sigXy, sigX2z * sigXz, sigX2w * sigXw,
++                    mmr_order3);
++        }
+     }
+ 
+-    float sig_old = sig;
++    return sx4;
++  #undef DOT_MMR
++}
+ 
+-    // Scale the signal to compensate for differences in the average brightness
+-    float slope = min(1.0f, sdr_avg / average);
+-    sig *= slope;
+-    peak *= slope;
 +void reshape_dovi_iptx4(float3 *ipt0,
 +                        float3 *ipt1,
 +                        float3 *ipt2,
@@ -983,18 +1053,18 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    dovi_params = src_dovi_params + (channel_offset)*8; \
 +    dovi_pivots = src_dovi_pivots + (channel_offset)*8; \
 +    dovi_coeffs = src_dovi_coeffs + (channel_offset)*8; \
-+    dovi_mmr = src_dovi_mmr + (channel_offset)*48; \
-+    dovi_num_pivots = dovi_params[0]; \
-+    dovi_has_mmr = dovi_params[1]; \
-+    dovi_has_poly = dovi_params[2]; \
-+    dovi_mmr_single = dovi_params[3]; \
-+    dovi_min_order = dovi_params[4]; \
-+    dovi_max_order = dovi_params[5]; \
-+    dovi_lo = dovi_params[6]; \
++    dovi_mmr = src_dovi_mmr + (channel_offset)*48;      \
++    dovi_num_pivots = dovi_params[0];                   \
++    dovi_has_mmr = dovi_params[1];                      \
++    dovi_has_poly = dovi_params[2];                     \
++    dovi_mmr_single = dovi_params[3];                   \
++    dovi_min_order = dovi_params[4];                    \
++    dovi_max_order = dovi_params[5];                    \
++    dovi_lo = dovi_params[6];                           \
 +    dovi_hi = dovi_params[7];
 +
 +  #define EXTRACT_COEFFS() \
-+    coeffs = dovi_coeffs[0]; \
++    coeffs = dovi_coeffs[0];  \
 +    coeffsx = (vec4)coeffs.x; \
 +    coeffsy = (vec4)coeffs.y; \
 +    coeffsz = (vec4)coeffs.z; \
@@ -1005,7 +1075,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    EXTRACT_COEFFS()
 +
 +    if (dovi_num_pivots > 2) {
-+      #ifdef DOVI_PERF_FP16
++  #ifdef DOVI_PERF_FP16
 +        const vec8 pivots0 = vload8(0, (__global const vec *)dovi_pivots);
 +        const vec8 coeffs0 = vload8(0, (__global const vec *)dovi_coeffs);
 +        const vec8 coeffs1 = vload8(1, (__global const vec *)dovi_coeffs);
@@ -1013,39 +1083,39 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +        const vec8 coeffs3 = vload8(3, (__global const vec *)dovi_coeffs);
 +
 +        const vec *pivots = (const vec *)&pivots0;
-+      #else
++  #else
 +        __global const vec *pivots = dovi_pivots;
 +        const vec8 coeffs0 = (vec8)(dovi_coeffs[0], dovi_coeffs[1]);
 +        const vec8 coeffs1 = (vec8)(dovi_coeffs[2], dovi_coeffs[3]);
 +        const vec8 coeffs2 = (vec8)(dovi_coeffs[4], dovi_coeffs[5]);
 +        const vec8 coeffs3 = (vec8)(dovi_coeffs[6], dovi_coeffs[7]);
-+      #endif
++  #endif
 +
-+      #define PICK_COEFF_FOR(LANE)                                                           \
-+         mix(                                                                                \
-+           mix(                                                                              \
-+             mix(coeffs0.lo, coeffs0.hi, (vec4)((LANE) >= pivots[0])),                       \
-+             mix(coeffs1.lo, coeffs1.hi, (vec4)((LANE) >= pivots[2])),                       \
-+             (vec4)((LANE) >= pivots[1])                                                     \
-+           ),                                                                                \
-+           mix(                                                                              \
-+             mix(coeffs2.lo, coeffs2.hi, (vec4)((LANE) >= pivots[4])),                       \
-+             mix(coeffs3.lo, coeffs3.hi, (vec4)((LANE) >= pivots[6])),                       \
-+             (vec4)((LANE) >= pivots[5])                                                     \
-+           ),                                                                                \
-+           (vec4)((LANE) >= pivots[3])                                                       \
-+         )
++  #define PICK_COEFF_FOR(LANE) \
++        mix(                                                          \
++          mix(                                                        \
++            mix(coeffs0.lo, coeffs0.hi, (vec4)((LANE) >= pivots[0])), \
++            mix(coeffs1.lo, coeffs1.hi, (vec4)((LANE) >= pivots[2])), \
++            (vec4)((LANE) >= pivots[1])                               \
++          ),                                                          \
++          mix(                                                        \
++            mix(coeffs2.lo, coeffs2.hi, (vec4)((LANE) >= pivots[4])), \
++            mix(coeffs3.lo, coeffs3.hi, (vec4)((LANE) >= pivots[6])), \
++            (vec4)((LANE) >= pivots[5])                               \
++          ),                                                          \
++          (vec4)((LANE) >= pivots[3])                                 \
++        )
 +
-+      #define PACK_COEFFS(LANE)         \
-+        coeffsx.LANE = coeffs_temp.x;   \
-+        coeffsy.LANE = coeffs_temp.y;   \
-+        coeffsz.LANE = coeffs_temp.z;   \
++  #define PACK_COEFFS(LANE) \
++        coeffsx.LANE = coeffs_temp.x; \
++        coeffsy.LANE = coeffs_temp.y; \
++        coeffsz.LANE = coeffs_temp.z; \
 +        coeffsw.LANE = coeffs_temp.w;
 +
 +        vec4 coeffs_temp = PICK_COEFF_FOR(sig_i4.x);
 +        PACK_COEFFS(x)
 +
-+        coeffs_temp = PICK_COEFF_FOR(sig_i4.y);;
++        coeffs_temp = PICK_COEFF_FOR(sig_i4.y);
 +        PACK_COEFFS(y)
  
 -    // Desaturate the color using a coefficient dependent on the signal level
@@ -1056,11 +1126,11 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -        rgb = mix(rgb, (float3)luma, (float3)coeff);
 -        sig = mix(sig, luma * slope, coeff);
 -    }
-+        coeffs_temp = PICK_COEFF_FOR(sig_i4.z);;
++        coeffs_temp = PICK_COEFF_FOR(sig_i4.z);
 +        PACK_COEFFS(z)
  
 -    sig = TONE_FUNC(sig, peak);
-+        coeffs_temp = PICK_COEFF_FOR(sig_i4.w);;
++        coeffs_temp = PICK_COEFF_FOR(sig_i4.w);
 +        PACK_COEFFS(w)
  
 -    sig = min(sig, 1.0f);
@@ -1074,16 +1144,16 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -    c = lrgb2lrgb(c);
 -    return c;
 -}
-+      #undef PICK_COEFF_FOR
-+      #undef PACK_COEFFS
++  #undef PICK_COEFF_FOR
++  #undef PACK_COEFFS
 +    }
 +
 +    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
-+    #ifdef DOVI_PERF_FP16
-+      coeffw_is_zero = convert_half4(coeffsw == (vec4)M_ZERO_VEC);
-+    #else
-+      coeffw_is_zero = coeffsw == (vec4)M_ZERO_VEC;
-+    #endif
++  #ifdef DOVI_PERF_FP16
++    coeffw_is_zero = convert_half4(coeffsw == (vec4)M_ZERO_VEC);
++  #else
++    coeffw_is_zero = coeffsw == (vec4)M_ZERO_VEC;
++  #endif
 +    do_poly = has_mmr_poly
 +              ? coeffw_is_zero
 +              : (vec4)(dovi_has_poly != M_ZERO_VEC);
@@ -1091,60 +1161,56 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    sx4 = mix(reshape_mmrx4(sig_i4, sig_p4, sig_t4,
 +                            coeffsx, coeffsy, coeffsz, coeffsw, dovi_mmr,
 +                            dovi_mmr_single, dovi_min_order, dovi_max_order),
-+                 reshape_polyx4(sig_i4, coeffsx, coeffsy, coeffsz),
-+                 do_poly);
++              reshape_polyx4(sig_i4, coeffsx, coeffsy, coeffsz),
++              do_poly);
 +  #ifdef DOVI_PERF_FP16
 +    result = convert_float4(clamp(sx4, dovi_lo, dovi_hi));
 +  #else
 +    result = clamp(sx4, dovi_lo, dovi_hi);
 +  #endif
-+    (*ipt0).x = result.x;
-+    (*ipt1).x = result.y;
-+    (*ipt2).x = result.z;
-+    (*ipt3).x = result.w;
++
++  #define STORE_RESULTS(LANE) \
++    (*ipt0).LANE = result.x; \
++    (*ipt1).LANE = result.y; \
++    (*ipt2).LANE = result.z; \
++    (*ipt3).LANE = result.w;
++
++    STORE_RESULTS(x)
 +
 +    // Reshape P
 +    SETUP_DOVI_PARAMS(1)
 +    EXTRACT_COEFFS()
 +
-+    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
-+    t = has_mmr_poly ? coeffs.w == M_ZERO_VEC : dovi_has_poly != M_ZERO_VEC;
++  #define RESHAPE_P_T(sig_x4) \
++    has_mmr_poly = dovi_has_mmr && dovi_has_poly;                            \
++    t = has_mmr_poly ? coeffs.w == M_ZERO_VEC : dovi_has_poly != M_ZERO_VEC; \
++    sx4 = t ? reshape_polyx4(sig_x4, coeffsx, coeffsy, coeffsz)              \
++            : reshape_mmr_ptx4(sig_i4, sig_p4, sig_t4,                       \
++                               coeffs, dovi_mmr,                             \
++                               dovi_mmr_single, dovi_min_order, dovi_max_order);
 +
-+    sx4 = t ? reshape_polyx4(sig_p4, coeffsx, coeffsy, coeffsz)
-+            : reshape_mmrx4(sig_i4, sig_p4, sig_t4,
-+                            coeffsx, coeffsy, coeffsz, coeffsw, dovi_mmr,
-+                            dovi_mmr_single, dovi_min_order, dovi_max_order);
++    RESHAPE_P_T(sig_p4)
 +  #ifdef DOVI_PERF_FP16
 +    result = convert_float4(clamp(sx4, dovi_lo, dovi_hi));
 +  #else
 +    result = clamp(sx4, dovi_lo, dovi_hi);
 +  #endif
-+    (*ipt0).y = result.x;
-+    (*ipt1).y = result.y;
-+    (*ipt2).y = result.z;
-+    (*ipt3).y = result.w;
++    STORE_RESULTS(y)
 +
 +    // Reshape T
 +    SETUP_DOVI_PARAMS(2)
 +    EXTRACT_COEFFS()
 +
-+    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
-+    t = has_mmr_poly ? coeffs.w == M_ZERO_VEC : dovi_has_poly != M_ZERO_VEC;
-+
-+    sx4 = t ? reshape_polyx4(sig_t4, coeffsx, coeffsy, coeffsz)
-+            : reshape_mmrx4(sig_i4, sig_p4, sig_t4,
-+                            coeffsx, coeffsy, coeffsz, coeffsw, dovi_mmr,
-+                            dovi_mmr_single, dovi_min_order, dovi_max_order);
++    RESHAPE_P_T(sig_t4)
 +  #ifdef DOVI_PERF_FP16
 +    result = convert_float4(clamp(sx4, dovi_lo, dovi_hi));
 +  #else
 +    result = clamp(sx4, dovi_lo, dovi_hi);
 +  #endif
-+    (*ipt0).z = result.x;
-+    (*ipt1).z = result.y;
-+    (*ipt2).z = result.z;
-+    (*ipt3).z = result.w;
++    STORE_RESULTS(z)
 +
++  #undef RESHAPE_P_T
++  #undef STORE_RESULTS
 +  #undef SETUP_DOVI_PARAMS
 +  #undef EXTRACT_COEFFS
 +}
@@ -1354,7 +1420,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +#endif
 +}
 +
-+float3 apply_lut3d(__global float3 *lut, float3 color)
++float3 apply_lut3d(__global const float3 *restrict lut, float3 color)
 +{
 +    color = clamp(color, 0.0f, 1.0f);
 +


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Vectorize the Dolby Vision reshaping process to handle 4 pixels at a time, similar to what is used in the tone mapping stage. This change allows us to read the dovi buffer once and reuse parameters for 4 pixels which reduces memory load.
Most of the pipeline, including the common polynomial reshaping, benefits from vectorization. The only exceptions are the coefficients lookup for intensity channel and MMR reshaping: intensity lookup remains scalar because it processes 4 vec4
values that must be handled sequentially, and MMR reshaping cannot be vectorized due to its inter-channel dot products.
With this optimization, 4K60 Dolby Vision tone mapping is now reliably achievable on the RK3588.

~~This currently still needs some cleanups to reduce code duplications.~~ Done

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->