### PR TITLE
Sync fixes from ffmpeg-rockchip

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["focal", "jammy", "noble"]'
+      codenames: '["jammy", "noble"]'
       architectures: '["amd64", "arm64"]'
       release: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["focal", "jammy", "noble"]'
+      codenames: '["jammy", "noble"]'
       architectures: '["amd64", "arm64"]'
       release: true
     secrets:
@@ -83,7 +83,6 @@ jobs:
         arrays: [
           {distro: 'debian', codename: 'bullseye'},
           {distro: 'debian', codename: 'bookworm'},
-          {distro: 'ubuntu', codename: 'focal'},
           {distro: 'ubuntu', codename: 'jammy'},
           {distro: 'ubuntu', codename: 'noble'}
         ]

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -24,6 +24,14 @@ ENV CPPFLAGS="-I${TARGET_DIR}/include $CPPFLAGS"
 ENV CFLAGS="-I${TARGET_DIR}/include $CFLAGS"
 ENV CMAKE_POLICY_VERSION_MINIMUM="3.5"
 
+# Use more reliable mirrors for Ubuntu packages
+RUN mkdir -p /etc/apt/sources.list.d/ \
+ && touch /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
+ && sed -i 's|archive.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
+    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
+ && sed -i 's|security.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
+    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources
+
 # Prepare Debian build environment
 RUN apt-get update \
  && apt-get dist-upgrade -y \

--- a/Dockerfile.win64.in
+++ b/Dockerfile.win64.in
@@ -23,6 +23,14 @@ ENV DEBIAN_FRONTEND=noninteractive \
     DLLTOOL="x86_64-w64-mingw32-dlltool" \
     CMAKE_POLICY_VERSION_MINIMUM="3.5"
 
+# Use more reliable mirrors for Ubuntu packages
+RUN mkdir -p /etc/apt/sources.list.d/ \
+ && touch /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
+ && sed -i 's|archive.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
+    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
+ && sed -i 's|security.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
+    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources
+
 # Prepare Debian and mingw-w64 build environment
 RUN apt-get update \
  && apt-get dist-upgrade -y \

--- a/build
+++ b/build
@@ -6,7 +6,6 @@ usage() {
     echo -e "Releases:          Arches:"
     echo -e " * bullseye         * amd64"
     echo -e " * bookworm         * arm64"
-    echo -e " * focal"
     echo -e " * jammy"
     echo -e " * noble"
 }
@@ -29,12 +28,6 @@ case ${cli_release} in
         gcc_ver="12"
         llvm_ver="19"
         llvmspirvlib_ver="15"
-    ;;
-    'focal')
-        release="ubuntu:focal"
-        gcc_ver="9"
-        llvm_ver="18"
-        llvmspirvlib_ver="10"
     ;;
     'jammy')
         release="ubuntu:jammy"

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.1.1-4"
+version: "7.1.1-5"
 packages:
   - bullseye-amd64
   - bullseye-arm64

--- a/build.yaml
+++ b/build.yaml
@@ -7,8 +7,6 @@ packages:
   - bullseye-arm64
   - bookworm-amd64
   - bookworm-arm64
-  - focal-amd64
-  - focal-arm64
   - jammy-amd64
   - jammy-arm64
   - noble-amd64

--- a/builder/images/base/Dockerfile
+++ b/builder/images/base/Dockerfile
@@ -1,6 +1,15 @@
 FROM ubuntu:noble
 
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Use more reliable mirrors for Ubuntu packages
+RUN mkdir -p /etc/apt/sources.list.d/ \
+ && touch /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
+ && sed -i 's|archive.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
+    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
+ && sed -i 's|security.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
+    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources
+
 RUN \
     apt-get -y update && \
     apt-get -y dist-upgrade && \

--- a/builder/scripts.d/50-rkrga.sh
+++ b/builder/scripts.d/50-rkrga.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/nyanmisaka/rk-mirrors.git"
-SCRIPT_COMMIT="dce1e7cc787f8fc13a6e39600caac94369c5c229"
+SCRIPT_COMMIT="571a880951583a3b2a04e7e1fa900861653befde"
 SCRIPT_BRANCH="jellyfin-rga-next"
 
 ffbuild_enabled() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+jellyfin-ffmpeg (7.1.1-5) unstable; urgency=medium
+
+  * rkmppdec: add RKMPP MJPEG decoder
+  * rkmppenc: add chroma_fmt option for MJPEG encoder
+  * rkrga: refine colorspace conversion handling
+  * rkmppenc: fix rgb2yuv CSC when the input is RGB formats
+  * Drop Ubuntu 20.04 Focal as it reached EOL
+
+ -- nyanmisaka <nst799610810@gmail.com>  Mon, 2 Jun 2025 14:31:36 +0800
+
 jellyfin-ffmpeg (7.1.1-4) unstable; urgency=medium
 
   * Add OpenCL based YADIF & BWDIF deinterlacing filters

--- a/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -57,10 +57,11 @@ Index: FFmpeg/configure
  hevc_vaapi_encoder_deps="VAEncPictureParameterBufferHEVC"
  hevc_vaapi_encoder_select="atsc_a53 cbs_h265 vaapi_encode"
  hevc_vulkan_encoder_select="atsc_a53 cbs_h265 vulkan_encode"
-@@ -3395,11 +3402,13 @@ mjpeg_qsv_encoder_deps="libmfx"
+@@ -3395,11 +3402,14 @@ mjpeg_qsv_encoder_deps="libmfx"
  mjpeg_qsv_encoder_select="qsvenc"
  mjpeg_vaapi_encoder_deps="VAEncPictureParameterBufferJPEG"
  mjpeg_vaapi_encoder_select="cbs_jpeg jpegtables vaapi_encode"
++mjpeg_rkmpp_decoder_deps="rkmpp"
 +mjpeg_rkmpp_encoder_deps="rkmpp"
  mp3_mf_encoder_deps="mediafoundation"
  mp3_mediacodec_decoder_deps="mediacodec"
@@ -71,7 +72,7 @@ Index: FFmpeg/configure
  mpeg2_cuvid_decoder_deps="cuvid"
  mpeg2_mmal_decoder_deps="mmal"
  mpeg2_mediacodec_decoder_deps="mediacodec"
-@@ -3407,6 +3416,7 @@ mpeg2_qsv_decoder_select="qsvdec"
+@@ -3407,6 +3417,7 @@ mpeg2_qsv_decoder_select="qsvdec"
  mpeg2_qsv_encoder_select="qsvenc"
  mpeg2_vaapi_encoder_select="cbs_mpeg2 vaapi_encode"
  mpeg2_v4l2m2m_decoder_deps="v4l2_m2m mpeg2_v4l2_m2m"
@@ -79,7 +80,7 @@ Index: FFmpeg/configure
  mpeg4_cuvid_decoder_deps="cuvid"
  mpeg4_mediacodec_decoder_deps="mediacodec"
  mpeg4_mediacodec_encoder_deps="mediacodec"
-@@ -3415,6 +3425,8 @@ mpeg4_mmal_decoder_deps="mmal"
+@@ -3415,6 +3426,8 @@ mpeg4_mmal_decoder_deps="mmal"
  mpeg4_omx_encoder_deps="omx"
  mpeg4_v4l2m2m_decoder_deps="v4l2_m2m mpeg4_v4l2_m2m"
  mpeg4_v4l2m2m_encoder_deps="v4l2_m2m mpeg4_v4l2_m2m"
@@ -88,7 +89,7 @@ Index: FFmpeg/configure
  vc1_cuvid_decoder_deps="cuvid"
  vc1_mmal_decoder_deps="mmal"
  vc1_qsv_decoder_select="qsvdec"
-@@ -3917,6 +3929,7 @@ overlay_qsv_filter_deps="libmfx"
+@@ -3917,6 +3930,7 @@ overlay_qsv_filter_deps="libmfx"
  overlay_qsv_filter_select="qsvvpp"
  overlay_vaapi_filter_deps="vaapi VAProcPipelineCaps_blend_flags"
  overlay_vulkan_filter_deps="vulkan spirv_compiler"
@@ -96,7 +97,7 @@ Index: FFmpeg/configure
  owdenoise_filter_deps="gpl"
  pad_opencl_filter_deps="opencl"
  pan_filter_deps="swresample"
-@@ -3939,6 +3952,7 @@ scale_filter_deps="swscale"
+@@ -3939,6 +3953,7 @@ scale_filter_deps="swscale"
  scale_opencl_filter_deps="opencl"
  scale_qsv_filter_deps="libmfx"
  scale_qsv_filter_select="qsvvpp"
@@ -104,7 +105,7 @@ Index: FFmpeg/configure
  scdet_filter_select="scene_sad"
  select_filter_select="scene_sad"
  sharpness_vaapi_filter_deps="vaapi"
-@@ -3982,6 +3996,7 @@ scale_vt_filter_deps="videotoolbox VTPix
+@@ -3982,6 +3997,7 @@ scale_vt_filter_deps="videotoolbox VTPix
  scale_vulkan_filter_deps="vulkan spirv_compiler"
  vpp_qsv_filter_deps="libmfx"
  vpp_qsv_filter_select="qsvvpp"
@@ -112,7 +113,7 @@ Index: FFmpeg/configure
  xfade_opencl_filter_deps="opencl"
  xfade_vulkan_filter_deps="vulkan spirv_compiler"
  yadif_cuda_filter_deps="ffnvcodec"
-@@ -4031,14 +4046,14 @@ cws2fws_extralibs="zlib_extralibs"
+@@ -4031,14 +4047,14 @@ cws2fws_extralibs="zlib_extralibs"
  
  # libraries, in any order
  avcodec_deps="avutil"
@@ -129,14 +130,14 @@ Index: FFmpeg/configure
  postproc_deps="avutil gpl"
  postproc_suggest="libm stdatomic"
  swresample_deps="avutil"
-@@ -7119,11 +7134,16 @@ enabled openssl           && { { check_p
+@@ -7119,11 +7135,16 @@ enabled openssl           && { { check_p
                                 check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
                                 die "ERROR: openssl not found"; }
  enabled pocketsphinx      && require_pkg_config pocketsphinx pocketsphinx pocketsphinx/pocketsphinx.h ps_init
 -enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/rk_mpi.h mpp_create &&
 -                               require_pkg_config rockchip_mpp "rockchip_mpp >= 1.3.7" rockchip/rk_mpi.h mpp_create &&
 +enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp rockchip/rk_mpi.h mpp_create &&
-+                               require_pkg_config rockchip_mpp "rockchip_mpp >= 1.3.8" rockchip/rk_mpi.h mpp_create &&
++                               require_pkg_config rockchip_mpp "rockchip_mpp >= 1.3.9" rockchip/rk_mpi.h mpp_create &&
                                 { enabled libdrm ||
                                   die "ERROR: rkmpp requires --enable-libdrm"; }
                               }
@@ -148,7 +149,7 @@ Index: FFmpeg/configure
  enabled vapoursynth       && require_headers "vapoursynth/VSScript4.h vapoursynth/VapourSynth4.h"
  
  
-@@ -7325,7 +7345,7 @@ fi
+@@ -7325,7 +7346,7 @@ fi
  if enabled_all opencl libdrm ; then
      check_type "CL/cl_intel.h" "clCreateImageFromFdINTEL_fn" &&
          enable opencl_drm_beignet
@@ -193,15 +194,16 @@ Index: FFmpeg/libavcodec/Makefile
  OBJS-$(CONFIG_HEVC_VAAPI_ENCODER)      += vaapi_encode_h265.o h265_profile_level.o \
                                            h2645data.o hw_base_encode_h265.o
  OBJS-$(CONFIG_HEVC_VULKAN_ENCODER)     += vulkan_encode.o vulkan_encode_h265.o \
-@@ -514,6 +518,7 @@ OBJS-$(CONFIG_MJPEGB_DECODER)          +
+@@ -514,6 +518,8 @@ OBJS-$(CONFIG_MJPEGB_DECODER)          +
  OBJS-$(CONFIG_MJPEG_CUVID_DECODER)     += cuviddec.o
  OBJS-$(CONFIG_MJPEG_QSV_ENCODER)       += qsvenc_jpeg.o
  OBJS-$(CONFIG_MJPEG_VAAPI_ENCODER)     += vaapi_encode_mjpeg.o
++OBJS-$(CONFIG_MJPEG_RKMPP_DECODER)     += rkmppdec.o
 +OBJS-$(CONFIG_MJPEG_RKMPP_ENCODER)     += rkmppenc.o
  OBJS-$(CONFIG_MLP_DECODER)             += mlpdec.o mlpdsp.o
  OBJS-$(CONFIG_MLP_ENCODER)             += mlpenc.o mlp.o
  OBJS-$(CONFIG_MMVIDEO_DECODER)         += mmvideo.o
-@@ -546,6 +551,7 @@ OBJS-$(CONFIG_MPEG1VIDEO_DECODER)      +
+@@ -546,6 +552,7 @@ OBJS-$(CONFIG_MPEG1VIDEO_DECODER)      +
  OBJS-$(CONFIG_MPEG1VIDEO_ENCODER)      += mpeg12enc.o mpeg12.o
  OBJS-$(CONFIG_MPEG1_CUVID_DECODER)     += cuviddec.o
  OBJS-$(CONFIG_MPEG1_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
@@ -209,7 +211,7 @@ Index: FFmpeg/libavcodec/Makefile
  OBJS-$(CONFIG_MPEG2_MMAL_DECODER)      += mmaldec.o
  OBJS-$(CONFIG_MPEG2_QSV_DECODER)       += qsvdec.o
  OBJS-$(CONFIG_MPEG2_QSV_ENCODER)       += qsvenc_mpeg2.o
-@@ -555,6 +561,7 @@ OBJS-$(CONFIG_MPEG2_CUVID_DECODER)     +
+@@ -555,6 +562,7 @@ OBJS-$(CONFIG_MPEG2_CUVID_DECODER)     +
  OBJS-$(CONFIG_MPEG2_MEDIACODEC_DECODER) += mediacodecdec.o
  OBJS-$(CONFIG_MPEG2_VAAPI_ENCODER)     += vaapi_encode_mpeg2.o
  OBJS-$(CONFIG_MPEG2_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
@@ -217,7 +219,7 @@ Index: FFmpeg/libavcodec/Makefile
  OBJS-$(CONFIG_MPEG4_DECODER)           += mpeg4videodsp.o xvididct.o
  OBJS-$(CONFIG_MPEG4_ENCODER)           += mpeg4videoenc.o
  OBJS-$(CONFIG_MPEG4_CUVID_DECODER)     += cuviddec.o
-@@ -563,6 +570,7 @@ OBJS-$(CONFIG_MPEG4_MEDIACODEC_ENCODER)
+@@ -563,6 +571,7 @@ OBJS-$(CONFIG_MPEG4_MEDIACODEC_ENCODER)
  OBJS-$(CONFIG_MPEG4_OMX_ENCODER)       += omx.o
  OBJS-$(CONFIG_MPEG4_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
  OBJS-$(CONFIG_MPEG4_V4L2M2M_ENCODER)   += v4l2_m2m_enc.o
@@ -269,7 +271,7 @@ Index: FFmpeg/libavcodec/allcodecs.c
  extern const FFCodec ff_hevc_amf_encoder;
  extern const FFCodec ff_hevc_cuvid_decoder;
  extern const FFCodec ff_hevc_d3d12va_encoder;
-@@ -863,11 +869,13 @@ extern const FFCodec ff_hevc_v4l2m2m_enc
+@@ -863,11 +869,14 @@ extern const FFCodec ff_hevc_v4l2m2m_enc
  extern const FFCodec ff_hevc_vaapi_encoder;
  extern const FFCodec ff_hevc_videotoolbox_encoder;
  extern const FFCodec ff_hevc_vulkan_encoder;
@@ -279,6 +281,7 @@ Index: FFmpeg/libavcodec/allcodecs.c
  extern const FFCodec ff_mjpeg_qsv_encoder;
  extern const FFCodec ff_mjpeg_qsv_decoder;
  extern const FFCodec ff_mjpeg_vaapi_encoder;
++extern const FFCodec ff_mjpeg_rkmpp_decoder;
 +extern const FFCodec ff_mjpeg_rkmpp_encoder;
  extern const FFCodec ff_mp3_mediacodec_decoder;
  extern const FFCodec ff_mp3_mf_encoder;
@@ -296,7 +299,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
   *
   * This file is part of FFmpeg.
   *
-@@ -19,551 +20,1301 @@
+@@ -19,551 +20,1475 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
  
@@ -310,6 +313,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 + * @file
 + * Rockchip MPP (Media Process Platform) video decoder
 + */
++
++#include "rkmppdec.h"
  
 -#include "avcodec.h"
 -#include "codec_internal.h"
@@ -350,8 +355,6 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    MppFrame frame;
 -    const RKMPPDecoder *decoder_ref; ///< RefStruct reference
 -} RKMPPFrameContext;
-+#include "rkmppdec.h"
-+
 +#include <fcntl.h>
 +#include <unistd.h>
 +#if CONFIG_RKRGA
@@ -371,6 +374,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    case AV_CODEC_ID_MPEG1VIDEO:    /* fallthrough */
 +    case AV_CODEC_ID_MPEG2VIDEO:    return MPP_VIDEO_CodingMPEG2;
 +    case AV_CODEC_ID_MPEG4:         return MPP_VIDEO_CodingMPEG4;
++    case AV_CODEC_ID_MJPEG:         return MPP_VIDEO_CodingMJPEG;
      default:                        return MPP_VIDEO_CodingUnused;
      }
  }
@@ -415,20 +419,6 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    if (ret != MPP_OK) {
 -        av_log(avctx, AV_LOG_ERROR, "Failed to init MPP packet (code = %d)\n", ret);
 -        return AVERROR_UNKNOWN;
--    }
--
--    mpp_packet_set_pts(packet, pts);
--
--    if (!buffer)
--        mpp_packet_set_eos(packet);
--
--    ret = decoder->mpi->decode_put_packet(decoder->ctx, packet);
--    if (ret != MPP_OK) {
--        if (ret == MPP_ERR_BUFFER_FULL) {
--            av_log(avctx, AV_LOG_DEBUG, "Buffer full writing %d bytes to decoder\n", size);
--            ret = AVERROR(EAGAIN);
--        } else
--            ret = AVERROR_UNKNOWN;
 +static uint32_t rkmpp_get_av_format(MppFrameFormat mpp_fmt)
 +{
 +    switch (mpp_fmt & MPP_FRAME_FMT_MASK) {
@@ -440,13 +430,16 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    default:                        return AV_PIX_FMT_NONE;
      }
 +}
-+
+ 
+-    mpp_packet_set_pts(packet, pts);
 +static int get_afbc_byte_stride(const AVPixFmtDescriptor *desc,
 +                                int *stride, int reverse)
 +{
 +    if (!desc || !stride || *stride <= 0)
 +        return AVERROR(EINVAL);
-+
+ 
+-    if (!buffer)
+-        mpp_packet_set_eos(packet);
 +    if (desc->nb_components == 1 ||
 +        (desc->flags & AV_PIX_FMT_FLAG_RGB) ||
 +        (!(desc->flags & AV_PIX_FMT_FLAG_RGB) &&
@@ -459,15 +452,19 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        *stride = reverse ? (*stride / 2) : (*stride * 2);
 +    else if (!desc->log2_chroma_w && !desc->log2_chroma_h)
 +        *stride = reverse ? (*stride / 3) : (*stride * 3);
-     else
--        av_log(avctx, AV_LOG_DEBUG, "Wrote %d bytes to decoder\n", size);
++    else
 +        return AVERROR(EINVAL);
  
--    mpp_packet_deinit(&packet);
+-    ret = decoder->mpi->decode_put_packet(decoder->ctx, packet);
+-    if (ret != MPP_OK) {
+-        if (ret == MPP_ERR_BUFFER_FULL) {
+-            av_log(avctx, AV_LOG_DEBUG, "Buffer full writing %d bytes to decoder\n", size);
+-            ret = AVERROR(EAGAIN);
+-        } else
+-            ret = AVERROR_UNKNOWN;
 +    return (*stride > 0) ? 0 : AVERROR(EINVAL);
 +}
- 
--    return ret;
++
 +static void read_soc_name(AVCodecContext *avctx, char *name, int size)
 +{
 +    const char *dt_path = "/proc/device-tree/compatible";
@@ -494,17 +491,16 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        }
 +
 +        close(fd);
-+    }
- }
+     }
+-    else
+-        av_log(avctx, AV_LOG_DEBUG, "Wrote %d bytes to decoder\n", size);
++}
  
--static int rkmpp_close_decoder(AVCodecContext *avctx)
+-    mpp_packet_deinit(&packet);
 +#if CONFIG_HEVC_RKMPP_DECODER
 +static SideDataFrame *find_sd_frames(SideDataFrame *list,
 +                                     int64_t cur_pts)
- {
--    RKMPPDecodeContext *rk_context = avctx->priv_data;
--    ff_refstruct_unref(&rk_context->decoder);
--    return 0;
++{
 +    while (list) {
 +        if (list->queued == 1) {
 +            AVFrame *frame = list->frame;
@@ -515,16 +511,19 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        }
 +        list = list->next;
 +    }
-+
+ 
+-    return ret;
 +    return NULL;
  }
  
--static void rkmpp_release_decoder(FFRefStructOpaque unused, void *obj)
+-static int rkmpp_close_decoder(AVCodecContext *avctx)
 +static void clear_unused_sd_frames(SideDataFrame *list,
 +                                   int64_t in_pts,
 +                                   int64_t out_pts)
  {
--    RKMPPDecoder *decoder = obj;
+-    RKMPPDecodeContext *rk_context = avctx->priv_data;
+-    ff_refstruct_unref(&rk_context->decoder);
+-    return 0;
 +    while (list) {
 +        if (list->queued == 1) {
 +            AVFrame *frame = list->frame;
@@ -539,11 +538,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        list = list->next;
 +    }
 +}
- 
--    if (decoder->mpi) {
--        decoder->mpi->reset(decoder->ctx);
--        mpp_destroy(decoder->ctx);
--        decoder->ctx = NULL;
++
 +static void clear_sd_frame_list(SideDataFrame **list)
 +{
 +    while (*list) {
@@ -554,12 +549,18 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        av_frame_free(&sd_frame->frame);
 +        av_freep(&sd_frame);
 +    }
-+}
-+
+ }
+ 
+-static void rkmpp_release_decoder(FFRefStructOpaque unused, void *obj)
 +static SideDataFrame *get_free_sd_frame(SideDataFrame **list)
-+{
+ {
+-    RKMPPDecoder *decoder = obj;
 +    SideDataFrame *out = *list;
-+
+ 
+-    if (decoder->mpi) {
+-        decoder->mpi->reset(decoder->ctx);
+-        mpp_destroy(decoder->ctx);
+-        decoder->ctx = NULL;
 +    for (; out; out = out->next) {
 +        if (!out->queued) {
 +            out->queued = 1;
@@ -632,20 +633,17 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        r->buf_mode == RKMPP_DEC_PURE_EXTERNAL) {
 +        mpp_buffer_group_put(r->buf_group);
 +        r->buf_group = NULL;
-     }
--    rk_context->decoder = decoder;
- 
--    av_log(avctx, AV_LOG_DEBUG, "Initializing RKMPP decoder.\n");
++    }
++    if (r->buf_group_misc) {
++        mpp_buffer_group_put(r->buf_group_misc);
++        r->buf_group_misc = NULL;
++    }
++
 +    if (r->hwframe)
 +        av_buffer_unref(&r->hwframe);
 +    if (r->hwdevice)
 +        av_buffer_unref(&r->hwdevice);
- 
--    codectype = rkmpp_get_codingtype(avctx);
--    if (codectype == MPP_VIDEO_CodingUnused) {
--        av_log(avctx, AV_LOG_ERROR, "Unknown codec type (%d).\n", avctx->codec_id);
--        ret = AVERROR_UNKNOWN;
--        goto fail;
++
 +    return 0;
 +}
 +
@@ -677,7 +675,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    case AV_PIX_FMT_YUVJ422P:
 +        pix_fmts[1] = AV_PIX_FMT_NV16;
 +        is_fmt_supported =
-+            avctx->codec_id == AV_CODEC_ID_H264;
++            avctx->codec_id == AV_CODEC_ID_H264 ||
++            avctx->codec_id == AV_CODEC_ID_MJPEG;
 +        break;
 +    case AV_PIX_FMT_YUV422P10:
 +        pix_fmts[1] = AV_PIX_FMT_NV20;
@@ -688,7 +687,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    case AV_PIX_FMT_YUVJ444P:
 +        pix_fmts[1] = AV_PIX_FMT_NV24;
 +        is_fmt_supported =
-+            avctx->codec_id == AV_CODEC_ID_HEVC;
++            avctx->codec_id == AV_CODEC_ID_HEVC ||
++            avctx->codec_id == AV_CODEC_ID_MJPEG;
 +        break;
 +    case AV_PIX_FMT_NONE: /* fallback to drm_prime */
 +        is_fmt_supported = 1;
@@ -712,21 +712,17 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        }
 +        avctx->pix_fmt = ret;
      }
+-    rk_context->decoder = decoder;
  
--    ret = mpp_check_support_format(MPP_CTX_DEC, codectype);
--    if (ret != MPP_OK) {
--        av_log(avctx, AV_LOG_ERROR, "Codec type (%d) unsupported by MPP\n", avctx->codec_id);
--        ret = AVERROR_UNKNOWN;
--        goto fail;
+-    av_log(avctx, AV_LOG_DEBUG, "Initializing RKMPP decoder.\n");
 +    if ((coding_type = rkmpp_get_coding_type(avctx)) == MPP_VIDEO_CodingUnused) {
 +        av_log(avctx, AV_LOG_ERROR, "Unknown codec id: %d\n", avctx->codec_id);
 +        return AVERROR(ENOSYS);
-     }
++    }
  
--    // Create the MPP context
--    ret = mpp_create(&decoder->ctx, &decoder->mpi);
--    if (ret != MPP_OK) {
--        av_log(avctx, AV_LOG_ERROR, "Failed to create MPP context (code = %d).\n", ret);
+-    codectype = rkmpp_get_codingtype(avctx);
+-    if (codectype == MPP_VIDEO_CodingUnused) {
+-        av_log(avctx, AV_LOG_ERROR, "Unknown codec type (%d).\n", avctx->codec_id);
 -        ret = AVERROR_UNKNOWN;
 -        goto fail;
 +    if ((ret = mpp_check_support_format(MPP_CTX_DEC, coding_type)) != MPP_OK) {
@@ -735,10 +731,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        return AVERROR(ENOSYS);
      }
  
--    // initialize mpp
--    ret = mpp_init(decoder->ctx, MPP_CTX_DEC, codectype);
+-    ret = mpp_check_support_format(MPP_CTX_DEC, codectype);
 -    if (ret != MPP_OK) {
--        av_log(avctx, AV_LOG_ERROR, "Failed to initialize MPP context (code = %d).\n", ret);
+-        av_log(avctx, AV_LOG_ERROR, "Codec type (%d) unsupported by MPP\n", avctx->codec_id);
 -        ret = AVERROR_UNKNOWN;
 +    if ((ret = mpp_create(&r->mctx, &r->mapi)) != MPP_OK) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to create MPP context and api: %d\n", ret);
@@ -746,11 +741,10 @@ Index: FFmpeg/libavcodec/rkmppdec.c
          goto fail;
      }
  
--    // make decode calls blocking with a timeout
--    paramS32 = MPP_POLL_BLOCK;
--    ret = decoder->mpi->control(decoder->ctx, MPP_SET_OUTPUT_BLOCK, &paramS32);
+-    // Create the MPP context
+-    ret = mpp_create(&decoder->ctx, &decoder->mpi);
 -    if (ret != MPP_OK) {
--        av_log(avctx, AV_LOG_ERROR, "Failed to set blocking mode on MPI (code = %d).\n", ret);
+-        av_log(avctx, AV_LOG_ERROR, "Failed to create MPP context (code = %d).\n", ret);
 -        ret = AVERROR_UNKNOWN;
 +    if ((ret = mpp_init(r->mctx, MPP_CTX_DEC, coding_type)) != MPP_OK) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to init MPP context: %d\n", ret);
@@ -758,10 +752,31 @@ Index: FFmpeg/libavcodec/rkmppdec.c
          goto fail;
      }
  
--    paramS64 = RECEIVE_FRAME_TIMEOUT;
--    ret = decoder->mpi->control(decoder->ctx, MPP_SET_OUTPUT_BLOCK_TIMEOUT, &paramS64);
+-    // initialize mpp
+-    ret = mpp_init(decoder->ctx, MPP_CTX_DEC, codectype);
 -    if (ret != MPP_OK) {
--        av_log(avctx, AV_LOG_ERROR, "Failed to set block timeout on MPI (code = %d).\n", ret);
+-        av_log(avctx, AV_LOG_ERROR, "Failed to initialize MPP context (code = %d).\n", ret);
+-        ret = AVERROR_UNKNOWN;
+-        goto fail;
++    if (avctx->codec_id == AV_CODEC_ID_MJPEG) {
++        r->buf_mode = RKMPP_DEC_HALF_INTERNAL;
++
++        /* Misc buffer group: for info change frame and bitstream only */
++        ret = mpp_buffer_group_get_internal(&r->buf_group_misc, MPP_BUFFER_TYPE_DRM |
++                                                                MPP_BUFFER_FLAGS_DMA32 |
++                                                                MPP_BUFFER_FLAGS_CACHABLE);
++        if (ret != MPP_OK) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to get MPP internal buffer group for Misc: %d\n", ret);
++            ret = AVERROR_EXTERNAL;
++            goto fail;
++        }
+     }
+ 
+-    // make decode calls blocking with a timeout
+-    paramS32 = MPP_POLL_BLOCK;
+-    ret = decoder->mpi->control(decoder->ctx, MPP_SET_OUTPUT_BLOCK, &paramS32);
+-    if (ret != MPP_OK) {
+-        av_log(avctx, AV_LOG_ERROR, "Failed to set blocking mode on MPI (code = %d).\n", ret);
 -        ret = AVERROR_UNKNOWN;
 +    if (avctx->skip_frame == AVDISCARD_NONKEY)
 +        r->deint = 0;
@@ -772,11 +787,12 @@ Index: FFmpeg/libavcodec/rkmppdec.c
          goto fail;
      }
  
--    ret = mpp_buffer_group_get_internal(&decoder->frame_group, MPP_BUFFER_TYPE_ION);
--    if (ret) {
--       av_log(avctx, AV_LOG_ERROR, "Failed to retrieve buffer group (code = %d)\n", ret);
--       ret = AVERROR_UNKNOWN;
--       goto fail;
+-    paramS64 = RECEIVE_FRAME_TIMEOUT;
+-    ret = decoder->mpi->control(decoder->ctx, MPP_SET_OUTPUT_BLOCK_TIMEOUT, &paramS64);
+-    if (ret != MPP_OK) {
+-        av_log(avctx, AV_LOG_ERROR, "Failed to set block timeout on MPI (code = %d).\n", ret);
+-        ret = AVERROR_UNKNOWN;
+-        goto fail;
 +    if (avctx->pix_fmt != AV_PIX_FMT_DRM_PRIME)
 +        r->afbc = 0;
 +
@@ -807,8 +823,13 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +#if CONFIG_RKRGA
 +        }
 +#endif
-+    }
-+
+     }
+ 
+-    ret = mpp_buffer_group_get_internal(&decoder->frame_group, MPP_BUFFER_TYPE_ION);
+-    if (ret) {
+-       av_log(avctx, AV_LOG_ERROR, "Failed to retrieve buffer group (code = %d)\n", ret);
+-       ret = AVERROR_UNKNOWN;
+-       goto fail;
 +    if (r->afbc) {
 +        MppFrameFormat afbc_fmt = MPP_FRAME_FBC_AFBC_V2;
 +
@@ -826,8 +847,12 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                   avcodec_get_name(avctx->codec_id));
 +            r->afbc = 0;
 +        }
-+    }
-+
+     }
+ 
+-    ret = decoder->mpi->control(decoder->ctx, MPP_DEC_SET_EXT_BUF_GROUP, decoder->frame_group);
+-    if (ret) {
+-        av_log(avctx, AV_LOG_ERROR, "Failed to assign buffer group (code = %d)\n", ret);
+-        ret = AVERROR_UNKNOWN;
 +    if (avctx->hw_device_ctx) {
 +        AVBufferRef *device_ref = avctx->hw_device_ctx;
 +        AVHWDeviceContext *device_ctx = (AVHWDeviceContext *)device_ref->data;
@@ -844,12 +869,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            goto fail;
 +        }
 +        av_log(avctx, AV_LOG_VERBOSE, "Created a RKMPP hardware device\n");
-     }
- 
--    ret = decoder->mpi->control(decoder->ctx, MPP_DEC_SET_EXT_BUF_GROUP, decoder->frame_group);
--    if (ret) {
--        av_log(avctx, AV_LOG_ERROR, "Failed to assign buffer group (code = %d)\n", ret);
--        ret = AVERROR_UNKNOWN;
++    }
++
 +#if CONFIG_HEVC_RKMPP_DECODER
 +    /* prepare for parsing dovi rpu for HEVC */
 +    r->dovi_ctx.logctx = avctx;
@@ -1040,7 +1061,23 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            break;
 +        default:
 +            return 0;
++    }
++
++    sd = av_frame_get_side_data(frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
++    if (sd)
++        mastering = (AVMasteringDisplayMetadata *)sd->data;
++    else
++        mastering = av_mastering_display_metadata_create_side_data(frame);
++    if (!mastering)
++        return AVERROR(ENOMEM);
++
++    for (i = 0; i < 3; i++) {
++        const int j = mapping[i];
++        mastering->display_primaries[i][0] = av_make_q(mpp_mastering.display_primaries[j][0], chroma_den);
++        mastering->display_primaries[i][1] = av_make_q(mpp_mastering.display_primaries[j][1], chroma_den);
      }
++    mastering->white_point[0] = av_make_q(mpp_mastering.white_point[0], chroma_den);
++    mastering->white_point[1] = av_make_q(mpp_mastering.white_point[1], chroma_den);
  
 -    // on first packet, send extradata
 -    if (decoder->first_packet) {
@@ -1060,26 +1097,10 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    ret = rkmpp_write_data(avctx, avpkt->data, avpkt->size, avpkt->pts);
 -    if (ret && ret!=AVERROR(EAGAIN))
 -        av_log(avctx, AV_LOG_ERROR, "Failed to write data to decoder (code = %d)\n", ret);
-+    sd = av_frame_get_side_data(frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
-+    if (sd)
-+        mastering = (AVMasteringDisplayMetadata *)sd->data;
-+    else
-+        mastering = av_mastering_display_metadata_create_side_data(frame);
-+    if (!mastering)
-+        return AVERROR(ENOMEM);
-+
-+    for (i = 0; i < 3; i++) {
-+        const int j = mapping[i];
-+        mastering->display_primaries[i][0] = av_make_q(mpp_mastering.display_primaries[j][0], chroma_den);
-+        mastering->display_primaries[i][1] = av_make_q(mpp_mastering.display_primaries[j][1], chroma_den);
-+    }
-+    mastering->white_point[0] = av_make_q(mpp_mastering.white_point[0], chroma_den);
-+    mastering->white_point[1] = av_make_q(mpp_mastering.white_point[1], chroma_den);
- 
--    return ret;
 +    mastering->max_luminance = av_make_q(mpp_mastering.max_luminance, max_luma_den);
 +    mastering->min_luminance = av_make_q(mpp_mastering.min_luminance, min_luma_den);
-+
+ 
+-    return ret;
 +    mastering->has_luminance = 1;
 +    mastering->has_primaries = 1;
 +
@@ -1215,7 +1236,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        layer->planes[1].pitch  = layer->planes[0].pitch;
 +
 +        if (avctx->sw_pix_fmt == AV_PIX_FMT_NV24)
-+            layer->planes[1].pitch *= 2;
++            layer->planes[1].pitch <<= 1;
      }
  
 -    if (mppframe) {
@@ -1357,6 +1378,30 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        avctx->chroma_sample_location = val;
 +}
 +
++static int rkmpp_mjpeg_get_frame(AVCodecContext *avctx, MppFrame *mpp_frame_out, int timeout)
++{
++    RKMPPDecContext *r = avctx->priv_data;
++    MppPacket mpp_pkt = NULL;
++    MppFrame mpp_frame = NULL;
++    MppMeta frame_meta = NULL;
++    int ret;
++
++    if ((ret = r->mapi->decode_get_frame(r->mctx, &mpp_frame)) != MPP_OK)
++        return timeout == MPP_TIMEOUT_BLOCK ? ret : MPP_ERR_TIMEOUT;
++
++    if (mpp_frame) {
++        frame_meta = mpp_frame_get_meta(mpp_frame);
++        if (frame_meta &&
++            (ret = mpp_meta_get_packet(frame_meta, KEY_INPUT_PACKET, &mpp_pkt)) == MPP_OK) {
++            if (mpp_pkt)
++                mpp_packet_deinit(&mpp_pkt);
++        }
++    }
++
++    *mpp_frame_out = mpp_frame;
++    return MPP_OK;
++}
++
 +static int rkmpp_get_frame(AVCodecContext *avctx, AVFrame *frame, int timeout)
 +{
 +    RKMPPDecContext *r = avctx->priv_data;
@@ -1367,16 +1412,24 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    if (r->eof)
 +        return AVERROR_EOF;
 +
++    if (avctx->codec_id == AV_CODEC_ID_MJPEG)
++        timeout = FFMAX(timeout, MPP_TIMEOUT_NON_BLOCK);
++
 +    if ((ret = r->mapi->control(r->mctx, MPP_SET_OUTPUT_TIMEOUT, (MppParam)&timeout)) != MPP_OK) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to set output timeout: %d\n", ret);
 +        return AVERROR_EXTERNAL;
 +    }
 +
-+    ret = r->mapi->decode_get_frame(r->mctx, &mpp_frame);
++    if (avctx->codec_id == AV_CODEC_ID_MJPEG)
++        ret = rkmpp_mjpeg_get_frame(avctx, &mpp_frame, timeout);
++    else
++        ret = r->mapi->decode_get_frame(r->mctx, &mpp_frame);
++
 +    if (ret != MPP_OK && ret != MPP_ERR_TIMEOUT) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to get frame: %d\n", ret);
 +        return AVERROR_EXTERNAL;
 +    }
++
 +    if (!mpp_frame) {
 +        if (timeout != MPP_TIMEOUT_NON_BLOCK)
 +            av_log(avctx, AV_LOG_DEBUG, "Timeout getting decoded frame\n");
@@ -1405,13 +1458,23 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        ret = AVERROR(EAGAIN);
 +        goto exit;
 +    }
-+    if (mpp_frame_get_errinfo(mpp_frame)) {
-+        av_log(avctx, AV_LOG_DEBUG, "Received a 'errinfo' frame\n");
++    if (ret = mpp_frame_get_errinfo(mpp_frame)) {
++        int ignore_err = (avctx->codec_id != AV_CODEC_ID_MJPEG) ||
++                         (avctx->err_recognition & AV_EF_IGNORE_ERR);
++        int log_level = ignore_err ? AV_LOG_DEBUG : AV_LOG_ERROR;
++
++        av_log(avctx, log_level, "Received a 'errinfo' frame: %d\n", ret);
++        if (avctx->codec_id == AV_CODEC_ID_MJPEG)
++            av_log(avctx, log_level, "The YCbCr format may not be supported. Supported: "
++                   "YUV420(2*2:1*1:1*1) | YUV422(2*1:1*1:1*1) | YUV444(1*1:1*1:1*1)\n");
++        if (!ignore_err)
++            r->eof = 1; /* bail out from the loop */
 +        ret = AVERROR(EAGAIN);
 +        goto exit;
 +    }
 +
-+    if (r->info_change = mpp_frame_get_info_change(mpp_frame)) {
++    if (r->info_change = mpp_frame_get_info_change(mpp_frame) ||
++        (avctx->codec_id == AV_CODEC_ID_MJPEG && !r->buf_group)) {
 +        char *opts = NULL;
 +        int fast_parse = r->fast_parse;
 +        int mpp_frame_mode = mpp_frame_get_mode(mpp_frame);
@@ -1550,6 +1613,10 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -        } else {
 -            av_log(avctx, AV_LOG_ERROR, "Failed to retrieve the frame buffer, frame is dropped (code = %d)\n", ret);
 -            mpp_frame_deinit(&mppframe);
++        /* there's no real info change, export the frame directly */
++        if (avctx->codec_id == AV_CODEC_ID_MJPEG)
++            goto export;
++
 +        /* no more new pkts after EOS, retry to get frame */
 +        if (r->draining) {
 +            mpp_frame_deinit(&mpp_frame);
@@ -1557,6 +1624,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        }
 +        goto exit;
 +    } else {
++export:
 +        av_log(avctx, AV_LOG_DEBUG, "Received a frame\n");
 +        r->got_frame = 1;
 +
@@ -1620,17 +1688,23 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        mpp_frame_deinit(&mpp_frame);
 +    return ret;
 +}
- 
--fail:
--    if (mppframe)
--        mpp_frame_deinit(&mppframe);
++
 +static int rkmpp_send_eos(AVCodecContext *avctx)
 +{
 +    RKMPPDecContext *r = avctx->priv_data;
 +    MppPacket mpp_pkt = NULL;
 +    int ret;
  
--    return ret;
+-fail:
+-    if (mppframe)
+-        mpp_frame_deinit(&mppframe);
++    /* unlike other video codecs, MJPEG decoder's I/O is 1-in-1-out,
++     * there's no need to send EOS and drain internally enqueued frames */
++    if (avctx->codec_id == AV_CODEC_ID_MJPEG) {
++        r->draining = 1;
++        return 0;
++    }
++
 +    if ((ret = mpp_packet_init(&mpp_pkt, NULL, 0)) != MPP_OK) {
 +        av_log(avctx, AV_LOG_ERROR, "Failed to init 'EOS' packet: %d\n", ret);
 +        return AVERROR_EXTERNAL;
@@ -1645,6 +1719,60 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +
 +    mpp_packet_deinit(&mpp_pkt);
 +    return 0;
++}
++
++static int rkmpp_mjpeg_put_packet(AVCodecContext *avctx, MppPacket mpp_pkt_with_buf)
++{
++    RKMPPDecContext *r = avctx->priv_data;
++    MppBufferGroup buf_group = r->buf_group ? r->buf_group : r->buf_group_misc;
++    MppBuffer mpp_buf = NULL;
++    MppFrame mpp_frame = NULL;
++    MppMeta pkt_meta = NULL;
++    size_t buf_sz = FFALIGN(avctx->width, 16) * FFALIGN(avctx->height, 16) << 2;
++    int ret;
++
++    av_assert0(buf_group);
++
++    if ((ret = mpp_frame_init(&mpp_frame)) != MPP_OK) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to init MPP frame: %d\n", ret);
++        ret = MPP_ERR_UNKNOW;
++        goto fail;
++    }
++    if ((ret = mpp_buffer_get(buf_group, &mpp_buf, buf_sz)) != MPP_OK) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to get buffer for frame: %d\n", ret);
++        ret = MPP_ERR_UNKNOW;
++        goto fail;
++    }
++    if (!mpp_buf) {
++        ret = MPP_ERR_UNKNOW;
++        goto fail;
++    }
++    mpp_frame_set_buffer(mpp_frame, mpp_buf);
++    mpp_buffer_put(mpp_buf);
+ 
++    pkt_meta = mpp_packet_get_meta(mpp_pkt_with_buf);
++    if (!pkt_meta || !mpp_packet_has_meta(mpp_pkt_with_buf)) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to get packet meta\n");
++        ret = MPP_ERR_UNKNOW;
++        goto fail;
++    }
++    if ((ret = mpp_meta_set_frame(pkt_meta, KEY_OUTPUT_FRAME, mpp_frame)) != MPP_OK) {
++        av_log(avctx, AV_LOG_ERROR, "Failed to set the key output frame\n");
++        ret = MPP_ERR_UNKNOW;
++        goto fail;
++    }
++
++    if ((ret = r->mapi->decode_put_packet(r->mctx, mpp_pkt_with_buf)) != MPP_OK) {
++        av_log(avctx, AV_LOG_TRACE, "Failed to put packet: %d\n", ret);
++        goto fail;
++    }
++
++    return MPP_OK;
++
++fail:
++    if (mpp_frame)
++        mpp_frame_deinit(&mpp_frame);
+     return ret;
  }
  
 -static int rkmpp_receive_frame(AVCodecContext *avctx, AVFrame *frame)
@@ -1702,21 +1830,60 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                       (avctx->pkt_timebase.num * framerate.num);
 +        }
 +        last_pts += pts_diff;
- 
--            ret = rkmpp_send_packet(avctx, &pkt);
--            av_packet_unref(&pkt);
++
 +        mpp_pkt_pts = PTS_TO_MPP_PTS(last_pts, avctx->pkt_timebase);
 +    }
- 
-+    if ((ret = mpp_packet_init(&mpp_pkt, pkt->data, pkt->size)) != MPP_OK) {
-+        av_log(avctx, AV_LOG_ERROR, "Failed to init packet: %d\n", ret);
-+        return AVERROR_EXTERNAL;
-+    }
-+    mpp_packet_set_pts(mpp_pkt, mpp_pkt_pts);
 +
-+    if ((ret = r->mapi->decode_put_packet(r->mctx, mpp_pkt)) != MPP_OK) {
++    if (avctx->codec_id == AV_CODEC_ID_MJPEG) {
++        MppBuffer mpp_buf = NULL;
++
++        av_assert0(r->buf_group_misc);
++
++        /* the input slot of the MJPEG decoder must be a DRM/DMA buffer,
++         * so borrow some from the frame buffer to write the pkt data */
++        if ((ret = mpp_buffer_get(r->buf_group_misc, &mpp_buf, pkt->size)) != MPP_OK) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to get buffer for packet: %d\n", ret);
++            return AVERROR_EXTERNAL;
++        }
++        if (!mpp_buf)
++            return AVERROR(ENOMEM);
++
++        if ((ret = mpp_buffer_write(mpp_buf, 0, pkt->data, pkt->size)) != MPP_OK) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to write buffer: %d\n", ret);
++            mpp_buffer_put(mpp_buf);
++            return AVERROR_EXTERNAL;
++        }
++        if ((ret = mpp_buffer_sync_partial_end(mpp_buf, 0, pkt->size)) != MPP_OK)
++            av_log(avctx, AV_LOG_DEBUG, "Failed to sync buffer write: %d\n", ret);
++
++        if ((ret = mpp_packet_init_with_buffer(&mpp_pkt, mpp_buf)) != MPP_OK) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to init packet with buffer: %d\n", ret);
++            mpp_buffer_put(mpp_buf);
++            return AVERROR_EXTERNAL;
++        }
++        mpp_buffer_put(mpp_buf);
++        mpp_packet_set_pts(mpp_pkt, mpp_pkt_pts);
++
++        ret = rkmpp_mjpeg_put_packet(avctx, mpp_pkt);
++        if (ret == MPP_ERR_UNKNOW) {
++            if (mpp_pkt)
++                mpp_packet_deinit(&mpp_pkt);
++            return AVERROR_EXTERNAL;
++        }
++    } else {
++        if ((ret = mpp_packet_init(&mpp_pkt, pkt->data, pkt->size)) != MPP_OK) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to init packet: %d\n", ret);
++            return AVERROR_EXTERNAL;
++        }
++        mpp_packet_set_pts(mpp_pkt, mpp_pkt_pts);
++
++        ret = r->mapi->decode_put_packet(r->mctx, mpp_pkt);
++    }
++
++    if (ret != MPP_OK) {
 +        av_log(avctx, AV_LOG_TRACE, "Decoder buffer is full\n");
-+        mpp_packet_deinit(&mpp_pkt);
++        if (mpp_pkt)
++            mpp_packet_deinit(&mpp_pkt);
 +        return AVERROR(EAGAIN);
 +    }
 +    /* update the last pts */
@@ -1779,7 +1946,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                   "Error splitting the input into NAL units\n");
 +            goto exit;
 +        }
-+
+ 
+-            ret = rkmpp_send_packet(avctx, &pkt);
+-            av_packet_unref(&pkt);
 +        /* check for RPU delimiter - unregistered NALs of type 62 */
 +        if (r->h2645_pkt.nb_nals > 1 && r->h2645_pkt.nals[r->h2645_pkt.nb_nals - 1].type == HEVC_NAL_UNSPEC62 &&
 +            r->h2645_pkt.nals[r->h2645_pkt.nb_nals - 1].size > 2 && !r->h2645_pkt.nals[r->h2645_pkt.nb_nals - 1].nuh_layer_id
@@ -1792,7 +1961,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            if (!r->rpu_buf)
 +                goto exit;
 +            memcpy(r->rpu_buf->data, nal->raw_data + 2, nal->raw_size - 2);
-+
+ 
 +            ret = ff_dovi_rpu_parse(&r->dovi_ctx, nal->data + 2, nal->size - 2,
 +                                    avctx->err_recognition);
              if (ret < 0) {
@@ -1801,9 +1970,12 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                av_buffer_unref(&r->rpu_buf);
 +                av_log(avctx, AV_LOG_DEBUG, "Error parsing DOVI NAL unit\n");
 +                goto exit;
-+            }
-+        }
-+
+             }
+         }
+ 
+-        // make sure we keep decoder full
+-        if (freeslots > 1)
+-            return AVERROR(EAGAIN);
 +        /* queue dovi sidedata to the list */
 +        {
 +            SideDataFrame *sd_frame = NULL;
@@ -1835,34 +2007,38 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            if (!sd_frame) {
 +                av_frame_free(&tmp_frame);
 +                goto exit;
-             }
++            }
 +
 +            sd_frame->frame = tmp_frame;
-         }
-+    }
++        }
+     }
 +#endif
-+
+ 
+-    return rkmpp_retrieve_frame(avctx, frame);
 +exit:
-+    mpp_packet_deinit(&mpp_pkt);
++    if (mpp_pkt && avctx->codec_id != AV_CODEC_ID_MJPEG)
++        mpp_packet_deinit(&mpp_pkt);
 +    return 0;
-+}
-+
+ }
+ 
+-static void rkmpp_flush(AVCodecContext *avctx)
 +static int rkmpp_decode_receive_frame(AVCodecContext *avctx, AVFrame *frame)
-+{
+ {
+-    RKMPPDecodeContext *rk_context = avctx->priv_data;
+-    RKMPPDecoder *decoder = rk_context->decoder;
+-    int ret = MPP_NOK;
 +    RKMPPDecContext *r = avctx->priv_data;
 +    AVPacket *pkt = &r->last_pkt;
 +    int ret;
-+
+ 
+-    av_log(avctx, AV_LOG_DEBUG, "Flush.\n");
 +    if (r->info_change && !r->buf_group)
 +        return AVERROR_EOF;
 +
 +    /* no more frames after EOS */
 +    if (r->eof)
 +        return AVERROR_EOF;
- 
--        // make sure we keep decoder full
--        if (freeslots > 1)
--            return AVERROR(EAGAIN);
++
 +    /* drain remain frames */
 +    if (r->draining) {
 +        ret = rkmpp_get_frame(avctx, frame, MPP_TIMEOUT_BLOCK);
@@ -1902,28 +2078,25 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                pkt->size = 0;
 +            }
 +        }
-     }
++    }
  
--    return rkmpp_retrieve_frame(avctx, frame);
+-    ret = decoder->mpi->reset(decoder->ctx);
+-    if (ret == MPP_OK) {
+-        decoder->first_packet = 1;
 +exit:
 +    if (r->draining &&
 +        ret == AVERROR(EAGAIN))
 +        ret = AVERROR_EOF;
 +    return ret;
- }
- 
--static void rkmpp_flush(AVCodecContext *avctx)
++}
++
 +static void rkmpp_decode_flush(AVCodecContext *avctx)
- {
--    RKMPPDecodeContext *rk_context = avctx->priv_data;
--    RKMPPDecoder *decoder = rk_context->decoder;
--    int ret = MPP_NOK;
++{
 +    RKMPPDecContext *r = avctx->priv_data;
 +    int ret;
 +
 +    av_log(avctx, AV_LOG_DEBUG, "Decoder flushing\n");
- 
--    av_log(avctx, AV_LOG_DEBUG, "Flush.\n");
++
 +    if ((ret = r->mapi->reset(r->mctx)) == MPP_OK) {
 +        r->eof = 0;
 +        r->draining = 0;
@@ -1939,10 +2112,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            clear_sd_frame_list(&r->sd_frame_list);
 +        }
 +#endif
- 
--    ret = decoder->mpi->reset(decoder->ctx);
--    if (ret == MPP_OK) {
--        decoder->first_packet = 1;
++
 +        av_packet_unref(&r->last_pkt);
      } else
 -        av_log(avctx, AV_LOG_ERROR, "Failed to reset MPI (code = %d)\n", ret);
@@ -2011,11 +2181,14 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +#if CONFIG_MPEG4_RKMPP_DECODER
 +DEFINE_RKMPP_DECODER(mpeg4, MPEG4, "dump_extra,mpeg4_unpack_bframes")
 +#endif
++#if CONFIG_MJPEG_RKMPP_DECODER
++DEFINE_RKMPP_DECODER(mjpeg, MJPEG, NULL)
++#endif
 Index: FFmpeg/libavcodec/rkmppdec.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppdec.h
-@@ -0,0 +1,177 @@
+@@ -0,0 +1,179 @@
 +/*
 + * Copyright (c) 2017 Lionel CHAZALLON
 + * Copyright (c) 2023 Huseyin BIYIK
@@ -2056,6 +2229,7 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 +#include "hwconfig.h"
 +#include "internal.h"
 +
++#include "libavutil/avassert.h"
 +#include "libavutil/avstring.h"
 +#include "libavutil/hwcontext_rkmpp.h"
 +#include "libavutil/mastering_display_metadata.h"
@@ -2085,6 +2259,7 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 +    MppApi        *mapi;
 +    MppCtx         mctx;
 +    MppBufferGroup buf_group;
++    MppBufferGroup buf_group_misc;
 +
 +    AVBufferRef   *hwdevice;
 +    AVBufferRef   *hwframe;
@@ -2197,7 +2372,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppenc.c
-@@ -0,0 +1,1220 @@
+@@ -0,0 +1,1289 @@
 +/*
 + * Copyright (c) 2023 Huseyin BIYIK
 + * Copyright (c) 2023 NyanMisaka
@@ -2273,9 +2448,19 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    switch (pix_fmt) {
 +    case AV_PIX_FMT_YUVJ420P:
 +    case AV_PIX_FMT_YUV420P:   return MPP_FMT_YUV420P;
++    case AV_PIX_FMT_YUVJ422P:
++    case AV_PIX_FMT_YUV422P:   return MPP_FMT_YUV422P;     /* RK3576+ only */
++    case AV_PIX_FMT_YUVJ444P:
++    case AV_PIX_FMT_YUV444P:   return MPP_FMT_YUV444P;     /* RK3576+ only */
 +    case AV_PIX_FMT_NV12:      return MPP_FMT_YUV420SP;
++    case AV_PIX_FMT_NV21:      return MPP_FMT_YUV420SP_VU; /* RK3576+ only */
++    case AV_PIX_FMT_NV16:      return MPP_FMT_YUV422SP;    /* RK3576+ only */
++    case AV_PIX_FMT_NV24:      return MPP_FMT_YUV444SP;    /* RK3576+ only */
 +    case AV_PIX_FMT_YUYV422:   return MPP_FMT_YUV422_YUYV;
 +    case AV_PIX_FMT_UYVY422:   return MPP_FMT_YUV422_UYVY;
++    case AV_PIX_FMT_YVYU422:   return MPP_FMT_YUV422_YVYU; /* RK3576+ only */
++
++    /* RGB: pre-RK3576 only */
 +    case AV_PIX_FMT_RGB444BE:  return MPP_FMT_RGB444;
 +    case AV_PIX_FMT_BGR444BE:  return MPP_FMT_BGR444;
 +    case AV_PIX_FMT_RGB555BE:  return MPP_FMT_RGB555;
@@ -2302,6 +2487,38 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    case MPP_FMT_YUV420SP: return DRM_FORMAT_YUV420_8BIT;
 +    case MPP_FMT_YUV422SP: return DRM_FORMAT_YUYV;
 +    default:               return DRM_FORMAT_INVALID;
++    }
++}
++
++static MppFrameChromaFormat rkmpp_fix_chroma_fmt(int chroma_fmt,
++                                                 enum AVPixelFormat pix_fmt)
++{
++    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(pix_fmt);
++    int log2_chroma_sum = desc->log2_chroma_w + desc->log2_chroma_h;
++    int is_yuv = !(desc->flags & AV_PIX_FMT_FLAG_RGB) &&
++                 desc->nb_components >= 2;
++
++    if (!is_yuv)
++        return MPP_CHROMA_UNSPECIFIED;
++
++    switch (chroma_fmt) {
++    case -1:
++        return log2_chroma_sum == 0 ? MPP_CHROMA_444 :
++               log2_chroma_sum == 1 ? MPP_CHROMA_422 :
++                                      MPP_CHROMA_UNSPECIFIED;
++    case MPP_CHROMA_400:
++        return chroma_fmt;
++    case MPP_CHROMA_420:
++        return log2_chroma_sum <= 2 ?
++            chroma_fmt : MPP_CHROMA_UNSPECIFIED;
++    case MPP_CHROMA_422:
++        return log2_chroma_sum <= 1 ?
++            chroma_fmt : MPP_CHROMA_UNSPECIFIED;
++    case MPP_CHROMA_444:
++        return log2_chroma_sum == 0 ?
++            chroma_fmt : MPP_CHROMA_UNSPECIFIED;
++    default:
++        return MPP_CHROMA_UNSPECIFIED;
 +    }
 +}
 +
@@ -2499,7 +2716,11 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    mpp_enc_cfg_set_s32(cfg, "prep:width", avctx->width);
 +    mpp_enc_cfg_set_s32(cfg, "prep:height", avctx->height);
 +
-+    mpp_enc_cfg_set_s32(cfg, "prep:colorspace", avctx->colorspace);
++    if (pix_desc->flags & AV_PIX_FMT_FLAG_RGB) /* RGB -> BT709 CSC */
++        mpp_enc_cfg_set_s32(cfg, "prep:colorspace", AVCOL_SPC_BT709);
++    else
++        mpp_enc_cfg_set_s32(cfg, "prep:colorspace", avctx->colorspace);
++
 +    mpp_enc_cfg_set_s32(cfg, "prep:colorprim", avctx->color_primaries);
 +    mpp_enc_cfg_set_s32(cfg, "prep:colortrc", avctx->color_trc);
 +
@@ -2508,6 +2729,12 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +        r->pix_fmt == AV_PIX_FMT_YUVJ422P ||
 +        r->pix_fmt == AV_PIX_FMT_YUVJ444P) {
 +        mpp_enc_cfg_set_s32(cfg, "prep:colorrange", AVCOL_RANGE_JPEG);
++    }
++
++    if (avctx->codec_id == AV_CODEC_ID_MJPEG) {
++        /* always output full range if the MJPEG encoder supports CSC */
++        mpp_enc_cfg_set_s32(cfg, "prep:range_out", AVCOL_RANGE_JPEG);
++        mpp_enc_cfg_set_s32(cfg, "prep:format_out", rkmpp_fix_chroma_fmt(r->chroma_fmt, r->pix_fmt));
 +    }
 +
 +    if (is_afbc) {
@@ -2540,7 +2767,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +{
 +    RKMPPEncContext *r = avctx->priv_data;
 +    MppEncCfg cfg = r->mcfg;
-+
++    const AVPixFmtDescriptor *pix_desc;
 +    RK_U32 rc_mode, fps_num, fps_den;
 +    MppEncHeaderMode header_mode;
 +    MppEncSeiMode sei_mode;
@@ -2552,12 +2779,17 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    mpp_enc_cfg_set_s32(cfg, "prep:height", avctx->height);
 +    mpp_enc_cfg_set_s32(cfg, "prep:hor_stride", FFALIGN(avctx->width, 64));
 +    mpp_enc_cfg_set_s32(cfg, "prep:ver_stride", FFALIGN(avctx->height, 64));
-+    mpp_enc_cfg_set_s32(cfg, "prep:format", MPP_FMT_YUV420SP);
++    mpp_enc_cfg_set_s32(cfg, "prep:format", r->mpp_fmt);
 +    mpp_enc_cfg_set_s32(cfg, "prep:mirroring", 0);
 +    mpp_enc_cfg_set_s32(cfg, "prep:rotation", 0);
 +    mpp_enc_cfg_set_s32(cfg, "prep:flip", 0);
 +
-+    mpp_enc_cfg_set_s32(cfg, "prep:colorspace", avctx->colorspace);
++    pix_desc = av_pix_fmt_desc_get(r->pix_fmt);
++    if (pix_desc->flags & AV_PIX_FMT_FLAG_RGB) /* RGB -> BT709 CSC */
++        mpp_enc_cfg_set_s32(cfg, "prep:colorspace", AVCOL_SPC_BT709);
++    else
++        mpp_enc_cfg_set_s32(cfg, "prep:colorspace", avctx->colorspace);
++
 +    mpp_enc_cfg_set_s32(cfg, "prep:colorprim", avctx->color_primaries);
 +    mpp_enc_cfg_set_s32(cfg, "prep:colortrc", avctx->color_trc);
 +
@@ -2566,6 +2798,12 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +        r->pix_fmt == AV_PIX_FMT_YUVJ422P ||
 +        r->pix_fmt == AV_PIX_FMT_YUVJ444P) {
 +        mpp_enc_cfg_set_s32(cfg, "prep:colorrange", AVCOL_RANGE_JPEG);
++    }
++
++    if (avctx->codec_id == AV_CODEC_ID_MJPEG) {
++        /* always output full range if the MJPEG encoder supports CSC */
++        mpp_enc_cfg_set_s32(cfg, "prep:range_out", AVCOL_RANGE_JPEG);
++        mpp_enc_cfg_set_s32(cfg, "prep:format_out", rkmpp_fix_chroma_fmt(r->chroma_fmt, r->pix_fmt));
 +    }
 +
 +    if (avctx->framerate.den > 0 && avctx->framerate.num > 0)
@@ -2878,6 +3116,8 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +        drm_frame = frame;
 +        mpp_enc_frame->frame = av_frame_clone(drm_frame);
 +    } else {
++        AVBufferRef *hw_frames_ctx = frame->hw_frames_ctx;
++
 +        drm_frame = av_frame_alloc();
 +        if (!drm_frame) {
 +            goto exit;
@@ -2886,15 +3126,19 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +            av_log(avctx, AV_LOG_ERROR, "Cannot allocate an internal frame: %d\n", ret);
 +            goto exit;
 +        }
++        frame->hw_frames_ctx = NULL; /* clear hwfc to avoid HW -> HW transfer */
 +        if ((ret = av_hwframe_transfer_data(drm_frame, frame, 0)) < 0) {
 +            av_log(avctx, AV_LOG_ERROR, "av_hwframe_transfer_data failed: %d\n", ret);
++            frame->hw_frames_ctx = hw_frames_ctx;
 +            goto exit;
 +        }
 +        if ((ret = av_frame_copy_props(drm_frame, frame)) < 0) {
 +            av_log(avctx, AV_LOG_ERROR, "av_frame_copy_props failed: %d\n", ret);
++            frame->hw_frames_ctx = hw_frames_ctx;
 +            goto exit;
 +        }
 +        mpp_enc_frame->frame = drm_frame;
++        frame->hw_frames_ctx = hw_frames_ctx; /* restore hwfc */
 +    }
 +
 +    drm_desc = (AVDRMFrameDescriptor *)drm_frame->data[0];
@@ -3422,7 +3666,7 @@ Index: FFmpeg/libavcodec/rkmppenc.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppenc.h
-@@ -0,0 +1,292 @@
+@@ -0,0 +1,310 @@
 +/*
 + * Copyright (c) 2023 Huseyin BIYIK
 + * Copyright (c) 2023 NyanMisaka
@@ -3508,6 +3752,7 @@ Index: FFmpeg/libavcodec/rkmppenc.h
 +    int                dct8x8;
 +    int                udu_sei;
 +    int                prefix_mode;
++    int                chroma_fmt;
 +} RKMPPEncContext;
 +
 +static const AVRational mpp_tb = { 1, 1000000 };
@@ -3616,6 +3861,13 @@ Index: FFmpeg/libavcodec/rkmppenc.h
 +            { .i64 = -1 }, -1, 99, VE, "qp_max" }, \
 +    { "qp_min", "Set the min QP/Q_Factor value", OFFSET(qp_min), AV_OPT_TYPE_INT, \
 +            { .i64 = -1 }, -1, 99, VE, "qp_min" }, \
++    { "chroma_fmt", "Specify the output chroma format for down subsampling", OFFSET(chroma_fmt), AV_OPT_TYPE_INT, \
++            { .i64 = MPP_CHROMA_UNSPECIFIED }, -1, MPP_CHROMA_444, VE, .unit = "chroma_fmt" }, \
++        { "auto", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = -1 }, 0, 0, VE, .unit = "chroma_fmt" },
++        { "400",  NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MPP_CHROMA_400 }, 0, 0, VE, .unit = "chroma_fmt" },
++        { "420",  NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MPP_CHROMA_420 }, 0, 0, VE, .unit = "chroma_fmt" },
++        { "422",  NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MPP_CHROMA_422 }, 0, 0, VE, .unit = "chroma_fmt" },
++        { "444",  NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MPP_CHROMA_444 }, 0, 0, VE, .unit = "chroma_fmt" },
 +    { NULL },
 +};
 +
@@ -3651,9 +3903,19 @@ Index: FFmpeg/libavcodec/rkmppenc.h
 +static const enum AVPixelFormat rkmpp_enc_pix_fmts_mjpeg[] = {
 +    AV_PIX_FMT_YUV420P,
 +    AV_PIX_FMT_YUVJ420P,
++    AV_PIX_FMT_YUV422P,  /* RK3576+ only */
++    AV_PIX_FMT_YUVJ422P,
++    AV_PIX_FMT_YUV444P,  /* RK3576+ only */
++    AV_PIX_FMT_YUVJ444P,
 +    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV21,     /* RK3576+ only */
++    AV_PIX_FMT_NV16,     /* RK3576+ only */
++    AV_PIX_FMT_NV24,     /* RK3576+ only */
 +    AV_PIX_FMT_YUYV422,
 +    AV_PIX_FMT_UYVY422,
++    AV_PIX_FMT_YVYU422,  /* RK3576+ only */
++
++    /* RGB: pre-RK3576 only */
 +    AV_PIX_FMT_RGB444BE,
 +    AV_PIX_FMT_BGR444BE,
 +    AV_PIX_FMT_RGB555BE,
@@ -3791,7 +4053,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/rkrga_common.c
-@@ -0,0 +1,1387 @@
+@@ -0,0 +1,1420 @@
 +/*
 + * Copyright (c) 2023 NyanMisaka
 + *
@@ -4053,78 +4315,90 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    return out;
 +}
 +
-+static void set_colorspace_info(RGAFrameInfo *in_info, const AVFrame *in,
-+                                RGAFrameInfo *out_info, AVFrame *out,
-+                                int *color_space_mode)
++static void set_colorspace_info(RGAFrameInfo *in_info,
++                                enum AVColorSpace in_spc,
++                                enum AVColorRange in_rng,
++                                RGAFrameInfo *out_info,
++                                enum AVColorSpace *out_spc,
++                                enum AVColorRange *out_rng,
++                                int *color_space_mode,
++                                int is_rga2_used)
 +{
-+    if (!in_info || !out_info || !in || !out || !color_space_mode)
++    int rgb_in, rgb_out, out_mode = 0;
++
++    if (!in_info || !out_info || !color_space_mode)
 +        return;
 +
-+    *color_space_mode = 0;
++    rgb_in  = in_info->pix_desc->flags & AV_PIX_FMT_FLAG_RGB;
++    rgb_out = out_info->pix_desc->flags & AV_PIX_FMT_FLAG_RGB;
 +
 +    /* rgb2yuv */
-+    if ((in_info->pix_desc->flags & AV_PIX_FMT_FLAG_RGB) &&
-+        !(out_info->pix_desc->flags & AV_PIX_FMT_FLAG_RGB)) {
++    if (rgb_in && !rgb_out) {
 +        /* rgb full -> yuv full/limit */
-+        if (in->color_range == AVCOL_RANGE_JPEG) {
-+            switch (in->colorspace) {
-+            case AVCOL_SPC_BT709:
-+                out->colorspace   = AVCOL_SPC_BT709;
-+                *color_space_mode = 0xb << 8; /* rgb2yuv_709_limit */
-+                break;
-+            case AVCOL_SPC_BT470BG:
-+                out->colorspace   = AVCOL_SPC_BT470BG;
-+                *color_space_mode = 2 << 2; /* IM_RGB_TO_YUV_BT601_LIMIT */
-+                break;
-+            }
-+        }
-+        if (*color_space_mode) {
-+            out->color_trc       = AVCOL_TRC_UNSPECIFIED;
-+            out->color_primaries = AVCOL_PRI_UNSPECIFIED;
-+            out->color_range     = AVCOL_RANGE_MPEG;
-+        }
-+    }
++        if (in_rng == AVCOL_RANGE_JPEG) {
++            if ((out_rng && *out_rng == AVCOL_RANGE_JPEG) ||
++                (out_spc && *out_spc == AVCOL_SPC_BT470BG)) {
++                if (out_spc)
++                    *out_spc = AVCOL_SPC_BT470BG;
 +
++                if (out_rng && *out_rng == AVCOL_RANGE_JPEG)
++                    out_mode = 1 << 2; /* IM_RGB_TO_YUV_BT601_FULL */
++                else {
++                    if (out_rng)
++                        *out_rng = AVCOL_RANGE_MPEG;
++                    out_mode = 2 << 2; /* IM_RGB_TO_YUV_BT601_LIMIT */
++                }
++            } else {
++                if (out_spc)
++                    *out_spc = AVCOL_SPC_BT709;
++                if (out_rng)
++                    *out_rng = AVCOL_RANGE_MPEG;
++                out_mode = is_rga2_used ? (0xb << 8) /* rgb2yuv_709_limit */
++                                        : (3 << 2);  /* IM_RGB_TO_YUV_BT709_LIMIT */
++            }
++        }
++        if (out_mode)
++            *color_space_mode |= out_mode;
++    }
 +    /* yuv2rgb */
-+    if (!(in_info->pix_desc->flags & AV_PIX_FMT_FLAG_RGB) &&
-+        (out_info->pix_desc->flags & AV_PIX_FMT_FLAG_RGB)) {
++    else if (!rgb_in && rgb_out) {
 +        /* yuv full/limit -> rgb full */
-+        switch (in->color_range) {
++        switch (in_rng) {
 +        case AVCOL_RANGE_MPEG:
-+            if (in->colorspace == AVCOL_SPC_BT709) {
-+                out->colorspace   = AVCOL_SPC_BT709;
-+                *color_space_mode = 3 << 0; /* IM_YUV_TO_RGB_BT709_LIMIT */
-+            }
-+            if (in->colorspace == AVCOL_SPC_BT470BG) {
-+                out->colorspace   = AVCOL_SPC_BT470BG;
-+                *color_space_mode = 1 << 0; /* IM_YUV_TO_RGB_BT601_LIMIT */
-+            }
++            if (in_spc == AVCOL_SPC_BT709)
++                out_mode = 3 << 0; /* IM_YUV_TO_RGB_BT709_LIMIT */
++            if (in_spc == AVCOL_SPC_BT470BG)
++                out_mode = 1 << 0; /* IM_YUV_TO_RGB_BT601_LIMIT */
 +            break;
 +        case AVCOL_RANGE_JPEG:
 +#if 0
-+            if (in->colorspace == AVCOL_SPC_BT709) {
-+                out->colorspace   = AVCOL_SPC_BT709;
-+                *color_space_mode = 0xc << 8; /* yuv2rgb_709_full */
-+            }
++            if (in_spc == AVCOL_SPC_BT709)
++                out_mode = 0xc << 8; /* yuv2rgb_709_full */
++            if (in_spc == AVCOL_SPC_BT470BG)
 +#endif
-+            if (in->colorspace == AVCOL_SPC_BT470BG) {
-+                out->colorspace   = AVCOL_SPC_BT470BG;
-+                *color_space_mode = 2 << 0; /* IM_YUV_TO_RGB_BT601_FULL */
-+            }
++                out_mode = 2 << 0; /* IM_YUV_TO_RGB_BT601_FULL */
 +            break;
 +        }
-+        if (*color_space_mode) {
-+            out->color_trc       = AVCOL_TRC_UNSPECIFIED;
-+            out->color_primaries = AVCOL_PRI_UNSPECIFIED;
-+            out->color_range     = AVCOL_RANGE_JPEG;
-+        }
++        if (out_spc)
++            *out_spc = AVCOL_SPC_RGB;
++        if (out_rng)
++            *out_rng = AVCOL_RANGE_JPEG;
++        if (out_mode)
++            *color_space_mode |= out_mode;
++    }
++    /* passthrough */
++    else {
++        if (out_spc)
++            *out_spc = in_spc;
++        if (out_rng)
++            *out_rng = in_rng;
 +    }
 +
 +    /* yuvj2yuv */
 +    if ((in_info->pix_fmt == AV_PIX_FMT_YUVJ420P ||
-+         in_info->pix_fmt == AV_PIX_FMT_YUVJ422P) &&
-+        !(out_info->pix_desc->flags & AV_PIX_FMT_FLAG_RGB)) {
-+        out->color_range = AVCOL_RANGE_JPEG;
++         in_info->pix_fmt == AV_PIX_FMT_YUVJ422P) && !rgb_out) {
++        if (out_rng)
++            *out_rng = AVCOL_RANGE_JPEG;
 +    }
 +}
 +
@@ -4186,7 +4460,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +}
 +
 +static RGAFrame *submit_frame(RKRGAContext *r, AVFilterLink *inlink,
-+                              AVFrame *picref, int do_overlay, int pat_preproc)
++                              const AVFrame *picref, int do_overlay, int pat_preproc)
 +{
 +    RGAFrame        *rga_frame;
 +    AVFilterContext *ctx = inlink->dst;
@@ -4327,7 +4601,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +}
 +
 +static RGAFrame *query_frame(RKRGAContext *r, AVFilterLink *outlink,
-+                             const AVFrame *in, int pat_preproc)
++                             const AVFrame *in, const AVFrame *picref_pat, int pat_preproc)
 +{
 +    FilterLink     *outl = ff_filter_link(outlink);
 +    AVFilterContext *ctx = outlink->src;
@@ -4407,8 +4681,29 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    if (out_info->uncompact_10b_msb)
 +        info.is_10b_compact = info.is_10b_endian = 1;
 +
-+    if (!pat_preproc)
-+        set_colorspace_info(in0_info, in, out_info, out_frame->frame, &info.color_space_mode);
++    if (!pat_preproc) {
++        int is_rga2_used = r->is_rga2_used || out_info->scheduler_core == (out_info->scheduler_core & 0xc);
++
++#ifdef RGA_NORMAL_DST_FULL_CSC_FIXUP
++        if (in1_info && picref_pat) {
++            enum AVColorSpace pat_colorspace = picref_pat->colorspace;
++            enum AVColorRange pat_color_range = picref_pat->color_range;
++            /* yuv2rgb src->pat */
++            set_colorspace_info(in0_info, in->colorspace, in->color_range,
++                                in1_info, &pat_colorspace, &pat_color_range,
++                                &info.color_space_mode, is_rga2_used);
++            /* rgb2yuv pat->dst */
++            set_colorspace_info(in1_info, pat_colorspace, pat_color_range,
++                                out_info, &out_frame->frame->colorspace, &out_frame->frame->color_range,
++                                &info.color_space_mode, is_rga2_used);
++        } else
++#endif
++        {
++            set_colorspace_info(in0_info, in->colorspace, in->color_range,
++                                out_info, &out_frame->frame->colorspace, &out_frame->frame->color_range,
++                                &info.color_space_mode, is_rga2_used);
++        }
++    }
 +
 +    if (pat_preproc)
 +        rga_set_rect(&info.rect, in1_info->overlay_x, in1_info->overlay_y,
@@ -5024,8 +5319,8 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +
 +#define PRINT_RGA_INFO(ctx, info, name) do { \
 +    if (info && name) \
-+        av_log(ctx, AV_LOG_DEBUG, "RGA %s | fd:%d mmu:%d rd_mode:%d | x:%d y:%d w:%d h:%d ws:%d hs:%d fmt:0x%x\n", \
-+               name, info->fd, info->mmuFlag, (info->rd_mode >> 1), info->rect.xoffset, info->rect.yoffset, \
++        av_log(ctx, AV_LOG_DEBUG, "RGA %s | fd:%d mmu:%d rd:%d csc:%d | x:%d y:%d w:%d h:%d ws:%d hs:%d fmt:0x%x\n", \
++               name, info->fd, info->mmuFlag, (info->rd_mode >> 1), info->color_space_mode, info->rect.xoffset, info->rect.yoffset, \
 +               info->rect.width, info->rect.height, info->rect.wstride, info->rect.hstride, (info->rect.format >> 8)); \
 +} while (0)
 +
@@ -5091,7 +5386,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +    }
 +
 +    /* DST */
-+    if (!(dst_frame = query_frame(r, outlink, src_frame->frame, 0))) {
++    if (!(dst_frame = query_frame(r, outlink, src_frame->frame, picref_pat, 0))) {
 +        av_log(ctx, AV_LOG_ERROR, "Failed to query an output frame\n");
 +        return AVERROR(ENOMEM);
 +    }
@@ -5114,7 +5409,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +                       FF_INLINK_IDX(inlink_pat));
 +                return AVERROR(ENOMEM);
 +            }
-+            if (!(pat_out = query_frame(r, outlink, picref_pat, 1))) {
++            if (!(pat_out = query_frame(r, outlink, picref_pat, NULL, 1))) {
 +                av_log(ctx, AV_LOG_ERROR, "Failed to query an output frame\n");
 +                return AVERROR(ENOMEM);
 +            }
@@ -6406,7 +6701,7 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
          {
              OpenCLDeviceSelector selector = {
                  .platform_index      = -1,
-@@ -3237,7 +3251,8 @@ static int opencl_map_from_drm_arm(AVHWF
+@@ -3184,7 +3198,8 @@ static int opencl_map_from_drm_arm(AVHWF
  {
      AVHWFramesContext *src_fc =
          (AVHWFramesContext*)src->hw_frames_ctx->data;
@@ -6416,7 +6711,7 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
      const AVDRMFrameDescriptor *desc;
      DRMARMtoOpenCLMapping *mapping = NULL;
      cl_mem_flags cl_flags;
-@@ -3271,8 +3286,8 @@ static int opencl_map_from_drm_arm(AVHWF
+@@ -3218,8 +3233,8 @@ static int opencl_map_from_drm_arm(AVHWF
          }
  
          mapping->object_buffers[i] =
@@ -6427,7 +6722,7 @@ Index: FFmpeg/libavutil/hwcontext_opencl.c
          if (!mapping->object_buffers[i]) {
              av_log(dst_fc, AV_LOG_ERROR, "Failed to create CL buffer "
                     "from object %d (fd %d, size %"SIZE_SPECIFIER") of DRM frame: %d.\n",
-@@ -3303,6 +3318,8 @@ static int opencl_map_from_drm_arm(AVHWF
+@@ -3250,6 +3265,8 @@ static int opencl_map_from_drm_arm(AVHWF
                  goto fail;
              }
  
@@ -6440,7 +6735,7 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavutil/hwcontext_rkmpp.c
-@@ -0,0 +1,604 @@
+@@ -0,0 +1,603 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -6904,7 +7199,6 @@ Index: FFmpeg/libavutil/hwcontext_rkmpp.c
 +
 +    dst->width  = src->width;
 +    dst->height = src->height;
-+    dst->hw_frames_ctx = NULL;
 +
 +    err = ff_hwframe_map_create(src->hw_frames_ctx, dst, src,
 +                                &rkmpp_unmap_frame, map);

--- a/debian/patches/0051-add-mjpeg-videotoolbox-encoder.patch
+++ b/debian/patches/0051-add-mjpeg-videotoolbox-encoder.patch
@@ -2,7 +2,7 @@ Index: FFmpeg/configure
 ===================================================================
 --- FFmpeg.orig/configure
 +++ FFmpeg/configure
-@@ -3524,6 +3524,8 @@ h264_videotoolbox_encoder_deps="pthreads
+@@ -3525,6 +3525,8 @@ h264_videotoolbox_encoder_deps="pthreads
  h264_videotoolbox_encoder_select="atsc_a53 videotoolbox_encoder"
  hevc_videotoolbox_encoder_deps="pthreads"
  hevc_videotoolbox_encoder_select="atsc_a53 videotoolbox_encoder"
@@ -20,9 +20,9 @@ Index: FFmpeg/libavcodec/Makefile
  OBJS-$(CONFIG_MJPEG_QSV_ENCODER)       += qsvenc_jpeg.o
  OBJS-$(CONFIG_MJPEG_VAAPI_ENCODER)     += vaapi_encode_mjpeg.o
 +OBJS-$(CONFIG_MJPEG_VIDEOTOOLBOX_ENCODER) += videotoolboxenc.o
+ OBJS-$(CONFIG_MJPEG_RKMPP_DECODER)     += rkmppdec.o
  OBJS-$(CONFIG_MJPEG_RKMPP_ENCODER)     += rkmppenc.o
  OBJS-$(CONFIG_MLP_DECODER)             += mlpdec.o mlpdsp.o
- OBJS-$(CONFIG_MLP_ENCODER)             += mlpenc.o mlp.o
 Index: FFmpeg/libavcodec/allcodecs.c
 ===================================================================
 --- FFmpeg.orig/libavcodec/allcodecs.c
@@ -32,9 +32,9 @@ Index: FFmpeg/libavcodec/allcodecs.c
  extern const FFCodec ff_mjpeg_qsv_decoder;
  extern const FFCodec ff_mjpeg_vaapi_encoder;
 +extern const FFCodec ff_mjpeg_videotoolbox_encoder;
+ extern const FFCodec ff_mjpeg_rkmpp_decoder;
  extern const FFCodec ff_mjpeg_rkmpp_encoder;
  extern const FFCodec ff_mp3_mediacodec_decoder;
- extern const FFCodec ff_mp3_mf_encoder;
 Index: FFmpeg/libavcodec/videotoolboxenc.c
 ===================================================================
 --- FFmpeg.orig/libavcodec/videotoolboxenc.c

--- a/debian/rules
+++ b/debian/rules
@@ -6,9 +6,6 @@ ORIG_VERSION := $(shell dpkg-parsechangelog -S version)
 VERSION_SUFFIX := $(shell lsb_release -c -s)
 PACKAGE_VERSION := "$(ORIG_VERSION)-$(VERSION_SUFFIX)"
 FLTO_OPTIONS := auto
-ifeq ($(VERSION_SUFFIX),focal)
-	FLTO_OPTIONS := $(shell nproc)
-endif
 
 CONFIG := --prefix=${TARGET_DIR} \
 	--target-os=linux \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 DEBIAN_ADDR=http://deb.debian.org/debian/
-UBUNTU_ARCHIVE_ADDR=http://archive.ubuntu.com/ubuntu/
+UBUNTU_ARCHIVE_ADDR=http://mirrors.kernel.org/ubuntu/ # http://archive.ubuntu.com/ubuntu/
 UBUNTU_PORTS_ADDR=http://ports.ubuntu.com/ubuntu-ports/
 
 # Prepare common extra libs for amd64 and arm64

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -62,10 +62,6 @@ prepare_extra_common() {
     # LIBXML2
     pushd ${SOURCE_DIR}
     libxml2_ver="v2.14.3"
-    if [[ $( lsb_release -c -s ) == "focal" ]]; then
-        # newer versions require automake 1.16.3+
-        libxml2_ver="v2.9.14"
-    fi
     git clone -b ${libxml2_ver} --depth=1 https://github.com/GNOME/libxml2.git
     pushd libxml2
     ./autogen.sh \
@@ -529,9 +525,6 @@ prepare_extra_amd64() {
 
     # SHADERC
     shaderc_ver="v2025.2"
-    if [[ ${GCC_VER} -lt 9 ]]; then
-        shaderc_ver="v2023.5"
-    fi
     pushd ${SOURCE_DIR}
     git clone -b ${shaderc_ver} --depth=1 https://github.com/google/shaderc.git
     pushd shaderc


### PR DESCRIPTION
**Changes**
* rkmppdec: add RKMPP MJPEG decoder
* rkmppenc: add chroma_fmt option for MJPEG encoder
* rkrga: refine colorspace conversion handling
* rkmppenc: fix rgb2yuv CSC when the input is RGB formats
* Update dependency for RKRGA
* Drop Ubuntu 20.04 Focal as it reached EOL
* Bump version to 7.1.1-5
* Use more reliable mirrors for Ubuntu packages