### PR TITLE
lavc/videotoolbox: don't return external error for invalid vt frame

### DIFF
--- a/debian/patches/0092-dont-return-ext-error-for-invalid-vt-frame
+++ b/debian/patches/0092-dont-return-ext-error-for-invalid-vt-frame
@@ -1,0 +1,13 @@
+Index: ffmpeg/libavcodec/videotoolbox.c
+===================================================================
+--- ffmpeg.orig/libavcodec/videotoolbox.c
++++ ffmpeg/libavcodec/videotoolbox.c
+@@ -124,7 +124,7 @@ static int videotoolbox_postproc_frame(v
+     if (!ref->pixbuf) {
+         av_log(avctx, AV_LOG_ERROR, "No frame decoded?\n");
+         av_frame_unref(frame);
+-        return AVERROR_EXTERNAL;
++        return 0;
+     }
+ 
+     frame->crop_right = 0;

--- a/debian/patches/0092-dont-return-ext-error-for-invalid-vt-frame.patch
+++ b/debian/patches/0092-dont-return-ext-error-for-invalid-vt-frame.patch
@@ -1,7 +1,7 @@
-Index: ffmpeg/libavcodec/videotoolbox.c
+Index: FFmpeg/libavcodec/videotoolbox.c
 ===================================================================
---- ffmpeg.orig/libavcodec/videotoolbox.c
-+++ ffmpeg/libavcodec/videotoolbox.c
+--- FFmpeg.orig/libavcodec/videotoolbox.c
++++ FFmpeg/libavcodec/videotoolbox.c
 @@ -124,7 +124,7 @@ static int videotoolbox_postproc_frame(v
      if (!ref->pixbuf) {
          av_log(avctx, AV_LOG_ERROR, "No frame decoded?\n");
@@ -9,5 +9,5 @@ Index: ffmpeg/libavcodec/videotoolbox.c
 -        return AVERROR_EXTERNAL;
 +        return 0;
      }
- 
+
      frame->crop_right = 0;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -89,4 +89,4 @@
 0089-fix-display-matrix-not-removed-after-autorotation.patch
 0090-unbreak-build-with-latest-svtav1-3-0.patch
 0091-backport-fix-for-missing-h264-sei-build-deps.patch
-0092-dont-return-ext-error-for-invalid-vt-frame
+0092-dont-return-ext-error-for-invalid-vt-frame.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -89,3 +89,4 @@
 0089-fix-display-matrix-not-removed-after-autorotation.patch
 0090-unbreak-build-with-latest-svtav1-3-0.patch
 0091-backport-fix-for-missing-h264-sei-build-deps.patch
+0092-dont-return-ext-error-for-invalid-vt-frame


### PR DESCRIPTION
Some video sources are not reliable and will contain frames that is not decodable with hardware accelerators. Current ffmpeg's scheduling has low tolarance for decoder errors it does not understand.

Just return 0 after unref the frame instead so that ffmpeg will no longer abort early due to videotoolbox is not able to decode a frame.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes #588