### PR TITLE
Add windows arm builder, disable gcc build for windows

### DIFF
--- a/.github/workflows/_meta_win_clang_portable.yaml
+++ b/.github/workflows/_meta_win_clang_portable.yaml
@@ -16,13 +16,25 @@ on:
 jobs:
   build:
     name: 'Build Portable FFmpeg'
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os.runner }}
     strategy:
       fail-fast: true
       matrix:
         os:
           - name: CLANG64
             arch: win64
+            runner: windows-latest
+            msystem: CLANG64
+            toolchain: mingw-w64-clang-x86_64-toolchain
+            nasm: mingw-w64-clang-x86_64-nasm
+            build_script: ./msys2/build.sh
+          - name: CLANGARM64
+            arch: winarm64
+            runner: windows-11-arm
+            msystem: CLANGARM64
+            toolchain: mingw-w64-clang-aarch64-toolchain
+            nasm: mingw-w64-clang-aarch64-nasm
+            build_script: ./msys2/buildarm64.sh
     defaults:
       run:
         shell: msys2 {0}
@@ -30,25 +42,25 @@ jobs:
       - uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2
         with:
           update: true
-          msystem: CLANG64
+          msystem: ${{ matrix.os.msystem }}
           install: >-
             git
             curl
             wget
             zip
-            mingw-w64-clang-x86_64-toolchain
+            ${{ matrix.os.toolchain }}
             quilt
             diffstat
-            mingw-w64-clang-x86_64-nasm
+            ${{ matrix.os.nasm }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Prepare prefix dir
         run: |
-          mkdir /clang64/ffbuild
+          mkdir /${{ matrix.os.msystem == 'CLANG64' && 'clang64' || 'clangarm64' }}/ffbuild
 
       - name: Build Portable
-        run: ./msys2/build.sh
+        run: ${{ matrix.os.build_script }}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -65,7 +77,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        arch: [win64]
+        arch: [win64, winarm64]
 
     steps:
       - name: Set Versions

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,12 +36,13 @@ jobs:
       architectures: '["amd64", "arm64"]'
       release: false
 
-  build_portable_windows:
-    uses: ./.github/workflows/_meta_portable.yaml
-    with:
-      os: 'windows'
-      architectures: '["win64"]'
-      release: false
+  # Disabled as clang is stable.
+  # build_portable_windows:
+  #   uses: ./.github/workflows/_meta_portable.yaml
+  #   with:
+  #     os: 'windows'
+  #     architectures: '["win64"]'
+  #     release: false
 
   build_portable_windows_clang:
     uses: ./.github/workflows/_meta_win_clang_portable.yaml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,16 +30,17 @@ jobs:
       deploy-user: ${{ secrets.REPO_USER }}
       deploy-key: ${{ secrets.REPO_KEY }}
 
-  build_publish_windows_portable:
-    uses: ./.github/workflows/_meta_portable.yaml
-    with:
-      os: 'windows'
-      architectures: '["win64"]'
-      release: true
-    secrets:
-      deploy-host: ${{ secrets.REPO_HOST }}
-      deploy-user: ${{ secrets.REPO_USER }}
-      deploy-key: ${{ secrets.REPO_KEY }}
+  # Disabled as clang is stable.
+  # build_publish_windows_portable:
+  #   uses: ./.github/workflows/_meta_portable.yaml
+  #   with:
+  #     os: 'windows'
+  #     architectures: '["win64"]'
+  #     release: true
+  #   secrets:
+  #     deploy-host: ${{ secrets.REPO_HOST }}
+  #     deploy-user: ${{ secrets.REPO_USER }}
+  #     deploy-key: ${{ secrets.REPO_KEY }}
 
   build_publish_windows_clang_portable:
       uses: ./.github/workflows/_meta_win_clang_portable.yaml

--- a/msys2/buildarm64.sh
+++ b/msys2/buildarm64.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -xe
+cd "$(dirname "$0")"
+export BUILDER_ROOT="$(pwd)"
+export FFBUILD_PREFIX="/clangarm64/ffbuild"
+export CMAKE_POLICY_VERSION_MINIMUM="3.5"
+
+arch="arm64"
+TARGET="winarm64-clang"
+VARIANT="gpl"
+
+# Copy libc++ to our prefix folder
+mkdir -p /clangarm64/ffbuild/lib
+cp /clangarm64/lib/libc++.a /clangarm64/ffbuild/lib/libc++.a
+
+cd "$BUILDER_ROOT"/PKGBUILD
+for pkg in *; do
+    if [ -d "$pkg" ]; then
+        echo "Installing $pkg"
+        cd "$pkg"
+
+        (MINGW_ARCH=clangarm64 makepkg-mingw -sLfi --noconfirm --skippgpcheck) || exit $?
+
+        cd ..
+      fi
+done
+
+cd "$BUILDER_ROOT"
+cd ..
+if [[ -f "debian/patches/series" ]]; then
+    ln -s debian/patches patches
+    quilt push -a
+fi
+
+PKG_CONFIG_PATH=/clangarm64/ffbuild/lib/pkgconfig ./configure --cc=clang \
+    --arch=arm64 \
+    --pkg-config-flags=--static \
+    --extra-cflags=-I/clangarm64/ffbuild/include \
+    --extra-ldflags=-L/clangarm64/ffbuild/lib \
+    --prefix=/clangarm64/ffbuild/jellyfin-ffmpeg \
+    --extra-version=Jellyfin \
+    --disable-ffplay \
+    --disable-debug \
+    --disable-doc \
+    --disable-sdl2 \
+    --enable-lto=thin \
+    --enable-gpl \
+    --enable-version3 \
+    --enable-schannel \
+    --enable-iconv \
+    --enable-libxml2 \
+    --enable-zlib \
+    --enable-lzma \
+    --enable-gmp \
+    --enable-chromaprint \
+    --enable-libfreetype \
+    --enable-libfribidi \
+    --enable-libfontconfig \
+    --enable-libharfbuzz \
+    --enable-libass \
+    --enable-libbluray \
+    --enable-libmp3lame \
+    --enable-libopus \
+    --enable-libtheora \
+    --enable-libvorbis \
+    --enable-libopenmpt \
+    --enable-libwebp \
+    --enable-libvpx \
+    --enable-libzimg \
+    --enable-libx264 \
+    --enable-libx265 \
+    --enable-libsvtav1 \
+    --enable-libdav1d \
+    --enable-libfdk-aac \
+    --enable-opencl \
+    --enable-dxva2 \
+    --enable-d3d11va \
+    --enable-d3d12va \
+    --enable-mediafoundation
+
+make -j$(nproc) V=1
+
+# We have to manually match lines to get version as there will be no dpkg-parsechangelog on msys2
+PKG_VER=0.0.0
+while IFS= read -r line; do
+    if [[ $line == jellyfin-ffmpeg* ]]; then
+        if [[ $line =~ \(([^\)]+)\) ]]; then
+            PKG_VER="${BASH_REMATCH[1]}"
+            break
+        fi
+    fi
+done < "$BUILDER_ROOT"/../debian/changelog
+
+PKG_NAME="jellyfin-ffmpeg_${PKG_VER}_portable_${TARGET}-${VARIANT}${ADDINS_STR:+-}${ADDINS_STR}"
+ARTIFACTS_PATH="$BUILDER_ROOT"/artifacts
+OUTPUT_FNAME="${PKG_NAME}.zip"
+cd "$BUILDER_ROOT"
+mkdir -p artifacts
+mv ../ffmpeg.exe ./
+mv ../ffprobe.exe ./
+zip -9 -r "${ARTIFACTS_PATH}/${OUTPUT_FNAME}" ffmpeg.exe ffprobe.exe
+cd "$BUILDER_ROOT"/..
+
+if [[ -n "$GITHUB_ACTIONS" ]]; then
+    echo "build_name=${BUILD_NAME}" >> "$GITHUB_OUTPUT"
+    echo "${OUTPUT_FNAME}" > "${ARTIFACTS_PATH}/${TARGET}-${VARIANT}${ADDINS_STR:+-}${ADDINS_STR}.txt"
+fi


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

This adds windows arm64 builder based on msys2 and its clang arm64 toolchain. Due to the toolchain constraints, the arm64 build has to be run on Windows arm64 runners, and unfortunately, some of the tools has to be run under x86 emulation, which could make the build taking longer than expected.

This PR also disabled the gcc runner for now. Our Clang build has been included by default in our windows releases for the entire 10.10 cycle and we did not receive any compatibility reports due to the compiler yet. The gcc build scripts is now in achieved mode and is only being used for downstream packagers/end users to cross build it on Linux if needed.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->