### PR TITLE
Fix DX11-OCL sync issue on newer AMDGPU when using array of tex

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.1.1-6"
+version: "7.1.1-7"
 packages:
   - bullseye-amd64
   - bullseye-arm64

--- a/builder/scripts.d/25-libxml2.sh
+++ b/builder/scripts.d/25-libxml2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/GNOME/libxml2.git"
-SCRIPT_COMMIT="8d509f483dd5ce268b2fded9c738132c47d820d8"
+SCRIPT_COMMIT="4c6b2c3096b1da0d0780fe0b4f147e837140468d"
 
 ffbuild_enabled() {
     return 0

--- a/builder/scripts.d/50-rkmpp.sh
+++ b/builder/scripts.d/50-rkmpp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/nyanmisaka/mpp.git"
-SCRIPT_COMMIT="48fb6aa79c8b48e1ca98ced18233fcd8a6ac68c5"
+SCRIPT_COMMIT="e5f505a21907a485038870b6d9a6bec97cfceaf3"
 SCRIPT_BRANCH="jellyfin-mpp-next"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-vaapi/40-libdrm.sh
+++ b/builder/scripts.d/50-vaapi/40-libdrm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://gitlab.freedesktop.org/mesa/drm.git"
-SCRIPT_COMMIT="38ec7dbd4df3141441afafe5ac62dfc9df36a77e"
+SCRIPT_COMMIT="76a1e97a9a7c29fa3035bb370d654791bdc23d90"
 
 ffbuild_enabled() {
     [[ $TARGET != linux* ]] && return -1

--- a/builder/scripts.d/50-vulkan/45-vulkan.sh
+++ b/builder/scripts.d/50-vulkan/45-vulkan.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/KhronosGroup/Vulkan-Headers.git"
-SCRIPT_COMMIT="v1.4.315"
+SCRIPT_COMMIT="v1.4.320"
 SCRIPT_TAGFILTER="v?.*.*"
 
 ffbuild_enabled() {

--- a/builder/scripts.d/50-x264.sh
+++ b/builder/scripts.d/50-x264.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/x264.git"
-SCRIPT_COMMIT="373697b467f7cd0af88f1e9e32d4f10540df4687"
+SCRIPT_COMMIT="b35605ace3ddf7c1a5d67a2eb553f034aef41d55"
 
 ffbuild_enabled() {
     [[ $VARIANT == lgpl* ]] && return -1

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+jellyfin-ffmpeg (7.1.1-7) unstable; urgency=medium
+
+  * No error out on unmatched DOVI RPU trailing padding bytes
+  * Fix two unreleased variables in RKMPP
+  * Fix DX11-OCL sync issue on newer AMDGPU when using array of tex
+  * Refine return value handling in RKMPP decoders
+
+ -- nyanmisaka <nst799610810@gmail.com>  Thu, 3 Jul 2025 21:28:33 +0800
+
 jellyfin-ffmpeg (7.1.1-6) unstable; urgency=medium
 
   * lavc/videotoolbox: don't return external error for invalid vt frame

--- a/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -299,7 +299,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
   *
   * This file is part of FFmpeg.
   *
-@@ -19,551 +20,1477 @@
+@@ -19,551 +20,1483 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
  
@@ -1246,34 +1246,34 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    if ((ret = frame_create_buf(frame, mpp_frame, mpp_frame_get_buf_size(mpp_frame),
 +                                rkmpp_free_mpp_frame, mpp_frame, AV_BUFFER_FLAG_READONLY)) < 0)
 +        return ret;
- 
--            av_log(avctx, AV_LOG_INFO, "Decoder noticed an info change (%dx%d), format=%d\n",
--                                        (int)mpp_frame_get_width(mppframe), (int)mpp_frame_get_height(mppframe),
--                                        (int)mpp_frame_get_fmt(mppframe));
++
 +    if ((ret = frame_create_buf(frame, (uint8_t *)desc, sizeof(*desc),
 +                                rkmpp_free_drm_desc, desc, AV_BUFFER_FLAG_READONLY)) < 0)
 +        return ret;
  
--            avctx->width = mpp_frame_get_width(mppframe);
--            avctx->height = mpp_frame_get_height(mppframe);
+-            av_log(avctx, AV_LOG_INFO, "Decoder noticed an info change (%dx%d), format=%d\n",
+-                                        (int)mpp_frame_get_width(mppframe), (int)mpp_frame_get_height(mppframe),
+-                                        (int)mpp_frame_get_fmt(mppframe));
 +    frame->data[0] = (uint8_t *)desc;
  
--            decoder->mpi->control(decoder->ctx, MPP_DEC_SET_INFO_CHANGE_READY, NULL);
+-            avctx->width = mpp_frame_get_width(mppframe);
+-            avctx->height = mpp_frame_get_height(mppframe);
 +    frame->hw_frames_ctx = av_buffer_ref(r->hwframe);
 +    if (!frame->hw_frames_ctx)
 +        return AVERROR(ENOMEM);
  
--            av_buffer_unref(&decoder->frames_ref);
+-            decoder->mpi->control(decoder->ctx, MPP_DEC_SET_INFO_CHANGE_READY, NULL);
 +    if ((ret = ff_decode_frame_props(avctx, frame)) < 0)
 +        return ret;
+ 
+-            av_buffer_unref(&decoder->frames_ref);
++    frame->width  = avctx->width;
++    frame->height = avctx->height;
  
 -            decoder->frames_ref = av_hwframe_ctx_alloc(decoder->device_ref);
 -            if (!decoder->frames_ref) {
 -                ret = AVERROR(ENOMEM);
 -                goto fail;
-+    frame->width  = avctx->width;
-+    frame->height = avctx->height;
-+
 +    mpp_frame_pts = mpp_frame_get_pts(mpp_frame);
 +    frame->pts    = MPP_PTS_TO_PTS(mpp_frame_pts, avctx->pkt_timebase);
 +
@@ -1323,11 +1323,15 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        clear_unused_sd_frames(r->sd_frame_list, r->last_pts_dovi, mpp_frame_pts); /* display order */
 +    }
 +#endif
++
++    return 0;
++}
  
 -            mppformat = mpp_frame_get_fmt(mppframe);
 -            drmformat = rkmpp_get_frameformat(mppformat);
-+    return 0;
-+}
++static void rkmpp_export_avctx_color_props(AVCodecContext *avctx, MppFrame mpp_frame)
++{
++    int val;
  
 -            hwframes = (AVHWFramesContext*)decoder->frames_ref->data;
 -            hwframes->format    = AV_PIX_FMT_DRM_PRIME;
@@ -1337,9 +1341,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -            ret = av_hwframe_ctx_init(decoder->frames_ref);
 -            if (ret < 0)
 -                goto fail;
-+static void rkmpp_export_avctx_color_props(AVCodecContext *avctx, MppFrame mpp_frame)
-+{
-+    int val;
++    if (!avctx || !mpp_frame)
++        return;
  
 -            // here decoder is fully initialized, we need to feed it again with data
 -            ret = AVERROR(EAGAIN);
@@ -1347,9 +1350,6 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -        } else if (mpp_frame_get_eos(mppframe)) {
 -            av_log(avctx, AV_LOG_DEBUG, "Received a EOS frame.\n");
 -            decoder->eos_reached = 1;
-+    if (!avctx || !mpp_frame)
-+        return;
-+
 +    if (avctx->color_primaries == AVCOL_PRI_RESERVED0)
 +        avctx->color_primaries = AVCOL_PRI_UNSPECIFIED;
 +    if ((val = mpp_frame_get_color_primaries(mpp_frame)) &&
@@ -1425,9 +1425,15 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    else
 +        ret = r->mapi->decode_get_frame(r->mctx, &mpp_frame);
 +
-+    if (ret != MPP_OK && ret != MPP_ERR_TIMEOUT) {
-+        av_log(avctx, AV_LOG_ERROR, "Failed to get frame: %d\n", ret);
-+        return AVERROR_EXTERNAL;
++    if (ret != MPP_OK) {
++        if (timeout == MPP_TIMEOUT_NON_BLOCK) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to get frame (non-block): %d\n", ret);
++            return AVERROR_EXTERNAL;
++        }
++        if (timeout != MPP_TIMEOUT_NON_BLOCK && ret != MPP_NOK && ret != MPP_ERR_TIMEOUT) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to get frame (timeout: %d): %d\n", timeout, ret);
++            return AVERROR_EXTERNAL;
++        }
 +    }
 +
 +    if (!mpp_frame) {

--- a/debian/patches/0086-add-array-of-textures-support-for-d3d11va-hwaccel.patch
+++ b/debian/patches/0086-add-array-of-textures-support-for-d3d11va-hwaccel.patch
@@ -169,7 +169,7 @@ Index: FFmpeg/libavcodec/dxva2.c
  
      sctx->decoder_ref = bufref_wrap_interface((IUnknown *)sctx->d3d11_decoder);
      if (!sctx->decoder_ref)
-@@ -716,9 +759,15 @@ int ff_dxva2_common_frame_params(AVCodec
+@@ -716,9 +759,19 @@ int ff_dxva2_common_frame_params(AVCodec
      if (frames_ctx->format == AV_PIX_FMT_D3D11) {
          AVD3D11VAFramesContext *frames_hwctx = frames_ctx->hwctx;
          AVD3D11VADeviceContext *device_hwctx = device_ctx->hwctx;
@@ -180,12 +180,16 @@ Index: FFmpeg/libavcodec/dxva2.c
          frames_hwctx->BindFlags |= D3D11_BIND_DECODER;
          frames_hwctx->require_sync = device_hwctx->device_desc.VendorId == 0x8086;
 +
-+        if (!d3d11va_get_decoder_desc_and_config(avctx, frames_ctx, 0, &decoder_guid, &desc, &config))
++        if (!d3d11va_get_decoder_desc_and_config(avctx, frames_ctx, 0, &decoder_guid, &desc, &config)) {
 +            frames_hwctx->array_of_tex = d3d11va_prefer_array_of_tex(avctx, config);
++
++            if (frames_hwctx->array_of_tex && device_hwctx->device_desc.VendorId == 0x1002)
++                frames_hwctx->require_sync = 1;
++        }
      }
  #endif
  
-@@ -823,14 +872,40 @@ int ff_dxva2_decode_uninit(AVCodecContex
+@@ -823,14 +876,40 @@ int ff_dxva2_decode_uninit(AVCodecContex
      return 0;
  }
  
@@ -228,7 +232,7 @@ Index: FFmpeg/libavcodec/dxva2.c
              av_log((void *)avctx, AV_LOG_ERROR, "get_buffer frame is invalid!\n");
              return NULL;
          }
-@@ -853,8 +928,10 @@ unsigned ff_dxva2_get_surface_index(cons
+@@ -853,8 +932,10 @@ unsigned ff_dxva2_get_surface_index(cons
      }
  #endif
  #if CONFIG_D3D11VA

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -47,7 +47,7 @@ popd
 popd
 
 # LIBXML2
-git clone -b v2.14.3 --depth=1 https://github.com/GNOME/libxml2.git
+git clone -b v2.14.4 --depth=1 https://github.com/GNOME/libxml2.git
 pushd libxml2
 ./autogen.sh \
     --prefix=${FF_DEPS_PREFIX} \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -61,7 +61,7 @@ prepare_extra_common() {
 
     # LIBXML2
     pushd ${SOURCE_DIR}
-    libxml2_ver="v2.14.3"
+    libxml2_ver="v2.14.4"
     git clone -b ${libxml2_ver} --depth=1 https://github.com/GNOME/libxml2.git
     pushd libxml2
     ./autogen.sh \
@@ -325,7 +325,7 @@ prepare_extra_amd64() {
     pushd ${SOURCE_DIR}
     mkdir libdrm
     pushd libdrm
-    libdrm_ver="2.4.124"
+    libdrm_ver="2.4.125"
     libdrm_link="https://dri.freedesktop.org/libdrm/libdrm-${libdrm_ver}.tar.xz"
     wget ${libdrm_link} -O libdrm.tar.xz
     tar xaf libdrm.tar.xz
@@ -388,7 +388,7 @@ prepare_extra_amd64() {
 
     # GMMLIB
     pushd ${SOURCE_DIR}
-    git clone -b intel-gmmlib-22.7.2 --depth=1 https://github.com/intel/gmmlib.git
+    git clone -b intel-gmmlib-22.7.3 --depth=1 https://github.com/intel/gmmlib.git
     pushd gmmlib
     mkdir build && pushd build
     cmake -DCMAKE_INSTALL_PREFIX=${TARGET_DIR} ..
@@ -448,7 +448,7 @@ prepare_extra_amd64() {
     # VPL-GPU-RT (RT only)
     # Provides VPL runtime (libmfx-gen.so.1.2) for 11th Gen Tiger Lake and newer
     pushd ${SOURCE_DIR}
-    git clone -b intel-onevpl-25.2.4 --depth=1 https://github.com/intel/vpl-gpu-rt.git
+    git clone -b intel-onevpl-25.2.6 --depth=1 https://github.com/intel/vpl-gpu-rt.git
     pushd vpl-gpu-rt
     # Fix missing entries in PicStruct validation
     wget -q -O - https://github.com/intel/vpl-gpu-rt/commit/c7eb030.patch | git apply
@@ -470,7 +470,7 @@ prepare_extra_amd64() {
     # Full Feature Build: ENABLE_KERNELS=ON(Default) ENABLE_NONFREE_KERNELS=ON(Default)
     # Free Kernel Build: ENABLE_KERNELS=ON ENABLE_NONFREE_KERNELS=OFF
     pushd ${SOURCE_DIR}
-    git clone -b intel-media-25.2.4 --depth=1 https://github.com/intel/media-driver.git
+    git clone -b intel-media-25.2.6 --depth=1 https://github.com/intel/media-driver.git
     pushd media-driver
     # Enable VC1 decode on DG2 (note that MTL+ is not supported)
     wget -q -O - https://github.com/intel/media-driver/commit/25fb926.patch | git apply
@@ -491,7 +491,7 @@ prepare_extra_amd64() {
 
     # Vulkan Headers
     pushd ${SOURCE_DIR}
-    git clone -b v1.4.315 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
+    git clone -b v1.4.320 --depth=1 https://github.com/KhronosGroup/Vulkan-Headers.git
     pushd Vulkan-Headers
     mkdir build && pushd build
     cmake \
@@ -504,7 +504,7 @@ prepare_extra_amd64() {
 
     # Vulkan ICD Loader
     pushd ${SOURCE_DIR}
-    git clone -b v1.4.315 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
+    git clone -b v1.4.320 --depth=1 https://github.com/KhronosGroup/Vulkan-Loader.git
     pushd Vulkan-Loader
     mkdir build && pushd build
     cmake \
@@ -524,7 +524,7 @@ prepare_extra_amd64() {
     popd
 
     # SHADERC
-    shaderc_ver="v2025.2"
+    shaderc_ver="v2025.3"
     pushd ${SOURCE_DIR}
     git clone -b ${shaderc_ver} --depth=1 https://github.com/google/shaderc.git
     pushd shaderc

--- a/msys2/PKGBUILD/20-mingw-w64-libxml2/PKGBUILD
+++ b/msys2/PKGBUILD/20-mingw-w64-libxml2/PKGBUILD
@@ -5,7 +5,7 @@ _realname=libxml2
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}"
          "${MINGW_PACKAGE_PREFIX}-jellyfin-${_realname}-docs")
-pkgver=2.14.3
+pkgver=2.14.4
 pkgrel=1
 arch=('any')
 mingw_arch=('mingw32' 'mingw64' 'ucrt64' 'clang64' 'clangarm64')
@@ -28,7 +28,7 @@ source=("https://download.gnome.org/sources/libxml2/${pkgver%.*}/${_realname}-${
         https://www.w3.org/XML/Test/xmlts20130923.tar.gz
         0027-decoding-segfault.patch
 	0029-xml2-config-win-paths.patch)
-sha256sums=('6de55cacc8c2bc758f2ef6f93c313cb30e4dd5d84ac5d3c7ccbd9344d8cc6833'
+sha256sums=('24175ec30a97cfa86bdf9befb7ccf4613f8f4b2713c5103e0dd0bc9c711a2773'
             '9b61db9f5dbffa545f4b8d78422167083a8568c59bd1129f94138f936cf6fc1f'
             '0391a4b267ba7251ca74ff2e98bf4c0332a14b618e8147a9341ec5617e45d9d9'
 	    '278b4531da3d2aabda080c412c5122b471202dd6df67768b38bb0c31c7a0e508')

--- a/msys2/PKGBUILD/40-mingw-w64-x264/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-x264/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=x264
 pkgbase=mingw-w64-jellyfin-${_realname}
 pkgname=("${MINGW_PACKAGE_PREFIX}-jellyfin-libx264")
-pkgver=0.164.r3191.373697b
+pkgver=0.164.r3191.b35605a
 pkgrel=1
 pkgdesc="Library for encoding H264/AVC video streams (mingw-w64)"
 arch=('any')
@@ -17,7 +17,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
                 || echo "${MINGW_PACKAGE_PREFIX}-nasm" )
              "git")
 options=('strip' 'staticlibs')
-_commit="373697b467f7cd0af88f1e9e32d4f10540df4687"
+_commit="b35605ace3ddf7c1a5d67a2eb553f034aef41d55"
 source=("${_realname}"::"git+https://code.videolan.org/videolan/${_realname}.git#commit=${_commit}"
         0001-beautify-pc.all.patch
         0002-install-avisynth_c.h.mingw.patch


### PR DESCRIPTION
**Changes**
- Fix DX11-OCL sync issue on newer AMDGPU when using array of tex
- Refine return value handling in RKMPP decoders
- Update dependencies
- Bump version to 7.1.1-7

**Issues**
- DX11-OCL sharing is out of sync, frames are shaking

  Reported by users using newer AMDGPU with array-of-texture support
  `[AVHWDeviceContext @ 000001ecebdbdb00] Using device 1002:15bf (AMD Radeon 780M Graphics).`