### PR TITLE
Cross compile x86_64 macOS build on arm64 runner

### DIFF
--- a/.github/workflows/_meta_mac_portable.yaml
+++ b/.github/workflows/_meta_mac_portable.yaml
@@ -20,11 +20,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # Currently, macOS 13 is x86 exclusive and macOS 14 is arm exclusive and we have no other way to specify arch
         os:
-          - name: macos-13
+          - name: macos-latest
             arch: x86_64
-          - name: macos-14
+          - name: macos-latest
             arch: arm64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -39,7 +38,7 @@ jobs:
           sudo chmod 777 /opt/ffbuild
 
       - name: Build Portable
-        run: ./builder/buildmac.sh
+        run: ./builder/buildmac.sh ${{ matrix.os.arch }}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/builder/buildmac.sh
+++ b/builder/buildmac.sh
@@ -16,7 +16,12 @@ get_output() {
     )
 }
 
-arch=$(uname -m)
+# Accept architecture as first argument, fallback to uname -m if not provided
+if [ -n "$1" ]; then
+    arch="$1"
+else
+    arch=$(uname -m)
+fi
 TARGET="macarm64"
 VARIANT="gpl"
 if [ "$arch" = "arm64" ]; then

--- a/builder/images/macos/cross/cross-x86_64.txt
+++ b/builder/images/macos/cross/cross-x86_64.txt
@@ -1,0 +1,14 @@
+[binaries]
+c = '/usr/bin/clang'
+cpp = '/usr/bin/clang++'
+ar = '/usr/bin/ar'
+
+[host_machine]
+system = 'darwin'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[properties]
+c_args = ['-arch', 'x86_64']
+cpp_args = ['-arch', 'x86_64']

--- a/builder/scripts.d/25-fribidi.sh
+++ b/builder/scripts.d/25-fribidi.sh
@@ -27,7 +27,11 @@ ffbuild_dockerbuild() {
             --cross-file=/cross.meson
         )
     elif [[ $TARGET == mac* ]]; then
-        :
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                --cross-file="$BUILDER_ROOT"/images/macos/cross/cross-x86_64.txt
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/builder/scripts.d/25-gmp.sh
+++ b/builder/scripts.d/25-gmp.sh
@@ -29,6 +29,11 @@ ffbuild_dockerbuild() {
         myconf+=(
             --enable-cxx
         )
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                --host="x86_64-apple-darwin" # Override GMP's autodetect
+            )
+        fi
         # The shipped configure script relies on an outdated libtool version
         # which causes linker errors due to name collisions on macOS
         # leads to wrongly compiled libraries

--- a/builder/scripts.d/25-openssl.sh
+++ b/builder/scripts.d/25-openssl.sh
@@ -49,7 +49,11 @@ ffbuild_dockerbuild() {
             linux-aarch64
         )
     elif [[ $TARGET == mac* ]]; then
-        :
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                darwin64-x86_64
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/builder/scripts.d/45-harfbuzz.sh
+++ b/builder/scripts.d/45-harfbuzz.sh
@@ -36,6 +36,11 @@ ffbuild_dockerbuild() {
     elif [[ $TARGET == mac* ]]; then
         # freetype's pkg-config usage cannot find static libbrotli
         export FREETYPE_LIBS="$(pkg-config --libs --static freetype2)"
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                --cross-file="$BUILDER_ROOT"/images/macos/cross/cross-x86_64.txt
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -24,7 +24,11 @@ ffbuild_dockerbuild() {
             --cross-file=/cross.meson
         )
     elif [[ $TARGET == mac* ]]; then
-        :
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                --cross-file="$BUILDER_ROOT"/images/macos/cross/cross-x86_64.txt
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/builder/scripts.d/50-libass.sh
+++ b/builder/scripts.d/50-libass.sh
@@ -26,7 +26,11 @@ ffbuild_dockerbuild() {
             --host="$FFBUILD_TOOLCHAIN"
         )
     elif [[ $TARGET == mac* ]]; then
-        :
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                --host="x86_64-apple-darwin" # Override libass's autodetect
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/builder/scripts.d/50-libmp3lame.sh
+++ b/builder/scripts.d/50-libmp3lame.sh
@@ -29,7 +29,11 @@ ffbuild_dockerbuild() {
             --host="$FFBUILD_TOOLCHAIN"
         )
     elif [[ $TARGET == mac* ]]; then
-        :
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                --host="x86_64-apple-darwin"
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -44,7 +44,11 @@ ffbuild_dockerbuild() {
         )
         export CROSS="$FFBUILD_CROSS_PREFIX"
     elif [[ $TARGET == mac* ]]; then
-        :
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                --target="x86_64-darwin21-gcc" # macOS 12 toolchain
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/builder/scripts.d/50-x264.sh
+++ b/builder/scripts.d/50-x264.sh
@@ -27,7 +27,11 @@ ffbuild_dockerbuild() {
             --cross-prefix="$FFBUILD_CROSS_PREFIX"
         )
     elif [[ $TARGET == mac* ]]; then
-        :
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                --host="x86_64-apple-darwin"
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/builder/scripts.d/50-zimg.sh
+++ b/builder/scripts.d/50-zimg.sh
@@ -26,7 +26,11 @@ ffbuild_dockerbuild() {
             --host="$FFBUILD_TOOLCHAIN"
         )
     elif [[ $TARGET == mac* ]]; then
-        :
+        if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+            myconf+=(
+                --host="x86_64-apple-darwin"
+            )
+        fi
     else
         echo "Unknown target"
         return -1

--- a/builder/variants/defaults-mac.sh
+++ b/builder/variants/defaults-mac.sh
@@ -1,5 +1,6 @@
 MACOS_MAJOR_VER="$(sw_vers -productVersion | awk -F '.' '{print $1}')"
 XCODE_MAJOR_VER="$(xcodebuild -version | grep 'Xcode' | awk '{print $2}' | cut -d '.' -f 1)"
+MACOS_BUILDER_CPU_ARCH="$(uname -m)"
 
 FF_CFLAGS+="-I"$FFBUILD_PREFIX"/include"
 FF_LDFLAGS+="-L"$FFBUILD_PREFIX"/lib"
@@ -22,3 +23,15 @@ export PKG_CONFIG_PATH=""$FFBUILD_PREFIX"/lib/pkgconfig"
 export RANLIB="/usr/bin/ranlib"
 export MACOSX_DEPLOYMENT_TARGET="12.0"
 export CMAKE_POLICY_VERSION_MINIMUM="3.5"
+
+if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
+    CROSS_CFLAGS="-arch x86_64"
+    CROSS_LDFLAGS="-arch x86_64"
+    FF_CFLAGS+=" $CROSS_CFLAGS"
+    FF_LDFLAGS+=" $CROSS_LDFLAGS"
+    FFBUILD_TARGET_FLAGS+=" --enable-cross-compile --arch=x86_64"
+    export CFLAGS="$CFLAGS $CROSS_CFLAGS"
+    export CXXFLAGS="$CXXFLAGS $CROSS_CFLAGS"
+    export LDFLAGS="$LDFLAGS $CROSS_LDFLAGS"
+    export CMAKE_OSX_ARCHITECTURES="x86_64"
+fi


### PR DESCRIPTION
GitHub officially deprecates the last x86_64 based public standard macOS runner `macos-13` and this runner will be fully unavailable on November 14, 2025. For more info, refer to https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/

It is still uncertain for how long Apple is going to maintain its x86_64 toolchain, but macOS 26 is announced as the last version of macOS that will support Intel Macs. We might have to drop Intel Mac support eventually after Apple stops maintaining the x86_64 toolchain. For now, cross-compile the x86_64 targets on arm64 runner instead. 

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->