### PR TITLE
Add nproc alias for macOS builder

### DIFF
--- a/builder/images/macos/00-dep.sh
+++ b/builder/images/macos/00-dep.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 ffbuild_macbase() {
-  brew install wget subversion mercurial autoconf automake cmake meson ninja pkg-config coreutils gcc make python-setuptools pcre2 libtool gnu-sed gnu-tar nasm quilt texinfo coreutils
+  # https://github.com/actions/runner-images/issues/12912
+  # uninstalled pinned cmake as we are ready for cmake 4.x already
+  brew list cmake && brew uninstall cmake
+  brew install wget subversion mercurial autoconf automake cmake meson ninja pkg-config coreutils gcc make python-setuptools pcre2 libtool gnu-sed gnu-tar nasm quilt texinfo
   mkdir /opt/ffbuild/bin
   cp "$BUILDER_ROOT"/images/base/git-mini-clone.sh /opt/ffbuild/bin/git-mini-clone
   chmod +x /opt/ffbuild/bin/git-mini-clone

--- a/builder/images/macos/00-dep.sh
+++ b/builder/images/macos/00-dep.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ffbuild_macbase() {
-  brew install wget subversion mercurial autoconf automake cmake meson ninja pkg-config coreutils gcc make python-setuptools pcre2 libtool gnu-sed gnu-tar nasm quilt texinfo
+  brew install wget subversion mercurial autoconf automake cmake meson ninja pkg-config coreutils gcc make python-setuptools pcre2 libtool gnu-sed gnu-tar nasm quilt texinfo coreutils
   mkdir /opt/ffbuild/bin
   cp "$BUILDER_ROOT"/images/base/git-mini-clone.sh /opt/ffbuild/bin/git-mini-clone
   chmod +x /opt/ffbuild/bin/git-mini-clone
@@ -9,8 +9,6 @@ ffbuild_macbase() {
   chmod +x /opt/ffbuild/bin/retry-tool
   cp "$BUILDER_ROOT"/images/base/check-wget.sh /opt/ffbuild/bin/check-wget
   chmod +x /opt/ffbuild/bin/check-wget
-  cp "$BUILDER_ROOT"/images/macos/bin/nproc /opt/ffbuild/bin/nproc
-  chmod +x /opt/ffbuild/bin/nproc
   export PATH="/opt/ffbuild/bin:$PATH"
   export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 }

--- a/builder/images/macos/00-dep.sh
+++ b/builder/images/macos/00-dep.sh
@@ -9,6 +9,8 @@ ffbuild_macbase() {
   chmod +x /opt/ffbuild/bin/retry-tool
   cp "$BUILDER_ROOT"/images/base/check-wget.sh /opt/ffbuild/bin/check-wget
   chmod +x /opt/ffbuild/bin/check-wget
+  cp "$BUILDER_ROOT"/images/macos/bin/nproc /opt/ffbuild/bin/nproc
+  chmod +x /opt/ffbuild/bin/nproc
   export PATH="/opt/ffbuild/bin:$PATH"
   export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 }

--- a/builder/images/macos/bin/nproc
+++ b/builder/images/macos/bin/nproc
@@ -1,2 +1,0 @@
-#!/bin/bash
-sysctl -n hw.logicalcpu

--- a/builder/images/macos/bin/nproc
+++ b/builder/images/macos/bin/nproc
@@ -1,0 +1,2 @@
+#!/bin/bash
+sysctl -n hw.logicalcpu


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

nproc is not a macOS built-in command and the closest equivalent is `sysctl -n hw.logicalcpu`. The GitHub runner used to provide the nproc alias but it seems like this is no longer the case. Make a script to redirect nproc instead.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->