### PR TITLE
Avoid amfenc assertion due to filter chain reset

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.1.2-1"
+version: "7.1.2-2"
 packages:
   - bullseye-amd64
   - bullseye-arm64

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+jellyfin-ffmpeg (7.1.2-2) unstable; urgency=medium
+
+  * Backport a fix for stripping FPS from setpts outlink
+  * Avoid amfenc assertion due to filter chain reset
+  * Sync changes from ffmpeg-rockchip
+
+ -- nyanmisaka <nst799610810@gmail.com>  Fri, 3 Oct 2025 16:36:03 +0800
+
 jellyfin-ffmpeg (7.1.2-1) unstable; urgency=medium
 
   * New upstream version 7.1.2

--- a/debian/patches/0005-add-amf-fixes-from-upstream-and-custom-tunings.patch
+++ b/debian/patches/0005-add-amf-fixes-from-upstream-and-custom-tunings.patch
@@ -77,7 +77,17 @@ Index: FFmpeg/libavcodec/amfenc.c
          AMF_RETURN_IF_FALSE(ctx, can_read > 0, AVERROR_UNKNOWN,
              "timestamp_list is empty while max_b_frames = %d\n", avctx->max_b_frames);
          av_fifo_peek(ctx->timestamp_list, &timestamp_last, 1, can_read - 1);
-@@ -766,11 +751,50 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -690,9 +675,6 @@ int ff_amf_receive_packet(AVCodecContext
+                 ID3D11Texture2D *texture = (ID3D11Texture2D*)frame->data[0]; // actual texture
+                 int index = (intptr_t)frame->data[1]; // index is a slice in texture array is - set to tell AMF which slice to use
+ 
+-                av_assert0(frame->hw_frames_ctx       && ctx->hw_frames_ctx &&
+-                           frame->hw_frames_ctx->data == ctx->hw_frames_ctx->data);
+-
+                 texture->lpVtbl->SetPrivateData(texture, &AMFTextureArrayIndexGUID, sizeof(index), &index);
+ 
+                 res = ctx->context->pVtbl->CreateSurfaceFromDX11Native(ctx->context, texture, &surface, NULL); // wrap to AMF surface
+@@ -766,11 +748,50 @@ int ff_amf_receive_packet(AVCodecContext
          switch (avctx->codec->id) {
          case AV_CODEC_ID_H264:
              AMF_ASSIGN_PROPERTY_INT64(res, surface, AMF_VIDEO_ENCODER_INSERT_AUD, !!ctx->aud);
@@ -129,7 +139,7 @@ Index: FFmpeg/libavcodec/amfenc.c
          default:
              break;
          }
-@@ -787,6 +811,13 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -787,6 +808,13 @@ int ff_amf_receive_packet(AVCodecContext
  
              av_frame_unref(frame);
              ret = av_fifo_write(ctx->timestamp_list, &pts, 1);
@@ -143,7 +153,7 @@ Index: FFmpeg/libavcodec/amfenc.c
              if (ret < 0)
                  return ret;
          }
-@@ -796,7 +827,7 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -796,7 +824,7 @@ int ff_amf_receive_packet(AVCodecContext
      do {
          block_and_wait = 0;
          // poll data
@@ -152,7 +162,7 @@ Index: FFmpeg/libavcodec/amfenc.c
              res_query = ctx->encoder->pVtbl->QueryOutput(ctx->encoder, &data);
              if (data) {
                  // copy data to packet
-@@ -806,6 +837,7 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -806,6 +834,7 @@ int ff_amf_receive_packet(AVCodecContext
                  data->pVtbl->QueryInterface(data, &guid, (void**)&buffer); // query for buffer interface
                  ret = amf_copy_buffer(avctx, avpkt, buffer);
  
@@ -160,7 +170,7 @@ Index: FFmpeg/libavcodec/amfenc.c
                  buffer->pVtbl->Release(buffer);
  
                  if (data->pVtbl->HasProperty(data, L"av_frame_ref")) {
-@@ -845,6 +877,7 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -845,6 +874,7 @@ int ff_amf_receive_packet(AVCodecContext
                  av_frame_unref(ctx->delayed_frame);
                  AMF_RETURN_IF_FALSE(ctx, res_resubmit == AMF_OK, AVERROR_UNKNOWN, "Repeated SubmitInput() failed with error %d\n", res_resubmit);
  
@@ -168,7 +178,7 @@ Index: FFmpeg/libavcodec/amfenc.c
                  ret = av_fifo_write(ctx->timestamp_list, &pts, 1);
                  if (ret < 0)
                      return ret;
-@@ -863,7 +896,12 @@ int ff_amf_receive_packet(AVCodecContext
+@@ -863,7 +893,12 @@ int ff_amf_receive_packet(AVCodecContext
          if (query_output_data_flag == 0) {
              if (res_resubmit == AMF_INPUT_FULL || ctx->delayed_drain || (ctx->eof && res_query != AMF_EOF) || (ctx->hwsurfaces_in_queue >= ctx->hwsurfaces_in_queue_max)) {
                  block_and_wait = 1;

--- a/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -2099,7 +2099,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    return ret;
 +}
 +
-+static void rkmpp_decode_flush(AVCodecContext *avctx)
++static av_cold void rkmpp_decode_flush(AVCodecContext *avctx)
 +{
 +    RKMPPDecContext *r = avctx->priv_data;
 +    int ret;
@@ -2381,7 +2381,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppenc.c
-@@ -0,0 +1,1297 @@
+@@ -0,0 +1,1307 @@
 +/*
 + * Copyright (c) 2023 Huseyin BIYIK
 + * Copyright (c) 2023 NyanMisaka
@@ -2923,6 +2923,15 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +            mpp_enc_cfg_set_s32(cfg, "rc:qp_min", qp_min);
 +            mpp_enc_cfg_set_s32(cfg, "rc:qp_max_i",qp_max_i);
 +            mpp_enc_cfg_set_s32(cfg, "rc:qp_min_i", qp_min_i);
++
++            /* Intra Refresh / GDR */
++            if (r->intra_refresh && r->refresh_num) {
++                mpp_enc_cfg_set_u32(cfg, "rc:refresh_en", 1);
++                mpp_enc_cfg_set_u32(cfg, "rc:refresh_mode", r->refresh_mode);
++                mpp_enc_cfg_set_u32(cfg, "rc:refresh_num", r->refresh_num);
++                av_log(avctx, AV_LOG_VERBOSE, "Requested to use Intra Refresh, "
++                       "Mode/Num is set to %d/%d\n", r->refresh_mode, r->refresh_num);
++            }
 +        }
 +        break;
 +    case AV_CODEC_ID_MJPEG:
@@ -3007,7 +3016,8 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +
 +    if (avctx->codec_id == AV_CODEC_ID_H264 ||
 +        avctx->codec_id == AV_CODEC_ID_HEVC) {
-+        sei_mode = r->udu_sei ? MPP_ENC_SEI_MODE_ONE_FRAME : MPP_ENC_SEI_MODE_DISABLE;
++        sei_mode = (r->udu_sei || (r->intra_refresh && r->refresh_num))
++                   ? MPP_ENC_SEI_MODE_ONE_FRAME : MPP_ENC_SEI_MODE_DISABLE;
 +        if ((ret = r->mapi->control(r->mctx, MPP_ENC_SET_SEI_CFG, &sei_mode)) != MPP_OK) {
 +            av_log(avctx, AV_LOG_ERROR, "Failed to set SEI config: %d\n", ret);
 +            return AVERROR_EXTERNAL;
@@ -3447,7 +3457,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    return 0;
 +}
 +
-+static int rkmpp_encode_close(AVCodecContext *avctx)
++static av_cold int rkmpp_encode_close(AVCodecContext *avctx)
 +{
 +    RKMPPEncContext *r = avctx->priv_data;
 +
@@ -3502,7 +3512,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    return 0;
 +}
 +
-+static int rkmpp_encode_init(AVCodecContext *avctx)
++static av_cold int rkmpp_encode_init(AVCodecContext *avctx)
 +{
 +    RKMPPEncContext *r = avctx->priv_data;
 +    enum AVPixelFormat pix_fmt = AV_PIX_FMT_NONE;
@@ -3683,7 +3693,7 @@ Index: FFmpeg/libavcodec/rkmppenc.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppenc.h
-@@ -0,0 +1,311 @@
+@@ -0,0 +1,322 @@
 +/*
 + * Copyright (c) 2023 Huseyin BIYIK
 + * Copyright (c) 2023 NyanMisaka
@@ -3771,6 +3781,9 @@ Index: FFmpeg/libavcodec/rkmppenc.h
 +    int                udu_sei;
 +    int                prefix_mode;
 +    int                chroma_fmt;
++    int                intra_refresh;
++    int                refresh_mode;
++    int                refresh_num;
 +} RKMPPEncContext;
 +
 +static const AVRational mpp_tb = { 1, 1000000 };
@@ -3801,6 +3814,14 @@ Index: FFmpeg/libavcodec/rkmppenc.h
 +            { .i64 = -1 }, -1, 51, VE, "qp_max_i" }, \
 +    { "qp_min_i", "Set the min QP value for I frame", OFFSET(qp_min_i), AV_OPT_TYPE_INT, \
 +            { .i64 = -1 }, -1, 51, VE, "qp_min_i" }, \
++    { "intra_refresh", "Use Intra Refresh instead of IDR frames", OFFSET(intra_refresh), AV_OPT_TYPE_BOOL, \
++            { .i64 = 0 }, 0, 1, VE, "intra_refresh" }, \
++    { "refresh_mode", "Set the Intra Refresh mode", OFFSET(refresh_mode), AV_OPT_TYPE_INT, \
++            { .i64 = MPP_ENC_RC_INTRA_REFRESH_ROW }, MPP_ENC_RC_INTRA_REFRESH_ROW, MPP_ENC_RC_INTRA_REFRESH_COL, VE, "refresh_mode" }, \
++        { "row", "Refresh by MB row",    0, AV_OPT_TYPE_CONST, { .i64 = MPP_ENC_RC_INTRA_REFRESH_ROW }, 0, 0, VE, .unit = "refresh_mode" }, \
++        { "col", "Refresh by MB column", 0, AV_OPT_TYPE_CONST, { .i64 = MPP_ENC_RC_INTRA_REFRESH_COL }, 0, 0, VE, .unit = "refresh_mode" }, \
++    { "refresh_num", "Set how many MB rows or columns refresh each time", OFFSET(refresh_num), AV_OPT_TYPE_INT, \
++            { .i64 = 1 }, 1, INT_MAX, VE, "refresh_num" }, \
 +
 +static const AVOption h264_options[] = {
 +    RKMPP_ENC_COMMON_OPTS


### PR DESCRIPTION
**Changes**
- Avoid amfenc assertion due to filter chain reset
- Sync changes from ffmpeg-rockchip
- Bump version to 7.1.2-2

**Issues**
```
before
[vf#0:0 @ 0000018ef5728c80] Reconfiguring filter graph because video parameters changed to d3d11(pc, bt709), 1920x1080
Assertion frame->hw_frames_ctx && ctx->hw_frames_ctx && frame->hw_frames_ctx->data == ctx->hw_frames_ctx->data failed at libavcodec/amfenc.c:679

after
[vf#0:0 @ 000001be217d7900] Reconfiguring filter graph because video parameters changed to d3d11(pc, bt709), 1920x1080
[vf#0:0 @ 000001be217d7900] Reconfiguring filter graph because video parameters changed to d3d11(tv, bt709), 1920x1080, hwaccel changed
```