### PR TITLE
fix license conflict for msys2 libunibreak

### DIFF
--- a/builder/scripts.d/50-dav1d.sh
+++ b/builder/scripts.d/50-dav1d.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://code.videolan.org/videolan/dav1d.git"
-SCRIPT_COMMIT="af5cf2b1e7f03d6f6de84477e1ca8eed1f3eb03d"
+SCRIPT_COMMIT="0bc6bd93417179cd0c30fac40d2fd11aa29c8523"
 
 ffbuild_enabled() {
     return 0

--- a/msys2/PKGBUILD/35-mingw-w64-libunibreak/PKGBUILD
+++ b/msys2/PKGBUILD/35-mingw-w64-libunibreak/PKGBUILD
@@ -50,6 +50,6 @@ package() {
   make install DESTDIR="${pkgdir}"
 
   mkdir -p "${pkgdir}"${MINGW_PREFIX}/share/licenses/${pkgname}
-  install -Dm644 "${srcdir}"/${pkgname}-${_realname}/LICENCE \
+  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENCE \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${pkgname}/LICENCE
 }

--- a/msys2/PKGBUILD/35-mingw-w64-libunibreak/PKGBUILD
+++ b/msys2/PKGBUILD/35-mingw-w64-libunibreak/PKGBUILD
@@ -49,6 +49,7 @@ package() {
 
   make install DESTDIR="${pkgdir}"
 
-  install -Dm644 "${srcdir}"/${pkgname}-${pkgver}/LICENCE \
+  mkdir -p "${pkgdir}"${MINGW_PREFIX}/share/licenses/${pkgname}
+  install -Dm644 "${srcdir}"/${pkgname}-${_realname}/LICENCE \
     "${pkgdir}"${MINGW_PREFIX}/share/licenses/${pkgname}/LICENCE
 }

--- a/msys2/PKGBUILD/35-mingw-w64-libunibreak/PKGBUILD
+++ b/msys2/PKGBUILD/35-mingw-w64-libunibreak/PKGBUILD
@@ -49,6 +49,6 @@ package() {
 
   make install DESTDIR="${pkgdir}"
 
-  install -Dm644 "${srcdir}"/${_realname}-${pkgver}/LICENCE \
-    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${_realname}/LICENCE
+  install -Dm644 "${srcdir}"/${pkgname}-${pkgver}/LICENCE \
+    "${pkgdir}"${MINGW_PREFIX}/share/licenses/${pkgname}/LICENCE
 }


### PR DESCRIPTION
using realname will conflict with the msys2 upstream libunibreak package that will fail the installation

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->