### PR TITLE
Fix inverted RGB/BGR order in FBCE in RGA runtime

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.1.2-2"
+version: "7.1.2-3"
 packages:
   - bullseye-amd64
   - bullseye-arm64

--- a/builder/scripts.d/50-rkrga.sh
+++ b/builder/scripts.d/50-rkrga.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/nyanmisaka/rk-mirrors.git"
-SCRIPT_COMMIT="571a880951583a3b2a04e7e1fa900861653befde"
+SCRIPT_COMMIT="1d330cc28551943bed3380261a5a9c6fbd58ff53"
 SCRIPT_BRANCH="jellyfin-rga-next"
 
 ffbuild_enabled() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+jellyfin-ffmpeg (7.1.2-3) unstable; urgency=medium
+
+  * Backport HEVC recovery point support from upstream
+  * Fix inverted RGB/BGR order in FBCE in RGA runtime
+
+ -- nyanmisaka <nst799610810@gmail.com>  Sun, 19 Oct 2025 16:31:34 +0800
+
 jellyfin-ffmpeg (7.1.2-2) unstable; urgency=medium
 
   * Backport a fix for stripping FPS from setpts outlink

--- a/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -4092,7 +4092,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/rkrga_common.c
-@@ -0,0 +1,1423 @@
+@@ -0,0 +1,1425 @@
 +/*
 + * Copyright (c) 2023 NyanMisaka
 + *
@@ -4775,6 +4775,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +            goto exit;
 +        }
 +
++#ifndef RGA_NORMAL_FBCE_RGB_BGR_FIXUP
 +        /* Inverted RGB/BGR order in FBCE */
 +        switch (info.rect.format) {
 +        case RK_FORMAT_RGBA_8888:
@@ -4784,6 +4785,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +            info.rect.format = RK_FORMAT_RGBA_8888;
 +            break;
 +        }
++#endif
 +
 +        info.rect.wstride = w_stride;
 +        info.rect.hstride = h_stride;


### PR DESCRIPTION
**Changes**
- Fix inverted RGB/BGR order in FBCE [in RGA runtime](https://github.com/nyanmisaka/rk-mirrors/commit/1d330cc28551943bed3380261a5a9c6fbd58ff53)
- Bump version to 7.1.2-3

**Issues**
- We cannot hardcode it in ffmpeg as newer RGA kernel driver versions [1.3.9+ have fixed](https://github.com/armbian/linux-rockchip/commit/5a4197c84dc678338e4bf725efe116c89ccfa15c) this issue. Otherwise, when users run images with these newer kernel versions, the RGB/BGR order of ASS/SSA subtitle overlays will be inverted.