### PR TITLE
Sync fixes from ffmpeg-rockchip

### DIFF
--- a/builder/scripts.d/50-rkmpp.sh
+++ b/builder/scripts.d/50-rkmpp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_REPO="https://github.com/nyanmisaka/mpp.git"
-SCRIPT_COMMIT="efab9bc8131d840cf8785f2bb477ae1107ea9e65"
+SCRIPT_COMMIT="7345ec9ce07a597fec4d43d7f2f7407e9bd56dbf"
 SCRIPT_BRANCH="jellyfin-mpp-next"
 
 ffbuild_enabled() {

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 jellyfin-ffmpeg (7.1.2-4) unstable; urgency=medium
 
   * Fix yadif_opencl failure on newer AMD drivers
+  * Sync fixes from ffmpeg-rockchip
 
  -- nyanmisaka <nst799610810@gmail.com>  Mon, 27 Oct 2025 19:12:50 +0800
 

--- a/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -2263,7 +2263,7 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 +#endif
 +
 +typedef struct RKMPPDecContext {
-+    AVClass       *class;
++    const AVClass *class;
 +
 +    MppApi        *mapi;
 +    MppCtx         mctx;
@@ -2381,7 +2381,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppenc.c
-@@ -0,0 +1,1307 @@
+@@ -0,0 +1,1311 @@
 +/*
 + * Copyright (c) 2023 Huseyin BIYIK
 + * Copyright (c) 2023 NyanMisaka
@@ -2780,7 +2780,9 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    RK_U32 rc_mode, fps_num, fps_den;
 +    MppEncHeaderMode header_mode;
 +    MppEncSeiMode sei_mode;
-+    int max_bps, min_bps;
++    int64_t target_bps = FFMIN(avctx->bit_rate, INT_MAX);
++    int64_t max_bps = FFMIN(avctx->rc_max_rate, INT_MAX);
++    int64_t min_bps = FFMIN(avctx->rc_min_rate, INT_MAX);
 +    int qp_init, qp_max, qp_min, qp_max_i, qp_min_i;
 +    int ret;
 +
@@ -2835,7 +2837,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    if (rc_mode == MPP_ENC_RC_MODE_BUTT) {
 +        if (r->qp_init >= 0)
 +            rc_mode = MPP_ENC_RC_MODE_FIXQP;
-+        else if (avctx->rc_max_rate > 0)
++        else if (max_bps > 0)
 +            rc_mode = MPP_ENC_RC_MODE_VBR;
 +        else
 +            rc_mode = MPP_ENC_RC_MODE_CBR;
@@ -2860,26 +2862,27 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    case MPP_ENC_RC_MODE_VBR:
 +    case MPP_ENC_RC_MODE_AVBR:
 +        /* VBR mode has wide bound */
-+        max_bps = (avctx->rc_max_rate > 0 && avctx->rc_max_rate >= avctx->bit_rate)
-+                  ? avctx->rc_max_rate : (avctx->bit_rate * 17 / 16);
-+        min_bps = (avctx->rc_min_rate > 0 && avctx->rc_min_rate <= avctx->bit_rate)
-+                  ? avctx->rc_min_rate : (avctx->bit_rate * 1 / 16);
++        max_bps = (max_bps > 0 && max_bps >= target_bps)
++                  ? max_bps : (target_bps * 17 / 16);
++        min_bps = (min_bps > 0 && min_bps <= target_bps)
++                  ? min_bps : (target_bps * 1 / 16);
 +        break;
 +    case MPP_ENC_RC_MODE_CBR:
 +    default:
 +        /* CBR mode has narrow bound */
-+        max_bps = avctx->bit_rate * 17 / 16;
-+        min_bps = avctx->bit_rate * 15 / 16;
++        max_bps = target_bps * 17 / 16;
++        min_bps = target_bps * 15 / 16;
 +        break;
 +    }
++    max_bps = FFMIN(max_bps, INT_MAX);
 +    if (rc_mode == MPP_ENC_RC_MODE_CBR ||
 +        rc_mode == MPP_ENC_RC_MODE_VBR ||
 +        rc_mode == MPP_ENC_RC_MODE_AVBR) {
-+        mpp_enc_cfg_set_u32(cfg, "rc:bps_target", avctx->bit_rate);
-+        mpp_enc_cfg_set_s32(cfg, "rc:bps_max", max_bps);
-+        mpp_enc_cfg_set_s32(cfg, "rc:bps_min", min_bps);
-+        av_log(avctx, AV_LOG_VERBOSE, "Bitrate Target/Min/Max is set to %ld/%d/%d\n",
-+               avctx->bit_rate, min_bps, max_bps);
++        mpp_enc_cfg_set_s32(cfg, "rc:bps_target", (int32_t)target_bps);
++        mpp_enc_cfg_set_s32(cfg, "rc:bps_max", (int32_t)max_bps);
++        mpp_enc_cfg_set_s32(cfg, "rc:bps_min", (int32_t)min_bps);
++        av_log(avctx, AV_LOG_VERBOSE, "Bitrate Target/Min/Max is set to %"PRId32"/%"PRId32"/%"PRId32"\n",
++               (int32_t)target_bps, (int32_t)min_bps, (int32_t)max_bps);
 +    }
 +
 +    if (avctx->rc_buffer_size > 0 &&
@@ -3595,8 +3598,9 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    else if (avctx->codec_id == AV_CODEC_ID_MJPEG)
 +        r->async_frames = MJPEG_ASYNC_FRAMES;
 +
-+    if (avctx->codec_id == AV_CODEC_ID_H264 ||
-+        avctx->codec_id == AV_CODEC_ID_HEVC) {
++    if ((avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) &&
++        (avctx->codec_id == AV_CODEC_ID_H264 ||
++         avctx->codec_id == AV_CODEC_ID_HEVC)) {
 +        RK_U8 enc_hdr_buf[H26X_HEADER_SIZE];
 +        size_t pkt_len = 0;
 +        void *pkt_pos = NULL;
@@ -3751,7 +3755,7 @@ Index: FFmpeg/libavcodec/rkmppenc.h
 +} MPPEncFrame;
 +
 +typedef struct RKMPPEncContext {
-+    AVClass           *class;
++    const AVClass     *class;
 +
 +    MppApi            *mapi;
 +    MppCtx             mctx;


### PR DESCRIPTION
**Changes**
- Sync fixes from ffmpeg-rockchip

	- fix bps print on 32bit system
	- fix global_header (extradata) cannot be disabled
	- mark AVClass as const