### PR TITLE
Enable free-disk-space for Linux portable builds

### DIFF
--- a/.github/workflows/_meta_portable.yaml
+++ b/.github/workflows/_meta_portable.yaml
@@ -32,6 +32,22 @@ jobs:
         arch: ${{fromJson(inputs.architectures)}}
   
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # this might remove tools that are actually needed,
+          # if set to "true" but frees about 6 GB
+          tool-cache: false
+          
+          # all of these default to true, but feel free to set to
+          # "false" if necessary for your workflow
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Build Portable


### PR DESCRIPTION
**Changes**
- Enable free-disk-space for Linux portable builds

**Issues**
```
2025-11-18T16:42:27.3271642Z ##[warning]You are running out of disk space. The runner will stop working when the machine runs out of disk space. Free space left: 7 MB
```