### PR TITLE
Install intel-gpu-tools for i965 shaders

### DIFF
--- a/docker-build.sh
+++ b/docker-build.sh
@@ -374,6 +374,8 @@ prepare_extra_amd64() {
     popd
 
     # INTEL-VAAPI-DRIVER
+    # intel-gpu-tools: for gen4asm shader compilers
+    yes | apt-get install -y intel-gpu-tools
     pushd ${SOURCE_DIR}
     git clone --depth=1 https://github.com/intel/intel-vaapi-driver.git
     pushd intel-vaapi-driver
@@ -385,6 +387,7 @@ prepare_extra_amd64() {
     echo "intel/dri/i965*.so usr/lib/jellyfin-ffmpeg/lib/dri" >> ${DPKG_INSTALL_LIST}
     popd
     popd
+    apt-get remove -y --auto-remove intel-gpu-tools
 
     # GMMLIB
     pushd ${SOURCE_DIR}


### PR DESCRIPTION
**Changes**
- Install intel-gpu-tools for i965 shaders

**Issues**
```
2025-12-09T06:25:36.3222490Z checking for intel-gen4asm >= 1.9... no
2025-12-09T06:25:36.3276371Z checking for intel-gen4asm... no
```