### PR TITLE
avformat/matroska: add support for VVC streams

### DIFF
--- a/libavformat/matroska.c
+++ b/libavformat/matroska.c
@@ -91,6 +91,7 @@ const CodecTags ff_mkv_codec_tags[]={
     {"V_MPEG4/ISO/SP"   , AV_CODEC_ID_MPEG4},
     {"V_MPEG4/ISO/AVC"  , AV_CODEC_ID_H264},
     {"V_MPEGH/ISO/HEVC" , AV_CODEC_ID_HEVC},
+    {"V_MPEGI/ISO/VVC"  , AV_CODEC_ID_VVC},
     {"V_MPEG4/MS/V3"    , AV_CODEC_ID_MSMPEG4V3},
     {"V_PRORES"         , AV_CODEC_ID_PRORES},
     {"V_REAL/RV10"      , AV_CODEC_ID_RV10},

--- a/libavformat/matroskaenc.c
+++ b/libavformat/matroskaenc.c
@@ -26,6 +26,7 @@
 #include "av1.h"
 #include "avc.h"
 #include "hevc.h"
+#include "vvc.h"
 #include "avformat.h"
 #include "avio_internal.h"
 #include "avlanguage.h"
@@ -1140,6 +1141,9 @@ static int mkv_assemble_native_codecprivate(AVFormatContext *s, AVIOContext *dyn
                                   extradata_size);
     case AV_CODEC_ID_HEVC:
         return ff_isom_write_hvcc(dyn_cp, extradata,
+                                  extradata_size, 0);
+    case AV_CODEC_ID_VVC:
+        return ff_isom_write_vvcc(dyn_cp, extradata,
                                   extradata_size, 0);
     case AV_CODEC_ID_ALAC:
         if (extradata_size < 36) {
@@ -3441,8 +3445,10 @@ static int mkv_init(struct AVFormatContext *s)
             break;
         case AV_CODEC_ID_H264:
         case AV_CODEC_ID_HEVC:
+        case AV_CODEC_ID_VVC:
             if ((par->codec_id == AV_CODEC_ID_H264 && par->extradata_size > 0 ||
-                 par->codec_id == AV_CODEC_ID_HEVC && par->extradata_size > 6) &&
+                 par->codec_id == AV_CODEC_ID_HEVC && par->extradata_size > 6 ||
+                 par->codec_id == AV_CODEC_ID_VVC  && par->extradata_size >= 6) &&
                 (AV_RB24(par->extradata) == 1 || AV_RB32(par->extradata) == 1))
                 track->reformat = mkv_reformat_h2645;
             break;


### PR DESCRIPTION
## Summary

Backport VVC/H.266 Matroska container support from upstream FFmpeg.

This enables playback of VVC-encoded video files in MKV containers, which currently fail with:
```
Unknown/unsupported AVCodecID V_MPEGI/ISO/VVC
```

## Changes

- Add `V_MPEGI/ISO/VVC` codec tag mapping in `matroska.c`
- Add VVC muxer support in `matroskaenc.c` (include, codec private, reformat condition)

## References

- Matroska specification: https://github.com/ietf-wg-cellar/matroska-specification/blob/master/codec_specs.md#v_mpegiisovvc
- Upstream FFmpeg commit: https://github.com/FFmpeg/FFmpeg/commit/df50370e1b10d39047fe92f7f4418094bb507eec
- FFmpeg ticket: https://trac.ffmpeg.org/ticket/11411

## Original Author

@jamrial