### PR TITLE
Fix build failures caused by recent outages of mirrors.kernel.org

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -24,14 +24,6 @@ ENV CPPFLAGS="-I${TARGET_DIR}/include $CPPFLAGS"
 ENV CFLAGS="-I${TARGET_DIR}/include $CFLAGS"
 ENV CMAKE_POLICY_VERSION_MINIMUM="3.5"
 
-# Use more reliable mirrors for Ubuntu packages
-RUN mkdir -p /etc/apt/sources.list.d/ \
- && touch /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
- && sed -i 's|archive.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
-    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
- && sed -i 's|security.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
-    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources
-
 # Prepare Debian build environment
 RUN apt-get update \
  && apt-get dist-upgrade -y \

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.1.3-2"
+version: "7.1.3-3"
 packages:
   - bullseye-amd64
   - bullseye-arm64

--- a/builder/images/base/Dockerfile
+++ b/builder/images/base/Dockerfile
@@ -2,14 +2,6 @@ FROM ubuntu:noble
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Use more reliable mirrors for Ubuntu packages
-RUN mkdir -p /etc/apt/sources.list.d/ \
- && touch /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
- && sed -i 's|archive.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
-    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources \
- && sed -i 's|security.ubuntu.com/ubuntu/|mirrors.kernel.org/ubuntu/|g' \
-    /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources
-
 RUN \
     apt-get -y update && \
     apt-get -y dist-upgrade && \

--- a/builder/images/macos/01-gettext.sh
+++ b/builder/images/macos/01-gettext.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ffbuild_macbase() {
-  wget https://mirrors.kernel.org/gnu/gettext/gettext-0.22.5.tar.gz -O gettext.tar.gz
+  wget https://mirrors.edge.kernel.org/gnu/gettext/gettext-0.22.5.tar.gz -O gettext.tar.gz
   tar xvf gettext.tar.gz
   cd gettext-0.22.5
   ./configure --disable-silent-rules --disable-shared --enable-static --with-included-glib --with-included-libcroco --with-included-libunistring --with-included-libxml --with-emacs --with-lispdir="$FFBUILD_PREFIX"/share --disable-java --disable-csharp --without-git --without-cvs --without-xz --with-included-gettext --prefix="$FFBUILD_PREFIX"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (7.1.3-3) unstable; urgency=medium
+
+  * Fix build failures caused by recent outages of mirrors.kernel.org
+
+ -- nyanmisaka <nst799610810@gmail.com>  Sat, 14 Feb 2026 19:49:27 +0800
+
 jellyfin-ffmpeg (7.1.3-2) unstable; urgency=medium
 
   * Update AC4 decoder patch to support 12 channel

--- a/docker-build-win64.sh
+++ b/docker-build-win64.sh
@@ -33,7 +33,7 @@ popd
 mkdir iconv
 pushd iconv
 iconv_ver="1.18"
-iconv_link="https://mirrors.kernel.org/gnu/libiconv/libiconv-${iconv_ver}.tar.gz"
+iconv_link="https://mirrors.edge.kernel.org/gnu/libiconv/libiconv-${iconv_ver}.tar.gz"
 wget ${iconv_link} -O iconv.tar.gz
 tar xaf iconv.tar.gz
 pushd libiconv-${iconv_ver}
@@ -100,7 +100,7 @@ sed -i 's/Cflags:/Cflags: -DFRIBIDI_LIB_STATIC/' ${FF_DEPS_PREFIX}/lib/pkgconfig
 mkdir gmp
 pushd gmp
 gmp_ver="6.3.0"
-gmp_link="https://mirrors.kernel.org/gnu/gmp/gmp-${gmp_ver}.tar.xz"
+gmp_link="https://mirrors.edge.kernel.org/gnu/gmp/gmp-${gmp_ver}.tar.xz"
 wget ${gmp_link} -O gmp.tar.gz
 tar xaf gmp.tar.gz
 pushd gmp-${gmp_ver}

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -6,7 +6,7 @@ set -o errexit
 set -o xtrace
 
 DEBIAN_ADDR=http://deb.debian.org/debian/
-UBUNTU_ARCHIVE_ADDR=http://mirrors.kernel.org/ubuntu/ # http://archive.ubuntu.com/ubuntu/
+UBUNTU_ARCHIVE_ADDR=http://archive.ubuntu.com/ubuntu/
 UBUNTU_PORTS_ADDR=http://ports.ubuntu.com/ubuntu-ports/
 
 # Prepare common extra libs for amd64 and arm64
@@ -31,7 +31,7 @@ prepare_extra_common() {
     mkdir iconv
     pushd iconv
     iconv_ver="1.18"
-    iconv_link="https://mirrors.kernel.org/gnu/libiconv/libiconv-${iconv_ver}.tar.gz"
+    iconv_link="https://mirrors.edge.kernel.org/gnu/libiconv/libiconv-${iconv_ver}.tar.gz"
     wget ${iconv_link} -O iconv.tar.gz
     tar xaf iconv.tar.gz
     pushd libiconv-${iconv_ver}

--- a/msys2/PKGBUILD/10-mingw-w64-bzip2/PKGBUILD
+++ b/msys2/PKGBUILD/10-mingw-w64-bzip2/PKGBUILD
@@ -17,7 +17,7 @@ license=("custom")
 depends=("${MINGW_PACKAGE_PREFIX}-gcc-libs")
 makedepends=("${MINGW_PACKAGE_PREFIX}-cc" "${MINGW_PACKAGE_PREFIX}-autotools")
 options=('strip' 'staticlibs')
-source=("https://mirrors.kernel.org/sourceware/bzip2/bzip2-${pkgver}.tar.gz"
+source=("https://mirrors.edge.kernel.org/sourceware/bzip2/bzip2-${pkgver}.tar.gz"
         "bzip2-cygming-1.0.6.src.all.patch"
         "bzip2-buildsystem.all.patch"
         "bzip2-1.0.6-progress.all.patch")

--- a/msys2/PKGBUILD/10-mingw-w64-libiconv/PKGBUILD
+++ b/msys2/PKGBUILD/10-mingw-w64-libiconv/PKGBUILD
@@ -15,7 +15,7 @@ makedepends=("${MINGW_PACKAGE_PREFIX}-cc"
              "${MINGW_PACKAGE_PREFIX}-autotools"
              "${MINGW_PACKAGE_PREFIX}-gettext-tools"
              "${MINGW_PACKAGE_PREFIX}-gperf")
-source=("https://mirrors.kernel.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"{,.sig}
+source=("https://mirrors.edge.kernel.org/gnu/${_realname}/${_realname}-${pkgver}.tar.gz"{,.sig}
         0003-add-cp65001-as-utf8-alias.patch
         0002-fix-cr-for-awk-in-configure.all.patch
         fix-pointer-buf.patch

--- a/msys2/PKGBUILD/20-mingw-w64-gmp/PKGBUILD
+++ b/msys2/PKGBUILD/20-mingw-w64-gmp/PKGBUILD
@@ -14,7 +14,7 @@ msys2_references=(
 )
 license=('LGPL3' 'GPL')
 makedepends=("${MINGW_PACKAGE_PREFIX}-autotools" "${MINGW_PACKAGE_PREFIX}-cc")
-source=(https://mirrors.kernel.org/gnu/gmp/${_realname}-${pkgver}.tar.xz{,.sig}
+source=(https://mirrors.edge.kernel.org/gnu/gmp/${_realname}-${pkgver}.tar.xz{,.sig}
         do-not-use-dllimport.diff
         gmp-staticlib.diff)
 sha256sums=('a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898'


### PR DESCRIPTION
**Changes**
- Fix build failures caused by recent outages of mirrors.kernel.org
- Bump version to 7.1.3-3

**Issues**
- mirrors.edge.kernel.org is more stable historically
- When using ubuntu-ports, also use "archive.ubuntu.com/ubuntu" to keep arm64 cross-packages synchronized and avoid conflicts