### PR TITLE
Fix mesa build with updated glibc/c23 in Ubuntu 26

### DIFF
--- a/debian/patches/0003-add-enhanced-cuda-pixfmt-converter-impl.patch
+++ b/debian/patches/0003-add-enhanced-cuda-pixfmt-converter-impl.patch
@@ -605,18 +605,17 @@ Index: FFmpeg/libavfilter/vf_scale_cuda.cu
      }
  
      DEF_F(Convert_uv, out_T_uv)
-@@ -1114,8 +1162,8 @@ __device__ static inline T Subsample_Bic
+@@ -1015,6 +1063,9 @@ typedef float4 (*coeffs_function_t)(floa
+ 
+ __device__ static inline float4 lanczos_coeffs(float x, float param)
  {
-     float hscale = (float)src_width / (float)dst_width;
-     float vscale = (float)src_height / (float)dst_height;
--    float xi = (xo + 0.5f) * hscale - 0.5f;
--    float yi = (yo + 0.5f) * vscale - 0.5f;
-+    float xi = xo * hscale + 0.5f * hscale - 0.5f; // avoid (x - v + v = x)
-+    float yi = yo * hscale + 0.5f * vscale - 0.5f;
-     float px = floor(xi);
-     float py = floor(yi);
-     float fx = xi - px;
-@@ -1147,7 +1195,9 @@ __device__ static inline T Subsample_Bic
++#if defined(__clang__) && (__clang_major__ >= 11)
++    #pragma clang fp reassociate(off)
++#endif
+     const float pi = 3.141592654f;
+ 
+     float4 res = make_float4(
+@@ -1147,7 +1198,9 @@ __device__ static inline T Subsample_Bic
      cudaTextureObject_t src_tex_2, cudaTextureObject_t src_tex_3, \
      T *dst_0, T *dst_1, T *dst_2, T *dst_3,                       \
      int dst_width, int dst_height, int dst_pitch,                 \
@@ -627,7 +626,7 @@ Index: FFmpeg/libavfilter/vf_scale_cuda.cu
  
  #define SUBSAMPLE(Convert, T) \
      cudaTextureObject_t src_tex[4] =                    \
-@@ -1159,7 +1209,9 @@ __device__ static inline T Subsample_Bic
+@@ -1159,7 +1212,9 @@ __device__ static inline T Subsample_Bic
      Convert(                                            \
          src_tex, dst, xo, yo,                           \
          dst_width, dst_height, dst_pitch,               \

--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -2,7 +2,7 @@ Index: FFmpeg/configure
 ===================================================================
 --- FFmpeg.orig/configure
 +++ FFmpeg/configure
-@@ -3312,6 +3312,8 @@ scale_cuda_filter_deps="ffnvcodec"
+@@ -3316,6 +3316,8 @@ scale_cuda_filter_deps="ffnvcodec"
  scale_cuda_filter_deps_any="cuda_nvcc cuda_llvm"
  thumbnail_cuda_filter_deps="ffnvcodec"
  thumbnail_cuda_filter_deps_any="cuda_nvcc cuda_llvm"
@@ -11,31 +11,23 @@ Index: FFmpeg/configure
  transpose_npp_filter_deps="ffnvcodec libnpp"
  overlay_cuda_filter_deps="ffnvcodec"
  overlay_cuda_filter_deps_any="cuda_nvcc cuda_llvm"
-@@ -4690,8 +4692,10 @@ if enabled cuda_nvcc; then
-     nvcc_default="nvcc"
-     nvccflags_default="-gencode arch=compute_30,code=sm_30 -O2"
- else
-+    # clang-20 emits ptx60 instruction 'brx.idx' even for ptx32 target (llvm/llvm-project@ccc3127)
-+    # default to ptx60/sm_30 to follow the changes made in clang-16+ (llvm/llvm-project@d677505)
-     nvcc_default="clang"
--    nvccflags_default="--cuda-gpu-arch=sm_30 -O2"
-+    nvccflags_default="--cuda-feature=+ptx60 --cuda-gpu-arch=sm_30 -O2 -ffast-math"
-     NVCC_C=""
- fi
- 
-@@ -4701,6 +4705,11 @@ if enabled cuda_nvcc; then
+@@ -4707,6 +4709,15 @@ if enabled cuda_nvcc; then
      if $nvcc $nvccflags_default 2>&1 | grep -qi unsupported; then
          nvccflags_default="-gencode arch=compute_60,code=sm_60 -O2"
      fi
 +else
++    clang_version=$($nvcc -dumpversion 2>/dev/null || echo 0)
++    # clang-11+ allows disabling reassociate with progma when fast-math is enabled
++    test ${clang_version%%[!0-9]*} -ge 11 && append nvccflags_default "-ffast-math"
++
++    # clang-20 emits ptx60 instruction 'brx.idx' even for ptx32 target (llvm/llvm-project@ccc3127)
++    # default to ptx60/sm_30 to follow the changes made in clang-16+ (llvm/llvm-project@d677505)
 +    # '--cuda-feature=+ptx*' option is not available before clang-15
-+    if $nvcc $nvccflags_default 2>&1 | grep -qi unsupported; then
-+        nvccflags_default="--cuda-gpu-arch=sm_30 -O2 -ffast-math"
-+    fi
++    test ${clang_version%%[!0-9]*} -ge 15 && append nvccflags_default "--cuda-feature=+ptx60"
  fi
  
  set_default arch cc cxx doxygen pkg_config ranlib strip sysinclude \
-@@ -6753,7 +6762,7 @@ fi
+@@ -6774,7 +6785,7 @@ fi
  if enabled cuda_nvcc; then
      nvccflags="$nvccflags -ptx"
  else
@@ -1129,8 +1121,8 @@ Index: FFmpeg/libavfilter/cuda/pixfmt.h
 +
 +static __inline__ __device__ float3 read_tex_px_flt(const FFCUDAFrame& frame, int x, int y)
 +{
-+    float ncoord_x = (float)(x + 1) * (1.0f / (frame.width + 1));
-+    float ncoord_y = (float)(y + 1) * (1.0f / (frame.height + 1));
++    float ncoord_x = (float)(x + 0.5f) / (float)frame.width;
++    float ncoord_y = (float)(y + 0.5f) / (float)frame.height;
 +
 +    float px_y = tex2D<float>(frame.tex[0], x, y);
 +    float2 px_uv = tex2D<float2>(frame.tex[1], ncoord_x, ncoord_y);

--- a/debian/patches/0006-add-opencl-scaler-and-pixfmt-converter-impl.patch
+++ b/debian/patches/0006-add-opencl-scaler-and-pixfmt-converter-impl.patch
@@ -2,7 +2,7 @@ Index: FFmpeg/configure
 ===================================================================
 --- FFmpeg.orig/configure
 +++ FFmpeg/configure
-@@ -3935,6 +3935,7 @@ rubberband_filter_deps="librubberband"
+@@ -3939,6 +3939,7 @@ rubberband_filter_deps="librubberband"
  sab_filter_deps="gpl swscale"
  scale2ref_filter_deps="swscale"
  scale_filter_deps="swscale"
@@ -373,7 +373,7 @@ Index: FFmpeg/libavfilter/vf_scale_opencl.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_scale_opencl.c
-@@ -0,0 +1,931 @@
+@@ -0,0 +1,942 @@
 +/*
 + * Copyright (c) 2018 Gabriel Machado
 + * Copyright (c) 2021 NyanMisaka
@@ -986,6 +986,13 @@ Index: FFmpeg/libavfilter/vf_scale_opencl.c
 +    if (ret < 0)
 +        return ret;
 +
++    if (inlink->sample_aspect_ratio.num)
++        outlink->sample_aspect_ratio = av_mul_q((AVRational){outlink->h * inlink->w,
++                                                             outlink->w * inlink->h},
++                                                inlink->sample_aspect_ratio);
++    else
++        outlink->sample_aspect_ratio = inlink->sample_aspect_ratio;
++
 +    return 0;
 +}
 +
@@ -1153,6 +1160,10 @@ Index: FFmpeg/libavfilter/vf_scale_opencl.c
 +        goto fail;
 +    output->width  = outlink->w;
 +    output->height = outlink->h;
++    av_reduce(&output->sample_aspect_ratio.num, &output->sample_aspect_ratio.den,
++              (int64_t)input->sample_aspect_ratio.num * outlink->h * inlink->w,
++              (int64_t)input->sample_aspect_ratio.den * outlink->w * inlink->h,
++              INT_MAX);
 +
 +    if (ctx->in_fmt == AV_PIX_FMT_NV15 && !(ctx->src_w == ctx->dst_w && ctx->src_h == ctx->dst_h)) {
 +        /* for scaling P010 compact: 1st pass conv & 2nd pass scale */

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -1368,10 +1368,10 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +        return;
 +
 +    float2 src1_sz_recip = native_recip(convert_float2(src1_sz));
-+    float2 ncoords_yuv0 = convert_float2((int2)(x,     y)) * src1_sz_recip;
-+    float2 ncoords_yuv1 = convert_float2((int2)(x + 1, y)) * src1_sz_recip;
-+    float2 ncoords_yuv2 = convert_float2((int2)(x,     y + 1)) * src1_sz_recip;
-+    float2 ncoords_yuv3 = convert_float2((int2)(x + 1, y + 1)) * src1_sz_recip;
++    float2 ncoords_yuv0 = (convert_float2((int2)(x,     y)) + 0.5f) * src1_sz_recip;
++    float2 ncoords_yuv1 = (convert_float2((int2)(x + 1, y)) + 0.5f) * src1_sz_recip;
++    float2 ncoords_yuv2 = (convert_float2((int2)(x,     y + 1)) + 0.5f) * src1_sz_recip;
++    float2 ncoords_yuv3 = (convert_float2((int2)(x + 1, y + 1)) + 0.5f) * src1_sz_recip;
 +
 +    float3 yuv0, yuv1, yuv2, yuv3;
 +
@@ -1651,10 +1651,10 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +        return;
 +
 +    float2 src1_sz_recip = native_recip(convert_float2(src1_sz));
-+    float2 ncoords_yuv0 = convert_float2((int2)(x,     y)) * src1_sz_recip;
-+    float2 ncoords_yuv1 = convert_float2((int2)(x + 1, y)) * src1_sz_recip;
-+    float2 ncoords_yuv2 = convert_float2((int2)(x,     y + 1)) * src1_sz_recip;
-+    float2 ncoords_yuv3 = convert_float2((int2)(x + 1, y + 1)) * src1_sz_recip;
++    float2 ncoords_yuv0 = (convert_float2((int2)(x,     y)) + 0.5f) * src1_sz_recip;
++    float2 ncoords_yuv1 = (convert_float2((int2)(x + 1, y)) + 0.5f) * src1_sz_recip;
++    float2 ncoords_yuv2 = (convert_float2((int2)(x,     y + 1)) + 0.5f) * src1_sz_recip;
++    float2 ncoords_yuv3 = (convert_float2((int2)(x + 1, y + 1)) + 0.5f) * src1_sz_recip;
 +
 +    float3 yuv0, yuv1, yuv2, yuv3;
 +

--- a/debian/patches/0016-add-fixes-for-nvdec-exceed-32-surfaces-error.patch
+++ b/debian/patches/0016-add-fixes-for-nvdec-exceed-32-surfaces-error.patch
@@ -2,16 +2,31 @@ Index: FFmpeg/libavcodec/nvdec.c
 ===================================================================
 --- FFmpeg.orig/libavcodec/nvdec.c
 +++ FFmpeg/libavcodec/nvdec.c
-@@ -300,8 +300,10 @@ static int nvdec_init_hwframes(AVCodecCo
-     frames_ctx = (AVHWFramesContext*)(*out_frames_ref)->data;
+@@ -399,8 +399,8 @@ int ff_nvdec_decode_init(AVCodecContext
+     params.OutputFormat        = output_format;
+     params.CodecType           = cuvid_codec_type;
+     params.ChromaFormat        = cuvid_chroma_format;
+-    params.ulNumDecodeSurfaces = frames_ctx->initial_pool_size;
+-    params.ulNumOutputSurfaces = unsafe_output ? frames_ctx->initial_pool_size : 1;
++    params.ulNumDecodeSurfaces = FFMIN(frames_ctx->initial_pool_size, 32);
++    params.ulNumOutputSurfaces = unsafe_output ? FFMIN(frames_ctx->initial_pool_size, 64) : 1;
  
-     if (dummy) {
--        // Copied from ff_decode_get_hw_frames_ctx for compatibility
--        frames_ctx->initial_pool_size += 3;
-+        // The function above guarantees 1 work surface, We must guarantee 4 work surfaces.
-+        // (the absolute minimum), so add the missing count without exceeding the maximum
-+        // recommended for nvdec.
-+        frames_ctx->initial_pool_size = FFMIN(frames_ctx->initial_pool_size + 3, 32);
+     ret = nvdec_decoder_create(&ctx->decoder, frames_ctx->device_ref, &params, avctx);
+     if (ret < 0) {
+@@ -424,7 +424,7 @@ int ff_nvdec_decode_init(AVCodecContext
+         ret = AVERROR(ENOMEM);
+         goto fail;
+     }
+-    pool->dpb_size = frames_ctx->initial_pool_size;
++    pool->dpb_size = FFMIN(frames_ctx->initial_pool_size, 32);
  
-         frames_ctx->free = nvdec_free_dummy;
-         frames_ctx->pool = av_buffer_pool_init(0, nvdec_alloc_dummy);
+     ctx->decoder_pool = ff_refstruct_pool_alloc_ext(sizeof(unsigned int), 0, pool,
+                                                     nvdec_decoder_frame_init,
+@@ -529,7 +529,6 @@ static int nvdec_retrieve_data(void *log
+         goto copy_fail;
+ 
+     unmap_data->idx = cf->idx;
+-    unmap_data->idx_ref = ff_refstruct_ref(cf->idx_ref);
+     unmap_data->decoder = ff_refstruct_ref(cf->decoder);
+ 
+     av_pix_fmt_get_chroma_sub_sample(hwctx->sw_format, &shift_h, &shift_v);

--- a/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0046-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -130,7 +130,7 @@ Index: FFmpeg/configure
  postproc_deps="avutil gpl"
  postproc_suggest="libm stdatomic"
  swresample_deps="avutil"
-@@ -7140,11 +7156,16 @@ enabled openssl           && { { check_p
+@@ -7142,11 +7158,16 @@ enabled openssl           && { { check_p
                                 check_lib openssl openssl/ssl.h SSL_library_init -lssl -lcrypto -lws2_32 -lgdi32 ||
                                 die "ERROR: openssl not found"; }
  enabled pocketsphinx      && require_pkg_config pocketsphinx pocketsphinx pocketsphinx/pocketsphinx.h ps_init
@@ -149,7 +149,7 @@ Index: FFmpeg/configure
  enabled vapoursynth       && require_headers "vapoursynth/VSScript4.h vapoursynth/VapourSynth4.h"
  
  
-@@ -7346,7 +7367,7 @@ fi
+@@ -7348,7 +7369,7 @@ fi
  if enabled_all opencl libdrm ; then
      check_type "CL/cl_intel.h" "clCreateImageFromFdINTEL_fn" &&
          enable opencl_drm_beignet
@@ -299,7 +299,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
   *
   * This file is part of FFmpeg.
   *
-@@ -19,551 +20,1484 @@
+@@ -19,551 +20,1483 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
  
@@ -886,7 +886,6 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    return 0;
 +
 +fail:
-+    rkmpp_decode_close(avctx);
 +    return ret;
 +}
 +
@@ -2197,7 +2196,7 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppdec.h
-@@ -0,0 +1,179 @@
+@@ -0,0 +1,180 @@
 +/*
 + * Copyright (c) 2017 Lionel CHAZALLON
 + * Copyright (c) 2023 Huseyin BIYIK
@@ -2371,6 +2370,7 @@ Index: FFmpeg/libavcodec/rkmppdec.h
 +    .p.capabilities = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AVOID_PROBING | \
 +                      AV_CODEC_CAP_HARDWARE, \
 +    .caps_internal  = FF_CODEC_CAP_NOT_INIT_THREADSAFE | \
++                      FF_CODEC_CAP_INIT_CLEANUP | \
 +                      FF_CODEC_CAP_SETS_FRAME_PROPS, \
 +    .hw_configs     = rkmpp_dec_hw_configs, \
 +    .p.wrapper_name = "rkmpp", \
@@ -2381,7 +2381,7 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavcodec/rkmppenc.c
-@@ -0,0 +1,1311 @@
+@@ -0,0 +1,1312 @@
 +/*
 + * Copyright (c) 2023 Huseyin BIYIK
 + * Copyright (c) 2023 NyanMisaka
@@ -3400,8 +3400,10 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    }
 +
 +    mpp_buf = mpp_frame_get_buffer(mpp_frame);
-+    if (!mpp_buf)
-+        return AVERROR(ENOMEM);
++    if (!mpp_buf) {
++        ret = AVERROR(ENOMEM);
++        goto exit;
++    }
 +
 +    /* mark buffer as unused (idx < 0) */
 +    mpp_buffer_set_index(mpp_buf, -1);
@@ -3680,7 +3682,6 @@ Index: FFmpeg/libavcodec/rkmppenc.c
 +    if (mpp_pkt)
 +        mpp_packet_deinit(&mpp_pkt);
 +
-+    rkmpp_encode_close(avctx);
 +    return ret;
 +}
 +
@@ -4096,7 +4097,7 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/rkrga_common.c
-@@ -0,0 +1,1425 @@
+@@ -0,0 +1,1439 @@
 +/*
 + * Copyright (c) 2023 NyanMisaka
 + *
@@ -4681,6 +4682,20 @@ Index: FFmpeg/libavfilter/rkrga_common.c
 +        goto fail;
 +    }
 +    out_frame->frame->crop_top = 0;
++    if ((in0_info->rotate_mode & 0x04) == 0x04 /* HAL_TRANSFORM_ROT_90 */ ||
++        (in0_info->rotate_mode & 0x07) == 0x07 /* HAL_TRANSFORM_ROT_270 */) {
++        av_reduce(&out_frame->frame->sample_aspect_ratio.den,
++                  &out_frame->frame->sample_aspect_ratio.num,
++                  (int64_t)in->sample_aspect_ratio.num * outlink->w * inlink->w,
++                  (int64_t)in->sample_aspect_ratio.den * outlink->h * inlink->h,
++                  INT_MAX);
++    } else {
++        av_reduce(&out_frame->frame->sample_aspect_ratio.num,
++                  &out_frame->frame->sample_aspect_ratio.den,
++                  (int64_t)in->sample_aspect_ratio.num * outlink->h * inlink->w,
++                  (int64_t)in->sample_aspect_ratio.den * outlink->w * inlink->h,
++                  INT_MAX);
++    }
 +
 +    if ((ret = av_hwframe_get_buffer(hw_frame_ctx, out_frame->frame, 0)) < 0) {
 +        av_log(ctx, AV_LOG_ERROR, "Cannot allocate an internal frame: %d\n", ret);

--- a/debian/patches/0050-add-vf-tonemap-videotoolbox-filter.patch
+++ b/debian/patches/0050-add-vf-tonemap-videotoolbox-filter.patch
@@ -857,10 +857,10 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +    if (xi >= dst2_sz.x || yi >= dst2_sz.y)
 +        return;
 +
-+    float2 ncoords_yuv0 = float2(int2(x, y)) / float2(src1_sz);
-+    float2 ncoords_yuv1 = float2(int2(x + 1, y)) / float2(src1_sz);
-+    float2 ncoords_yuv2 = float2(int2(x, y + 1)) / float2(src1_sz);
-+    float2 ncoords_yuv3 = float2(int2(x + 1, y + 1)) / float2(src1_sz);
++    float2 ncoords_yuv0 = (float2(int2(x, y)) + 0.5f) / float2(src1_sz);
++    float2 ncoords_yuv1 = (float2(int2(x + 1, y)) + 0.5f) / float2(src1_sz);
++    float2 ncoords_yuv2 = (float2(int2(x, y + 1)) + 0.5f) / float2(src1_sz);
++    float2 ncoords_yuv3 = (float2(int2(x + 1, y + 1)) + 0.5f) / float2(src1_sz);
 +
 +    float3 yuv0, yuv1, yuv2, yuv3;
 +

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -571,7 +571,9 @@ prepare_extra_amd64() {
         wget ${mesa_link} -O mesa.tar.gz
         tar xaf mesa.tar.gz
         # Cherry-pick fixes targeting mesa-stable
-        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/ee4d7e98.patch | git -C mesa-${mesa_ver} apply
+        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/ee4d7e98.patch | patch -p1 -d mesa-${mesa_ver}
+        # Fix duplicate definitions in C23/glibc
+        wget -q -O - https://gitlab.freedesktop.org/mesa/mesa/-/commit/179e744f.patch | patch -p1 -d mesa-${mesa_ver}
         meson setup mesa-${mesa_ver} mesa_build \
             --prefix=${TARGET_DIR} \
             --libdir=lib \


### PR DESCRIPTION
**Changes**
- Fix mesa build with updated glibc/c23 in Ubuntu 26
- Backport some fixes from new branch (8.1)

**Issues**
```
src/c11/impl/libmesa_util_c11.a.p/threads_posix.c.o -c ../mesa-mesa-25.0.7/src/c11/impl/threads_posix.c
2026-03-18T08:04:12.3543877Z In file included from ../mesa-mesa-25.0.7/src/c11/impl/threads_posix.c:13:
2026-03-18T08:04:12.3545001Z ../mesa-mesa-25.0.7/src/c11/threads.h:121:25: error: conflicting types for 'once_flag'; have 'pthread_once_t' {aka 'int'}
2026-03-18T08:04:12.3545966Z   121 | typedef pthread_once_t  once_flag;
2026-03-18T08:04:12.3546406Z       |                         ^~~~~~~~~
2026-03-18T08:04:12.3546892Z In file included from /usr/include/stdlib.h:1191,
2026-03-18T08:04:12.3547511Z                  from ../mesa-mesa-25.0.7/src/c11/impl/threads_posix.c:5:
2026-03-18T08:04:12.3548566Z /usr/include/x86_64-linux-gnu/bits/types/once_flag.h:24:21: note: previous declaration of 'once_flag' with type 'once_flag'
2026-03-18T08:04:12.3549519Z    24 | typedef __once_flag once_flag;
2026-03-18T08:04:12.3549933Z       |                     ^~~~~~~~~
2026-03-18T08:04:12.3550584Z ../mesa-mesa-25.0.7/src/c11/threads.h:122:11: warning: 'ONCE_FLAG_INIT' redefined
2026-03-18T08:04:12.3551571Z   122 | #  define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
2026-03-18T08:04:12.3552046Z       |           ^~~~~~~~~~~~~~
2026-03-18T08:04:12.3552846Z /usr/include/x86_64-linux-gnu/bits/types/once_flag.h:25:9: note: this is the location of the previous definition
2026-03-18T08:04:12.3553756Z    25 | #define ONCE_FLAG_INIT __ONCE_FLAG_INIT
2026-03-18T08:04:12.3554208Z       |         ^~~~~~~~~~~~~~
2026-03-18T08:04:12.3555172Z ../mesa-mesa-25.0.7/src/c11/threads.h:151:6: error: conflicting types for 'call_once'; have 'void(int *, void (*)(void))'
2026-03-18T08:04:12.3556146Z   151 | void call_once(once_flag *, void (*)(void));
2026-03-18T08:04:12.3556611Z       |      ^~~~~~~~~
2026-03-18T08:04:12.3557396Z /usr/include/stdlib.h:1195:13: note: previous declaration of 'call_once' with type 'void(once_flag *, void (*)(void))'
2026-03-18T08:04:12.3558444Z  1195 | extern void call_once (once_flag *__flag, void (*__func)(void));
2026-03-18T08:04:12.3559020Z       |             ^~~~~~~~~
2026-03-18T08:04:12.3559918Z ../mesa-mesa-25.0.7/src/c11/impl/threads_posix.c:50:1: error: conflicting types for 'call_once'; have 'void(int *, void (*)(void))'
2026-03-18T08:04:12.3561112Z    50 | call_once(once_flag *flag, void (*func)(void))
2026-03-18T08:04:12.3561692Z       | ^~~~~~~~~
2026-03-18T08:04:12.3562443Z /usr/include/stdlib.h:1195:13: note: previous declaration of 'call_once' with type 'void(once_flag *, void (*)(void))'
2026-03-18T08:04:12.3563496Z  1195 | extern void call_once (once_flag *__flag, void (*__func)(void));
2026-03-18T08:04:12.3564088Z       |             ^~~~~~~~~
```