### PR TITLE
add safe bail out for fisrt-vframe ffprobe opt

### DIFF
--- a/debian/patches/0079-add-first-vframe-only-to-ffprobe.patch
+++ b/debian/patches/0079-add-first-vframe-only-to-ffprobe.patch
@@ -2,36 +2,43 @@ Index: FFmpeg/fftools/ffprobe.c
 ===================================================================
 --- FFmpeg.orig/fftools/ffprobe.c
 +++ FFmpeg/fftools/ffprobe.c
-@@ -147,6 +147,8 @@ static int show_private_data
+@@ -147,6 +147,12 @@ static int show_private_data
  #define SHOW_OPTIONAL_FIELDS_ALWAYS      1
  static int show_optional_fields = SHOW_OPTIONAL_FIELDS_AUTO;
  
 +static int only_show_first_video_frame = 0;
 +
++#define ONLY_FIRST_VFRAME_MAX_PACKETS_PER_STREAM 4096
++#define ONLY_FIRST_VFRAME_MAX_PACKETS_TOTAL     65536
++#define ONLY_FIRST_VFRAME_MAX_DECODE_ITERATIONS 4096
++
  static char *output_format;
  static char *stream_specifier;
  static char *show_data_hash;
-@@ -3108,9 +3110,10 @@ static int read_interval_packets(WriterC
+@@ -3108,9 +3114,12 @@ static int read_interval_packets(WriterC
      AVFormatContext *fmt_ctx = ifile->fmt_ctx;
      AVPacket *pkt = NULL;
      AVFrame *frame = NULL;
 -    int ret = 0, i = 0, frame_count = 0;
 +    int ret = 0, i = 0, frame_count = 0, nb_video_streams = 0;
++    int nb_finished_video_streams = 0, total_video_packets = 0;
      int64_t start = -INT64_MAX, end = interval->end;
      int has_start = 0, has_end = interval->has_end && !interval->end_is_offset;
-+    unsigned char *checked_stream = NULL;
++    unsigned char *finished_video_stream = NULL;
++    unsigned int *video_packets = NULL;
  
      av_log(NULL, AV_LOG_VERBOSE, "Processing read interval ");
      log_read_interval(interval, NULL, AV_LOG_VERBOSE);
-@@ -3149,6 +3152,22 @@ static int read_interval_packets(WriterC
+@@ -3149,6 +3158,25 @@ static int read_interval_packets(WriterC
          ret = AVERROR(ENOMEM);
          goto end;
      }
 +
 +    if (only_show_first_video_frame) {
 +        int si = 0;
-+        checked_stream = av_calloc(ifile->nb_streams, sizeof(unsigned char));
-+        if (!checked_stream) {
++        finished_video_stream = av_calloc(ifile->nb_streams, sizeof(*finished_video_stream));
++        video_packets = av_calloc(ifile->nb_streams, sizeof(*video_packets));
++        if (!finished_video_stream || !video_packets) {
 +            ret = AVERROR(ENOMEM);
 +            goto end;
 +        }
@@ -42,51 +49,119 @@ Index: FFmpeg/fftools/ffprobe.c
 +                selected_streams[si] = 1;
 +            }
 +        }
++        if (!nb_video_streams)
++            goto end;
 +    }
      while (!av_read_frame(fmt_ctx, pkt)) {
          if (fmt_ctx->nb_streams > nb_streams) {
              REALLOCZ_ARRAY_STREAM(nb_streams_frames,  nb_streams, fmt_ctx->nb_streams);
-@@ -3181,6 +3200,12 @@ static int read_interval_packets(WriterC
+@@ -3181,6 +3209,37 @@ static int read_interval_packets(WriterC
              }
  
              frame_count++;
 +
 +            if (only_show_first_video_frame) {
 +                AVCodecParameters *par = ifile->streams[pkt->stream_index].st->codecpar;
-+                if (par->codec_type != AVMEDIA_TYPE_VIDEO) continue;
++                if (par->codec_type != AVMEDIA_TYPE_VIDEO)
++                    continue;
++                if (finished_video_stream[pkt->stream_index])
++                    continue;
++
++                total_video_packets++;
++                video_packets[pkt->stream_index]++;
++
++                if (total_video_packets > ONLY_FIRST_VFRAME_MAX_PACKETS_TOTAL) {
++                    av_log(NULL, AV_LOG_WARNING,
++                           "Stopping only_first_vframe after %d video packets "
++                           "without decoding a first frame for all video streams\n",
++                           total_video_packets);
++                    break;
++                }
++                if (video_packets[pkt->stream_index] > ONLY_FIRST_VFRAME_MAX_PACKETS_PER_STREAM) {
++                    finished_video_stream[pkt->stream_index] = 1;
++                    nb_finished_video_streams++;
++                    av_log(NULL, AV_LOG_WARNING,
++                           "Stopping only_first_vframe for stream %d after %u video packets "
++                           "without receiving a frame\n",
++                           pkt->stream_index, video_packets[pkt->stream_index]);
++                    if (nb_finished_video_streams >= nb_video_streams)
++                        break;
++                    continue;
++                }
 +            }
 +
              if (do_read_packets) {
                  if (do_show_packets)
                      show_packet(w, ifile, pkt, i++);
-@@ -3201,6 +3226,16 @@ static int read_interval_packets(WriterC
- 
-                 while (process_frame(w, ifile, frame, pkt, &packet_new) > 0);
+@@ -3188,6 +3247,8 @@ static int read_interval_packets(WriterC
              }
-+            if (only_show_first_video_frame) {
-+                int nb_checked_streams = 0, si = 0;
-+                checked_stream[pkt->stream_index] = 1;
-+                for (si = 0; si < ifile->nb_streams; si ++) {
-+                    nb_checked_streams += checked_stream[si];
+             if (do_read_frames) {
+                 int packet_new = 1;
++                int decode_iterations = 0;
++                int frame_count_before = nb_streams_frames[pkt->stream_index];
+                 FrameData *fd;
+ 
+                 pkt->opaque_ref = av_buffer_allocz(sizeof(*fd));
+@@ -3199,25 +3260,50 @@ static int read_interval_packets(WriterC
+                 fd->pkt_pos  = pkt->pos;
+                 fd->pkt_size = pkt->size;
+ 
+-                while (process_frame(w, ifile, frame, pkt, &packet_new) > 0);
++                while (1) {
++                    int frame_ret = process_frame(w, ifile, frame, pkt, &packet_new);
++
++                    if (frame_ret <= 0)
++                        break;
++                    if (!only_show_first_video_frame)
++                        continue;
++                    if (++decode_iterations >= ONLY_FIRST_VFRAME_MAX_DECODE_ITERATIONS) {
++                        av_log(NULL, AV_LOG_WARNING,
++                               "Stopping only_first_vframe after %d decoder iterations "
++                               "for stream %d on a single packet\n",
++                               decode_iterations, pkt->stream_index);
++                        break;
++                    }
 +                }
-+                if (nb_checked_streams >= nb_video_streams) {
-+                    break;
++                if (only_show_first_video_frame &&
++                    nb_streams_frames[pkt->stream_index] > frame_count_before) {
++                    finished_video_stream[pkt->stream_index] = 1;
++                    nb_finished_video_streams++;
++                    if (nb_finished_video_streams >= nb_video_streams)
++                        break;
 +                }
-+            }
+             }
          }
          av_packet_unref(pkt);
      }
-@@ -3218,6 +3253,9 @@ static int read_interval_packets(WriterC
+     av_packet_unref(pkt);
+-    //Flush remaining frames that are cached in the decoder
+-    for (i = 0; i < ifile->nb_streams; i++) {
+-        pkt->stream_index = i;
+-        if (do_read_frames) {
+-            while (process_frame(w, ifile, frame, pkt, &(int){1}) > 0);
+-            if (ifile->streams[i].dec_ctx)
+-                avcodec_flush_buffers(ifile->streams[i].dec_ctx);
++    if (!only_show_first_video_frame) {
++        //Flush remaining frames that are cached in the decoder
++        for (i = 0; i < ifile->nb_streams; i++) {
++            pkt->stream_index = i;
++            if (do_read_frames) {
++                while (process_frame(w, ifile, frame, pkt, &(int){1}) > 0);
++                if (ifile->streams[i].dec_ctx)
++                    avcodec_flush_buffers(ifile->streams[i].dec_ctx);
++            }
+         }
+     }
+ 
  end:
      av_frame_free(&frame);
      av_packet_free(&pkt);
-+    if (checked_stream) {
-+        av_freep(&checked_stream);
-+    }
++    av_freep(&finished_video_stream);
++    av_freep(&video_packets);
      if (ret < 0) {
          av_log(NULL, AV_LOG_ERROR, "Could not read packets in interval ");
          log_read_interval(interval, NULL, AV_LOG_ERROR);
-@@ -4609,6 +4647,7 @@ static const OptionDef real_options[] =
+@@ -4609,6 +4695,7 @@ static const OptionDef real_options[] =
      { "print_filename",        OPT_TYPE_FUNC, OPT_FUNC_ARG, {.func_arg = opt_print_filename}, "override the printed input filename", "print_file"},
      { "find_stream_info",      OPT_TYPE_BOOL, OPT_INPUT | OPT_EXPERT, { &find_stream_info },
          "read and decode the streams to fill missing information with heuristics" },


### PR DESCRIPTION
The `only_firsrt_vframe` option was broken when a video stream is sparse, starts late, is corrupt, or keeps feeding non-decodable packets. My test videos are too good to not revealing this, but our users would have files that is in an unideal state which make this option to read forever untill EOF, and when the file is huge enough or a livestream, This option would hang the probing for a long time.

This adds a few safeguard to bail out after a reasonable amount of packets have being decoded.

Probably fixes https://github.com/jellyfin/jellyfin/issues/16048