### PR TITLE
ffprobe: avoid runaway only_first_vframe probing

### DIFF
--- a/debian/patches/0079-add-first-vframe-only-to-ffprobe.patch
+++ b/debian/patches/0079-add-first-vframe-only-to-ffprobe.patch
@@ -9,43 +9,54 @@ Index: FFmpeg/fftools/ffprobe.c
 +static int only_show_first_video_frame = 0;
 +
 +#define ONLY_FIRST_VFRAME_MAX_PACKETS_PER_STREAM 4096
-+#define ONLY_FIRST_VFRAME_MAX_PACKETS_TOTAL     65536
++#define ONLY_FIRST_VFRAME_MAX_PACKETS_SCANNED   65536
 +#define ONLY_FIRST_VFRAME_MAX_DECODE_ITERATIONS 4096
 +
  static char *output_format;
  static char *stream_specifier;
  static char *show_data_hash;
-@@ -3108,9 +3114,12 @@ static int read_interval_packets(WriterC
+@@ -3108,9 +3114,13 @@ static int read_interval_packets(WriterC
      AVFormatContext *fmt_ctx = ifile->fmt_ctx;
      AVPacket *pkt = NULL;
      AVFrame *frame = NULL;
 -    int ret = 0, i = 0, frame_count = 0;
 +    int ret = 0, i = 0, frame_count = 0, nb_video_streams = 0;
-+    int nb_finished_video_streams = 0, total_video_packets = 0;
++    int nb_finished_video_streams = 0, total_packets_scanned = 0;
      int64_t start = -INT64_MAX, end = interval->end;
      int has_start = 0, has_end = interval->has_end && !interval->end_is_offset;
 +    unsigned char *finished_video_stream = NULL;
++    unsigned char *target_video_stream = NULL;
 +    unsigned int *video_packets = NULL;
  
      av_log(NULL, AV_LOG_VERBOSE, "Processing read interval ");
      log_read_interval(interval, NULL, AV_LOG_VERBOSE);
-@@ -3149,6 +3158,25 @@ static int read_interval_packets(WriterC
+@@ -3149,6 +3159,35 @@ static int read_interval_packets(WriterC
          ret = AVERROR(ENOMEM);
          goto end;
      }
 +
 +    if (only_show_first_video_frame) {
-+        int si = 0;
++        int si = 0, have_non_attached_video = 0;
 +        finished_video_stream = av_calloc(ifile->nb_streams, sizeof(*finished_video_stream));
++        target_video_stream = av_calloc(ifile->nb_streams, sizeof(*target_video_stream));
 +        video_packets = av_calloc(ifile->nb_streams, sizeof(*video_packets));
-+        if (!finished_video_stream || !video_packets) {
++        if (!finished_video_stream || !target_video_stream || !video_packets) {
 +            ret = AVERROR(ENOMEM);
 +            goto end;
 +        }
 +        for (si = 0; si < ifile->nb_streams; si ++) {
 +            AVCodecParameters *par = ifile->streams[si].st->codecpar;
-+            if (par->codec_type == AVMEDIA_TYPE_VIDEO) {
++            if (par->codec_type == AVMEDIA_TYPE_VIDEO &&
++                !(ifile->streams[si].st->disposition & AV_DISPOSITION_ATTACHED_PIC))
++                have_non_attached_video = 1;
++        }
++        for (si = 0; si < ifile->nb_streams; si ++) {
++            AVCodecParameters *par = ifile->streams[si].st->codecpar;
++            if (par->codec_type == AVMEDIA_TYPE_VIDEO &&
++                (!have_non_attached_video ||
++                 !(ifile->streams[si].st->disposition & AV_DISPOSITION_ATTACHED_PIC))) {
 +                nb_video_streams++;
++                target_video_stream[si] = 1;
 +                selected_streams[si] = 1;
 +            }
 +        }
@@ -55,28 +66,34 @@ Index: FFmpeg/fftools/ffprobe.c
      while (!av_read_frame(fmt_ctx, pkt)) {
          if (fmt_ctx->nb_streams > nb_streams) {
              REALLOCZ_ARRAY_STREAM(nb_streams_frames,  nb_streams, fmt_ctx->nb_streams);
-@@ -3181,6 +3209,37 @@ static int read_interval_packets(WriterC
+@@ -3156,6 +3195,14 @@ static int read_interval_packets(WriterC
+             REALLOCZ_ARRAY_STREAM(selected_streams,   nb_streams, fmt_ctx->nb_streams);
+             nb_streams = fmt_ctx->nb_streams;
+         }
++        if (only_show_first_video_frame && nb_finished_video_streams < nb_video_streams &&
++            ++total_packets_scanned > ONLY_FIRST_VFRAME_MAX_PACKETS_SCANNED) {
++            av_log(NULL, AV_LOG_WARNING,
++                   "Stopping only_first_vframe after scanning %d packets "
++                   "without decoding a first frame for all target video streams\n",
++                   total_packets_scanned);
++            break;
++        }
+         if (selected_streams[pkt->stream_index]) {
+             AVRational tb = ifile->streams[pkt->stream_index].st->time_base;
+             int64_t pts = pkt->pts != AV_NOPTS_VALUE ? pkt->pts : pkt->dts;
+@@ -3181,6 +3228,28 @@ static int read_interval_packets(WriterC
              }
  
              frame_count++;
 +
 +            if (only_show_first_video_frame) {
-+                AVCodecParameters *par = ifile->streams[pkt->stream_index].st->codecpar;
-+                if (par->codec_type != AVMEDIA_TYPE_VIDEO)
++                if (!target_video_stream[pkt->stream_index])
 +                    continue;
 +                if (finished_video_stream[pkt->stream_index])
 +                    continue;
 +
-+                total_video_packets++;
 +                video_packets[pkt->stream_index]++;
 +
-+                if (total_video_packets > ONLY_FIRST_VFRAME_MAX_PACKETS_TOTAL) {
-+                    av_log(NULL, AV_LOG_WARNING,
-+                           "Stopping only_first_vframe after %d video packets "
-+                           "without decoding a first frame for all video streams\n",
-+                           total_video_packets);
-+                    break;
-+                }
 +                if (video_packets[pkt->stream_index] > ONLY_FIRST_VFRAME_MAX_PACKETS_PER_STREAM) {
 +                    finished_video_stream[pkt->stream_index] = 1;
 +                    nb_finished_video_streams++;
@@ -93,7 +110,7 @@ Index: FFmpeg/fftools/ffprobe.c
              if (do_read_packets) {
                  if (do_show_packets)
                      show_packet(w, ifile, pkt, i++);
-@@ -3188,6 +3247,8 @@ static int read_interval_packets(WriterC
+@@ -3188,6 +3257,8 @@ static int read_interval_packets(WriterC
              }
              if (do_read_frames) {
                  int packet_new = 1;
@@ -102,7 +119,7 @@ Index: FFmpeg/fftools/ffprobe.c
                  FrameData *fd;
  
                  pkt->opaque_ref = av_buffer_allocz(sizeof(*fd));
-@@ -3199,25 +3260,50 @@ static int read_interval_packets(WriterC
+@@ -3199,25 +3270,51 @@ static int read_interval_packets(WriterC
                  fd->pkt_pos  = pkt->pos;
                  fd->pkt_size = pkt->size;
  
@@ -157,11 +174,12 @@ Index: FFmpeg/fftools/ffprobe.c
      av_frame_free(&frame);
      av_packet_free(&pkt);
 +    av_freep(&finished_video_stream);
++    av_freep(&target_video_stream);
 +    av_freep(&video_packets);
      if (ret < 0) {
          av_log(NULL, AV_LOG_ERROR, "Could not read packets in interval ");
          log_read_interval(interval, NULL, AV_LOG_ERROR);
-@@ -4609,6 +4695,7 @@ static const OptionDef real_options[] =
+@@ -4609,6 +4706,7 @@ static const OptionDef real_options[] =
      { "print_filename",        OPT_TYPE_FUNC, OPT_FUNC_ARG, {.func_arg = opt_print_filename}, "override the printed input filename", "print_file"},
      { "find_stream_info",      OPT_TYPE_BOOL, OPT_INPUT | OPT_EXPERT, { &find_stream_info },
          "read and decode the streams to fill missing information with heuristics" },


### PR DESCRIPTION
`only_first_vframe` originally waited for the first decoded frame from every video stream. That breaks on files with multiple video streams where one target stream never reaches "first frame seen" in this path.

For example, a Matroska file with one real HEVC video stream and two attached-picture streams and one of them is PNG. With `-threads 1`, all three streams were marked finished quickly as `avcodec_receive_frame()` returns a frame for all three streams. With `-threads 0`, the attached PNG stream was opened with auto threading, its only packet was consumed, but `avcodec_receive_frame()` returned `EAGAIN` and no frame was emitted with multi thread decoding. Since that stream had no second packet, it never became finished. ffprobe then kept demuxing the rest of the file while waiting for all target video streams to finish, which could read essentially to EOF and appear to consume unbounded memory.

Fix this in two ways:
- exclude attached-picture streams from the `only_first_vframe` target set, so the mode only waits for real video streams
- change the safety fallback from counting packets for unresolved target streams to counting overall scanned packets, so even unknown future cases still terminate instead of scanning forever

This preserves the intended "first real video frame" behavior while making the mode safe for problematic multi-stream inputs.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->

Fixes https://github.com/jellyfin/jellyfin/issues/16549