### PR TITLE
fftools/ffmpeg_mux: fix stream-copied audio dropped with -ss and -output_ts_offset

### DIFF
--- a/debian/patches/0095-preserve-timestamps-with-copyts-and-output-ss.patch
+++ b/debian/patches/0095-preserve-timestamps-with-copyts-and-output-ss.patch
@@ -1,0 +1,46 @@
+Index: FFmpeg/fftools/ffmpeg_enc.c
+===================================================================
+--- FFmpeg.orig/fftools/ffmpeg_enc.c
++++ FFmpeg/fftools/ffmpeg_enc.c
+@@ -357,9 +357,13 @@ int enc_open(void *opaque, const AVFrame
+ static int check_recording_time(OutputStream *ost, int64_t ts, AVRational tb)
+ {
+     OutputFile *of = ost->file;
++    int64_t end_time = of->recording_time;
++
++    if (copy_ts && of->start_time != AV_NOPTS_VALUE)
++        end_time += of->start_time;
+ 
+     if (of->recording_time != INT64_MAX &&
+-        av_compare_ts(ts, tb, of->recording_time, AV_TIME_BASE_Q) >= 0) {
++        av_compare_ts(ts, tb, end_time, AV_TIME_BASE_Q) >= 0) {
+         return 0;
+     }
+     return 1;
+Index: FFmpeg/fftools/ffmpeg_mux.c
+===================================================================
+--- FFmpeg.orig/fftools/ffmpeg_mux.c
++++ FFmpeg/fftools/ffmpeg_mux.c
+@@ -484,7 +484,8 @@ static int of_streamcopy(OutputFile *of,
+             return AVERROR(EAGAIN);
+     }
+ 
+-    ts_offset = av_rescale_q(start_time, AV_TIME_BASE_Q, pkt->time_base);
++    ts_offset = copy_ts ? 0 :
++                av_rescale_q(start_time, AV_TIME_BASE_Q, pkt->time_base);
+ 
+     if (pkt->pts != AV_NOPTS_VALUE)
+         pkt->pts -= ts_offset;
+Index: FFmpeg/fftools/ffmpeg_mux_init.c
+===================================================================
+--- FFmpeg.orig/fftools/ffmpeg_mux_init.c
++++ FFmpeg/fftools/ffmpeg_mux_init.c
+@@ -943,7 +943,7 @@ ost_bind_filter(const Muxer *mux, MuxStr
+         .output_tb        = enc_tb,
+         .trim_start_us    = mux->of.start_time,
+         .trim_duration_us = mux->of.recording_time,
+-        .ts_offset        = mux->of.start_time == AV_NOPTS_VALUE ?
++        .ts_offset        = (copy_ts || mux->of.start_time == AV_NOPTS_VALUE) ?
+                             0 : mux->of.start_time,
+         .vs               = vs,
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -92,3 +92,4 @@
 0092-add-hevc-recovery-point-support-backport-from-upstream.patch
 0093-backport-a-fix-for-unnecessary-rescale-av-nopts-in-lavfi.patch
 0094-backport-a-fix-to-unbreak-svt-av1-v4.patch
+0095-preserve-timestamps-with-copyts-and-output-ss.patch


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**

When using `-copyts` with output `-ss`, timestamps are zeroed to ~0 instead of
being preserved at the seek position.

Without `-copyts`, output `-ss 120` correctly produces output starting at 0.
With `-copyts` but without output `-ss`, timestamps are correctly preserved at ~120.
However, `-copyts` combined with output `-ss 120` incorrectly zeros timestamps to ~0.

## Root cause

Three places unconditionally subtract `start_time` from timestamps regardless
of `-copyts`:

1. `of_streamcopy()` subtracts `start_time` from stream-copied packet timestamps
2. The encoder filter chain uses `ts_offset = start_time` to shift encoded output
   back to zero
3. `check_recording_time()` in the encoder compares frame PTS against
   `recording_time` without accounting for the preserved timestamps

With `-copyts`, the demuxer preserves original timestamps (~120s). Subtracting
`start_time` zeros them, which is correct without `-copyts` (where the demuxer
already reset to ~0) but wrong with `-copyts`.

## Fix

Three changes, all gated on `copy_ts`:

- **`fftools/ffmpeg_mux.c`**: Skip `start_time` subtraction in `of_streamcopy()`
  when `copy_ts` is set. Stream-copied packets keep their original PTS.

- **`fftools/ffmpeg_mux_init.c`**: Set filter `ts_offset = 0` when `copy_ts` is
  set. With `-copyts`, input frames already carry the real PTS, so the trim
  filter sees them directly without a round-trip shift.

- **`fftools/ffmpeg_enc.c`**: In `check_recording_time()`, compare against
  `recording_time + start_time` when `copy_ts` is set. This matches the existing
  stream-copy check at `ffmpeg_mux.c:469` and prevents `-t` from stopping
  encoding immediately when frame PTS is at the seek position.

Both encoded and stream-copied packets stay at their original PTS throughout the
pipeline, so the interleaver sees no DTS gap between streams.

## Tests

8 new FATE tests covering all flag combinations:

HLS tests (`hlsenc.mak`, framecrc):
- `fate-streamcopy-extaudio-nocopyts`: `-output_ts_offset` without `-copyts`
- `fate-streamcopy-extaudio-plain`: output `-ss` only
- `fate-streamcopy-extaudio-partial-offset`: partial `-output_ts_offset`
- `fate-streamcopy-extaudio-copyts`: `-copyts` with output `-ss`
- `fate-streamcopy-extaudio-copyts-interleave`: 30s seek with `-copyts`

Encoder tests (`enc-copyts.mak`, transcode md5+framecrc):
- `fate-enc-copyts-mpeg4-ss`: input `-ss` only
- `fate-enc-copyts-mpeg4-ss-copyts`: input `-ss` + `-copyts`
- `fate-enc-copyts-mpeg4-ss-outss-copyts-offset`: explicit `-output_ts_offset`

All tests use built-in encoders only (mpeg4, mp2fixed). Full FATE suite
passes with `--assert-level=2`.

**Issues**

https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/22765
https://github.com/jellyfin/jellyfin/pull/16580