### PR TITLE
msys2: workaround buggy strndup in libass for MinGW

### DIFF
--- a/msys2/PKGBUILD/40-mingw-w64-libass/PKGBUILD
+++ b/msys2/PKGBUILD/40-mingw-w64-libass/PKGBUILD
@@ -23,14 +23,17 @@ depends=("${MINGW_PACKAGE_PREFIX}-jellyfin-fribidi"
          "${MINGW_PACKAGE_PREFIX}-jellyfin-freetype"
          "${MINGW_PACKAGE_PREFIX}-jellyfin-libunibreak"
          "${MINGW_PACKAGE_PREFIX}-jellyfin-harfbuzz")
-source=(https://github.com/libass/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.xz)
-sha256sums=('SKIP')
+source=(https://github.com/libass/${_realname}/releases/download/${pkgver}/${_realname}-${pkgver}.tar.xz
+        fix-strndup-mingw.patch)
+sha256sums=('SKIP'
+            'SKIP')
 
 export MINGW_TOOLCHAIN_PREFIX="${MINGW_PREFIX}"
 export FF_MINGW_PREFIX="${MINGW_TOOLCHAIN_PREFIX}/ffbuild"
 
 prepare() {
   cd "${srcdir}/${_realname}-${pkgver}"
+  patch -p1 -i "${srcdir}/fix-strndup-mingw.patch"
   # autoreconf to get updated libtool for clang
   autoreconf -fiv
 }

--- a/msys2/PKGBUILD/40-mingw-w64-libass/fix-strndup-mingw.patch
+++ b/msys2/PKGBUILD/40-mingw-w64-libass/fix-strndup-mingw.patch
@@ -1,0 +1,12 @@
+--- a/libass/ass_compat.h
++++ b/libass/ass_compat.h
+@@ -41,6 +41,9 @@
+ #define strdup ass_strdup_fallback
+ #endif
+ 
++#ifdef _WIN32
++#undef HAVE_STRNDUP
++#endif
+ #ifndef HAVE_STRNDUP
+ #include <stddef.h>
+ char *ass_strndup_fallback(const char *s, size_t n); // definition in ass_utils.c


### PR DESCRIPTION
**Changes**
Recent updates to mingw exposes `strdup` but is only available in c23 mode. This makes libass' build toolchain to believe `strdup` is available as the symbol is provided regardless of the c standard, but during the actual build it is not available as libass does not use c23 build at the moment, which would cause windows build to fail. Force libass to use its own fallback like before for now.
**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->