### PR TITLE
Remove hardening for arm64

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -61,8 +61,7 @@ CONFIG_x86 := --arch=amd64 \
 	--enable-nvdec \
 	--enable-nvenc \
 
-CONFIG_ARM_COMMON := --toolchain=hardened \
-	--enable-cross-compile \
+CONFIG_ARM_COMMON := --enable-cross-compile \
 	--enable-rkmpp \
 	--enable-rkrga \
 


### PR DESCRIPTION
**Changes**
Removing the `--toolchain=hardened` flag makes H.265 decode performance on CPU roughly 30-35% faster. It makes H.264 decode a few percent faster and probably has a modest performance benefit elsewhere as well.

It doesn't seem like amd64 or macOS builds use this flag, so it was specifically penalizing arm64 Linux. I noticed this while running Docker Desktop on a Mac and seeing a huge difference in transcoding performance between the host portable macOS build and the Debian build in the container (4K H.265 -> 4K H.265 transcoding in particular was 5.6x slower).

Some other observations (not directly relevant to the PR, but possibly useful):
* For encoding, setting `-x265-params pools=14` alone had a 4.6x uplift for 4K as it seems the encoder doesn't set up a thread pool automatically on Linux arm64
* The portable Linux arm64 build is ~6% faster than the Debian build as of this PR. Unlike the Debian build, it did not have hardening set and has some performance uplift from better inlining etc.