### PR TITLE
Fix HLG OOTF to use luma-weighted scaling

### DIFF
--- a/debian/patches/0004-add-cuda-tonemap-impl.patch
+++ b/debian/patches/0004-add-cuda-tonemap-impl.patch
@@ -352,7 +352,7 @@ Index: FFmpeg/libavfilter/cuda/colorspace_common.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/cuda/colorspace_common.h
-@@ -0,0 +1,341 @@
+@@ -0,0 +1,331 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -409,6 +409,7 @@ Index: FFmpeg/libavfilter/cuda/colorspace_common.h
 +extern __constant__ const float input_uv_scale;
 +extern __constant__ const float output_quantization_factor;
 +extern __constant__ const float output_quantization_scale;
++extern __constant__ const float hlg_gm1;
 +
 +
 +static __inline__ __device__ float get_luma_dst(float3 c, const float3& luma_dst) {
@@ -476,21 +477,6 @@ Index: FFmpeg/libavfilter/cuda/colorspace_common.h
 +    return inverse_eotf_st2084_common(x);
 +}
 +
-+static __inline__ __device__ float ootf_1_2(float x) {
-+    return x > 0.0f ? __powf(x, 1.2f) : x;
-+}
-+
-+static __inline__ __device__ float inverse_ootf_1_2(float x) {
-+    return x > 0.0f ? __powf(x, 1.0f / 1.2f) : x;
-+}
-+
-+static __inline__ __device__ float oetf_arib_b67(float x) {
-+    x = max(x, 0.0f);
-+    return x <= (1.0f / 12.0f)
-+           ? sqrtf(3.0f * x)
-+           : (ARIB_B67_A * __logf(12.0f * x - ARIB_B67_B) + ARIB_B67_C);
-+}
-+
 +static __inline__ __device__ float inverse_oetf_arib_b67(float x) {
 +    x = max(x, 0.0f);
 +    return x <= 0.5f
@@ -498,14 +484,18 @@ Index: FFmpeg/libavfilter/cuda/colorspace_common.h
 +           : (__expf((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) * (1.0f / 12.0f);
 +}
 +
-+// linearizer for HLG/ARIB-B67
++// linearizer for HLG/ARIB-B67 (scene-light only; OOTF is applied separately by ootf_hlg)
 +static __inline__ __device__ float eotf_arib_b67(float x) {
-+    return ootf_1_2(inverse_oetf_arib_b67(x)) * (12.0f / REFERENCE_WHITE_ALT);
++    return inverse_oetf_arib_b67(x) * (12.0f / REFERENCE_WHITE_HLG);
 +}
 +
-+// delinearizer for HLG/ARIB-B67
-+static __inline__ __device__ float inverse_eotf_arib_b67(float x) {
-+    return oetf_arib_b67(inverse_ootf_1_2(x / (12.0f / REFERENCE_WHITE_ALT)));
++// BT.2100 luma-weighted OOTF for HLG. Input is display-scale RGB (post 12/REF_HLG factor).
++// hlg_gm1 is baked at PTX link time so __powf can use the constant-exponent fast path.
++static __inline__ __device__ float3 ootf_hlg(float3 c) {
++    float Y_disp = 0.2627f * c.x + 0.6780f * c.y + 0.0593f * c.z;
++    float Y_scene = Y_disp * (REFERENCE_WHITE_HLG / 12.0f);
++    float gain = Y_scene > 0.0f ? __powf(Y_scene, hlg_gm1) : 0.0f;
++    return make_float3(c.x * gain, c.y * gain, c.z * gain);
 +}
 +
 +// delinearizer for BT709, BT2020-10
@@ -698,7 +688,7 @@ Index: FFmpeg/libavfilter/cuda/host_util.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/cuda/host_util.c
-@@ -0,0 +1,77 @@
+@@ -0,0 +1,74 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -725,7 +715,7 @@ Index: FFmpeg/libavfilter/cuda/host_util.c
 +#define CHECK_CU(x) FF_CUDA_CHECK_DL(ctx, cu, x)
 +#define DEPTH_BYTES(depth) (((depth) + 7) / 8)
 +
-+int ff_make_cuda_frame(AVFilterContext *ctx, CudaFunctions *cu, int make_cuTex,
++int ff_make_cuda_frame(AVFilterContext *ctx, CudaFunctions *cu, int make_cu_tex,
 +                       FFCUDAFrame *dst, const AVFrame *src, const AVPixFmtDescriptor *src_desc)
 +{
 +    int i, ret = 0;
@@ -738,26 +728,23 @@ Index: FFmpeg/libavfilter/cuda/host_util.c
 +        dst->tex[i] = 0;
 +    }
 +
-+    for (i = 0; make_cuTex && (i < dst->planes); i++) {
-+#ifndef CU_TRSF_NORMALIZED_COORDINATES
-+  #define CU_TRSF_NORMALIZED_COORDINATES 2
-+#endif
++    for (i = 0; make_cu_tex && (i < dst->planes); i++) {
 +        CUDA_TEXTURE_DESC tex_desc = {
 +            .addressMode = { CU_TR_ADDRESS_MODE_CLAMP, CU_TR_ADDRESS_MODE_CLAMP },
-+            .filterMode = i == 0 ? CU_TR_FILTER_MODE_POINT : CU_TR_FILTER_MODE_LINEAR,
-+            .flags = i == 0 ? 0 : CU_TRSF_NORMALIZED_COORDINATES,
++            .filterMode  = i ? CU_TR_FILTER_MODE_LINEAR : CU_TR_FILTER_MODE_POINT,
++            .flags       = i ? 2 /* CU_TRSF_NORMALIZED_COORDINATES */ : 0
 +        };
 +
 +        CUDA_RESOURCE_DESC res_desc = {
-+            .resType = CU_RESOURCE_TYPE_PITCH2D,
-+            .res.pitch2D.format = DEPTH_BYTES(src_desc->comp[i].depth) == 1 ?
-+                                  CU_AD_FORMAT_UNSIGNED_INT8 :
-+                                  CU_AD_FORMAT_UNSIGNED_INT16,
-+            .res.pitch2D.numChannels = i == 0 ? 1 : (dst->planes == 2 ? 2 : 1),
-+            .res.pitch2D.width = i == 0 ? src->width : AV_CEIL_RSHIFT(src->width, src_desc->log2_chroma_w),
-+            .res.pitch2D.height = i == 0 ? src->height : AV_CEIL_RSHIFT(src->height, src_desc->log2_chroma_h),
++            .resType                  = CU_RESOURCE_TYPE_PITCH2D,
++            .res.pitch2D.format       = DEPTH_BYTES(src_desc->comp[i].depth) == 1 ?
++                                        CU_AD_FORMAT_UNSIGNED_INT8 :
++                                        CU_AD_FORMAT_UNSIGNED_INT16,
++            .res.pitch2D.numChannels  = i ? (dst->planes == 2 ? 2 : 1) : 1,
++            .res.pitch2D.width        = AV_CEIL_RSHIFT(src->width,  i ? src_desc->log2_chroma_w : 0),
++            .res.pitch2D.height       = AV_CEIL_RSHIFT(src->height, i ? src_desc->log2_chroma_h : 0),
 +            .res.pitch2D.pitchInBytes = src->linesize[i],
-+            .res.pitch2D.devPtr = (CUdeviceptr)src->data[i],
++            .res.pitch2D.devPtr       = (CUdeviceptr)src->data[i]
 +        };
 +
 +        if ((ret = CHECK_CU(cu->cuTexObjectCreate(&dst->tex[i], &res_desc, &tex_desc, NULL))) < 0)
@@ -807,7 +794,7 @@ Index: FFmpeg/libavfilter/cuda/host_util.h
 +#include "libavfilter/avfilter.h"
 +#include "shared.h"
 +
-+int ff_make_cuda_frame(AVFilterContext *ctx, CudaFunctions *cu, int make_cuTex,
++int ff_make_cuda_frame(AVFilterContext *ctx, CudaFunctions *cu, int make_cu_tex,
 +                       FFCUDAFrame *dst, const AVFrame *src, const AVPixFmtDescriptor *src_desc);
 +
 +#endif /* AVFILTER_CUDA_HOST_UTIL_H */
@@ -1173,7 +1160,7 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/cuda/tonemap.cu
-@@ -0,0 +1,661 @@
+@@ -0,0 +1,669 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -1200,6 +1187,7 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +extern __constant__ const enum TonemapAlgorithm tonemap_func;
 +extern __constant__ const float tone_param;
 +extern __constant__ const float desat_param;
++extern __constant__ const int lut_size;
 +extern __constant__ const int enable_dither;
 +extern __constant__ const float dither_size;
 +extern __constant__ const float dither_quantization;
@@ -1210,11 +1198,10 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +#define dot3(a, b) ((a).z * (b).z + ((a).y * (b).y + (a).x * (b).x))
 +#define dot4(a, b) ((a).w * (b).w + ((a).z * (b).z + ((a).y * (b).y + (a).x * (b).x)))
 +
-+#define LUT_SIZE 65
-+
++template <typename T, typename S>
 +static __inline__ __device__
-+float3 clamp3(const float3 a, const float min_val, const float max_val) {
-+    float3 result;
++T clamp3(const T a, const S min_val, const S max_val) {
++    T result;
 +    result.x = clamp(a.x, min_val, max_val);
 +    result.y = clamp(a.y, min_val, max_val);
 +    result.z = clamp(a.z, min_val, max_val);
@@ -1436,6 +1423,8 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +static __inline__ __device__
 +float3 map_to_src_space_from_yuv(float3 yuv) {
 +    float3 c = yuv2lrgb(yuv);
++    if (trc_src == AVCOL_TRC_ARIB_STD_B67)
++        c = ootf_hlg(c);
 +    return c;
 +}
 +
@@ -1443,6 +1432,8 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +float3 map_to_src_space_from_yuv_dovi(float3 yuv) {
 +    float3 c = ycc2rgb(yuv.x, yuv.y, yuv.z);
 +    c = lms2rgb(c.x, c.y, c.z);
++    if (trc_src == AVCOL_TRC_ARIB_STD_B67)
++        c = ootf_hlg(c);
 +    return c;
 +}
 +
@@ -1450,6 +1441,8 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +static __inline__ __device__
 +float3 map_to_dst_space_from_yuv(float3 yuv) {
 +    float3 c = yuv2lrgb(yuv);
++    if (trc_src == AVCOL_TRC_ARIB_STD_B67)
++        c = ootf_hlg(c);
 +    return lrgb2lrgb(c);
 +}
 +
@@ -1457,8 +1450,9 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +float3 map_to_dst_space_from_yuv_dovi(float3 yuv) {
 +    float3 c = ycc2rgb(yuv.x, yuv.y, yuv.z);
 +    c = lms2rgb(c.x, c.y, c.z);
-+    c = lrgb2lrgb(c);
-+    return c;
++    if (trc_src == AVCOL_TRC_ARIB_STD_B67)
++        c = ootf_hlg(c);
++    return lrgb2lrgb(c);
 +}
 +
 +static __inline__ __device__
@@ -1573,56 +1567,57 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +    float4 lut_val;
 +    color = clamp3(color, 0.0f, 1.0f);
 +
-+    // Scale the color to the LUT grid.
-+    float3 pos = color * (float)(LUT_SIZE - 1);
++    // Scale the color to the LUT grid
++    float3 pos = color * (float)(lut_size - 1);
 +
-+    // Get the integer base indices in the LUT.
-+    int3 base = make_int3((int)floorf(pos.x), (int)floorf(pos.y), (int)floorf(pos.z));
-+    // Compute the fractional part within the cell.
++    // Get the integer base indices in the LUT
++    int3 base = clamp3(make_int3((int)floorf(pos.x),
++                                 (int)floorf(pos.y),
++                                 (int)floorf(pos.z)), 0, lut_size - 2);
++
++    // Compute the fractional part within the cell
 +    float3 f = pos - make_float3((float)base.x, (float)base.y, (float)base.z);
 +
-+    // Compute the base linear index.
-+    unsigned base_idx = base.x + base.y * LUT_SIZE + base.z * LUT_SIZE * LUT_SIZE;
++    // Sort the fraction offsets, so that we always have f_max>=f_mid>=f_min
++    float f_max = max(f.x, max(f.y, f.z));
++    float f_min = min(f.x, min(f.y, f.z));
++    float f_mid = f.x + f.y + f.z - f_max - f_min;
 +
-+    // Sort the fraction offsets, so that we always have a>=b>=c
-+    float a = max(f.x, max(f.y, f.z));
-+    float c = min(f.x, min(f.y, f.z));
-+    float b = f.x + f.y + f.z - a - c;
-+
-+#define LUT_IDX_MAX (LUT_SIZE * LUT_SIZE * LUT_SIZE - 1)
++    // Compute the base linear index
++    unsigned base_idx = base.x + base.y * lut_size + base.z * lut_size * lut_size;
 +
 +    // The initial and the last corner values of current cube will always be fetched
-+    lut_val = lut[min(base_idx, (unsigned)LUT_IDX_MAX)];
++    lut_val = lut[base_idx];
 +    float3 c000 = make_float3(lut_val.x, lut_val.y, lut_val.z);
-+    lut_val = lut[min(base_idx + 1 + LUT_SIZE + LUT_SIZE * LUT_SIZE, (unsigned)LUT_IDX_MAX)];
++    lut_val = lut[base_idx + 1 + lut_size + lut_size * lut_size];
 +    float3 c111 = make_float3(lut_val.x, lut_val.y, lut_val.z);
 +
-+    // Select the index for vertices of the tetrahedron.
++    // Select the index for vertices of the tetrahedron
 +    unsigned idx100 = base_idx + 1;
-+    unsigned idx010 = base_idx + LUT_SIZE;
-+    unsigned idx110 = base_idx + 1 + LUT_SIZE;
-+    unsigned idx001 = base_idx + LUT_SIZE * LUT_SIZE;
-+    unsigned idx101 = base_idx + 1 + LUT_SIZE * LUT_SIZE;
-+    unsigned idx011 = base_idx + LUT_SIZE + LUT_SIZE * LUT_SIZE;
++    unsigned idx010 = base_idx + lut_size;
++    unsigned idx110 = base_idx + 1 + lut_size;
++    unsigned idx001 = base_idx + lut_size * lut_size;
++    unsigned idx101 = base_idx + 1 + lut_size * lut_size;
++    unsigned idx011 = base_idx + lut_size + lut_size * lut_size;
 +
 +    // Although we have a and c as max and min value, we cannot use them in the
-+    // following selection as float equality comparison is not accurate on GPU.
-+    unsigned idx0 = select(select(idx001, idx010, (f.y >= f.z && f.y >= f.x)), idx100, (f.x >= f.y && f.x >= f.z));
-+    unsigned idx1 = select(select(idx110, idx101, (f.y <= f.z && f.y <= f.x)), idx011, (f.x <= f.y && f.x <= f.z));
++    // following selection as float equality comparison is not accurate on GPU
++    unsigned y_max = f.y >= f.z && f.y >= f.x;
++    unsigned x_max = f.x >= f.y && f.x >= f.z;
++    unsigned idx0 = select(select(idx001, idx010, y_max), idx100, x_max);
++    unsigned y_min = f.y <= f.z && f.y <= f.x;
++    unsigned x_min = f.x <= f.y && f.x <= f.z;
++    unsigned idx1 = select(select(idx110, idx101, y_min), idx011, x_min);
 +
 +    // Fetch LUT value with determined tetrahedron
-+    lut_val = lut[min(idx0, (unsigned)LUT_IDX_MAX)];
++    lut_val = lut[idx0];
 +    float3 c0 = make_float3(lut_val.x, lut_val.y, lut_val.z);
-+    lut_val = lut[min(idx1, (unsigned)LUT_IDX_MAX)];
++    lut_val = lut[idx1];
 +    float3 c1 = make_float3(lut_val.x, lut_val.y, lut_val.z);
 +
-+    float3 ca = c0 - c000;
-+    float3 cb = c1 - c0;
-+    float3 cc = c111 - c1;
-+
-+    float3 result = c000 + a * ca + b * cb + c * cc;
-+
-+    return clamp3(result, 0.0f, 1.0f);
++    return clamp3(c000 + f_max * (c0   - c000)
++                       + f_mid * (c1   - c0)
++                       + f_min * (c111 - c1), 0.0f, 1.0f);
 +}
 +
 +extern "C" {
@@ -1775,16 +1770,16 @@ Index: FFmpeg/libavfilter/cuda/tonemap.cu
 +                          int skip_tonemap,
 +                          int dovi_reshape)
 +{
-+    const int total_entries = LUT_SIZE * LUT_SIZE * LUT_SIZE;
++    const int total_entries = lut_size * lut_size * lut_size;
 +    int idx = blockIdx.x * blockDim.x + threadIdx.x;
 +    if (idx >= total_entries) return;
-+    int z = idx / (LUT_SIZE * LUT_SIZE);
-+    int rem = idx - (z * LUT_SIZE * LUT_SIZE);
-+    int y = rem / LUT_SIZE;
-+    int x = rem % LUT_SIZE;
-+    float fx = (float)x / (LUT_SIZE - 1);
-+    float fy = (float)y / (LUT_SIZE - 1);
-+    float fz = (float)z / (LUT_SIZE - 1);
++    int z = idx / (lut_size * lut_size);
++    int rem = idx - (z * lut_size * lut_size);
++    int y = rem / lut_size;
++    int x = rem % lut_size;
++    float fx = (float)x / (lut_size - 1);
++    float fy = (float)y / (lut_size - 1);
++    float fz = (float)z / (lut_size - 1);
 +    float3 c = make_float3(fx, fy, fz);
 +    if (tonemap_mode == TONEMAP_MODE_ITP) {
 +        c = dovi_reshape
@@ -1994,7 +1989,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_cuda.c
-@@ -0,0 +1,1271 @@
+@@ -0,0 +1,1288 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -2063,6 +2058,10 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +
 +#define REF_WHITE_SCALE (REFERENCE_WHITE / REFERENCE_WHITE_ALT)
 +
++// BT.2100 adaptive γ-1 for HLG OOTF; src_peak is REFERENCE_WHITE_ALT-normalized.
++#define HLG_GAMMA_M1(src_peak) \
++    (float)(FFMAX(1.0, 1.2 + 0.42 * log10((src_peak) * REFERENCE_WHITE_ALT / 1000.0)) - 1.0)
++
 +typedef struct TonemapCUDAContext {
 +    const AVClass *class;
 +
@@ -2095,7 +2094,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    CUfunction  cu_func_dovi;
 +    CUfunction  cu_func_dovi_pq;
 +
-+#define LUT_SIZE (65 * 65 * 65)
++#define LUT_SIZE 65
 +    CUdeviceptr lut_buffer;
 +
 +    CUdeviceptr dither_buffer;
@@ -2113,8 +2112,10 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    struct DoviMetadata *dovi;
 +    float *dovi_pbuf;
 +
-+    enum TonemapAlgorithm tonemap;
-+    enum TonemapMode tonemap_mode;
++    /* enum TonemapAlgorithm */
++    int tonemap;
++    /* enum TonemapMode */
++    int tonemap_mode;
 +    int apply_dovi;
 +    int tradeoff;
 +    int init_with_dovi;
@@ -2125,6 +2126,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    double src_peak;
 +    double dst_peak;
 +    double scene_threshold;
++    float  hlg_gm1;
++    float  baked_hlg_gm1;
 +
 +    const AVPixFmtDescriptor *in_desc, *out_desc;
 +} TonemapCUDAContext;
@@ -2257,30 +2260,28 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +        .srcPitch      = ff_fruit_dither_size * sizeof(ff_fruit_dither_matrix[0]),
 +        .dstPitch      = ff_fruit_dither_size * sizeof(ff_fruit_dither_matrix[0]),
 +        .WidthInBytes  = ff_fruit_dither_size * sizeof(ff_fruit_dither_matrix[0]),
-+        .Height        = ff_fruit_dither_size,
++        .Height        = ff_fruit_dither_size
 +    };
 +
-+#ifndef CU_TRSF_NORMALIZED_COORDINATES
-+  #define CU_TRSF_NORMALIZED_COORDINATES 2
-+#endif
 +    CUDA_TEXTURE_DESC tex_desc = {
 +        .addressMode = { CU_TR_ADDRESS_MODE_WRAP,
 +                         CU_TR_ADDRESS_MODE_WRAP },
-+        .filterMode = CU_TR_FILTER_MODE_POINT,
-+        .flags = CU_TRSF_NORMALIZED_COORDINATES,
++        .filterMode  = CU_TR_FILTER_MODE_POINT,
++        .flags       = 2 /* CU_TRSF_NORMALIZED_COORDINATES */
 +    };
 +
 +    CUDA_RESOURCE_DESC res_desc = {
-+        .resType = CU_RESOURCE_TYPE_PITCH2D,
-+        .res.pitch2D.format = CU_AD_FORMAT_UNSIGNED_INT16,
-+        .res.pitch2D.numChannels = 1,
-+        .res.pitch2D.width = ff_fruit_dither_size,
-+        .res.pitch2D.height = ff_fruit_dither_size,
++        .resType                  = CU_RESOURCE_TYPE_PITCH2D,
++        .res.pitch2D.format       = CU_AD_FORMAT_UNSIGNED_INT16,
++        .res.pitch2D.numChannels  = 1,
++        .res.pitch2D.width        = ff_fruit_dither_size,
++        .res.pitch2D.height       = ff_fruit_dither_size,
 +        .res.pitch2D.pitchInBytes = ff_fruit_dither_size * sizeof(ff_fruit_dither_matrix[0]),
-+        .res.pitch2D.devPtr = 0,
++        .res.pitch2D.devPtr       = 0
 +    };
 +
-+    av_assert0(sizeof(ff_fruit_dither_matrix) == sizeof(ff_fruit_dither_matrix[0]) * ff_fruit_dither_size * ff_fruit_dither_size);
++    av_assert0(sizeof(ff_fruit_dither_matrix) ==
++        sizeof(ff_fruit_dither_matrix[0]) * ff_fruit_dither_size * ff_fruit_dither_size);
 +
 +    if ((ret = CHECK_CU(cu->cuCtxPushCurrent(cuda_ctx))) < 0)
 +        return ret;
@@ -2594,6 +2595,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    if (s->src_peak <= REF_WHITE_SCALE)
 +        s->src_peak = 10.0f * REF_WHITE_SCALE;
 +
++    s->hlg_gm1 = HLG_GAMMA_M1(s->src_peak);
 +    s->dst_peak = 1.0f;
 +
 +    if (in_trc == AVCOL_TRC_UNSPECIFIED)
@@ -2714,6 +2716,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    CONSTANT(".u32 chroma_loc_src      = %i", (int)s->in_chroma_loc);
 +    CONSTANT(".u32 chroma_loc_dst      = %i", (int)s->out_chroma_loc);
 +    CONSTANT(".u32 tonemap_func        = %i", (int)s->tonemap);
++    CONSTANT(".u32 lut_size            = %i", (int)(LUT_SIZE));
 +    CONSTANT(".u32 enable_dither       = %i", (int)(s->in_desc->comp[0].depth > s->out_desc->comp[0].depth));
 +    CONSTANT(".f32 dither_size         = %.1f", (float)ff_fruit_dither_size);
 +    CONSTANT(".f32 dither_quantization = %.1f", (float)((1 << s->out_desc->comp[0].depth) - 1));
@@ -2725,6 +2728,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    CONSTANT(".f32 output_quantization_offset = %.13lf", output_quantization_offset);
 +    CONSTANT(".f32 output_quantization_factor = %.13lf", output_quantization_factor);
 +    CONSTANT(".f32 output_quantization_scale = %.13lf", output_quantization_scale);
++    CONSTANT(".f32 hlg_gm1 = %.6f", s->hlg_gm1);
++    s->baked_hlg_gm1 = s->hlg_gm1;
 +    CONSTANT_M("rgb_matrix", (s->dovi ? s->dovi->nonlinear : rgb_matrix));
 +    CONSTANT_M("yuv_matrix", yuv_matrix);
 +    CONSTANT_A(".u8 rgb2rgb_passthrough = %i", 1, in_pri == out_pri);
@@ -2783,6 +2788,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +        if (ret < 0)
 +            goto fail;
 +
++        s->cu_func_build_lut = NULL;
 +        s->cu_func_tm = NULL;
 +        s->cu_func_dovi = NULL;
 +        s->cu_func_dovi_pq = NULL;
@@ -2813,7 +2819,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +
 +    if (s->tradeoff == 1) {
 +        const size_t lut_size = LUT_SIZE;
-+        const size_t lut_buffer_size = lut_size * sizeof(float) * 4;
++        const size_t lut_size_3d = lut_size * lut_size * lut_size;
++        const size_t lut_buffer_size = lut_size_3d * sizeof(float) * 4;
 +        float peak = (float)s->src_peak;
 +        float dst_peak = (float)s->dst_peak;
 +        int skip_tonemap = s->out_trc == AVCOL_TRC_SMPTE2084;
@@ -2840,7 +2847,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +            void *args[] = { &s->lut_buffer, &peak, &dst_peak, &s->tonemap_mode, &skip_tonemap, &dovi_reshape };
 +
 +            ret = CHECK_CU(cu->cuLaunchKernel(s->cu_func_build_lut,
-+                                              lut_size, 1, 1,
++                                              lut_size_3d, 1, 1,
 +                                              1, 1, 1, 0, s->hwctx->stream, args, NULL));
 +            if (ret < 0)
 +                goto fail2;
@@ -3040,6 +3047,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +            s->src_peak = ff_determine_signal_peak(in);
 +            s->src_peak *= REF_WHITE_SCALE;
 +        }
++        s->hlg_gm1 = HLG_GAMMA_M1(s->src_peak);
 +        av_log(ctx, AV_LOG_DEBUG, "Computed signal peak: %f "
 +               "at pts %"PRId64"\n", s->src_peak, in->pts);
 +    }
@@ -3066,13 +3074,17 @@ Index: FFmpeg/libavfilter/vf_tonemap_cuda.c
 +    if (!s->init_with_dovi && s->dovi && s->cu_func_tm)
 +        uninit_common(ctx);
 +
++    // hlg_gm1 is baked into the PTX as a __constant__ for __powf fast-path;
++    // rebuild the module if it changed (e.g. DOVI per-scene peak update).
 +    if (!s->cu_func_tm ||
 +        !s->cu_func_dovi ||
 +        s->in_trc        != in->color_trc ||
 +        s->in_spc        != in->colorspace ||
 +        s->in_pri        != in->color_primaries ||
 +        s->in_range      != in->color_range ||
-+        s->in_chroma_loc != in->chroma_location) {
++        s->in_chroma_loc != in->chroma_location ||
++        (in->color_trc == AVCOL_TRC_ARIB_STD_B67 &&
++         s->hlg_gm1    != s->baked_hlg_gm1)) {
 +        s->in_trc        = in->color_trc;
 +        s->in_spc        = in->colorspace;
 +        s->in_pri        = in->color_primaries;

--- a/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
+++ b/debian/patches/0007-add-bt2390-eetf-and-code-refactor-to-opencl-tonemap.patch
@@ -159,7 +159,7 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
  
  #if chroma_loc == 1
      #define chroma_sample(a,b,c,d) (((a) + (c)) * 0.5f)
-@@ -33,88 +46,128 @@
+@@ -33,88 +46,117 @@
      #define chroma_sample(a,b,c,d) (((a) + (b) + (c) + (d)) * 0.25f)
  #endif
  
@@ -241,8 +241,10 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
 -    c /= powr(get_luma_dst(c), (gamma - 1.0f) / gamma);
 -    return c;
 +    return eotf_st2084_common(x) * ST2084_MAX_LUMINANCE / REFERENCE_WHITE_ALT;
-+}
-+
+ }
+ 
+-float inverse_eotf_bt1886(float c) {
+-    return c < 0.0f ? 0.0f : powr(c, 1.0f / 2.4f);
 +// delinearizer for PQ/ST2084
 +float inverse_eotf_st2084_common(float x) {
 +    x = fmax(x, 0.0f);
@@ -271,32 +273,6 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
 +    x.z = eotf_st2084_common(x.z);
 +    x.w = eotf_st2084_common(x.w);
 +    return x * ST2084_MAX_LUMINANCE / REFERENCE_WHITE_ALT;
-+}
-+
-+float4 inverse_eotf_st2084x4(float4 x) {
-+    x *= REFERENCE_WHITE_ALT / ST2084_MAX_LUMINANCE;
-+    x.x = inverse_eotf_st2084_common(x.x);
-+    x.y = inverse_eotf_st2084_common(x.y);
-+    x.z = inverse_eotf_st2084_common(x.z);
-+    x.w = inverse_eotf_st2084_common(x.w);
-+    return x;
-+}
-+
-+float ootf_1_2(float x) {
-+    return x > 0.0f ? native_powr(x, 1.2f) : x;
-+}
-+
-+float inverse_ootf_1_2(float x) {
-+    return x > 0.0f ? native_powr(x, 1.0f / 1.2f) : x;
- }
- 
--float inverse_eotf_bt1886(float c) {
--    return c < 0.0f ? 0.0f : powr(c, 1.0f / 2.4f);
-+float oetf_arib_b67(float x) {
-+    x = fmax(x, 0.0f);
-+    return x <= (1.0f / 12.0f)
-+           ? native_sqrt(3.0f * x)
-+           : (ARIB_B67_A * native_log(12.0f * x - ARIB_B67_B) + ARIB_B67_C);
  }
  
 -float oetf_bt709(float c) {
@@ -309,6 +285,15 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
 -    float r1 = c / 4.5f;
 -    float r2 = powr((c + 0.099f) / 1.099f, 1.0f / 0.45f);
 -    return c < 0.081f ? r1 : r2;
++float4 inverse_eotf_st2084x4(float4 x) {
++    x *= REFERENCE_WHITE_ALT / ST2084_MAX_LUMINANCE;
++    x.x = inverse_eotf_st2084_common(x.x);
++    x.y = inverse_eotf_st2084_common(x.y);
++    x.z = inverse_eotf_st2084_common(x.z);
++    x.w = inverse_eotf_st2084_common(x.w);
++    return x;
++}
++
 +float inverse_oetf_arib_b67(float x) {
 +    x = fmax(x, 0.0f);
 +    return x <= 0.5f
@@ -316,14 +301,18 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
 +           : (native_exp((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) * (1.0f / 12.0f);
 +}
 +
-+// linearizer for HLG/ARIB-B67
++// linearizer for HLG/ARIB-B67 (scene-light only; OOTF is applied separately by ootf_hlg)
 +float eotf_arib_b67(float x) {
-+    return ootf_1_2(inverse_oetf_arib_b67(x)) * (12.0f / REFERENCE_WHITE_HLG);
++    return inverse_oetf_arib_b67(x) * (12.0f / REFERENCE_WHITE_HLG);
 +}
 +
-+// delinearizer for HLG/ARIB-B67
-+float inverse_eotf_arib_b67(float x) {
-+    return oetf_arib_b67(inverse_ootf_1_2(x / (12.0f / REFERENCE_WHITE_HLG)));
++// BT.2100 luma-weighted OOTF for HLG. Input is display-scale RGB (post 12/REF_HLG factor).
++// HLG_GM1 is baked at JIT compile time so native_powr can use the constant-exponent fast path.
++float3 ootf_hlg(float3 c) {
++    float Y_disp = 0.2627f * c.x + 0.6780f * c.y + 0.0593f * c.z;
++    float Y_scene = Y_disp * (REFERENCE_WHITE_HLG / 12.0f);
++    float gain = Y_scene > 0.0f ? native_powr(Y_scene, HLG_GM1) : 0.0f;
++    return c * gain;
 +}
 +
 +// delinearizer for BT709, BT2020-10
@@ -349,7 +338,7 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
  #endif
      float r = y * rgb_matrix[0] + u * rgb_matrix[1] + v * rgb_matrix[2];
      float g = y * rgb_matrix[3] + u * rgb_matrix[4] + v * rgb_matrix[5];
-@@ -138,19 +191,35 @@ float3 rgb2yuv(float r, float g, float b
+@@ -138,19 +180,35 @@ float3 rgb2yuv(float r, float g, float b
      float y = r*yuv_matrix[0] + g*yuv_matrix[1] + b*yuv_matrix[2];
      float u = r*yuv_matrix[3] + g*yuv_matrix[4] + b*yuv_matrix[5];
      float v = r*yuv_matrix[6] + g*yuv_matrix[7] + b*yuv_matrix[8];
@@ -391,7 +380,7 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
      return y;
  }
  
-@@ -188,18 +257,97 @@ float3 lrgb2lrgb(float3 c) {
+@@ -188,18 +246,97 @@ float3 lrgb2lrgb(float3 c) {
  #endif
  }
  
@@ -434,7 +423,7 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
 +    bb = inverse_eotf_st2084_common(bb);
 +    return (float3)(rr, gg, bb);
 +}
- #endif
++#endif
 +
 +#ifdef TONE_MODE_ITP
 +// The following assumes bt2020
@@ -461,7 +450,7 @@ Index: FFmpeg/libavfilter/opencl/colorspace_common.cl
 +    *g4 = -0.791329555598929f * ll4 + 1.983600451792291f * mm4 - 0.192270896193362f * ss4;
 +    *b4 = -0.025949899690593f * ll4 - 0.098913714711726f * mm4 + 1.124863614402319f * ss4;
 +}
-+#endif
+ #endif
 +
 +float parabolic(float x, float t0, float x0, float y0) {
 +    float s = (y0 - t0) / native_sqrt(x0 - y0);
@@ -501,7 +490,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 ===================================================================
 --- FFmpeg.orig/libavfilter/opencl/tonemap.cl
 +++ FFmpeg/libavfilter/opencl/tonemap.cl
-@@ -16,54 +16,89 @@
+@@ -16,54 +16,90 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
  
@@ -538,6 +527,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 -extern float  get_luma_dst(float3);
 -extern float3 ootf(float3 c, float peak);
 -extern float3 inverse_ootf(float3 c, float peak);
++extern float3 ootf_hlg(float3);
 +extern float  eotf_st2084(float);
 +extern float  inverse_eotf_st2084(float);
 +extern float4 get_luma_dst4(float4, float4, float4);
@@ -612,7 +602,7 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
      float j = tone_param;
      float a, b;
  
-@@ -71,202 +106,1016 @@ float mobius(float s, float peak) {
+@@ -71,202 +107,1013 @@ float mobius(float s, float peak) {
          return s;
  
      a = -j * j * (peak - 1.0f) / (j * j - 2.0f * j + peak);
@@ -822,20 +812,6 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    c = rgb2lrgb(c);
 +#else
 +    float3 c = yuv2lrgb(yuv);
-+#endif
-+    return c;
-+}
-+
-+// Map from source space YUV to destination space RGB
-+float3 map_to_dst_space_from_yuv(float3 yuv) {
-+#ifdef DOVI_RESHAPE
-+    float3 c = ycc2rgb(yuv.x, yuv.y, yuv.z);
-+    c = lms2rgb(c.x, c.y, c.z);
-+    c = rgb2lrgb(c);
-+    c = lrgb2lrgb(c);
-+#else
-+    float3 c = yuv2lrgb(yuv);
-+    c = lrgb2lrgb(c);
 +#endif
 +    return c;
 +}
@@ -1135,9 +1111,8 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +
 +  #undef PICK_COEFF_FOR
 +  #undef PACK_COEFFS
-     }
- 
--    sig = TONE_FUNC(sig, peak);
++    }
++
 +    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
 +  #ifdef DOVI_PERF_FP16
 +    coeffw_is_zero = convert_half4(coeffsw == (vec4)M_ZERO_VEC);
@@ -1205,22 +1180,13 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +  #undef EXTRACT_COEFFS
 +}
 +#endif //#ifndef IS_QCOM_GPU
- 
--    sig = min(sig, 1.0f);
--    rgb *= (sig/sig_old);
--    return rgb;
++
 +// Qualcomm has a really bad OpenCL compiler that is having performance regression with vectorized reshaping kernel
 +// Make a scalar version just for them
 +#ifdef IS_QCOM_GPU
 +static inline vec reshape_poly(vec s, vec4 coeffs) {
 +    return (coeffs.z * s + coeffs.y) * s + coeffs.x;
- }
--// map from source space YUV to destination space RGB
--float3 map_to_dst_space_from_yuv(float3 yuv, float peak) {
--    float3 c = yuv2lrgb(yuv);
--    c = ootf(c, peak);
--    c = lrgb2lrgb(c);
--    return c;
++}
 +
 +static inline void reshape_dovi_sig(float *dst,
 +                                    const vec src,
@@ -1279,11 +1245,15 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +                         mix(coeffs3.lo, coeffs3.hi, (vec4)(s >= pivots[6])),
 +                         (vec4)(s >= pivots[5])),
 +                     (vec4)(s >= pivots[3]));
-+    }
-+
+     }
+ 
+-    sig = TONE_FUNC(sig, peak);
 +    has_mmr_poly = dovi_has_mmr && dovi_has_poly;
 +    t = (has_mmr_poly && coeffs.w == M_ZERO_VEC) || (!has_mmr_poly && dovi_has_poly);
-+
+ 
+-    sig = min(sig, 1.0f);
+-    rgb *= (sig/sig_old);
+-    return rgb;
 +    s = t ? reshape_poly(s, coeffs)
 +          : reshape_mmr(*sig, coeffs, dovi_mmr,
 +                        dovi_mmr_single, dovi_min_order, dovi_max_order);
@@ -1292,7 +1262,13 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +  #else
 +    *dst = clamp(s, dovi_lo, dovi_hi);
 +  #endif
-+}
+ }
+-// map from source space YUV to destination space RGB
+-float3 map_to_dst_space_from_yuv(float3 yuv, float peak) {
+-    float3 c = yuv2lrgb(yuv);
+-    c = ootf(c, peak);
+-    c = lrgb2lrgb(c);
+-    return c;
 +
 +void reshape_dovi_ipt(float3 *ipt,
 +                      __global const vec *src_dovi_params,
@@ -1450,16 +1426,23 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +#endif
 +
 +    float3 c0, c1, c2, c3;
-+#ifndef MAP_IN_DST_SPACE
 +    c0 = map_to_src_space_from_yuv(yuv0);
 +    c1 = map_to_src_space_from_yuv(yuv1);
 +    c2 = map_to_src_space_from_yuv(yuv2);
 +    c3 = map_to_src_space_from_yuv(yuv3);
-+#else
-+    c0 = map_to_dst_space_from_yuv(yuv0);
-+    c1 = map_to_dst_space_from_yuv(yuv1);
-+    c2 = map_to_dst_space_from_yuv(yuv2);
-+    c3 = map_to_dst_space_from_yuv(yuv3);
++
++#ifdef HLG_INPUT
++    c0 = ootf_hlg(c0);
++    c1 = ootf_hlg(c1);
++    c2 = ootf_hlg(c2);
++    c3 = ootf_hlg(c3);
++#endif
++
++#ifdef MAP_IN_DST_SPACE
++    c0 = lrgb2lrgb(c0);
++    c1 = lrgb2lrgb(c1);
++    c2 = lrgb2lrgb(c2);
++    c3 = lrgb2lrgb(c3);
 +#endif
 +
 +#ifndef SKIP_TONEMAP
@@ -1766,10 +1749,14 @@ Index: FFmpeg/libavfilter/opencl/tonemap.cl
 +    float fy = (float)y / (LUT_SIZE - 1);
 +    float fz = (float)z / (LUT_SIZE - 1);
 +    float3 c = (float3)(fx, fy, fz);
-+#ifndef MAP_IN_DST_SPACE
 +    c = map_to_src_space_from_yuv(c);
-+#else
-+    c = map_to_dst_space_from_yuv(c);
++
++#ifdef HLG_INPUT
++    c = ootf_hlg(c);
++#endif
++
++#ifdef MAP_IN_DST_SPACE
++    c = lrgb2lrgb(c);
 +#endif
 +    float4 r4 = (float4)(c.x, c.x, c.x, c.x);
 +    float4 g4 = (float4)(c.y, c.y, c.y, c.y);
@@ -1802,7 +1789,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
   * This file is part of FFmpeg.
   *
   * FFmpeg is free software; you can redistribute it and/or
-@@ -15,27 +15,49 @@
+@@ -15,27 +15,53 @@
   * License along with FFmpeg; if not, write to the Free Software
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
@@ -1840,6 +1827,10 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 -#define DETECTION_FRAMES 63
 +#define REF_WHITE_SCALE (REFERENCE_WHITE / REFERENCE_WHITE_ALT)
 +
++// BT.2100 adaptive γ-1 for HLG OOTF; src_peak is REFERENCE_WHITE_ALT-normalized.
++#define HLG_GAMMA_M1(src_peak) \
++    (float)(FFMAX(1.0, 1.2 + 0.42 * log10((src_peak) * REFERENCE_WHITE_ALT / 1000.0)) - 1.0)
++
 +static const enum AVPixelFormat supported_formats[] = {
 +    AV_PIX_FMT_YUV420P,
 +    AV_PIX_FMT_YUV420P16,
@@ -1858,7 +1849,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
  enum TonemapAlgorithm {
      TONEMAP_NONE,
-@@ -45,7 +67,17 @@ enum TonemapAlgorithm {
+@@ -45,7 +71,17 @@ enum TonemapAlgorithm {
      TONEMAP_REINHARD,
      TONEMAP_HABLE,
      TONEMAP_MOBIUS,
@@ -1877,7 +1868,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  };
  
  typedef struct TonemapOpenCLContext {
-@@ -56,23 +88,48 @@ typedef struct TonemapOpenCLContext {
+@@ -56,23 +92,50 @@ typedef struct TonemapOpenCLContext {
      enum AVColorPrimaries primaries, primaries_in, primaries_out;
      enum AVColorRange range, range_in, range_out;
      enum AVChromaLocation chroma_loc;
@@ -1914,6 +1905,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    int                   tradeoff;
      int                   initialised;
 +    int                   init_with_dovi;
++    float                 hlg_gm1;
++    float                 baked_hlg_gm1;
      cl_kernel             kernel;
 +    cl_kernel             lut_generation_kernel;
 +    cl_mem                dither_image;
@@ -1930,7 +1923,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  };
  
  static const char *const delinearize_funcs[AVCOL_TRC_NB] = {
-@@ -80,7 +137,7 @@ static const char *const delinearize_fun
+@@ -80,7 +143,7 @@ static const char *const delinearize_fun
      [AVCOL_TRC_BT2020_10] = "inverse_eotf_bt1886",
  };
  
@@ -1939,7 +1932,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      [TONEMAP_NONE]     = "direct",
      [TONEMAP_LINEAR]   = "linear",
      [TONEMAP_GAMMA]    = "gamma",
-@@ -88,6 +145,14 @@ static const char *const tonemap_func[TO
+@@ -88,6 +151,14 @@ static const char *const tonemap_func[TO
      [TONEMAP_REINHARD] = "reinhard",
      [TONEMAP_HABLE]    = "hable",
      [TONEMAP_MOBIUS]   = "mobius",
@@ -1954,7 +1947,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  };
  
  static int get_rgb2rgb_matrix(enum AVColorPrimaries in, enum AVColorPrimaries out,
-@@ -108,90 +173,453 @@ static int get_rgb2rgb_matrix(enum AVCol
+@@ -108,90 +179,453 @@ static int get_rgb2rgb_matrix(enum AVCol
      return 0;
  }
  
@@ -2437,7 +2430,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_bprintf(&header, "#define chroma_loc %d\n", (int)ctx->chroma_loc);
  
      if (rgb2rgb_passthrough)
-@@ -199,19 +627,41 @@ static int tonemap_opencl_init(AVFilterC
+@@ -199,19 +633,41 @@ static int tonemap_opencl_init(AVFilterC
      else
          ff_opencl_print_const_matrix_3x3(&header, "rgb2rgb", rgb2rgb);
  
@@ -2486,7 +2479,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
                 ctx->colorspace_out, av_color_space_name(ctx->colorspace_out));
          goto fail;
      }
-@@ -219,24 +669,13 @@ static int tonemap_opencl_init(AVFilterC
+@@ -219,24 +675,18 @@ static int tonemap_opencl_init(AVFilterC
      ff_fill_rgb2yuv_table(luma_dst, rgb2yuv);
      ff_opencl_print_const_matrix_3x3(&header, "yuv_matrix", rgb2yuv);
  
@@ -2513,10 +2506,15 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_bprintf(&header, "#define linearize %s\n", linearize_funcs[ctx->trc_in]);
 +        av_bprintf(&header, "#define delinearize %s\n", delinearize_funcs[ctx->trc_out]);
 +    }
++    if (ctx->trc_in == AVCOL_TRC_ARIB_STD_B67) {
++        av_bprintf(&header, "#define HLG_INPUT\n");
++        av_bprintf(&header, "#define HLG_GM1 %ff\n", ctx->hlg_gm1);
++        ctx->baked_hlg_gm1 = ctx->hlg_gm1;
++    }
  
      av_log(avctx, AV_LOG_DEBUG, "Generated OpenCL header:\n%s\n", header.str);
      opencl_sources[0] = header.str;
-@@ -254,46 +693,231 @@ static int tonemap_opencl_init(AVFilterC
+@@ -254,46 +704,231 @@ static int tonemap_opencl_init(AVFilterC
      CL_FAIL_ON_ERROR(AVERROR(EIO), "Failed to create OpenCL "
                       "command queue %d.\n", cle);
  
@@ -2751,13 +2749,14 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported output format: %s\n",
 +               av_get_pix_fmt_name(out_format));
 +        return AVERROR(ENOSYS);
-     }
++    }
 +    if (in_desc->comp[0].depth != 10 && in_desc->comp[0].depth != 16) {
 +        av_log(ctx, AV_LOG_ERROR, "Unsupported input format depth: %d\n",
 +               in_desc->comp[0].depth);
 +        return AVERROR(ENOSYS);
-+    }
-+
+     }
+ 
+-    s->ocf.output_format = s->format == AV_PIX_FMT_NONE ? AV_PIX_FMT_NV12 : s->format;
 +    ctx->in_fmt     = in_format;
 +    ctx->out_fmt    = out_format;
 +    ctx->in_desc    = in_desc;
@@ -2765,12 +2764,11 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    ctx->in_planes  = av_pix_fmt_count_planes(in_format);
 +    ctx->out_planes = av_pix_fmt_count_planes(out_format);
 +    ctx->ocf.output_format = out_format;
- 
--    s->ocf.output_format = s->format == AV_PIX_FMT_NONE ? AV_PIX_FMT_NV12 : s->format;
++
      ret = ff_opencl_filter_config_output(outlink);
      if (ret < 0)
          return ret;
-@@ -308,13 +932,49 @@ static int launch_kernel(AVFilterContext
+@@ -308,13 +943,49 @@ static int launch_kernel(AVFilterContext
      size_t global_work[2];
      size_t local_work[2];
      cl_int cle;
@@ -2785,13 +2783,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +        err = AVERROR(EIO);
 +        goto fail;
 +    }
- 
--    CL_SET_KERNEL_ARG(kernel, 0, cl_mem, &output->data[0]);
--    CL_SET_KERNEL_ARG(kernel, 1, cl_mem, &input->data[0]);
--    CL_SET_KERNEL_ARG(kernel, 2, cl_mem, &output->data[1]);
--    CL_SET_KERNEL_ARG(kernel, 3, cl_mem, &input->data[1]);
--    CL_SET_KERNEL_ARG(kernel, 4, cl_mem, &ctx->util_mem);
--    CL_SET_KERNEL_ARG(kernel, 5, cl_float, &peak);
++
 +    if (ctx->in_planes > 2 && !input->data[2]) {
 +        err = AVERROR(EIO);
 +        goto fail;
@@ -2809,7 +2801,13 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +    if (ctx->out_planes > 2) {
 +        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &output->data[2]);
 +    }
-+
+ 
+-    CL_SET_KERNEL_ARG(kernel, 0, cl_mem, &output->data[0]);
+-    CL_SET_KERNEL_ARG(kernel, 1, cl_mem, &input->data[0]);
+-    CL_SET_KERNEL_ARG(kernel, 2, cl_mem, &output->data[1]);
+-    CL_SET_KERNEL_ARG(kernel, 3, cl_mem, &input->data[1]);
+-    CL_SET_KERNEL_ARG(kernel, 4, cl_mem, &ctx->util_mem);
+-    CL_SET_KERNEL_ARG(kernel, 5, cl_float, &peak);
 +    if (ctx->in_planes > 2) {
 +        CL_SET_KERNEL_ARG(kernel, idx_arg++, cl_mem, &input->data[2]);
 +    }
@@ -2826,7 +2824,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      local_work[0]  = 16;
      local_work[1]  = 16;
-@@ -338,12 +998,10 @@ static int tonemap_opencl_filter_frame(A
+@@ -338,12 +1009,10 @@ static int tonemap_opencl_filter_frame(A
      AVFilterContext    *avctx = inlink->dst;
      AVFilterLink     *outlink = avctx->outputs[0];
      TonemapOpenCLContext *ctx = avctx->priv;
@@ -2840,7 +2838,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      av_log(ctx, AV_LOG_DEBUG, "Filter input: %s, %ux%u (%"PRId64").\n",
             av_get_pix_fmt_name(input->format),
-@@ -351,7 +1009,6 @@ static int tonemap_opencl_filter_frame(A
+@@ -351,7 +1020,6 @@ static int tonemap_opencl_filter_frame(A
  
      if (!input->hw_frames_ctx)
          return AVERROR(EINVAL);
@@ -2848,7 +2846,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      output = ff_get_video_buffer(outlink, outlink->w, outlink->h);
      if (!output) {
-@@ -363,17 +1020,65 @@ static int tonemap_opencl_filter_frame(A
+@@ -363,17 +1031,66 @@ static int tonemap_opencl_filter_frame(A
      if (err < 0)
          goto fail;
  
@@ -2881,6 +2879,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 +            ctx->src_peak = ff_determine_signal_peak(input);
 +            ctx->src_peak *= REF_WHITE_SCALE;
 +        }
++        ctx->hlg_gm1 = HLG_GAMMA_M1(ctx->src_peak);
 +        av_log(ctx, AV_LOG_DEBUG, "Computed signal peak: %f "
 +               "at pts %"PRId64"\n", ctx->src_peak, input->pts);
 +    }
@@ -2920,7 +2919,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
  
      ctx->trc_in = input->color_trc;
      ctx->trc_out = output->color_trc;
-@@ -385,72 +1090,50 @@ static int tonemap_opencl_filter_frame(A
+@@ -385,72 +1102,56 @@ static int tonemap_opencl_filter_frame(A
      ctx->range_out = output->color_range;
      ctx->chroma_loc = output->chroma_location;
  
@@ -2931,13 +2930,18 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
 -            err = AVERROR(ENOSYS);
 -            goto fail;
 -        }
--
++    if (!ctx->init_with_dovi && ctx->dovi && ctx->initialised)
++        tonemap_opencl_uninit_common(avctx);
+ 
 -        if (input_frames_ctx->sw_format != AV_PIX_FMT_P010) {
 -            av_log(ctx, AV_LOG_ERROR, "unsupported format in tonemap_opencl.\n");
 -            err = AVERROR(ENOSYS);
 -            goto fail;
 -        }
-+    if (!ctx->init_with_dovi && ctx->dovi && ctx->initialised)
++    // HLG_GM1 is baked into the kernel as a JIT compile-time constant for native_powr
++    // fast-path; rebuild the program if it changed (e.g. DOVI per-scene peak update).
++    if (ctx->initialised && ctx->trc_in == AVCOL_TRC_ARIB_STD_B67 &&
++        ctx->hlg_gm1 != ctx->baked_hlg_gm1)
 +        tonemap_opencl_uninit_common(avctx);
  
 +    if (!ctx->initialised) {
@@ -3016,7 +3020,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      av_frame_free(&input);
      av_frame_free(&output);
      return err;
-@@ -458,62 +1141,101 @@ fail:
+@@ -458,62 +1159,101 @@ fail:
  
  static av_cold void tonemap_opencl_uninit(AVFilterContext *avctx)
  {
@@ -3165,7 +3169,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_opencl.c
      { NULL }
  };
  
-@@ -541,11 +1263,12 @@ const AVFilter ff_vf_tonemap_opencl = {
+@@ -541,11 +1281,12 @@ const AVFilter ff_vf_tonemap_opencl = {
      .description    = NULL_IF_CONFIG_SMALL("Perform HDR to SDR conversion with tonemapping."),
      .priv_size      = sizeof(TonemapOpenCLContext),
      .priv_class     = &tonemap_opencl_class,

--- a/debian/patches/0050-add-vf-tonemap-videotoolbox-filter.patch
+++ b/debian/patches/0050-add-vf-tonemap-videotoolbox-filter.patch
@@ -40,7 +40,7 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
-@@ -0,0 +1,921 @@
+@@ -0,0 +1,885 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -120,9 +120,9 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +constant float3 yuv_matrix_3 [[function_constant(31)]];
 +constant float3 luma_dst [[function_constant(32)]];
 +constant short linearize_type [[function_constant(33)]];
-+constant short delinearize_type [[function_constant(34)]];
 +constant bool map_in_src_space [[function_constant(35)]];
 +constant bool is_tone_mode_itp [[function_constant(36)]];
++constant float hlg_gm1 [[function_constant(37)]];
 +
 +enum AVChromaLocation {
 +    AVCHROMA_LOC_UNSPECIFIED,
@@ -200,21 +200,6 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +    return x;
 +}
 +
-+float ootf_1_2(float x) {
-+    return x > 0.0f ? powr(x, 1.2f) : x;
-+}
-+
-+float inverse_ootf_1_2(float x) {
-+    return x > 0.0f ? powr(x, 1.0f / 1.2f) : x;
-+}
-+
-+float oetf_arib_b67(float x) {
-+    x = fmax(x, 0.0f);
-+    return x <= (1.0f / 12.0f)
-+           ? sqrt(3.0f * x)
-+           : (ARIB_B67_A * log(12.0f * x - ARIB_B67_B) + ARIB_B67_C);
-+}
-+
 +float inverse_oetf_arib_b67(float x) {
 +    x = fmax(x, 0.0f);
 +    return x <= 0.5f
@@ -222,30 +207,18 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +           : (exp((x - ARIB_B67_C) / ARIB_B67_A) + ARIB_B67_B) * (1.0f / 12.0f);
 +}
 +
-+// linearizer for HLG/ARIB-B67
++// linearizer for HLG/ARIB-B67 (scene-light only)
 +float eotf_arib_b67(float x) {
-+    return ootf_1_2(inverse_oetf_arib_b67(x)) * (12.0f / REFERENCE_WHITE_HLG);
++    return inverse_oetf_arib_b67(x) * (12.0f / REFERENCE_WHITE_HLG);
 +}
 +
-+// delinearizer for HLG/ARIB-B67
-+float inverse_eotf_arib_b67(float x) {
-+    return oetf_arib_b67(inverse_ootf_1_2(x / (12.0f / REFERENCE_WHITE_HLG)));
-+}
-+
-+float4 oetf_arib_b67x4(float4 x) {
-+    x.x = oetf_arib_b67(x.x);
-+    x.y = oetf_arib_b67(x.y);
-+    x.z = oetf_arib_b67(x.z);
-+    x.w = oetf_arib_b67(x.w);
-+    return x;
-+}
-+
-+float4 inverse_oetf_arib_b67x4(float4 x) {
-+    x.x = inverse_oetf_arib_b67(x.x);
-+    x.y = inverse_oetf_arib_b67(x.y);
-+    x.z = inverse_oetf_arib_b67(x.z);
-+    x.w = inverse_oetf_arib_b67(x.w);
-+    return x;
++// BT.2100 luma-weighted OOTF for HLG. Input is display-scale RGB (post 12/REF_HLG factor).
++// hlg_gm1 is baked as a function constant so powr can use the constant-exponent fast path.
++float3 ootf_hlg(float3 c) {
++    float Y_disp = 0.2627f * c.x + 0.6780f * c.y + 0.0593f * c.z;
++    float Y_scene = Y_disp * (REFERENCE_WHITE_HLG / 12.0f);
++    float gain = Y_scene > 0.0f ? powr(Y_scene, hlg_gm1) : 0.0f;
++    return c * gain;
 +}
 +
 +// delinearizer for BT709, BT2020-10
@@ -701,25 +674,9 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +    if (dovi_reshape) {
 +        float3 c = ycc2rgb(yuv.x, yuv.y, yuv.z);
 +        c = lms2rgb(c.x, c.y, c.z);
-+        c = rgb2lrgb(c);
-+        return c;
++        return rgb2lrgb(c);
 +    } else {
-+        float3 c = yuv2lrgb(yuv);
-+        return c;
-+    }
-+}
-+
-+// Map from source space YUV to destination space RGB
-+float3 map_to_dst_space_from_yuv(float3 yuv) {
-+    if (dovi_reshape) {
-+        float3 c = ycc2rgb(yuv.x, yuv.y, yuv.z);
-+        c = lms2rgb(c.x, c.y, c.z);
-+        c = rgb2lrgb(c);
-+        return lrgb2lrgb(c);
-+    } else {
-+        float3 c = yuv2lrgb(yuv);
-+        c = lrgb2lrgb(c);
-+        return c;
++        return yuv2lrgb(yuv);
 +    }
 +}
 +
@@ -894,16 +851,23 @@ Index: FFmpeg/libavfilter/metal/vf_tonemap_videotoolbox.metal
 +
 +    float3 c0, c1, c2, c3;
 +
-+    if (map_in_src_space) {
-+        c0 = map_to_src_space_from_yuv(yuv0);
-+        c1 = map_to_src_space_from_yuv(yuv1);
-+        c2 = map_to_src_space_from_yuv(yuv2);
-+        c3 = map_to_src_space_from_yuv(yuv3);
-+    } else {
-+        c0 = map_to_dst_space_from_yuv(yuv0);
-+        c1 = map_to_dst_space_from_yuv(yuv1);
-+        c2 = map_to_dst_space_from_yuv(yuv2);
-+        c3 = map_to_dst_space_from_yuv(yuv3);
++    c0 = map_to_src_space_from_yuv(yuv0);
++    c1 = map_to_src_space_from_yuv(yuv1);
++    c2 = map_to_src_space_from_yuv(yuv2);
++    c3 = map_to_src_space_from_yuv(yuv3);
++
++    if (linearize_type == 2) {
++        c0 = ootf_hlg(c0);
++        c1 = ootf_hlg(c1);
++        c2 = ootf_hlg(c2);
++        c3 = ootf_hlg(c3);
++    }
++
++    if (!map_in_src_space) {
++        c0 = lrgb2lrgb(c0);
++        c1 = lrgb2lrgb(c1);
++        c2 = lrgb2lrgb(c2);
++        c3 = lrgb2lrgb(c3);
 +    }
 +
 +    if(!skip_tonemap) {
@@ -966,7 +930,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
-@@ -0,0 +1,1211 @@
+@@ -0,0 +1,1226 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -1069,6 +1033,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    double                      peak;
 +    double                      src_peak;
 +    double                      target_peak;
++    float                       hlg_gm1;
++    float                       baked_hlg_gm1;
 +    double                      param;
 +    double                      final_param;
 +    double                      desat_param;
@@ -1087,14 +1053,9 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    CVMetalTextureCacheRef      texture_cache;
 +} TonemapVideoToolboxContext;
 +
-+static const short linearize_funcs[AVCOL_TRC_NB] = {
++static const short linearize_funcs[] = {
 +    [AVCOL_TRC_SMPTE2084]    = 1, //"eotf_st2084",
 +    [AVCOL_TRC_ARIB_STD_B67] = 2, //"eotf_arib_b67",
-+};
-+
-+static const short delinearize_funcs[AVCOL_TRC_NB] = {
-+    [AVCOL_TRC_BT709]     = 1, //"inverse_eotf_bt1886",
-+    [AVCOL_TRC_BT2020_10] = 1, //"inverse_eotf_bt1886",
 +};
 +
 +static const double dovi_lms2rgb_matrix[3][3] =
@@ -1111,6 +1072,10 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +            return 1;
 +    return 0;
 +}
++
++// BT.2100 adaptive γ-1 for HLG OOTF; src_peak is REFERENCE_WHITE_ALT-normalized.
++#define HLG_GAMMA_M1(src_peak) \
++    (float)(FFMAX(1.0, 1.2 + 0.42 * log10((src_peak) * REFERENCE_WHITE_ALT / 1000.0)) - 1.0)
 +
 +static int get_rgb2rgb_matrix(enum AVColorPrimaries in, enum AVColorPrimaries out,
 +                              double rgb2rgb[3][3])
@@ -1367,6 +1332,8 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    if (ctx->src_peak <= REF_WHITE_SCALE)
 +        ctx->src_peak = 10.0f * REF_WHITE_SCALE;
 +
++    ctx->hlg_gm1 = HLG_GAMMA_M1(ctx->src_peak);
++
 +    // SDR peak is 1.0f
 +    ctx->target_peak = 1.0f;
 +
@@ -1612,7 +1579,10 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +
 +    if (ctx->trc_out != AVCOL_TRC_SMPTE2084) {
 +        [constant_values setConstantValue:&linearize_funcs[ctx->trc_in] type:MTLDataTypeShort withName:@"linearize_type"];
-+        [constant_values setConstantValue:&delinearize_funcs[ctx->trc_in] type:MTLDataTypeShort withName:@"delinearize_type"];
++    }
++    if (ctx->trc_in == AVCOL_TRC_ARIB_STD_B67) {
++        [constant_values setConstantValue:&ctx->hlg_gm1 type:MTLDataTypeFloat withName:@"hlg_gm1"];
++        ctx->baked_hlg_gm1 = ctx->hlg_gm1;
 +    }
 +
 +    if (enable_dither) {
@@ -1874,6 +1844,7 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +            ctx->src_peak = ff_determine_signal_peak(input);
 +            ctx->src_peak *= REF_WHITE_SCALE;
 +        }
++        ctx->hlg_gm1 = HLG_GAMMA_M1(ctx->src_peak);
 +        av_log(ctx, AV_LOG_DEBUG, "Computed signal peak: %f "
 +               "at pts %"PRId64"\n", ctx->src_peak, input->pts);
 +    }
@@ -1917,6 +1888,13 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +
 +    // Some DOVI video does not carry metadata in the first few frames, and we have to reset the pipeline.
 +    if (!ctx->init_with_dovi && ctx->dovi && ctx->initialised) {
++        tonemap_videotoolbox_uninit_common(avctx);
++    }
++
++    // hlg_gm1 is baked into the pipeline as a Metal function constant for powr fast-path;
++    // rebuild the pipeline if it changed (e.g. DOVI per-scene peak update).
++    if (ctx->initialised && ctx->trc_in == AVCOL_TRC_ARIB_STD_B67 &&
++        ctx->hlg_gm1 != ctx->baked_hlg_gm1) {
 +        tonemap_videotoolbox_uninit_common(avctx);
 +    }
 +
@@ -2177,4 +2155,5 @@ Index: FFmpeg/libavfilter/vf_tonemap_videotoolbox.m
 +    FILTER_OUTPUTS(tonemap_videotoolbox_outputs),
 +    FILTER_QUERY_FUNC(tonemap_videotoolbox_query_formats),
 +    .flags_internal = FF_FILTER_FLAG_HWFRAME_AWARE,
++    .flags          = AVFILTER_FLAG_HWDEVICE,
 +};

--- a/debian/patches/0057-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0057-add-simd-optimized-tonemapx-filter.patch
@@ -94,7 +94,7 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
-@@ -0,0 +1,2406 @@
+@@ -0,0 +1,2411 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -419,15 +419,18 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +    b_linx4a = vld1q_f32(b_lin4a);
 +    b_linx4b = vld1q_f32(b_lin4b);
 +
-+    // HLG OOTF (BT.2100): luma-weighted scale via ootf_lut (nearest-neighbor); applied before gamut conversion.
-+    if (ootf_lut) {
++    // HLG OOTF (BT.2100): kick off the luma-weighted gain gather early so the
++    // stack-store/scalar-load latency overlaps with the gamut conversion below.
++    float32x4_t ga, gb;
++    int have_ootf = (ootf_lut != NULL);
++    if (have_ootf) {
 +        const float cr = (float)av_q2d(coeffs->cr);
 +        const float cg = (float)av_q2d(coeffs->cg);
 +        const float cb = (float)av_q2d(coeffs->cb);
 +        int32x4_t idx_lo = vdupq_n_s32(0);
 +        int32x4_t idx_hi = vdupq_n_s32(OOTF_LUT_SIZE - 1);
 +        float32x4_t lut_scale = vdupq_n_f32((float)(OOTF_LUT_SIZE - 1));
-+        float32x4_t Ya, Yb, ga, gb;
++        float32x4_t Ya, Yb;
 +        int32x4_t ia, ib;
 +        int32_t ia_arr[4], ib_arr[4];
 +        float aa[4], ab[4];
@@ -452,13 +455,6 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +        ab[2] = ootf_lut[ib_arr[2]]; ab[3] = ootf_lut[ib_arr[3]];
 +        ga = vld1q_f32(aa);
 +        gb = vld1q_f32(ab);
-+
-+        r_linx4a = vmulq_f32(r_linx4a, ga);
-+        g_linx4a = vmulq_f32(g_linx4a, ga);
-+        b_linx4a = vmulq_f32(b_linx4a, ga);
-+        r_linx4b = vmulq_f32(r_linx4b, gb);
-+        g_linx4b = vmulq_f32(g_linx4b, gb);
-+        b_linx4b = vmulq_f32(b_linx4b, gb);
 +    }
 +
 +    if (!rgb2rgb_passthrough) {
@@ -485,6 +481,15 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +        b_linx4b = vmulq_n_f32(b0_b, (float)(*rgb2rgb)[2][2]);
 +        b_linx4b = vfmaq_n_f32(b_linx4b, r0_b, (float)(*rgb2rgb)[2][0]);
 +        b_linx4b = vfmaq_n_f32(b_linx4b, g0_b, (float)(*rgb2rgb)[2][1]);
++    }
++
++    if (have_ootf) {
++        r_linx4a = vmulq_f32(r_linx4a, ga);
++        g_linx4a = vmulq_f32(g_linx4a, ga);
++        b_linx4a = vmulq_f32(b_linx4a, ga);
++        r_linx4b = vmulq_f32(r_linx4b, gb);
++        g_linx4b = vmulq_f32(g_linx4b, gb);
++        b_linx4b = vmulq_f32(b_linx4b, gb);
 +    }
 +
 +    if (desat > 0) {
@@ -2674,7 +2679,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.c
-@@ -0,0 +1,1996 @@
+@@ -0,0 +1,2001 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -3439,16 +3444,15 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    g_lin = lin_lut[g_in];
 +    b_lin = lin_lut[b_in];
 +
-+    // HLG OOTF (BT.2100): luma-weighted scale, applied in source primaries before gamut conversion.
++    // HLG OOTF (BT.2100): kick off the luma-weighted gain lookup early so it
++    // overlaps with the gamut conversion below.
++    float ootf_gain = 1.0f;
 +    if (ootf_lut) {
 +        float Y_s = av_q2d(coeffs->cr) * r_lin
 +                  + av_q2d(coeffs->cg) * g_lin
 +                  + av_q2d(coeffs->cb) * b_lin;
-+        float gain = ootf_lut[av_clip_uintp2((int)(Y_s * (OOTF_LUT_SIZE - 1) + 0.5f),
-+                                              15)];
-+        r_lin *= gain;
-+        g_lin *= gain;
-+        b_lin *= gain;
++        ootf_gain = ootf_lut[av_clip_uintp2((int)(Y_s * (OOTF_LUT_SIZE - 1) + 0.5f),
++                                            15)];
 +    }
 +
 +    if (!rgb2rgb_passthrough) {
@@ -3456,6 +3460,12 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +        r_lin = (*rgb2rgb)[0][0] * r0 + (*rgb2rgb)[0][1] * g0 + (*rgb2rgb)[0][2] * b0;
 +        g_lin = (*rgb2rgb)[1][0] * r0 + (*rgb2rgb)[1][1] * g0 + (*rgb2rgb)[1][2] * b0;
 +        b_lin = (*rgb2rgb)[2][0] * r0 + (*rgb2rgb)[2][1] * g0 + (*rgb2rgb)[2][2] * b0;
++    }
++
++    if (ootf_lut) {
++        r_lin *= ootf_gain;
++        g_lin *= ootf_gain;
++        b_lin *= ootf_gain;
 +    }
 +
 +    /* desaturate to prevent unnatural colors */
@@ -4675,7 +4685,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.h
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,146 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -4725,9 +4735,6 @@ Index: FFmpeg/libavfilter/vf_tonemapx.h
 +#    endif // ARCH_X86
 +#endif // CC_SUPPORTS_TONEMAPX_INTRINSICS
 +
-+/* HLG OOTF gain LUT: number of evenly-spaced samples in Y_s ∈ [0, 1]. */
-+#define OOTF_LUT_SIZE 32768
-+
 +#define params_cnt 8
 +#define pivots_cnt (7+1)
 +#define coeffs_cnt 8*4
@@ -4747,6 +4754,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.h
 +#define TEN_BIT_ROUNDING 512
 +#define TEN_BIT_BIPLANAR_SHIFT 6
 +#define TEN_BIT_SCALE_SHIFT 19
++#define OOTF_LUT_SIZE 32768
 +
 +typedef struct TonemapIntParams {
 +    double lut_peak;
@@ -4841,7 +4849,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
-@@ -0,0 +1,2601 @@
+@@ -0,0 +1,2606 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -5202,12 +5210,15 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +    g_linx8 = _mm256_loadu_ps(g_lin8);
 +    b_linx8 = _mm256_loadu_ps(b_lin8);
 +
-+    // HLG OOTF (BT.2100): luma-weighted scale via ootf_lut (nearest-neighbor); applied before gamut conversion.
-+    if (ootf_lut) {
++    // HLG OOTF (BT.2100): kick off the luma-weighted gain gather early so its
++    // latency overlaps with the gamut conversion below.
++    __m256 ootf_gain8;
++    int have_ootf = (ootf_lut != NULL);
++    if (have_ootf) {
 +        const float cr = (float)av_q2d(coeffs->cr);
 +        const float cg = (float)av_q2d(coeffs->cg);
 +        const float cb = (float)av_q2d(coeffs->cb);
-+        __m256 Y, g8;
++        __m256 Y;
 +        __m256i idx;
 +
 +        Y = _mm256_mul_ps(r_linx8, _mm256_set1_ps(cr));
@@ -5216,11 +5227,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +
 +        idx = _mm256_cvttps_epi32(_mm256_add_ps(offset, _mm256_mul_ps(Y, intermediate_upper_bound)));
 +        idx = _mm256_min_epi32(_mm256_max_epi32(idx, zerox8), upper_bound);
-+        g8 = _mm256_i32gather_ps(ootf_lut, idx, sizeof(float));
-+
-+        r_linx8 = _mm256_mul_ps(r_linx8, g8);
-+        g_linx8 = _mm256_mul_ps(g_linx8, g8);
-+        b_linx8 = _mm256_mul_ps(b_linx8, g8);
++        ootf_gain8 = _mm256_i32gather_ps(ootf_lut, idx, sizeof(float));
 +    }
 +
 +    if (!rgb2rgb_passthrough) {
@@ -5237,6 +5244,12 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +        b_linx8 = _mm256_mul_ps(b0, _mm256_set1_ps((float)(*rgb2rgb)[2][2]));
 +        b_linx8 = _mm256_fmadd_ps(r0, _mm256_set1_ps((float)(*rgb2rgb)[2][0]), b_linx8);
 +        b_linx8 = _mm256_fmadd_ps(g0, _mm256_set1_ps((float)(*rgb2rgb)[2][1]), b_linx8);
++    }
++
++    if (have_ootf) {
++        r_linx8 = _mm256_mul_ps(r_linx8, ootf_gain8);
++        g_linx8 = _mm256_mul_ps(g_linx8, ootf_gain8);
++        b_linx8 = _mm256_mul_ps(b_linx8, ootf_gain8);
 +    }
 +
 +    if (desat > 0) {
@@ -7527,7 +7540,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
-@@ -0,0 +1,2772 @@
+@@ -0,0 +1,2777 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -7850,12 +7863,15 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +    g_linx4 = _mm_loadu_ps(g_lin4);
 +    b_linx4 = _mm_loadu_ps(b_lin4);
 +
-+    // HLG OOTF (BT.2100): luma-weighted scale via ootf_lut (nearest-neighbor); applied before gamut conversion.
-+    if (ootf_lut) {
++    // HLG OOTF (BT.2100): kick off the luma-weighted gain gather early so its
++    // latency overlaps with the gamut conversion below.
++    __m128 ootf_gain4;
++    int have_ootf = (ootf_lut != NULL);
++    if (have_ootf) {
 +        const float cr = (float)av_q2d(coeffs->cr);
 +        const float cg = (float)av_q2d(coeffs->cg);
 +        const float cb = (float)av_q2d(coeffs->cb);
-+        __m128 Y, g4;
++        __m128 Y;
 +        __m128i idx;
 +        int idx_arr[4];
 +        float g_arr[4];
@@ -7870,11 +7886,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +        _mm_storeu_si128((__m128i *)idx_arr, idx);
 +        g_arr[0] = ootf_lut[idx_arr[0]]; g_arr[1] = ootf_lut[idx_arr[1]];
 +        g_arr[2] = ootf_lut[idx_arr[2]]; g_arr[3] = ootf_lut[idx_arr[3]];
-+        g4 = _mm_loadu_ps(g_arr);
-+
-+        r_linx4 = _mm_mul_ps(r_linx4, g4);
-+        g_linx4 = _mm_mul_ps(g_linx4, g4);
-+        b_linx4 = _mm_mul_ps(b_linx4, g4);
++        ootf_gain4 = _mm_loadu_ps(g_arr);
 +    }
 +
 +    if (!rgb2rgb_passthrough) {
@@ -7891,6 +7903,12 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +        b_linx4 = _mm_mul_ps(b0, _mm_set1_ps((float)(*rgb2rgb)[2][2]));
 +        b_linx4 = _mm_add_ps(b_linx4, _mm_mul_ps(r0, _mm_set1_ps((float)(*rgb2rgb)[2][0])));
 +        b_linx4 = _mm_add_ps(b_linx4, _mm_mul_ps(g0, _mm_set1_ps((float)(*rgb2rgb)[2][1])));
++    }
++
++    if (have_ootf) {
++        r_linx4 = _mm_mul_ps(r_linx4, ootf_gain4);
++        g_linx4 = _mm_mul_ps(g_linx4, ootf_gain4);
++        b_linx4 = _mm_mul_ps(b_linx4, ootf_gain4);
 +    }
 +
 +    if (desat > 0) {

--- a/debian/patches/0057-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0057-add-simd-optimized-tonemapx-filter.patch
@@ -94,7 +94,7 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
-@@ -0,0 +1,2363 @@
+@@ -0,0 +1,2406 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -366,6 +366,7 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +static inline void tonemap_int16x8_neon(uint16x8_t r_in, uint16x8_t g_in, uint16x8_t b_in,
 +                                        int16_t *r_out, int16_t *g_out, int16_t *b_out,
 +                                        float *lin_lut, float *tonemap_lut, uint16_t *delin_lut,
++                                        float *ootf_lut,
 +                                        const AVLumaCoefficients *coeffs,
 +                                        const AVLumaCoefficients *ocoeffs, double desat,
 +                                        double (*rgb2rgb)[3][3],
@@ -417,6 +418,48 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +    g_linx4b = vld1q_f32(g_lin4b);
 +    b_linx4a = vld1q_f32(b_lin4a);
 +    b_linx4b = vld1q_f32(b_lin4b);
++
++    // HLG OOTF (BT.2100): luma-weighted scale via ootf_lut (nearest-neighbor); applied before gamut conversion.
++    if (ootf_lut) {
++        const float cr = (float)av_q2d(coeffs->cr);
++        const float cg = (float)av_q2d(coeffs->cg);
++        const float cb = (float)av_q2d(coeffs->cb);
++        int32x4_t idx_lo = vdupq_n_s32(0);
++        int32x4_t idx_hi = vdupq_n_s32(OOTF_LUT_SIZE - 1);
++        float32x4_t lut_scale = vdupq_n_f32((float)(OOTF_LUT_SIZE - 1));
++        float32x4_t Ya, Yb, ga, gb;
++        int32x4_t ia, ib;
++        int32_t ia_arr[4], ib_arr[4];
++        float aa[4], ab[4];
++
++        Ya = vmulq_n_f32(r_linx4a, cr);
++        Ya = vfmaq_n_f32(Ya, g_linx4a, cg);
++        Ya = vfmaq_n_f32(Ya, b_linx4a, cb);
++        Yb = vmulq_n_f32(r_linx4b, cr);
++        Yb = vfmaq_n_f32(Yb, g_linx4b, cg);
++        Yb = vfmaq_n_f32(Yb, b_linx4b, cb);
++
++        ia = vcvtnq_s32_f32(vmulq_f32(Ya, lut_scale));
++        ib = vcvtnq_s32_f32(vmulq_f32(Yb, lut_scale));
++        ia = vminq_s32(vmaxq_s32(ia, idx_lo), idx_hi);
++        ib = vminq_s32(vmaxq_s32(ib, idx_lo), idx_hi);
++
++        vst1q_s32(ia_arr, ia);
++        vst1q_s32(ib_arr, ib);
++        aa[0] = ootf_lut[ia_arr[0]]; aa[1] = ootf_lut[ia_arr[1]];
++        aa[2] = ootf_lut[ia_arr[2]]; aa[3] = ootf_lut[ia_arr[3]];
++        ab[0] = ootf_lut[ib_arr[0]]; ab[1] = ootf_lut[ib_arr[1]];
++        ab[2] = ootf_lut[ib_arr[2]]; ab[3] = ootf_lut[ib_arr[3]];
++        ga = vld1q_f32(aa);
++        gb = vld1q_f32(ab);
++
++        r_linx4a = vmulq_f32(r_linx4a, ga);
++        g_linx4a = vmulq_f32(g_linx4a, ga);
++        b_linx4a = vmulq_f32(b_linx4a, ga);
++        r_linx4b = vmulq_f32(r_linx4b, gb);
++        g_linx4b = vmulq_f32(g_linx4b, gb);
++        b_linx4b = vmulq_f32(b_linx4b, gb);
++    }
 +
 +    if (!rgb2rgb_passthrough) {
 +        float32x4_t r0_a = r_linx4a, g0_a = g_linx4a, b0_a = b_linx4a;
@@ -768,11 +811,11 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +
 +
 +            tonemap_int16x8_neon(r0x8, g0x8, b0x8, (int16_t *) &r, (int16_t *) &g, (int16_t *) &b,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +            tonemap_int16x8_neon(r1x8, g1x8, b1x8, (int16_t *) &r1, (int16_t *) &g1, (int16_t *) &b1,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +
@@ -978,11 +1021,11 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +            yuv2rgbx8(&r1x8, &g1x8, &b1x8, y1x8, ux8, vx8, cy, crv, cgu, cgv, cbu);
 +
 +            tonemap_int16x8_neon(r0x8, g0x8, b0x8, (int16_t *) &r, (int16_t *) &g, (int16_t *) &b,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +            tonemap_int16x8_neon(r1x8, g1x8, b1x8, (int16_t *) &r1, (int16_t *) &g1, (int16_t *) &b1,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +
@@ -1196,11 +1239,11 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +            yuv2rgbx8(&r1x8, &g1x8, &b1x8, y1x8, ux8, vx8, cy, crv, cgu, cgv, cbu);
 +
 +            tonemap_int16x8_neon(r0x8, g0x8, b0x8, (int16_t *) &r, (int16_t *) &g, (int16_t *) &b,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +            tonemap_int16x8_neon(r1x8, g1x8, b1x8, (int16_t *) &r1, (int16_t *) &g1, (int16_t *) &b1,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +
@@ -1553,11 +1596,11 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +            b1x8 = vminq_u16(b1x8, vdupq_n_u16(INT16_MAX));
 +
 +            tonemap_int16x8_neon(r0x8, g0x8, b0x8, (int16_t *) &r, (int16_t *) &g, (int16_t *) &b,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +            tonemap_int16x8_neon(r1x8, g1x8, b1x8, (int16_t *) &r1, (int16_t *) &g1, (int16_t *) &b1,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +
@@ -2106,11 +2149,11 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +            yuv2rgbx8(&r1x8, &g1x8, &b1x8, y1x8, ux8, vx8, cy, crv, cgu, cgv, cbu);
 +
 +            tonemap_int16x8_neon(r0x8, g0x8, b0x8, (int16_t *) &r, (int16_t *) &g, (int16_t *) &b,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +            tonemap_int16x8_neon(r1x8, g1x8, b1x8, (int16_t *) &r1, (int16_t *) &g1, (int16_t *) &b1,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +
@@ -2323,11 +2366,11 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +            yuv2rgbx8(&r1x8, &g1x8, &b1x8, y1x8, ux8, vx8, cy, crv, cgu, cgv, cbu);
 +
 +            tonemap_int16x8_neon(r0x8, g0x8, b0x8, (int16_t *) &r, (int16_t *) &g, (int16_t *) &b,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +            tonemap_int16x8_neon(r1x8, g1x8, b1x8, (int16_t *) &r1, (int16_t *) &g1, (int16_t *) &b1,
-+                                 params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                 params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                 params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                 params->rgb2rgb_passthrough);
 +
@@ -2631,7 +2674,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.c
-@@ -0,0 +1,1949 @@
+@@ -0,0 +1,1996 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -2711,7 +2754,8 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +typedef struct TonemapxContext {
 +    const AVClass *class;
 +
-+    enum TonemapAlgorithm tonemap;
++    /* enum TonemapAlgorithm */
++    int tonemap;
 +    enum AVColorTransferCharacteristic trc;
 +    enum AVColorSpace spc;
 +    enum AVColorPrimaries pri;
@@ -2730,6 +2774,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    float *lin_lut;
 +    float *tonemap_lut;
 +    uint16_t *delin_lut;
++    float *ootf_lut;
 +    int in_yuv_off, out_yuv_off;
 +
 +    struct DoviMetadata *dovi;
@@ -3159,10 +3204,10 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +
 +static float linearize(float x, enum AVColorTransferCharacteristic trc_src)
 +{
++    // HLG is handled separately by compute_trc_luts/compute_tonemap_lut
++    // (scene-light + luma-weighted OOTF), so this function only sees PQ/SDR.
 +    if (trc_src == AVCOL_TRC_SMPTE2084)
 +        return eotf_st2084(x, REFERENCE_WHITE_ALT);
-+    else if (trc_src == AVCOL_TRC_ARIB_STD_B67)
-+        return eotf_arib_b67(x);
 +    else
 +        return x;
 +}
@@ -3187,7 +3232,13 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +
 +    for (i = 0; i < 32768; i++) {
 +        float v = (float)i / JPEG_SCALE;
-+        s->lin_lut[i] = FFMAX(linearize(v, trc_src), 0);
++        /* For HLG, lin_lut holds inverse OETF scene-light; the luma-weighted
++         * OOTF is applied per-pixel in tonemap_int16 (BT.2100). For PQ/SDR the
++         * LUT remains display-light as before. */
++        if (trc_src == AVCOL_TRC_ARIB_STD_B67)
++            s->lin_lut[i] = FFMAX(inverse_oetf_arib_b67(v), 0);
++        else
++            s->lin_lut[i] = FFMAX(linearize(v, trc_src), 0);
 +        s->delin_lut[i] = av_clip_int16((int)rintf(delinearize(v, trc_dst) * JPEG_SCALE));
 +    }
 +
@@ -3198,13 +3249,37 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +{
 +    int i;
 +    double peak = s->lut_peak;
++    // BT.2100 adaptive HLG system γ; peak is REFERENCE_WHITE_ALT-normalized.
++    double gamma = 1.2;
++    if (trc_src == AVCOL_TRC_ARIB_STD_B67) {
++        double g = 1.2 + 0.42 * log10(peak * REFERENCE_WHITE_ALT / 1000.0);
++        gamma = FFMAX(1.0, g);
++
++        if (!s->ootf_lut && !(s->ootf_lut = av_calloc(OOTF_LUT_SIZE, sizeof(float))))
++            return AVERROR(ENOMEM);
++        for (i = 0; i < OOTF_LUT_SIZE; i++) {
++            float y = (float)i / (OOTF_LUT_SIZE - 1);
++            s->ootf_lut[i] = y > 0.0f
++                ? (float)(pow(y, gamma - 1.0) * (12.0 / REFERENCE_WHITE_HLG))
++                : 0.0f;
++        }
++    } else {
++        av_freep(&s->ootf_lut);
++    }
 +
 +    if (!s->tonemap_lut && !(s->tonemap_lut = av_calloc(32768, sizeof(float))))
 +        return AVERROR(ENOMEM);
 +
 +    for (i = 0; i < 32768; i++) {
 +        float v = (float)i / JPEG_SCALE;
-+        float sig = linearize(v, trc_src);
++        float sig;
++        if (trc_src == AVCOL_TRC_ARIB_STD_B67) {
++            /* Gray-pixel OOTF: assume R=G=B=v_scene so Y_s = v_scene. */
++            double scene = inverse_oetf_arib_b67(v);
++            sig = (float)(pow(scene, gamma) * (12.0 / REFERENCE_WHITE_HLG));
++        } else {
++            sig = linearize(v, trc_src);
++        }
 +        float mapped = mapsig(s->tonemap, sig, peak, s->param);
 +        s->tonemap_lut[i] = (sig > 0.0f && mapped > 0.0f) ? mapped / sig : 0.0f;
 +    }
@@ -3335,6 +3410,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +inline static void tonemap_int16(int16_t r_in, int16_t g_in, int16_t b_in,
 +                                 int16_t *r_out, int16_t *g_out, int16_t *b_out,
 +                                 float *lin_lut, float *tonemap_lut, uint16_t *delin_lut,
++                                 float *ootf_lut,
 +                                 const AVLumaCoefficients *coeffs,
 +                                 const AVLumaCoefficients *ocoeffs, double desat,
 +                                 double (*rgb2rgb)[3][3],
@@ -3362,6 +3438,18 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    r_lin = lin_lut[r_in];
 +    g_lin = lin_lut[g_in];
 +    b_lin = lin_lut[b_in];
++
++    // HLG OOTF (BT.2100): luma-weighted scale, applied in source primaries before gamut conversion.
++    if (ootf_lut) {
++        float Y_s = av_q2d(coeffs->cr) * r_lin
++                  + av_q2d(coeffs->cg) * g_lin
++                  + av_q2d(coeffs->cb) * b_lin;
++        float gain = ootf_lut[av_clip_uintp2((int)(Y_s * (OOTF_LUT_SIZE - 1) + 0.5f),
++                                              15)];
++        r_lin *= gain;
++        g_lin *= gain;
++        b_lin *= gain;
++    }
 +
 +    if (!rgb2rgb_passthrough) {
 +        float r0 = r_lin, g0 = g_lin, b0 = b_lin;
@@ -3455,16 +3543,16 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +            b[3] = av_clip_int16((y11 * cy + cbu * u + in_rnd) >> in_sh);
 +
 +            tonemap_int16(r[0], g[0], b[0], &r[0], &g[0], &b[0],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[1], g[1], b[1], &r[1], &g[1], &b[1],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[2], g[2], b[2], &r[2], &g[2], &b[2],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[3], g[3], b[3], &r[3], &g[3], &b[3],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +
 +            r00 = r[0], g00 = g[0], b00 = b[0];
@@ -3552,16 +3640,16 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +            b[3] = av_clip_int16((y11 * cy + cbu * u + in_rnd) >> in_sh);
 +
 +            tonemap_int16(r[0], g[0], b[0], &r[0], &g[0], &b[0],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[1], g[1], b[1], &r[1], &g[1], &b[1],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[2], g[2], b[2], &r[2], &g[2], &b[2],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[3], g[3], b[3], &r[3], &g[3], &b[3],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +
 +            r00 = r[0], g00 = g[0], b00 = b[0];
@@ -3626,16 +3714,16 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +            dovi2rgb(y00, y01, y10, y11, u, v, params, in_rng, r, g, b);
 +
 +            tonemap_int16(r[0], g[0], b[0], &r[0], &g[0], &b[0],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[1], g[1], b[1], &r[1], &g[1], &b[1],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[2], g[2], b[2], &r[2], &g[2], &b[2],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[3], g[3], b[3], &r[3], &g[3], &b[3],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +
 +            r00 = r[0], g00 = g[0], b00 = b[0];
@@ -3700,16 +3788,16 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +            dovi2rgb(y00, y01, y10, y11, u, v, params, in_rng, r, g, b);
 +
 +            tonemap_int16(r[0], g[0], b[0], &r[0], &g[0], &b[0],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[1], g[1], b[1], &r[1], &g[1], &b[1],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[2], g[2], b[2], &r[2], &g[2], &b[2],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[3], g[3], b[3], &r[3], &g[3], &b[3],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +
 +            r00 = r[0], g00 = g[0], b00 = b[0];
@@ -3856,16 +3944,16 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +            b[3] = av_clip_int16((y11 * cy + cbu * u + in_rnd) >> in_sh);
 +
 +            tonemap_int16(r[0], g[0], b[0], &r[0], &g[0], &b[0],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[1], g[1], b[1], &r[1], &g[1], &b[1],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[2], g[2], b[2], &r[2], &g[2], &b[2],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[3], g[3], b[3], &r[3], &g[3], &b[3],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +
 +            r00 = r[0], g00 = g[0], b00 = b[0];
@@ -3951,16 +4039,16 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +            b[3] = av_clip_int16((y11 * cy + cbu * u + in_rnd) >> in_sh);
 +
 +            tonemap_int16(r[0], g[0], b[0], &r[0], &g[0], &b[0],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[1], g[1], b[1], &r[1], &g[1], &b[1],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[2], g[2], b[2], &r[2], &g[2], &b[2],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +            tonemap_int16(r[3], g[3], b[3], &r[3], &g[3], &b[3],
-+                          params->lin_lut, params->tonemap_lut, params->delin_lut,
++                          params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                          params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs, params->rgb2rgb_passthrough);
 +
 +            r00 = r[0], g00 = g[0], b00 = b[0];
@@ -3995,6 +4083,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +.lin_lut             = s->lin_lut,                              \
 +.tonemap_lut         = s->tonemap_lut,                          \
 +.delin_lut           = s->delin_lut,                            \
++.ootf_lut            = s->ootf_lut,                             \
 +.in_yuv_off          = s->in_yuv_off,                           \
 +.out_yuv_off         = s->out_yuv_off,                          \
 +.yuv2rgb_coeffs      = &s->yuv2rgb_coeffs,                      \
@@ -4274,6 +4363,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    av_freep(&s->lin_lut);
 +    av_freep(&s->delin_lut);
 +    av_freep(&s->tonemap_lut);
++    av_freep(&s->ootf_lut);
 +
 +    if (s->dovi)
 +        av_freep(&s->dovi);
@@ -4569,7 +4659,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    },
 +};
 +
-+AVFilter ff_vf_tonemapx = {
++const AVFilter ff_vf_tonemapx = {
 +    .name            = "tonemapx",
 +    .description     = NULL_IF_CONFIG_SMALL("SIMD optimized HDR to SDR tonemapping"),
 +    .init            = init,
@@ -4585,7 +4675,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.h
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,148 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -4635,6 +4725,9 @@ Index: FFmpeg/libavfilter/vf_tonemapx.h
 +#    endif // ARCH_X86
 +#endif // CC_SUPPORTS_TONEMAPX_INTRINSICS
 +
++/* HLG OOTF gain LUT: number of evenly-spaced samples in Y_s ∈ [0, 1]. */
++#define OOTF_LUT_SIZE 32768
++
 +#define params_cnt 8
 +#define pivots_cnt (7+1)
 +#define coeffs_cnt 8*4
@@ -4660,6 +4753,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.h
 +    float *lin_lut;
 +    float *tonemap_lut;
 +    uint16_t *delin_lut;
++    float *ootf_lut;
 +    int in_yuv_off, out_yuv_off;
 +    int (*yuv2rgb_coeffs)[3][3][8];
 +    int (*rgb2yuv_coeffs)[3][3][8];
@@ -4747,7 +4841,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
-@@ -0,0 +1,2579 @@
+@@ -0,0 +1,2601 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -5065,6 +5159,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +X86_64_V3 static inline void tonemap_int32x8_avx(__m256i r_in, __m256i g_in, __m256i b_in,
 +                                                 int16_t *r_out, int16_t *g_out, int16_t *b_out,
 +                                                 float *lin_lut, float *tonemap_lut, uint16_t *delin_lut,
++                                                 float *ootf_lut,
 +                                                 const AVLumaCoefficients *coeffs,
 +                                                 const AVLumaCoefficients *ocoeffs, double desat,
 +                                                 double (*rgb2rgb)[3][3],
@@ -5106,6 +5201,27 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +    r_linx8 = _mm256_loadu_ps(r_lin8);
 +    g_linx8 = _mm256_loadu_ps(g_lin8);
 +    b_linx8 = _mm256_loadu_ps(b_lin8);
++
++    // HLG OOTF (BT.2100): luma-weighted scale via ootf_lut (nearest-neighbor); applied before gamut conversion.
++    if (ootf_lut) {
++        const float cr = (float)av_q2d(coeffs->cr);
++        const float cg = (float)av_q2d(coeffs->cg);
++        const float cb = (float)av_q2d(coeffs->cb);
++        __m256 Y, g8;
++        __m256i idx;
++
++        Y = _mm256_mul_ps(r_linx8, _mm256_set1_ps(cr));
++        Y = _mm256_fmadd_ps(g_linx8, _mm256_set1_ps(cg), Y);
++        Y = _mm256_fmadd_ps(b_linx8, _mm256_set1_ps(cb), Y);
++
++        idx = _mm256_cvttps_epi32(_mm256_add_ps(offset, _mm256_mul_ps(Y, intermediate_upper_bound)));
++        idx = _mm256_min_epi32(_mm256_max_epi32(idx, zerox8), upper_bound);
++        g8 = _mm256_i32gather_ps(ootf_lut, idx, sizeof(float));
++
++        r_linx8 = _mm256_mul_ps(r_linx8, g8);
++        g_linx8 = _mm256_mul_ps(g_linx8, g8);
++        b_linx8 = _mm256_mul_ps(b_linx8, g8);
++    }
 +
 +    if (!rgb2rgb_passthrough) {
 +        __m256 r0 = r_linx8, g0 = g_linx8, b0 = b_linx8;
@@ -5371,19 +5487,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +            b1x8b = av_clip_int16_avx(b1x8b);
 +
 +            tonemap_int32x8_avx(r0x8a, g0x8a, b0x8a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8a, g1x8a, b1x8a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r0x8b, g0x8b, b0x8b, &r[8], &g[8], &b[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8b, g1x8b, b1x8b, &r1[8], &g1[8], &b1[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -5698,19 +5814,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +            b1x8b = av_clip_int16_avx(b1x8b);
 +
 +            tonemap_int32x8_avx(r0x8a, g0x8a, b0x8a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8a, g1x8a, b1x8a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r0x8b, g0x8b, b0x8b, &r[8], &g[8], &b[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8b, g1x8b, b1x8b, &r1[8], &g1[8], &b1[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -6292,19 +6408,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +            b1x8b = av_clip_int16_avx(b1x8b);
 +
 +            tonemap_int32x8_avx(r0x8a, g0x8a, b0x8a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8a, g1x8a, b1x8a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r0x8b, g0x8b, b0x8b, &r[8], &g[8], &b[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8b, g1x8b, b1x8b, &r1[8], &g1[8], &b1[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -6592,19 +6708,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +            b1x8b = av_clip_int16_avx(b1x8b);
 +
 +            tonemap_int32x8_avx(r0x8a, g0x8a, b0x8a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8a, g1x8a, b1x8a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r0x8b, g0x8b, b0x8b, &r[8], &g[8], &b[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8b, g1x8b, b1x8b, &r1[8], &g1[8], &b1[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -6894,19 +7010,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +            b1x8b = av_clip_int16_avx(b1x8b);
 +
 +            tonemap_int32x8_avx(r0x8a, g0x8a, b0x8a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8a, g1x8a, b1x8a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r0x8b, g0x8b, b0x8b, &r[8], &g[8], &b[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8b, g1x8b, b1x8b, &r1[8], &g1[8], &b1[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -7193,19 +7309,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +            b1x8b = av_clip_int16_avx(b1x8b);
 +
 +            tonemap_int32x8_avx(r0x8a, g0x8a, b0x8a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8a, g1x8a, b1x8a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r0x8b, g0x8b, b0x8b, &r[8], &g[8], &b[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x8_avx(r1x8b, g1x8b, b1x8b, &r1[8], &g1[8], &b1[8],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -7411,7 +7527,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
-@@ -0,0 +1,2742 @@
+@@ -0,0 +1,2772 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -7476,6 +7592,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +    return _mm_or_si128(_mm_and_si128(cmp, a), _mm_andnot_si128(cmp, xor_result));
 +}
 +
++/*
 +X86_64_V2 inline static __m128 mix_float32x4(__m128 x, __m128 y, __m128 a)
 +{
 +    __m128 n = _mm_sub_ps(y, x);
@@ -7483,6 +7600,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +    n = _mm_add_ps(n, x);
 +    return n;
 +}
++*/
 +
 +X86_64_V2 inline static float reduce_floatx4(__m128 x) {
 +    x = _mm_hadd_ps(x, x);
@@ -7694,6 +7812,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +X86_64_V2 static inline void tonemap_int32x4_sse(__m128i r_in, __m128i g_in, __m128i b_in,
 +                                                 int16_t *r_out, int16_t *g_out, int16_t *b_out,
 +                                                 float *lin_lut, float *tonemap_lut, uint16_t *delin_lut,
++                                                 float *ootf_lut,
 +                                                 const AVLumaCoefficients *coeffs,
 +                                                 const AVLumaCoefficients *ocoeffs, double desat,
 +                                                 double (*rgb2rgb)[3][3],
@@ -7730,6 +7849,33 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +    r_linx4 = _mm_loadu_ps(r_lin4);
 +    g_linx4 = _mm_loadu_ps(g_lin4);
 +    b_linx4 = _mm_loadu_ps(b_lin4);
++
++    // HLG OOTF (BT.2100): luma-weighted scale via ootf_lut (nearest-neighbor); applied before gamut conversion.
++    if (ootf_lut) {
++        const float cr = (float)av_q2d(coeffs->cr);
++        const float cg = (float)av_q2d(coeffs->cg);
++        const float cb = (float)av_q2d(coeffs->cb);
++        __m128 Y, g4;
++        __m128i idx;
++        int idx_arr[4];
++        float g_arr[4];
++
++        Y = _mm_mul_ps(r_linx4, _mm_set1_ps(cr));
++        Y = _mm_add_ps(Y, _mm_mul_ps(g_linx4, _mm_set1_ps(cg)));
++        Y = _mm_add_ps(Y, _mm_mul_ps(b_linx4, _mm_set1_ps(cb)));
++
++        idx = _mm_cvttps_epi32(_mm_add_ps(offset, _mm_mul_ps(Y, intermediate_upper_bound)));
++        idx = _mm_min_epi32(_mm_max_epi32(idx, _mm_setzero_si128()),
++                            _mm_set1_epi32(OOTF_LUT_SIZE - 1));
++        _mm_storeu_si128((__m128i *)idx_arr, idx);
++        g_arr[0] = ootf_lut[idx_arr[0]]; g_arr[1] = ootf_lut[idx_arr[1]];
++        g_arr[2] = ootf_lut[idx_arr[2]]; g_arr[3] = ootf_lut[idx_arr[3]];
++        g4 = _mm_loadu_ps(g_arr);
++
++        r_linx4 = _mm_mul_ps(r_linx4, g4);
++        g_linx4 = _mm_mul_ps(g_linx4, g4);
++        b_linx4 = _mm_mul_ps(b_linx4, g4);
++    }
 +
 +    if (!rgb2rgb_passthrough) {
 +        __m128 r0 = r_linx4, g0 = g_linx4, b0 = b_linx4;
@@ -8077,19 +8223,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +            b1x4b = av_clip_int16_sse(b1x4b);
 +
 +            tonemap_int32x4_sse(r0x4a, g0x4a, b0x4a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4a, g1x4a, b1x4a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r0x4b, g0x4b, b0x4b, &r[4], &g[4], &b[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4b, g1x4b, b1x4b, &r1[4], &g1[4], &b1[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -8478,19 +8624,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +            b1x4b = av_clip_int16_sse(b1x4b);
 +
 +            tonemap_int32x4_sse(r0x4a, g0x4a, b0x4a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4a, g1x4a, b1x4a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r0x4b, g0x4b, b0x4b, &r[4], &g[4], &b[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4b, g1x4b, b1x4b, &r1[4], &g1[4], &b1[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -9142,19 +9288,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +            b1x4b = av_clip_int16_sse(b1x4b);
 +
 +            tonemap_int32x4_sse(r0x4a, g0x4a, b0x4a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4a, g1x4a, b1x4a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r0x4b, g0x4b, b0x4b, &r[4], &g[4], &b[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4b, g1x4b, b1x4b, &r1[4], &g1[4], &b1[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -9435,19 +9581,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +            b1x4b = av_clip_int16_sse(b1x4b);
 +
 +            tonemap_int32x4_sse(r0x4a, g0x4a, b0x4a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4a, g1x4a, b1x4a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r0x4b, g0x4b, b0x4b, &r[4], &g[4], &b[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4b, g1x4b, b1x4b, &r1[4], &g1[4], &b1[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -9729,19 +9875,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +            b1x4b = av_clip_int16_sse(b1x4b);
 +
 +            tonemap_int32x4_sse(r0x4a, g0x4a, b0x4a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4a, g1x4a, b1x4a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r0x4b, g0x4b, b0x4b, &r[4], &g[4], &b[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4b, g1x4b, b1x4b, &r1[4], &g1[4], &b1[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +
@@ -10025,19 +10171,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +            b1x4b = av_clip_int16_sse(b1x4b);
 +
 +            tonemap_int32x4_sse(r0x4a, g0x4a, b0x4a, r, g, b,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4a, g1x4a, b1x4a, r1, g1, b1,
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r0x4b, g0x4b, b0x4b, &r[4], &g[4], &b[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +            tonemap_int32x4_sse(r1x4b, g1x4b, b1x4b, &r1[4], &g1[4], &b1[4],
-+                                params->lin_lut, params->tonemap_lut, params->delin_lut,
++                                params->lin_lut, params->tonemap_lut, params->delin_lut, params->ootf_lut,
 +                                params->coeffs, params->ocoeffs, params->desat, params->rgb2rgb_coeffs,
 +                                params->rgb2rgb_passthrough);
 +

--- a/debian/patches/0057-add-simd-optimized-tonemapx-filter.patch
+++ b/debian/patches/0057-add-simd-optimized-tonemapx-filter.patch
@@ -94,7 +94,7 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
-@@ -0,0 +1,2360 @@
+@@ -0,0 +1,2363 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -419,26 +419,29 @@ Index: FFmpeg/libavfilter/aarch64/vf_tonemapx_intrin_neon.c
 +    b_linx4b = vld1q_f32(b_lin4b);
 +
 +    if (!rgb2rgb_passthrough) {
-+        r_linx4a = vmulq_n_f32(r_linx4a, (float)(*rgb2rgb)[0][0]);
-+        r_linx4a = vfmaq_n_f32(r_linx4a, g_linx4a, (float)(*rgb2rgb)[0][1]);
-+        r_linx4a = vfmaq_n_f32(r_linx4a, b_linx4a, (float)(*rgb2rgb)[0][2]);
-+        r_linx4b = vmulq_n_f32(r_linx4b, (float)(*rgb2rgb)[0][0]);
-+        r_linx4b = vfmaq_n_f32(r_linx4b, g_linx4b, (float)(*rgb2rgb)[0][1]);
-+        r_linx4b = vfmaq_n_f32(r_linx4b, b_linx4b, (float)(*rgb2rgb)[0][2]);
++        float32x4_t r0_a = r_linx4a, g0_a = g_linx4a, b0_a = b_linx4a;
++        float32x4_t r0_b = r_linx4b, g0_b = g_linx4b, b0_b = b_linx4b;
 +
-+        g_linx4a = vmulq_n_f32(g_linx4a, (float)(*rgb2rgb)[1][1]);
-+        g_linx4a = vfmaq_n_f32(g_linx4a, r_linx4a, (float)(*rgb2rgb)[1][0]);
-+        g_linx4a = vfmaq_n_f32(g_linx4a, b_linx4a, (float)(*rgb2rgb)[1][2]);
-+        g_linx4b = vmulq_n_f32(g_linx4b, (float)(*rgb2rgb)[1][1]);
-+        g_linx4b = vfmaq_n_f32(g_linx4b, r_linx4b, (float)(*rgb2rgb)[1][0]);
-+        g_linx4b = vfmaq_n_f32(g_linx4b, b_linx4b, (float)(*rgb2rgb)[1][2]);
++        r_linx4a = vmulq_n_f32(r0_a, (float)(*rgb2rgb)[0][0]);
++        r_linx4a = vfmaq_n_f32(r_linx4a, g0_a, (float)(*rgb2rgb)[0][1]);
++        r_linx4a = vfmaq_n_f32(r_linx4a, b0_a, (float)(*rgb2rgb)[0][2]);
++        r_linx4b = vmulq_n_f32(r0_b, (float)(*rgb2rgb)[0][0]);
++        r_linx4b = vfmaq_n_f32(r_linx4b, g0_b, (float)(*rgb2rgb)[0][1]);
++        r_linx4b = vfmaq_n_f32(r_linx4b, b0_b, (float)(*rgb2rgb)[0][2]);
 +
-+        b_linx4a = vmulq_n_f32(b_linx4a, (float)(*rgb2rgb)[2][2]);
-+        b_linx4a = vfmaq_n_f32(b_linx4a, r_linx4a, (float)(*rgb2rgb)[2][0]);
-+        b_linx4a = vfmaq_n_f32(b_linx4a, g_linx4a, (float)(*rgb2rgb)[2][1]);
-+        b_linx4b = vmulq_n_f32(b_linx4b, (float)(*rgb2rgb)[2][2]);
-+        b_linx4b = vfmaq_n_f32(b_linx4b, r_linx4b, (float)(*rgb2rgb)[2][0]);
-+        b_linx4b = vfmaq_n_f32(b_linx4b, g_linx4b, (float)(*rgb2rgb)[2][1]);
++        g_linx4a = vmulq_n_f32(g0_a, (float)(*rgb2rgb)[1][1]);
++        g_linx4a = vfmaq_n_f32(g_linx4a, r0_a, (float)(*rgb2rgb)[1][0]);
++        g_linx4a = vfmaq_n_f32(g_linx4a, b0_a, (float)(*rgb2rgb)[1][2]);
++        g_linx4b = vmulq_n_f32(g0_b, (float)(*rgb2rgb)[1][1]);
++        g_linx4b = vfmaq_n_f32(g_linx4b, r0_b, (float)(*rgb2rgb)[1][0]);
++        g_linx4b = vfmaq_n_f32(g_linx4b, b0_b, (float)(*rgb2rgb)[1][2]);
++
++        b_linx4a = vmulq_n_f32(b0_a, (float)(*rgb2rgb)[2][2]);
++        b_linx4a = vfmaq_n_f32(b_linx4a, r0_a, (float)(*rgb2rgb)[2][0]);
++        b_linx4a = vfmaq_n_f32(b_linx4a, g0_a, (float)(*rgb2rgb)[2][1]);
++        b_linx4b = vmulq_n_f32(b0_b, (float)(*rgb2rgb)[2][2]);
++        b_linx4b = vfmaq_n_f32(b_linx4b, r0_b, (float)(*rgb2rgb)[2][0]);
++        b_linx4b = vfmaq_n_f32(b_linx4b, g0_b, (float)(*rgb2rgb)[2][1]);
 +    }
 +
 +    if (desat > 0) {
@@ -2628,7 +2631,7 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/vf_tonemapx.c
-@@ -0,0 +1,1948 @@
+@@ -0,0 +1,1949 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -3361,9 +3364,10 @@ Index: FFmpeg/libavfilter/vf_tonemapx.c
 +    b_lin = lin_lut[b_in];
 +
 +    if (!rgb2rgb_passthrough) {
-+        r_lin = (*rgb2rgb)[0][0] * r_lin + (*rgb2rgb)[0][1] * g_lin + (*rgb2rgb)[0][2] * b_lin;
-+        g_lin = (*rgb2rgb)[1][0] * r_lin + (*rgb2rgb)[1][1] * g_lin + (*rgb2rgb)[1][2] * b_lin;
-+        b_lin = (*rgb2rgb)[2][0] * r_lin + (*rgb2rgb)[2][1] * g_lin + (*rgb2rgb)[2][2] * b_lin;
++        float r0 = r_lin, g0 = g_lin, b0 = b_lin;
++        r_lin = (*rgb2rgb)[0][0] * r0 + (*rgb2rgb)[0][1] * g0 + (*rgb2rgb)[0][2] * b0;
++        g_lin = (*rgb2rgb)[1][0] * r0 + (*rgb2rgb)[1][1] * g0 + (*rgb2rgb)[1][2] * b0;
++        b_lin = (*rgb2rgb)[2][0] * r0 + (*rgb2rgb)[2][1] * g0 + (*rgb2rgb)[2][2] * b0;
 +    }
 +
 +    /* desaturate to prevent unnatural colors */
@@ -4743,7 +4747,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
-@@ -0,0 +1,2577 @@
+@@ -0,0 +1,2579 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -5104,17 +5108,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_avx.c
 +    b_linx8 = _mm256_loadu_ps(b_lin8);
 +
 +    if (!rgb2rgb_passthrough) {
-+        r_linx8 = _mm256_mul_ps(r_linx8, _mm256_set1_ps((float)(*rgb2rgb)[0][0]));
-+        r_linx8 = _mm256_fmadd_ps(g_linx8, _mm256_set1_ps((float)(*rgb2rgb)[0][1]), r_linx8);
-+        r_linx8 = _mm256_fmadd_ps(b_linx8, _mm256_set1_ps((float)(*rgb2rgb)[0][2]), r_linx8);
++        __m256 r0 = r_linx8, g0 = g_linx8, b0 = b_linx8;
 +
-+        g_linx8 = _mm256_mul_ps(g_linx8, _mm256_set1_ps((float)(*rgb2rgb)[1][1]));
-+        g_linx8 = _mm256_fmadd_ps(r_linx8, _mm256_set1_ps((float)(*rgb2rgb)[1][0]), g_linx8);
-+        g_linx8 = _mm256_fmadd_ps(b_linx8, _mm256_set1_ps((float)(*rgb2rgb)[1][2]), g_linx8);
++        r_linx8 = _mm256_mul_ps(r0, _mm256_set1_ps((float)(*rgb2rgb)[0][0]));
++        r_linx8 = _mm256_fmadd_ps(g0, _mm256_set1_ps((float)(*rgb2rgb)[0][1]), r_linx8);
++        r_linx8 = _mm256_fmadd_ps(b0, _mm256_set1_ps((float)(*rgb2rgb)[0][2]), r_linx8);
 +
-+        b_linx8 = _mm256_mul_ps(b_linx8, _mm256_set1_ps((float)(*rgb2rgb)[2][2]));
-+        b_linx8 = _mm256_fmadd_ps(r_linx8, _mm256_set1_ps((float)(*rgb2rgb)[2][0]), b_linx8);
-+        b_linx8 = _mm256_fmadd_ps(g_linx8, _mm256_set1_ps((float)(*rgb2rgb)[2][1]), b_linx8);
++        g_linx8 = _mm256_mul_ps(g0, _mm256_set1_ps((float)(*rgb2rgb)[1][1]));
++        g_linx8 = _mm256_fmadd_ps(r0, _mm256_set1_ps((float)(*rgb2rgb)[1][0]), g_linx8);
++        g_linx8 = _mm256_fmadd_ps(b0, _mm256_set1_ps((float)(*rgb2rgb)[1][2]), g_linx8);
++
++        b_linx8 = _mm256_mul_ps(b0, _mm256_set1_ps((float)(*rgb2rgb)[2][2]));
++        b_linx8 = _mm256_fmadd_ps(r0, _mm256_set1_ps((float)(*rgb2rgb)[2][0]), b_linx8);
++        b_linx8 = _mm256_fmadd_ps(g0, _mm256_set1_ps((float)(*rgb2rgb)[2][1]), b_linx8);
 +    }
 +
 +    if (desat > 0) {
@@ -7405,7 +7411,7 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
-@@ -0,0 +1,2740 @@
+@@ -0,0 +1,2742 @@
 +/*
 + * Copyright (c) 2024 Gnattu OC <gnattuoc@me.com>
 + *
@@ -7726,17 +7732,19 @@ Index: FFmpeg/libavfilter/x86/vf_tonemapx_intrin_sse.c
 +    b_linx4 = _mm_loadu_ps(b_lin4);
 +
 +    if (!rgb2rgb_passthrough) {
-+        r_linx4 = _mm_mul_ps(r_linx4, _mm_set1_ps((float)(*rgb2rgb)[0][0]));
-+        r_linx4 = _mm_add_ps(r_linx4, _mm_mul_ps(g_linx4, _mm_set1_ps((float)(*rgb2rgb)[0][1])));
-+        r_linx4 = _mm_add_ps(r_linx4, _mm_mul_ps(b_linx4, _mm_set1_ps((float)(*rgb2rgb)[0][2])));
++        __m128 r0 = r_linx4, g0 = g_linx4, b0 = b_linx4;
 +
-+        g_linx4 = _mm_mul_ps(g_linx4, _mm_set1_ps((float)(*rgb2rgb)[1][1]));
-+        g_linx4 = _mm_add_ps(g_linx4, _mm_mul_ps(r_linx4, _mm_set1_ps((float)(*rgb2rgb)[1][0])));
-+        g_linx4 = _mm_add_ps(g_linx4, _mm_mul_ps(b_linx4, _mm_set1_ps((float)(*rgb2rgb)[1][2])));
++        r_linx4 = _mm_mul_ps(r0, _mm_set1_ps((float)(*rgb2rgb)[0][0]));
++        r_linx4 = _mm_add_ps(r_linx4, _mm_mul_ps(g0, _mm_set1_ps((float)(*rgb2rgb)[0][1])));
++        r_linx4 = _mm_add_ps(r_linx4, _mm_mul_ps(b0, _mm_set1_ps((float)(*rgb2rgb)[0][2])));
 +
-+        b_linx4 = _mm_mul_ps(b_linx4, _mm_set1_ps((float)(*rgb2rgb)[2][2]));
-+        b_linx4 = _mm_add_ps(b_linx4, _mm_mul_ps(r_linx4, _mm_set1_ps((float)(*rgb2rgb)[2][0])));
-+        b_linx4 = _mm_add_ps(b_linx4, _mm_mul_ps(g_linx4, _mm_set1_ps((float)(*rgb2rgb)[2][1])));
++        g_linx4 = _mm_mul_ps(g0, _mm_set1_ps((float)(*rgb2rgb)[1][1]));
++        g_linx4 = _mm_add_ps(g_linx4, _mm_mul_ps(r0, _mm_set1_ps((float)(*rgb2rgb)[1][0])));
++        g_linx4 = _mm_add_ps(g_linx4, _mm_mul_ps(b0, _mm_set1_ps((float)(*rgb2rgb)[1][2])));
++
++        b_linx4 = _mm_mul_ps(b0, _mm_set1_ps((float)(*rgb2rgb)[2][2]));
++        b_linx4 = _mm_add_ps(b_linx4, _mm_mul_ps(r0, _mm_set1_ps((float)(*rgb2rgb)[2][0])));
++        b_linx4 = _mm_add_ps(b_linx4, _mm_mul_ps(g0, _mm_set1_ps((float)(*rgb2rgb)[2][1])));
 +    }
 +
 +    if (desat > 0) {


### PR DESCRIPTION
In [this](https://github.com/immich-app/immich/issues/28408) issue, a user showed that their videos have a reddish hue compared to the original, which happens regardless of tone-mapping algorithm unless they disable tone-mapping completely (no tonemapx). With the sample video they shared, I looked into this with help from Claude. The changes were simplified and optimized by me and tested on an M4 Max, 7800x3D and RTX 4090. The tests used hable and bt2390, but the fixes apply to all algorithms.

I know there's active work on 8.1.1 (which I'm looking forward to!), so I'm happy to base this PR on #664 if you prefer.

## Changes
* tonemap_cuda, tonemap_opencl, tonemap_videotoolbox and tonemapx now all use luma-weighted scaling for OOTF instead of per-channel. This is completely free on all but tonemapx, where it incurs a cost due to the added LUT that ranges from 2.6% if transcoding to medium preset H264 to 12.8% for ultrafast. The cost is only for HLG content since the LUT is not built or used for PQ or SDR.
* tonemapx's `rgb2rgb` now snapshots red, green and blue for computations. Updating `r_lin` in-place and using the new value to update `g_lin` and `b_lin` was wrong. The other filters didn't have this bug.
* A few methods in these filters ended up becoming dead code after the changes, so they were removed.

## Comparisons

<details>
<summary>hable</summary>

### Before
<img width="1080" height="1920" alt="buggy_proper" src="https://github.com/user-attachments/assets/7f3eec20-734b-4453-9536-9012f9f77522" />

### After

<img width="1080" height="1920" alt="C_proper" src="https://github.com/user-attachments/assets/5de77626-bc2d-4783-9b13-dde631271269" />

### libplacebo

<img width="1080" height="1920" alt="placebo_hable" src="https://github.com/user-attachments/assets/1df50ac0-773a-4c83-aa99-2ba23dc0dcc0" />

</details>

<details>
<summary>BT.2390</summary>

### Before

<img width="1080" height="1920" alt="buggy_bt2390" src="https://github.com/user-attachments/assets/ff261d9a-9832-4aac-a9c6-84bf3094b34e" />

### After

<img width="1080" height="1920" alt="C_bt2390" src="https://github.com/user-attachments/assets/58c0a059-5f98-4ace-b08f-9aa423d07c73" />

### libplacebo

I have no idea why libplacebo BT.2390 looks this bad. BT.2446a and ST 2094-40 look normal and closer to tonemapx BT.2390, so I'm including them below for a broader comparison.

<img width="1080" height="1920" alt="placebo_bt2390" src="https://github.com/user-attachments/assets/bdf4d4f2-8a51-44bf-9a25-a054f0fe72ab" />

#### BT.2446a

<img width="1080" height="1920" alt="placebo_bt2446a" src="https://github.com/user-attachments/assets/2a76fd85-e936-4a0a-890b-95d6988e26d5" />

#### ST 2094-40

<img width="1080" height="1920" alt="placebo_st2094_40" src="https://github.com/user-attachments/assets/40af27b2-7a45-4371-93b9-168ec5a9100e" />

</details>
