### PR TITLE
Add webp to matroskadec image mime types

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,9 @@ jellyfin-ffmpeg (8.1.1-1) unstable; urgency=medium
 
   * New upstream version 8.1.1
   * Rename package to jellyin-ffmpeg8
+  * Use EOTF from BT 2446 Method B for HLG tonemap
+  * Add dtsx detection for dts hra
+  * Add webp to matroskadec image mime types
 
  -- nyanmisaka <nst799610810@gmail.com>  Thu, 28 May 2026 10:55:42 +0800
 

--- a/debian/patches/0089-add-webp-to-matroskadec-image-mime-types.patch
+++ b/debian/patches/0089-add-webp-to-matroskadec-image-mime-types.patch
@@ -1,0 +1,12 @@
+Index: FFmpeg/libavformat/matroskadec.c
+===================================================================
+--- FFmpeg.orig/libavformat/matroskadec.c
++++ FFmpeg/libavformat/matroskadec.c
+@@ -818,6 +818,7 @@ static const CodecMime mkv_image_mime_ta
+     {"image/jpeg"                 , AV_CODEC_ID_MJPEG},
+     {"image/png"                  , AV_CODEC_ID_PNG},
+     {"image/tiff"                 , AV_CODEC_ID_TIFF},
++    {"image/webp"                 , AV_CODEC_ID_WEBP},
+ 
+     {""                           , AV_CODEC_ID_NONE}
+ };

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -86,3 +86,4 @@
 0086-workaround-amd-hevc-vaapi-encoder-out-of-band-vtag-hvc1.patch
 0087-backport-a-fix-from-upstream-for-magicyuv-decoder.patch
 0088-add-dtsx-detect-for-dts-hd-hra.patch
+0089-add-webp-to-matroskadec-image-mime-types.patch


### PR DESCRIPTION
FFmpeg already allows formats other than JPG and PNG in matroskadec, so let's also allow WEBP.

**Changes**
- Add webp to matroskadec image mime types

**Issues**
- Fixes https://github.com/jellyfin/jellyfin/issues/14569