### PR TITLE
Add prereleased to GH actions trigger

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - released
+      - prereleased
 
 jobs:
   build_publish_debian:


### PR DESCRIPTION
Currently, using pre-release will not trigger a build. It used to work, but it seems to have changed now.

**Changes**
- Add prereleased to GH actions trigger