### PR TITLE
Fix extracting mkv acttachments with non-ascii filenames

### DIFF
--- a/debian/patches/0090-fix-extracting-mkv-attachments-with-non-ascii-filenames.patch
+++ b/debian/patches/0090-fix-extracting-mkv-attachments-with-non-ascii-filenames.patch
@@ -1,0 +1,15 @@
+Index: FFmpeg/fftools/ffmpeg_demux.c
+===================================================================
+--- FFmpeg.orig/fftools/ffmpeg_demux.c
++++ FFmpeg/fftools/ffmpeg_demux.c
+@@ -1789,6 +1789,10 @@ static int safe_filename(const char *f,
+         return 0;
+ 
+     for (; *f; f++) {
++        /* Non-ASCII bytes cannot be '/' or '.' */
++        if ((unsigned char)*f > 127)
++            continue;
++
+         /* A-Za-z0-9_- */
+         if (!((unsigned)((*f | 32) - 'a') < 26 ||
+               (unsigned)(*f - '0') < 10 || *f == '_' || *f == '-')) {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -87,3 +87,4 @@
 0087-backport-a-fix-from-upstream-for-magicyuv-decoder.patch
 0088-add-dtsx-detect-for-dts-hd-hra.patch
 0089-add-webp-to-matroskadec-image-mime-types.patch
+0090-fix-extracting-mkv-attachments-with-non-ascii-filenames.patch


### PR DESCRIPTION
**Changes**
- Fix extracting mkv acttachments with non-ascii filenames

**Issues**
- Upstream regression in https://github.com/FFmpeg/FFmpeg/commit/1e7d7c4f5203a5badc63de82747b5abb1e56b5a0: failed to extract CJK fonts from MKV.
```
[aist#0:4/ttf @ 000001e74c85eb00] Filename 方正粗宋_GBK.ttf is unsafe
```