### PR TITLE
Patch to enable ffnvcodec in winarm64 build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+jellyfin-ffmpeg (8.1.1-2) unstable; urgency=medium
+
+  * Fix extracting mkv acttachments with non-ascii filenames
+  * Patch to enable ffnvcodec in winarm64 build
+
+ -- nyanmisaka <nst799610810@gmail.com>  Fri, 5 Jun 2026 12:01:54 +0800
+
 jellyfin-ffmpeg (8.1.1-1) unstable; urgency=medium
 
   * New upstream version 8.1.1

--- a/debian/patches/0083-backport-fixes-for-nvenc-and-cuvid-from-upstream.patch
+++ b/debian/patches/0083-backport-fixes-for-nvenc-and-cuvid-from-upstream.patch
@@ -1,3 +1,16 @@
+Index: FFmpeg/configure
+===================================================================
+--- FFmpeg.orig/configure
++++ FFmpeg/configure
+@@ -7870,7 +7870,7 @@ if enabled x86; then
+     esac
+ elif enabled_any aarch64 ppc64 && ! enabled bigendian; then
+     case $target_os in
+-        linux)
++        linux|mingw32*|mingw64*|win32|win64)
+             ;;
+         *)
+             disable ffnvcodec cuvid nvdec nvenc
 Index: FFmpeg/libavcodec/cuviddec.c
 ===================================================================
 --- FFmpeg.orig/libavcodec/cuviddec.c
@@ -93,3 +106,18 @@ Index: FFmpeg/libavcodec/nvenc.c
              break;
          case NV_ENC_H264_PROFILE_MAIN:
              cc->profileGUID = NV_ENC_H264_PROFILE_MAIN_GUID;
+Index: FFmpeg/libavfilter/vf_scale_cuda.h
+===================================================================
+--- FFmpeg.orig/libavfilter/vf_scale_cuda.h
++++ FFmpeg/libavfilter/vf_scale_cuda.h
+@@ -24,9 +24,8 @@
+ #define AVFILTER_SCALE_CUDA_H
+ 
+ #if defined(__CUDACC__) || defined(__CUDA__)
+-#include <stdint.h>
+ typedef cudaTextureObject_t CUtexObject;
+-typedef uint8_t* CUdeviceptr;
++typedef unsigned char* CUdeviceptr;
+ #else
+ #include <ffnvcodec/dynlink_cuda.h>
+ #endif

--- a/msys2/buildarm64.sh
+++ b/msys2/buildarm64.sh
@@ -90,7 +90,13 @@ PKG_CONFIG_PATH=/clangarm64/ffbuild/lib/pkgconfig ./configure \
     --enable-dxva2 \
     --enable-d3d11va \
     --enable-d3d12va \
-    --enable-mediafoundation
+    --enable-mediafoundation \
+    --enable-ffnvcodec \
+    --enable-cuda \
+    --enable-cuda-llvm \
+    --enable-cuvid \
+    --enable-nvdec \
+    --enable-nvenc
 
 make -j$(nproc) V=1
 


### PR DESCRIPTION
It might be useful at some point in the future.

**Changes**
- Patch to enable ffnvcodec in winarm64 build
- Bump version to 8.1.1-2