### PR TITLE
[7.1] Fix extracting mkv attachments with non-ascii filenames

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,12 +8,14 @@ on:
   push:
     branches:
       - jellyfin
+      - jellyfin-7.1
     paths-ignore:
       - '**/*.md'
 
   pull_request:
     branches:
       - jellyfin
+      - jellyfin-7.1
     paths-ignore:
       - '**/*.md'
 

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "7.1.4-1"
+version: "7.1.4-2"
 packages:
   - bullseye-amd64
   - bullseye-arm64

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jellyfin-ffmpeg (7.1.4-2) unstable; urgency=medium
+
+  * Fix extracting mkv attachments with non-ascii filenames
+
+ -- nyanmisaka <nst799610810@gmail.com>  Fri, 5 Jun 2026 17:32:10 +0800
+
 jellyfin-ffmpeg (7.1.4-1) unstable; urgency=medium
 
   * New upstream version 7.1.4

--- a/debian/patches/0095-fix-extracting-mkv-attachments-with-non-ascii-filenames.patch
+++ b/debian/patches/0095-fix-extracting-mkv-attachments-with-non-ascii-filenames.patch
@@ -1,0 +1,15 @@
+Index: FFmpeg/fftools/ffmpeg_demux.c
+===================================================================
+--- FFmpeg.orig/fftools/ffmpeg_demux.c
++++ FFmpeg/fftools/ffmpeg_demux.c
+@@ -1601,6 +1601,10 @@ static int safe_filename(const char *f,
+         return 0;
+ 
+     for (; *f; f++) {
++        /* Non-ASCII bytes cannot be '/' or '.' */
++        if ((unsigned char)*f > 127)
++            continue;
++
+         /* A-Za-z0-9_- */
+         if (!((unsigned)((*f | 32) - 'a') < 26 ||
+               (unsigned)(*f - '0') < 10 || *f == '_' || *f == '-')) {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -92,3 +92,4 @@
 0092-add-hevc-recovery-point-support-backport-from-upstream.patch
 0093-backport-fixes-by-comparing-n7.1.4-and-release-7.1.patch
 0094-backport-a-fix-from-upstream-for-magicyuv-decoder.patch
+0095-fix-extracting-mkv-attachments-with-non-ascii-filenames.patch


### PR DESCRIPTION
**Changes**
- [7.1] Fix extracting mkv attachments with non-ascii filenames

**Issues**
- The upstream backported the offending commit to 7.1.4