### PR TITLE
avfilter(scale_vt): fix broken macro place for scale_vt patch

### DIFF
--- a/debian/patches/0043-add-format-option-to-vt-scale-filter.patch
+++ b/debian/patches/0043-add-format-option-to-vt-scale-filter.patch
@@ -29,54 +29,11 @@ Index: FFmpeg/libavfilter/vf_scale_vt.c
  static av_cold int scale_vt_init(AVFilterContext *avctx)
  {
      ScaleVtContext *s = avctx->priv;
-@@ -58,24 +73,6 @@ static av_cold int scale_vt_init(AVFilte
-         return AVERROR_EXTERNAL;
-     }
- 
--#define STRING_OPTION(var_name, func_name, default_value)                \
--    do {                                                                 \
--        if (s->var_name##_string) {                                      \
--            int var = av_##func_name##_from_name(s->var_name##_string);  \
--            if (var < 0) {                                               \
--                av_log(avctx, AV_LOG_ERROR, "Invalid %s.\n", #var_name); \
--                return AVERROR(EINVAL);                                  \
--            }                                                            \
--            s->var_name = var;                                           \
--        } else {                                                         \
--            s->var_name = default_value;                                 \
--        }                                                                \
--    } while (0)
--
--    STRING_OPTION(colour_primaries, color_primaries, AVCOL_PRI_UNSPECIFIED);
--    STRING_OPTION(colour_transfer,  color_transfer,  AVCOL_TRC_UNSPECIFIED);
--    STRING_OPTION(colour_matrix,    color_space,     AVCOL_SPC_UNSPECIFIED);
--
-     if (s->colour_primaries != AVCOL_PRI_UNSPECIFIED) {
-         value = av_map_videotoolbox_color_primaries_from_av(s->colour_primaries);
-         if (!value) {
-@@ -241,6 +238,35 @@ static int scale_vt_config_output(AVFilt
+@@ -241,6 +256,17 @@ static int scale_vt_config_output(AVFilt
      FilterLink        *inl = ff_filter_link(inlink);
      AVHWFramesContext *hw_frame_ctx_in;
      AVHWFramesContext *hw_frame_ctx_out;
 +    enum AVPixelFormat out_format;
-+
-+#define STRING_OPTION(var_name, func_name, default_value)                \
-+    do {                                                                 \
-+        if (s->var_name##_string) {                                      \
-+            int var = av_##func_name##_from_name(s->var_name##_string);  \
-+            if (var < 0) {                                               \
-+                av_log(avctx, AV_LOG_ERROR, "Invalid %s.\n", #var_name); \
-+                return AVERROR(EINVAL);                                  \
-+            }                                                            \
-+            s->var_name = var;                                           \
-+        } else {                                                         \
-+            s->var_name = default_value;                                 \
-+        }                                                                \
-+    } while (0)
-+
-+    STRING_OPTION(colour_primaries, color_primaries, AVCOL_PRI_UNSPECIFIED);
-+    STRING_OPTION(colour_transfer,  color_transfer,  AVCOL_TRC_UNSPECIFIED);
-+    STRING_OPTION(colour_matrix,    color_space,     AVCOL_SPC_UNSPECIFIED);
 +
 +    if (!((s->colour_primaries == AVCOL_PRI_UNSPECIFIED &&
 +           s->colour_transfer == AVCOL_TRC_UNSPECIFIED) ||


### PR DESCRIPTION
The setup macro should be in init function, not in configure output function. Current placment would break scale_vt based tone mapping as the output color parameters are never initialized and cannot be mapped correctly.

Our old patch accidentally moved it, probably due to 7.1 and 8.1 differences, but we should follow upstream here for this one.

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->