### PR TITLE
feat: add riscv64 (RISC-V) Debian/Ubuntu package and portable build s…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,15 +40,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["jammy"]'
-      architectures: '["amd64", "arm64", "riscv64"]'
-      release: false
-
-  build_ubuntu_riscv64:
-    uses: ./.github/workflows/_meta.yaml
-    with:
-      distro: 'ubuntu'
-      codenames: '["noble", "resolute"]'
+      codenames: '["jammy", "noble", "resolute"]'
       architectures: '["amd64", "arm64", "riscv64"]'
       release: false
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,21 +17,39 @@ on:
     paths-ignore:
       - '**/*.md'
 
+  workflow_dispatch:
+
 jobs:
   build_debian:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'debian'
-      codenames: '["bullseye", "bookworm", "trixie"]'
+      codenames: '["bullseye", "bookworm"]'
       architectures: '["amd64", "arm64"]'
+      release: false
+
+  build_debian_trixie:
+    uses: ./.github/workflows/_meta.yaml
+    with:
+      distro: 'debian'
+      codenames: '["trixie"]'
+      architectures: '["amd64", "arm64", "riscv64"]'
       release: false
 
   build_ubuntu:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'ubuntu'
-      codenames: '["jammy", "noble", "resolute"]'
-      architectures: '["amd64", "arm64"]'
+      codenames: '["jammy"]'
+      architectures: '["amd64", "arm64", "riscv64"]'
+      release: false
+
+  build_ubuntu_riscv64:
+    uses: ./.github/workflows/_meta.yaml
+    with:
+      distro: 'ubuntu'
+      codenames: '["noble", "resolute"]'
+      architectures: '["amd64", "arm64", "riscv64"]'
       release: false
 
   # Disabled as clang is stable.
@@ -51,7 +69,7 @@ jobs:
     uses: ./.github/workflows/_meta_portable.yaml
     with:
       os: 'linux'
-      architectures: '["amd64", "arm64"]'
+      architectures: '["amd64", "arm64", "riscv64"]'
       release: false
 
   build_portable_mac:

--- a/build
+++ b/build
@@ -6,7 +6,7 @@ usage() {
     echo -e "Releases:          Arches:"
     echo -e " * bullseye         * amd64"
     echo -e " * bookworm         * arm64"
-    echo -e " * trixie"
+    echo -e " * trixie            * riscv64"
     echo -e " * jammy"
     echo -e " * noble"
     echo -e " * resolute"
@@ -69,6 +69,9 @@ case ${cli_arch} in
     ;;
     'arm64')
         arch="arm64"
+    ;;
+    'riscv64')
+        arch="riscv64"
     ;;
     *)
         echo "Invalid architecture."

--- a/build-linux-riscv64
+++ b/build-linux-riscv64
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o xtrace
+set -o errexit
+
+# Check for dependencies
+for dep in bash docker; do
+    command -v ${dep} &>/dev/null || { echo "The command '${dep}' is required."; exit 1; }
+done
+
+# Build the jellyfin-ffmpeg portable version
+[[ $(docker image ls 'ghcr.io/jellyfin/jellyfin-ffmpeg/linuxriscv64-gpl:latest' | wc -l) -eq 1 ]] && \
+    ./builder/makeimage.sh linuxriscv64 gpl
+
+./builder/build.sh linuxriscv64 gpl
+
+# If no 1st parameter was specified, move pkg to parent directory
+if [[ -z ${1} ]]; then
+    path="../bin"
+else
+    path="${1}"
+fi
+mkdir ${path} &>/dev/null || true
+mv builder/artifacts/jellyfin-ffmpeg*portable_linuxriscv64-gpl*.tar.xz "${path}"

--- a/build.yaml
+++ b/build.yaml
@@ -9,9 +9,13 @@ packages:
   - bookworm-arm64
   - trixie-amd64
   - trixie-arm64
+  - trixie-riscv64
   - jammy-amd64
   - jammy-arm64
+  - jammy-riscv64
   - noble-amd64
   - noble-arm64
+  - noble-riscv64
   - resolute-amd64
   - resolute-arm64
+  - resolute-riscv64

--- a/builder/images/base-linuxriscv64/Dockerfile
+++ b/builder/images/base-linuxriscv64/Dockerfile
@@ -1,0 +1,56 @@
+ARG GH_REPO=ghcr.io/jellyfin/jellyfin-ffmpeg
+FROM $GH_REPO/base:latest
+
+RUN --mount=src=ct-ng-config,dst=/.config \
+    git clone --filter=blob:none https://github.com/crosstool-ng/crosstool-ng.git /ct-ng && cd /ct-ng && \
+    ./bootstrap && \
+    ./configure --enable-local && \
+    make -j$(nproc) && \
+    cp /.config .config && \
+    ./ct-ng build && \
+    cd / && \
+    rm -rf ct-ng
+
+# Prepare cross environment to heavily favour static builds
+RUN \
+    find /opt/ct-ng -type l \
+        -and -name '*.so' \
+        -and -not -ipath '*plugin*' \
+        -and -not -name 'libdl.*' \
+        -and -not -name 'libc.*' \
+        -and -not -name 'libm.*' \
+        -and -not -name 'libmvec.*' \
+        -and -not -name 'librt.*' \
+        -and -not -name 'libpthread.*' \
+        -delete && \
+    mkdir /opt/ffbuild
+
+RUN rustup target add riscv64gc-unknown-linux-gnu
+
+ADD toolchain.cmake /toolchain.cmake
+ADD cross.meson /cross.meson
+
+ADD gen-implib.sh /usr/bin/gen-implib
+RUN git clone --filter=blob:none --depth=1 https://github.com/yugr/Implib.so /opt/implib
+
+ENV FFBUILD_TOOLCHAIN=riscv64-ffbuild-linux-gnu
+ENV PATH="/opt/ct-ng/bin:${PATH}" \
+    FFBUILD_TARGET_FLAGS="--pkg-config=pkg-config --pkg-config-flags=--static --cross-prefix=${FFBUILD_TOOLCHAIN}- --arch=riscv64 --cpu=rv64gc --target-os=linux" \
+    FFBUILD_CROSS_PREFIX="${FFBUILD_TOOLCHAIN}-" \
+    FFBUILD_RUST_TARGET="riscv64gc-unknown-linux-gnu" \
+    FFBUILD_PREFIX=/opt/ffbuild \
+    FFBUILD_CMAKE_TOOLCHAIN=/toolchain.cmake \
+    PKG_CONFIG=pkg-config \
+    PKG_CONFIG_LIBDIR=/opt/ffbuild/lib/pkgconfig:/opt/ffbuild/share/pkgconfig \
+    CC="${FFBUILD_TOOLCHAIN}-gcc" \
+    CXX="${FFBUILD_TOOLCHAIN}-g++" \
+    LD="${FFBUILD_TOOLCHAIN}-ld" \
+    AR="${FFBUILD_TOOLCHAIN}-gcc-ar" \
+    RANLIB="${FFBUILD_TOOLCHAIN}-gcc-ranlib" \
+    NM="${FFBUILD_TOOLCHAIN}-gcc-nm" \
+    CFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -march=rv64gc -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -pthread" \
+    CXXFLAGS="-static-libgcc -static-libstdc++ -I/opt/ffbuild/include -O2 -pipe -march=rv64gc -fPIC -DPIC -D_FORTIFY_SOURCE=2 -fstack-protector-strong -pthread" \
+    LDFLAGS="-static-libgcc -static-libstdc++ -L/opt/ffbuild/lib -O2 -pipe -march=rv64gc -fstack-protector-strong -Wl,-z,relro,-z,now -pthread -lm" \
+    STAGE_CFLAGS="" \
+    STAGE_CXXFLAGS="" \
+    CMAKE_POLICY_VERSION_MINIMUM="3.5"

--- a/builder/images/base-linuxriscv64/cross.meson
+++ b/builder/images/base-linuxriscv64/cross.meson
@@ -1,0 +1,13 @@
+[binaries]
+c = 'riscv64-ffbuild-linux-gnu-gcc'
+cpp = 'riscv64-ffbuild-linux-gnu-g++'
+ld = 'riscv64-ffbuild-linux-gnu-ld'
+ar = 'riscv64-ffbuild-linux-gnu-gcc-ar'
+ranlib = 'riscv64-ffbuild-linux-gnu-gcc-ranlib'
+strip = 'riscv64-ffbuild-linux-gnu-strip'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'riscv64'
+cpu = 'riscv64'
+endian = 'little'

--- a/builder/images/base-linuxriscv64/ct-ng-config
+++ b/builder/images/base-linuxriscv64/ct-ng-config
@@ -1,0 +1,1134 @@
+#
+# Automatically generated file; DO NOT EDIT.
+# crosstool-NG 1.28.0.23_185f348 Configuration
+#
+CT_CONFIGURE_has_static_link=y
+CT_CONFIGURE_has_cxx11=y
+CT_CONFIGURE_has_wget=y
+CT_CONFIGURE_has_curl=y
+CT_CONFIGURE_has_meson=y
+CT_CONFIGURE_has_ninja=y
+CT_CONFIGURE_has_make_3_81_or_newer=y
+CT_CONFIGURE_has_make_4_0_or_newer=y
+CT_CONFIGURE_has_make_4_4_or_newer=y
+CT_CONFIGURE_has_libtool_2_4_or_newer=y
+CT_CONFIGURE_has_libtoolize_2_4_or_newer=y
+CT_CONFIGURE_has_autoconf_2_65_or_newer=y
+CT_CONFIGURE_has_autoreconf_2_65_or_newer=y
+CT_CONFIGURE_has_automake_1_15_or_newer=y
+CT_CONFIGURE_has_gnu_m4_1_4_12_or_newer=y
+CT_CONFIGURE_has_python_3_4_or_newer=y
+CT_CONFIGURE_has_bison_2_7_or_newer=y
+CT_CONFIGURE_has_bison_3_0_4_or_newer=y
+CT_CONFIGURE_has_python=y
+CT_CONFIGURE_has_dtc=y
+CT_CONFIGURE_has_svn=y
+CT_CONFIGURE_has_git=y
+CT_CONFIGURE_has_md5sum=y
+CT_CONFIGURE_has_sha1sum=y
+CT_CONFIGURE_has_sha256sum=y
+CT_CONFIGURE_has_sha512sum=y
+CT_CONFIGURE_has_install_with_strip_program=y
+CT_VERSION="1.28.0.23_185f348"
+CT_VCHECK=""
+CT_CONFIG_VERSION_ENV="4"
+CT_CONFIG_VERSION_CURRENT="4"
+CT_CONFIG_VERSION="4"
+CT_MODULES=y
+
+#
+# Paths and misc options
+#
+
+#
+# crosstool-NG behavior
+#
+CT_OBSOLETE=y
+CT_EXPERIMENTAL=y
+CT_ALLOW_BUILD_AS_ROOT=y
+CT_ALLOW_BUILD_AS_ROOT_SURE=y
+# CT_ENABLE_EXPERIMENTAL_BUNDLED_PATCHES is not set
+# CT_DEBUG_CT is not set
+
+#
+# Paths
+#
+CT_LOCAL_TARBALLS_DIR="${HOME}/src"
+# CT_SAVE_TARBALLS is not set
+# CT_TARBALLS_BUILDROOT_LAYOUT is not set
+CT_WORK_DIR="${CT_TOP_DIR}/build"
+CT_BUILD_TOP_DIR="${CT_WORK_DIR:-${CT_TOP_DIR}/.build}/${CT_HOST:+HOST-${CT_HOST}/}${CT_TARGET}"
+CT_BUILD_DIR="${CT_BUILD_TOP_DIR}/build"
+CT_PREFIX_DIR="/opt/ct-ng"
+CT_RM_RF_PREFIX_DIR=y
+CT_REMOVE_DOCS=y
+# CT_INSTALL_LICENSES is not set
+# CT_PREFIX_DIR_RO is not set
+CT_STRIP_HOST_TOOLCHAIN_EXECUTABLES=y
+CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES=y
+# CT_TARBALL_RESULT is not set
+
+#
+# Downloading
+#
+CT_DOWNLOAD_AGENT_WGET=y
+# CT_DOWNLOAD_AGENT_CURL is not set
+# CT_DOWNLOAD_AGENT_NONE is not set
+# CT_FORBID_DOWNLOAD is not set
+# CT_FORCE_DOWNLOAD is not set
+CT_CONNECT_TIMEOUT=10
+CT_DOWNLOAD_WGET_OPTIONS="--passive-ftp --tries=3 -nc --progress=dot:binary"
+# CT_ONLY_DOWNLOAD is not set
+# CT_USE_MIRROR is not set
+CT_VERIFY_DOWNLOAD_DIGEST=y
+CT_VERIFY_DOWNLOAD_DIGEST_SHA512=y
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA256 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_SHA1 is not set
+# CT_VERIFY_DOWNLOAD_DIGEST_MD5 is not set
+CT_VERIFY_DOWNLOAD_DIGEST_ALG="sha512"
+# CT_VERIFY_DOWNLOAD_SIGNATURE is not set
+
+#
+# Extracting
+#
+# CT_FORCE_EXTRACT is not set
+CT_OVERRIDE_CONFIG_GUESS_SUB=y
+# CT_ONLY_EXTRACT is not set
+CT_PATCH_BUNDLED=y
+# CT_PATCH_LOCAL is not set
+# CT_PATCH_BUNDLED_LOCAL is not set
+# CT_PATCH_LOCAL_BUNDLED is not set
+# CT_PATCH_NONE is not set
+CT_PATCH_ORDER="bundled"
+
+#
+# Build behavior
+#
+CT_PARALLEL_JOBS=0
+CT_LOAD=""
+CT_USE_PIPES=y
+CT_EXTRA_CFLAGS_FOR_BUILD="-fPIC -DPIC"
+CT_EXTRA_CXXFLAGS_FOR_BUILD="-fPIC -DPIC"
+CT_EXTRA_LDFLAGS_FOR_BUILD=""
+CT_EXTRA_CFLAGS_FOR_HOST="-fPIC -DPIC"
+CT_EXTRA_LDFLAGS_FOR_HOST=""
+# CT_CONFIG_SHELL_SH is not set
+# CT_CONFIG_SHELL_ASH is not set
+CT_CONFIG_SHELL_BASH=y
+# CT_CONFIG_SHELL_CUSTOM is not set
+CT_CONFIG_SHELL="${bash}"
+
+#
+# Logging
+#
+# CT_LOG_ERROR is not set
+# CT_LOG_WARN is not set
+# CT_LOG_INFO is not set
+# CT_LOG_EXTRA is not set
+# CT_LOG_ALL is not set
+CT_LOG_DEBUG=y
+CT_LOG_LEVEL_MAX="DEBUG"
+# CT_LOG_SEE_TOOLS_WARN is not set
+# CT_LOG_TO_FILE is not set
+# end of Paths and misc options
+
+#
+# Target options
+#
+# CT_ARCH_ALPHA is not set
+# CT_ARCH_ARC is not set
+CT_ARCH_RISCV=y
+# CT_ARCH_AVR is not set
+# CT_ARCH_BPF is not set
+# CT_ARCH_C6X is not set
+# CT_ARCH_LM32 is not set
+# CT_ARCH_LOONGARCH is not set
+# CT_ARCH_M68K is not set
+# CT_ARCH_MICROBLAZE is not set
+# CT_ARCH_MIPS is not set
+# CT_ARCH_MOXIE is not set
+# CT_ARCH_MSP430 is not set
+# CT_ARCH_NIOS2 is not set
+# CT_ARCH_OPENRISC is not set
+# CT_ARCH_PARISC is not set
+# CT_ARCH_POWERPC is not set
+# CT_ARCH_PRU is not set
+# CT_ARCH_ARM is not set
+# CT_ARCH_RX is not set
+# CT_ARCH_S390 is not set
+# CT_ARCH_SH is not set
+# CT_ARCH_SPARC is not set
+# CT_ARCH_TRICORE is not set
+# CT_ARCH_X86 is not set
+# CT_ARCH_XTENSA is not set
+CT_ARCH="riscv"
+CT_ARCH_CHOICE_KSYM="RISCV"
+CT_ARCH_CPU=""
+CT_ARCH_TUNE=""
+CT_ARCH_RISCV_SHOW=y
+
+#
+# Options for riscv
+#
+CT_ARCH_RISCV_PKG_KSYM=""
+CT_ALL_ARCH_CHOICES="ALPHA ARC ARM AVR BPF C6X LM32 LOONGARCH M68K MICROBLAZE MIPS MOXIE MSP430 NIOS2 OPENRISC PARISC POWERPC PRU RISCV RX S390 SH SPARC TRICORE X86 XTENSA"
+CT_ARCH_SUFFIX=""
+# CT_OMIT_TARGET_VENDOR is not set
+
+#
+# Generic target options
+#
+# CT_MULTILIB is not set
+CT_DEMULTILIB=y
+CT_ARCH_SUPPORTS_BOTH_MMU=y
+CT_ARCH_DEFAULT_HAS_MMU=y
+CT_ARCH_USE_MMU=y
+CT_ARCH_SUPPORTS_FLAT_FORMAT=y
+CT_ARCH_SUPPORTS_LIBSANITIZER=y
+CT_ARCH_SUPPORTS_EITHER_ENDIAN=y
+CT_ARCH_DEFAULT_LE=y
+# CT_ARCH_BE is not set
+CT_ARCH_LE=y
+CT_ARCH_ENDIAN="little"
+CT_ARCH_SUPPORTS_32=y
+CT_ARCH_SUPPORTS_64=y
+CT_ARCH_DEFAULT_32=y
+CT_ARCH_BITNESS=64
+# CT_ARCH_32 is not set
+CT_ARCH_64=y
+
+#
+# Target optimisations
+#
+CT_ARCH_SUPPORTS_WITH_ARCH=y
+CT_ARCH_SUPPORTS_WITH_CPU=y
+CT_ARCH_SUPPORTS_WITH_TUNE=y
+CT_ARCH_EXCLUSIVE_WITH_CPU=y
+CT_ARCH_ARCH=""
+CT_TARGET_CFLAGS="-fPIC -DPIC"
+CT_TARGET_LDFLAGS=""
+# end of Target options
+
+#
+# Toolchain options
+#
+
+#
+# General toolchain options
+#
+CT_USE_SYSROOT=y
+CT_SYSROOT_NAME="sysroot"
+CT_SYSROOT_DIR_PREFIX=""
+# CT_STATIC_TOOLCHAIN is not set
+CT_SHOW_CT_VERSION=y
+CT_TOOLCHAIN_PKGVERSION=""
+CT_TOOLCHAIN_BUGURL=""
+
+#
+# Tuple completion and aliasing
+#
+CT_TARGET_VENDOR="ffbuild"
+CT_TARGET_ALIAS_SED_EXPR=""
+CT_TARGET_ALIAS=""
+
+#
+# Toolchain type
+#
+# CT_NATIVE is not set
+CT_CROSS=y
+# CT_CROSS_NATIVE is not set
+# CT_CANADIAN is not set
+CT_TOOLCHAIN_TYPE="cross"
+
+#
+# Build system
+#
+CT_BUILD=""
+CT_BUILD_PREFIX=""
+CT_BUILD_SUFFIX=""
+
+#
+# Misc options
+#
+# CT_TOOLCHAIN_ENABLE_NLS is not set
+CT_TOOLCHAIN_CMAKE_TOOLCHAIN_FILE=y
+# end of Toolchain options
+
+#
+# Operating System
+#
+CT_KERNEL_SUPPORTS_SHARED_LIBS=y
+# CT_KERNEL_BARE_METAL is not set
+CT_KERNEL_LINUX=y
+# CT_KERNEL_WINDOWS is not set
+CT_KERNEL="linux"
+CT_KERNEL_CHOICE_KSYM="LINUX"
+CT_KERNEL_LINUX_SHOW=y
+
+#
+# Options for linux
+#
+CT_KERNEL_LINUX_PKG_KSYM="LINUX"
+CT_LINUX_DIR_NAME="linux"
+CT_LINUX_PKG_NAME="linux"
+CT_LINUX_SRC_RELEASE=y
+# CT_LINUX_SRC_DEVEL is not set
+# CT_LINUX_SRC_CUSTOM is not set
+CT_LINUX_PATCH_GLOBAL=y
+# CT_LINUX_PATCH_BUNDLED is not set
+# CT_LINUX_PATCH_LOCAL is not set
+# CT_LINUX_PATCH_BUNDLED_LOCAL is not set
+# CT_LINUX_PATCH_LOCAL_BUNDLED is not set
+# CT_LINUX_PATCH_NONE is not set
+CT_LINUX_PATCH_ORDER="global"
+# CT_LINUX_V_6_18 is not set
+# CT_LINUX_V_6_17 is not set
+# CT_LINUX_V_6_16 is not set
+# CT_LINUX_V_6_15 is not set
+# CT_LINUX_V_6_14 is not set
+# CT_LINUX_V_6_13 is not set
+# CT_LINUX_V_6_12 is not set
+# CT_LINUX_V_6_11 is not set
+# CT_LINUX_V_6_10 is not set
+# CT_LINUX_V_6_9 is not set
+# CT_LINUX_V_6_8 is not set
+# CT_LINUX_V_6_7 is not set
+# CT_LINUX_V_6_6 is not set
+# CT_LINUX_V_6_5 is not set
+# CT_LINUX_V_6_4 is not set
+# CT_LINUX_V_6_3 is not set
+# CT_LINUX_V_6_2 is not set
+CT_LINUX_V_6_1=y
+# CT_LINUX_V_6_0 is not set
+# CT_LINUX_V_5_19 is not set
+# CT_LINUX_V_5_18 is not set
+# CT_LINUX_V_5_17 is not set
+# CT_LINUX_V_5_16 is not set
+# CT_LINUX_V_5_15 is not set
+# CT_LINUX_V_5_14 is not set
+# CT_LINUX_V_5_13 is not set
+# CT_LINUX_V_5_12 is not set
+# CT_LINUX_V_5_11 is not set
+# CT_LINUX_V_5_10 is not set
+# CT_LINUX_V_5_9 is not set
+# CT_LINUX_V_5_8 is not set
+# CT_LINUX_V_5_7 is not set
+# CT_LINUX_V_5_5 is not set
+# CT_LINUX_V_5_4 is not set
+# CT_LINUX_V_5_3 is not set
+# CT_LINUX_V_5_2 is not set
+# CT_LINUX_V_5_1 is not set
+# CT_LINUX_V_5_0 is not set
+# CT_LINUX_V_4_20 is not set
+# CT_LINUX_V_4_19 is not set
+# CT_LINUX_V_4_18 is not set
+# CT_LINUX_V_4_17 is not set
+# CT_LINUX_V_4_16 is not set
+# CT_LINUX_V_4_15 is not set
+# CT_LINUX_V_4_14 is not set
+# CT_LINUX_V_4_13 is not set
+# CT_LINUX_V_4_12 is not set
+# CT_LINUX_V_4_11 is not set
+# CT_LINUX_V_4_10 is not set
+# CT_LINUX_V_4_9 is not set
+# CT_LINUX_V_4_4 is not set
+# CT_LINUX_V_4_1 is not set
+# CT_LINUX_V_3_18 is not set
+# CT_LINUX_V_3_16 is not set
+# CT_LINUX_V_3_13 is not set
+# CT_LINUX_V_3_12 is not set
+# CT_LINUX_V_3_10 is not set
+CT_LINUX_VERSION="6.1.100"
+CT_LINUX_MIRRORS="$(CT_Mirrors kernel.org linux ${CT_LINUX_VERSION})"
+CT_LINUX_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_LINUX_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_LINUX_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_LINUX_SIGNATURE_FORMAT="unpacked/.sign"
+CT_LINUX_6_12_or_older=y
+CT_LINUX_older_than_6_12=y
+CT_LINUX_6_6_or_older=y
+CT_LINUX_older_than_6_6=y
+CT_LINUX_6_1_or_later=y
+CT_LINUX_6_1_or_older=y
+CT_LINUX_later_than_5_19=y
+CT_LINUX_5_19_or_later=y
+CT_LINUX_later_than_5_12=y
+CT_LINUX_5_12_or_later=y
+CT_LINUX_later_than_5_5=y
+CT_LINUX_5_5_or_later=y
+CT_LINUX_later_than_5_3=y
+CT_LINUX_5_3_or_later=y
+CT_LINUX_later_than_4_8=y
+CT_LINUX_4_8_or_later=y
+CT_LINUX_later_than_3_7=y
+CT_LINUX_3_7_or_later=y
+CT_LINUX_REQUIRE_3_7_or_later=y
+CT_LINUX_later_than_3_2=y
+CT_LINUX_3_2_or_later=y
+CT_LINUX_REQUIRE_3_2_or_later=y
+CT_KERNEL_has_rsync=y
+CT_KERNEL_DEP_RSYNC=y
+CT_KERNEL_LINUX_VERBOSITY_0=y
+# CT_KERNEL_LINUX_VERBOSITY_1 is not set
+# CT_KERNEL_LINUX_VERBOSITY_2 is not set
+CT_KERNEL_LINUX_VERBOSE_LEVEL=0
+# CT_KERNEL_LINUX_INSTALL_CHECK is not set
+CT_ALL_KERNEL_CHOICES="BARE_METAL LINUX WINDOWS"
+
+#
+# Common kernel options
+#
+CT_SHARED_LIBS=y
+# end of Operating System
+
+#
+# Binary utilities
+#
+CT_ARCH_BINFMT_ELF=y
+CT_BINUTILS_BINUTILS=y
+CT_BINUTILS="binutils"
+CT_BINUTILS_CHOICE_KSYM="BINUTILS"
+CT_BINUTILS_BINUTILS_SHOW=y
+
+#
+# Options for binutils
+#
+CT_BINUTILS_BINUTILS_PKG_KSYM="BINUTILS"
+CT_BINUTILS_DIR_NAME="binutils"
+CT_BINUTILS_USE_GNU=y
+# CT_BINUTILS_USE_LINARO is not set
+# CT_BINUTILS_USE_ORACLE is not set
+CT_BINUTILS_USE="BINUTILS"
+CT_BINUTILS_PKG_NAME="binutils"
+CT_BINUTILS_SRC_RELEASE=y
+# CT_BINUTILS_SRC_DEVEL is not set
+# CT_BINUTILS_SRC_CUSTOM is not set
+CT_BINUTILS_PATCH_GLOBAL=y
+# CT_BINUTILS_PATCH_BUNDLED is not set
+# CT_BINUTILS_PATCH_LOCAL is not set
+# CT_BINUTILS_PATCH_BUNDLED_LOCAL is not set
+# CT_BINUTILS_PATCH_LOCAL_BUNDLED is not set
+# CT_BINUTILS_PATCH_NONE is not set
+CT_BINUTILS_PATCH_ORDER="global"
+CT_BINUTILS_V_2_46=y
+# CT_BINUTILS_V_2_45 is not set
+# CT_BINUTILS_V_2_44 is not set
+# CT_BINUTILS_V_2_43 is not set
+# CT_BINUTILS_V_2_42 is not set
+# CT_BINUTILS_V_2_41 is not set
+# CT_BINUTILS_V_2_40 is not set
+# CT_BINUTILS_V_2_39 is not set
+# CT_BINUTILS_V_2_38 is not set
+# CT_BINUTILS_V_2_37 is not set
+# CT_BINUTILS_V_2_36 is not set
+# CT_BINUTILS_V_2_35 is not set
+# CT_BINUTILS_V_2_34 is not set
+# CT_BINUTILS_V_2_33 is not set
+# CT_BINUTILS_V_2_32 is not set
+# CT_BINUTILS_V_2_31 is not set
+# CT_BINUTILS_V_2_30 is not set
+# CT_BINUTILS_V_2_29 is not set
+# CT_BINUTILS_V_2_28 is not set
+# CT_BINUTILS_V_2_27 is not set
+# CT_BINUTILS_V_2_26 is not set
+CT_BINUTILS_VERSION="2.46.0"
+CT_BINUTILS_MIRRORS="$(CT_Mirrors GNU binutils) $(CT_Mirrors sourceware binutils/releases)"
+CT_BINUTILS_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_BINUTILS_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_BINUTILS_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_BINUTILS_SIGNATURE_FORMAT="packed/.sig"
+CT_BINUTILS_2_46_0_or_later=y
+CT_BINUTILS_2_46_0_or_older=y
+CT_BINUTILS_later_than_2_45=y
+CT_BINUTILS_2_45_or_later=y
+CT_BINUTILS_later_than_2_44=y
+CT_BINUTILS_2_44_or_later=y
+CT_BINUTILS_later_than_2_41=y
+CT_BINUTILS_2_41_or_later=y
+CT_BINUTILS_later_than_2_39=y
+CT_BINUTILS_2_39_or_later=y
+CT_BINUTILS_later_than_2_30=y
+CT_BINUTILS_2_30_or_later=y
+CT_BINUTILS_later_than_2_27=y
+CT_BINUTILS_2_27_or_later=y
+CT_BINUTILS_later_than_2_26=y
+CT_BINUTILS_2_26_or_later=y
+
+#
+# GNU binutils
+#
+CT_BINUTILS_GOLD_SUPPORTS_ARCH=y
+CT_BINUTILS_FORCE_LD_BFD_DEFAULT=y
+CT_BINUTILS_LINKER_LD=y
+CT_BINUTILS_LINKERS_LIST="ld"
+CT_BINUTILS_LINKER_DEFAULT="bfd"
+CT_BINUTILS_PLUGINS=y
+CT_BINUTILS_RELRO=m
+CT_BINUTILS_DETERMINISTIC_ARCHIVES=y
+CT_BINUTILS_EXTRA_CONFIG_ARRAY=""
+# CT_BINUTILS_FOR_TARGET is not set
+# CT_BINUTILS_GPROFNG is not set
+CT_ALL_BINUTILS_CHOICES="BINUTILS"
+# end of Binary utilities
+
+#
+# C-library
+#
+CT_LIBC_GLIBC=y
+# CT_LIBC_MUSL is not set
+# CT_LIBC_UCLIBC_NG is not set
+CT_LIBC="glibc"
+CT_LIBC_CHOICE_KSYM="GLIBC"
+CT_LIBC_GLIBC_SHOW=y
+
+#
+# Options for glibc
+#
+CT_LIBC_GLIBC_PKG_KSYM="GLIBC"
+CT_GLIBC_DIR_NAME="glibc"
+CT_GLIBC_USE_GNU=y
+# CT_GLIBC_USE_ORACLE is not set
+CT_GLIBC_USE="GLIBC"
+CT_GLIBC_PKG_NAME="glibc"
+CT_GLIBC_SRC_RELEASE=y
+# CT_GLIBC_SRC_DEVEL is not set
+# CT_GLIBC_SRC_CUSTOM is not set
+CT_GLIBC_PATCH_GLOBAL=y
+# CT_GLIBC_PATCH_BUNDLED is not set
+# CT_GLIBC_PATCH_LOCAL is not set
+# CT_GLIBC_PATCH_BUNDLED_LOCAL is not set
+# CT_GLIBC_PATCH_LOCAL_BUNDLED is not set
+# CT_GLIBC_PATCH_NONE is not set
+CT_GLIBC_PATCH_ORDER="global"
+# CT_GLIBC_V_2_43 is not set
+CT_GLIBC_V_2_42=y
+# CT_GLIBC_V_2_41 is not set
+# CT_GLIBC_V_2_40 is not set
+# CT_GLIBC_V_2_39 is not set
+# CT_GLIBC_V_2_38 is not set
+# CT_GLIBC_V_2_37 is not set
+# CT_GLIBC_V_2_36 is not set
+# CT_GLIBC_V_2_35 is not set
+# CT_GLIBC_V_2_34 is not set
+# CT_GLIBC_V_2_33 is not set
+# CT_GLIBC_V_2_32 is not set
+# CT_GLIBC_V_2_31 is not set
+# CT_GLIBC_V_2_30 is not set
+# CT_GLIBC_V_2_29 is not set
+# CT_GLIBC_V_2_28 is not set
+# CT_GLIBC_V_2_27 is not set
+# CT_GLIBC_V_2_26 is not set
+# CT_GLIBC_V_2_25 is not set
+# CT_GLIBC_V_2_24 is not set
+# CT_GLIBC_V_2_23 is not set
+# CT_GLIBC_V_2_19 is not set
+# CT_GLIBC_V_2_17 is not set
+CT_GLIBC_VERSION="2.42"
+CT_GLIBC_MIRRORS="$(CT_Mirrors GNU glibc)"
+CT_GLIBC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GLIBC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GLIBC_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_GLIBC_SIGNATURE_FORMAT="packed/.sig"
+CT_GLIBC_2_43_or_older=y
+CT_GLIBC_older_than_2_43=y
+CT_GLIBC_2_42_or_later=y
+CT_GLIBC_2_42_or_older=y
+# CT_GLIBC_older_than_2_42 is not set
+CT_GLIBC_later_than_2_41=y
+CT_GLIBC_2_41_or_later=y
+CT_GLIBC_later_than_2_38=y
+CT_GLIBC_2_38_or_later=y
+CT_GLIBC_later_than_2_37=y
+CT_GLIBC_2_37_or_later=y
+CT_GLIBC_later_than_2_36=y
+CT_GLIBC_2_36_or_later=y
+CT_GLIBC_later_than_2_34=y
+CT_GLIBC_2_34_or_later=y
+CT_GLIBC_later_than_2_32=y
+CT_GLIBC_2_32_or_later=y
+CT_GLIBC_later_than_2_31=y
+CT_GLIBC_2_31_or_later=y
+CT_GLIBC_later_than_2_30=y
+CT_GLIBC_2_30_or_later=y
+CT_GLIBC_later_than_2_29=y
+CT_GLIBC_2_29_or_later=y
+CT_GLIBC_later_than_2_28=y
+CT_GLIBC_2_28_or_later=y
+CT_GLIBC_later_than_2_27=y
+CT_GLIBC_2_27_or_later=y
+CT_GLIBC_later_than_2_26=y
+CT_GLIBC_2_26_or_later=y
+CT_GLIBC_later_than_2_25=y
+CT_GLIBC_2_25_or_later=y
+CT_GLIBC_later_than_2_24=y
+CT_GLIBC_2_24_or_later=y
+CT_GLIBC_later_than_2_23=y
+CT_GLIBC_2_23_or_later=y
+CT_GLIBC_later_than_2_20=y
+CT_GLIBC_2_20_or_later=y
+CT_GLIBC_later_than_2_17=y
+CT_GLIBC_2_17_or_later=y
+CT_GLIBC_later_than_2_14=y
+CT_GLIBC_2_14_or_later=y
+CT_GLIBC_DEP_KERNEL_HEADERS_VERSION=y
+CT_GLIBC_DEP_BINUTILS=y
+CT_GLIBC_DEP_GCC=y
+CT_GLIBC_DEP_PYTHON=y
+CT_GLIBC_DEP_MAKE_4_3=y
+CT_GLIBC_SPARC_ALLOW_V7=y
+CT_THREADS="nptl"
+CT_GLIBC_BUILD_SSP=y
+CT_GLIBC_HAS_LIBIDN_ADDON=y
+# CT_GLIBC_USE_LIBIDN_ADDON is not set
+CT_GLIBC_NO_SPARC_V8=y
+CT_GLIBC_HAS_OBSOLETE_RPC=y
+CT_GLIBC_EXTRA_CONFIG_ARRAY="--with-pic"
+CT_GLIBC_CONFIGPARMS=""
+# CT_GLIBC_ENABLE_DEBUG is not set
+CT_GLIBC_EXTRA_CFLAGS="-fPIC -DPIC"
+CT_GLIBC_ENABLE_OBSOLETE_RPC=y
+# CT_GLIBC_ENABLE_FORTIFIED_BUILD is not set
+# CT_GLIBC_DISABLE_VERSIONING is not set
+CT_GLIBC_OLDEST_ABI=""
+CT_GLIBC_FORCE_UNWIND=y
+# CT_GLIBC_LOCALES is not set
+# CT_GLIBC_KERNEL_VERSION_NONE is not set
+CT_GLIBC_KERNEL_VERSION_AS_HEADERS=y
+# CT_GLIBC_KERNEL_VERSION_CHOSEN is not set
+CT_GLIBC_MIN_KERNEL="4.18.20"
+CT_GLIBC_SSP_DEFAULT=y
+# CT_GLIBC_SSP_NO is not set
+# CT_GLIBC_SSP_YES is not set
+# CT_GLIBC_SSP_ALL is not set
+# CT_GLIBC_SSP_STRONG is not set
+CT_GLIBC_ENABLE_COMMON_FLAG=y
+CT_ALL_LIBC_CHOICES="AVR_LIBC GLIBC MINGW_W64 MOXIEBOX MUSL NEWLIB NONE PICOLIBC UCLIBC_NG"
+CT_LIBC_SUPPORT_THREADS_ANY=y
+CT_LIBC_SUPPORT_THREADS_NATIVE=y
+
+#
+# Common C library options
+#
+CT_THREADS_NATIVE=y
+# CT_CREATE_LDSO_CONF is not set
+CT_LIBC_XLDD=y
+# end of C-library
+
+#
+# C compiler
+#
+CT_CC_CORE_NEEDED=y
+CT_CC_SUPPORT_CXX=y
+CT_CC_SUPPORT_FORTRAN=y
+CT_CC_SUPPORT_ADA=y
+CT_CC_SUPPORT_D=y
+CT_CC_SUPPORT_JIT=y
+CT_CC_SUPPORT_OBJC=y
+CT_CC_SUPPORT_OBJCXX=y
+CT_CC_SUPPORT_GOLANG=y
+CT_CC_GCC=y
+CT_CC="gcc"
+CT_CC_CHOICE_KSYM="GCC"
+CT_CC_GCC_SHOW=y
+
+#
+# Options for gcc
+#
+CT_CC_GCC_PKG_KSYM="GCC"
+CT_GCC_DIR_NAME="gcc"
+CT_GCC_USE_GNU=y
+# CT_GCC_USE_LINARO is not set
+# CT_GCC_USE_ORACLE is not set
+CT_GCC_USE="GCC"
+CT_GCC_PKG_NAME="gcc"
+CT_GCC_SRC_RELEASE=y
+# CT_GCC_SRC_DEVEL is not set
+# CT_GCC_SRC_CUSTOM is not set
+CT_GCC_PATCH_GLOBAL=y
+# CT_GCC_PATCH_BUNDLED is not set
+# CT_GCC_PATCH_LOCAL is not set
+# CT_GCC_PATCH_BUNDLED_LOCAL is not set
+# CT_GCC_PATCH_LOCAL_BUNDLED is not set
+# CT_GCC_PATCH_NONE is not set
+CT_GCC_PATCH_ORDER="global"
+CT_GCC_V_15=y
+# CT_GCC_V_14 is not set
+# CT_GCC_V_13 is not set
+# CT_GCC_V_12 is not set
+# CT_GCC_V_11 is not set
+# CT_GCC_V_10 is not set
+# CT_GCC_V_9 is not set
+# CT_GCC_V_8 is not set
+# CT_GCC_V_7 is not set
+# CT_GCC_V_6 is not set
+# CT_GCC_V_5 is not set
+# CT_GCC_V_4_9 is not set
+CT_GCC_VERSION="15.2.0"
+CT_GCC_MIRRORS="$(CT_Mirrors GNU gcc/gcc-${CT_GCC_VERSION}) $(CT_Mirrors sourceware gcc/releases/gcc-${CT_GCC_VERSION})"
+CT_GCC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GCC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GCC_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_GCC_SIGNATURE_FORMAT=""
+CT_GCC_later_than_15=y
+CT_GCC_15_or_later=y
+CT_GCC_later_than_14=y
+CT_GCC_14_or_later=y
+CT_GCC_later_than_13=y
+CT_GCC_13_or_later=y
+CT_GCC_later_than_12=y
+CT_GCC_12_or_later=y
+CT_GCC_later_than_11=y
+CT_GCC_11_or_later=y
+CT_GCC_later_than_10=y
+CT_GCC_10_or_later=y
+CT_GCC_later_than_9=y
+CT_GCC_9_or_later=y
+CT_GCC_later_than_8=y
+CT_GCC_8_or_later=y
+CT_GCC_later_than_7=y
+CT_GCC_7_or_later=y
+CT_GCC_later_than_6=y
+CT_GCC_6_or_later=y
+CT_GCC_later_than_5=y
+CT_GCC_5_or_later=y
+CT_GCC_later_than_4_9=y
+CT_GCC_4_9_or_later=y
+CT_GCC_REQUIRE_4_9_or_later=y
+CT_CC_GCC_ENABLE_PLUGINS=y
+CT_CC_GCC_HAS_LIBMPX=y
+CT_CC_GCC_ENABLE_CXX_FLAGS=""
+CT_CC_GCC_CORE_EXTRA_CONFIG_ARRAY="--enable-host-shared --enable-default-ssp"
+CT_CC_GCC_EXTRA_CONFIG_ARRAY="--enable-host-shared --enable-default-ssp --with-build-config=bootstrap-lto-lean --enable-link-serialization=2"
+# CT_CC_GCC_STATIC_LIBSTDCXX is not set
+# CT_CC_GCC_SYSTEM_ZLIB is not set
+CT_CC_GCC_CONFIG_TLS=m
+
+#
+# Optimisation features
+#
+CT_CC_GCC_USE_GRAPHITE=y
+CT_CC_GCC_USE_LTO=y
+CT_CC_GCC_LTO_ZSTD=m
+
+#
+# Settings for libraries running on target
+#
+CT_CC_GCC_ENABLE_DEFAULT_PIE=y
+# CT_CC_GCC_ENABLE_TARGET_OPTSPACE is not set
+CT_CC_GCC_LIBSTDCXX=m
+# CT_CC_GCC_LIBSTDCXX_HOSTED_DISABLE is not set
+CT_CC_GCC_LIBSTDCXX_TARGET_CXXFLAGS="-O2 -pipe"
+# CT_CC_GCC_LIBMUDFLAP is not set
+CT_CC_GCC_LIBGOMP=y
+CT_CC_GCC_LIBSSP=m
+# CT_CC_GCC_LIBQUADMATH is not set
+# CT_CC_GCC_LIBSANITIZER is not set
+# CT_CC_GCC_LIBSTDCXX_VERBOSE is not set
+
+#
+# Misc. obscure options.
+#
+CT_CC_CXA_ATEXIT=y
+CT_CC_GCC_TM_CLONE_REGISTRY=m
+# CT_CC_GCC_DISABLE_PCH is not set
+CT_CC_GCC_SJLJ_EXCEPTIONS=m
+CT_CC_GCC_LDBL_128=m
+# CT_CC_GCC_BUILD_ID is not set
+CT_CC_GCC_LNK_HASH_STYLE_DEFAULT=y
+# CT_CC_GCC_LNK_HASH_STYLE_SYSV is not set
+# CT_CC_GCC_LNK_HASH_STYLE_GNU is not set
+# CT_CC_GCC_LNK_HASH_STYLE_BOTH is not set
+CT_CC_GCC_LNK_HASH_STYLE=""
+CT_CC_GCC_DEC_FLOATS_AUTO=y
+# CT_CC_GCC_DEC_FLOATS_BID is not set
+# CT_CC_GCC_DEC_FLOATS_DPD is not set
+# CT_CC_GCC_DEC_FLOATS_NO is not set
+CT_CC_GCC_DEC_FLOATS=""
+CT_ALL_CC_CHOICES="GCC"
+
+#
+# Additional supported languages:
+#
+CT_CC_LANG_CXX=y
+# CT_CC_LANG_FORTRAN is not set
+# CT_CC_LANG_JIT is not set
+# CT_CC_LANG_ADA is not set
+# CT_CC_LANG_D is not set
+# CT_CC_LANG_OBJC is not set
+# CT_CC_LANG_OBJCXX is not set
+# CT_CC_LANG_GOLANG is not set
+CT_CC_LANG_OTHERS=""
+# end of C compiler
+
+#
+# Linkers
+#
+
+#
+# BFD enabled in binutils
+#
+CT_LINKER_MOLD=y
+CT_LINKER_MOLD_PKG_KSYM="MOLD"
+CT_MOLD_DIR_NAME="mold"
+CT_MOLD_PKG_NAME="mold"
+CT_MOLD_SRC_RELEASE=y
+# CT_MOLD_SRC_DEVEL is not set
+# CT_MOLD_SRC_CUSTOM is not set
+CT_MOLD_PATCH_GLOBAL=y
+# CT_MOLD_PATCH_BUNDLED is not set
+# CT_MOLD_PATCH_LOCAL is not set
+# CT_MOLD_PATCH_BUNDLED_LOCAL is not set
+# CT_MOLD_PATCH_LOCAL_BUNDLED is not set
+# CT_MOLD_PATCH_NONE is not set
+CT_MOLD_PATCH_ORDER="global"
+CT_MOLD_V_2_40_4=y
+# CT_MOLD_V_2_39_1 is not set
+# CT_MOLD_V_2_38_1 is not set
+# CT_MOLD_V_2_37_1 is not set
+# CT_MOLD_V_2_36_0 is not set
+# CT_MOLD_V_2_33_0 is not set
+# CT_MOLD_V_2_32_0 is not set
+# CT_MOLD_V_2_31_0 is not set
+CT_MOLD_VERSION="2.40.4"
+CT_MOLD_MIRRORS="https://github.com/rui314/mold/archive/refs/tags"
+CT_MOLD_ARCHIVE_FILENAME="v@{version}"
+CT_MOLD_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MOLD_ARCHIVE_FORMATS=".tar.gz"
+CT_MOLD_SIGNATURE_FORMAT=""
+CT_LINKER_MOLD_has_cmake=y
+CT_ALL_LINKER_CHOICES="MOLD"
+# end of Linkers
+
+#
+# Debug facilities
+#
+# CT_DEBUG_DUMA is not set
+# CT_DEBUG_GDB is not set
+# CT_DEBUG_LTRACE is not set
+# CT_DEBUG_STRACE is not set
+CT_ALL_DEBUG_CHOICES="DUMA GDB LTRACE STRACE"
+# end of Debug facilities
+
+#
+# Companion libraries
+#
+# CT_COMPLIBS_CHECK is not set
+# CT_COMP_LIBS_CLOOG is not set
+# CT_COMP_LIBS_EXPAT is not set
+CT_COMP_LIBS_GETTEXT=y
+CT_COMP_LIBS_GETTEXT_PKG_KSYM="GETTEXT"
+CT_GETTEXT_DIR_NAME="gettext"
+CT_GETTEXT_PKG_NAME="gettext"
+CT_GETTEXT_SRC_RELEASE=y
+# CT_GETTEXT_SRC_DEVEL is not set
+# CT_GETTEXT_SRC_CUSTOM is not set
+CT_GETTEXT_PATCH_GLOBAL=y
+# CT_GETTEXT_PATCH_BUNDLED is not set
+# CT_GETTEXT_PATCH_LOCAL is not set
+# CT_GETTEXT_PATCH_BUNDLED_LOCAL is not set
+# CT_GETTEXT_PATCH_LOCAL_BUNDLED is not set
+# CT_GETTEXT_PATCH_NONE is not set
+CT_GETTEXT_PATCH_ORDER="global"
+CT_GETTEXT_V_0_26=y
+# CT_GETTEXT_V_0_23_1 is not set
+# CT_GETTEXT_V_0_22_5 is not set
+# CT_GETTEXT_V_0_21 is not set
+# CT_GETTEXT_V_0_20_1 is not set
+# CT_GETTEXT_V_0_19_8_1 is not set
+CT_GETTEXT_VERSION="0.26"
+CT_GETTEXT_MIRRORS="$(CT_Mirrors GNU gettext)"
+CT_GETTEXT_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GETTEXT_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GETTEXT_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_GETTEXT_SIGNATURE_FORMAT="packed/.sig"
+CT_GETTEXT_later_than_0_23=y
+CT_GETTEXT_0_23_or_later=y
+CT_GETTEXT_later_than_0_21=y
+CT_GETTEXT_0_21_or_later=y
+CT_GETTEXT_INCOMPATIBLE_WITH_UCLIBC_NG=y
+
+#
+# This version of gettext is not compatible with uClibc-NG. Select
+#
+
+#
+# a different version if uClibc-NG is used on the target or (in a
+#
+
+#
+# Canadian cross build) on the host.
+#
+CT_COMP_LIBS_GMP=y
+CT_COMP_LIBS_GMP_PKG_KSYM="GMP"
+CT_GMP_DIR_NAME="gmp"
+CT_GMP_PKG_NAME="gmp"
+CT_GMP_SRC_RELEASE=y
+# CT_GMP_SRC_DEVEL is not set
+# CT_GMP_SRC_CUSTOM is not set
+CT_GMP_PATCH_GLOBAL=y
+# CT_GMP_PATCH_BUNDLED is not set
+# CT_GMP_PATCH_LOCAL is not set
+# CT_GMP_PATCH_BUNDLED_LOCAL is not set
+# CT_GMP_PATCH_LOCAL_BUNDLED is not set
+# CT_GMP_PATCH_NONE is not set
+CT_GMP_PATCH_ORDER="global"
+CT_GMP_V_6_3=y
+# CT_GMP_V_6_2 is not set
+# CT_GMP_V_6_1 is not set
+CT_GMP_VERSION="6.3.0"
+CT_GMP_MIRRORS="https://gmplib.org/download/gmp https://gmplib.org/download/gmp/archive $(CT_Mirrors GNU gmp)"
+CT_GMP_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_GMP_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_GMP_ARCHIVE_FORMATS=".tar.xz .tar.lz .tar.bz2"
+CT_GMP_SIGNATURE_FORMAT="packed/.sig"
+CT_GMP_EXTRA_CFLAGS="-std=gnu17"
+CT_COMP_LIBS_ISL=y
+CT_COMP_LIBS_ISL_PKG_KSYM="ISL"
+CT_ISL_DIR_NAME="isl"
+CT_ISL_PKG_NAME="isl"
+CT_ISL_SRC_RELEASE=y
+# CT_ISL_SRC_DEVEL is not set
+# CT_ISL_SRC_CUSTOM is not set
+CT_ISL_PATCH_GLOBAL=y
+# CT_ISL_PATCH_BUNDLED is not set
+# CT_ISL_PATCH_LOCAL is not set
+# CT_ISL_PATCH_BUNDLED_LOCAL is not set
+# CT_ISL_PATCH_LOCAL_BUNDLED is not set
+# CT_ISL_PATCH_NONE is not set
+CT_ISL_PATCH_ORDER="global"
+CT_ISL_V_0_27=y
+# CT_ISL_V_0_26 is not set
+# CT_ISL_V_0_25 is not set
+# CT_ISL_V_0_24 is not set
+# CT_ISL_V_0_23 is not set
+# CT_ISL_V_0_22 is not set
+# CT_ISL_V_0_21 is not set
+# CT_ISL_V_0_20 is not set
+# CT_ISL_V_0_19 is not set
+# CT_ISL_V_0_18 is not set
+# CT_ISL_V_0_17 is not set
+# CT_ISL_V_0_16 is not set
+# CT_ISL_V_0_15 is not set
+# CT_ISL_V_0_11 is not set
+CT_ISL_VERSION="0.27"
+CT_ISL_MIRRORS="https://libisl.sourceforge.io"
+CT_ISL_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ISL_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ISL_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz"
+CT_ISL_SIGNATURE_FORMAT=""
+CT_ISL_later_than_0_18=y
+CT_ISL_0_18_or_later=y
+CT_ISL_later_than_0_15=y
+CT_ISL_0_15_or_later=y
+# CT_COMP_LIBS_LIBELF is not set
+CT_COMP_LIBS_LIBICONV=y
+CT_COMP_LIBS_LIBICONV_PKG_KSYM="LIBICONV"
+CT_LIBICONV_DIR_NAME="libiconv"
+CT_LIBICONV_PKG_NAME="libiconv"
+CT_LIBICONV_SRC_RELEASE=y
+# CT_LIBICONV_SRC_DEVEL is not set
+# CT_LIBICONV_SRC_CUSTOM is not set
+CT_LIBICONV_PATCH_GLOBAL=y
+# CT_LIBICONV_PATCH_BUNDLED is not set
+# CT_LIBICONV_PATCH_LOCAL is not set
+# CT_LIBICONV_PATCH_BUNDLED_LOCAL is not set
+# CT_LIBICONV_PATCH_LOCAL_BUNDLED is not set
+# CT_LIBICONV_PATCH_NONE is not set
+CT_LIBICONV_PATCH_ORDER="global"
+CT_LIBICONV_V_1_18=y
+# CT_LIBICONV_V_1_16 is not set
+# CT_LIBICONV_V_1_15 is not set
+CT_LIBICONV_VERSION="1.18"
+CT_LIBICONV_MIRRORS="$(CT_Mirrors GNU libiconv)"
+CT_LIBICONV_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_LIBICONV_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_LIBICONV_ARCHIVE_FORMATS=".tar.gz"
+CT_LIBICONV_SIGNATURE_FORMAT="packed/.sig"
+CT_COMP_LIBS_MPC=y
+CT_COMP_LIBS_MPC_PKG_KSYM="MPC"
+CT_MPC_DIR_NAME="mpc"
+CT_MPC_PKG_NAME="mpc"
+CT_MPC_SRC_RELEASE=y
+# CT_MPC_SRC_DEVEL is not set
+# CT_MPC_SRC_CUSTOM is not set
+CT_MPC_PATCH_GLOBAL=y
+# CT_MPC_PATCH_BUNDLED is not set
+# CT_MPC_PATCH_LOCAL is not set
+# CT_MPC_PATCH_BUNDLED_LOCAL is not set
+# CT_MPC_PATCH_LOCAL_BUNDLED is not set
+# CT_MPC_PATCH_NONE is not set
+CT_MPC_PATCH_ORDER="global"
+CT_MPC_V_1_3=y
+CT_MPC_VERSION="1.3.1"
+CT_MPC_MIRRORS="https://www.multiprecision.org/downloads $(CT_Mirrors GNU mpc)"
+CT_MPC_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MPC_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MPC_ARCHIVE_FORMATS=".tar.gz"
+CT_MPC_SIGNATURE_FORMAT="packed/.sig"
+CT_COMP_LIBS_MPFR=y
+CT_COMP_LIBS_MPFR_PKG_KSYM="MPFR"
+CT_MPFR_DIR_NAME="mpfr"
+CT_MPFR_PKG_NAME="mpfr"
+CT_MPFR_SRC_RELEASE=y
+# CT_MPFR_SRC_DEVEL is not set
+# CT_MPFR_SRC_CUSTOM is not set
+CT_MPFR_PATCH_GLOBAL=y
+# CT_MPFR_PATCH_BUNDLED is not set
+# CT_MPFR_PATCH_LOCAL is not set
+# CT_MPFR_PATCH_BUNDLED_LOCAL is not set
+# CT_MPFR_PATCH_LOCAL_BUNDLED is not set
+# CT_MPFR_PATCH_NONE is not set
+CT_MPFR_PATCH_ORDER="global"
+CT_MPFR_V_4_2=y
+CT_MPFR_VERSION="4.2.2"
+CT_MPFR_MIRRORS="https://www.mpfr.org/mpfr-${CT_MPFR_VERSION} $(CT_Mirrors GNU mpfr)"
+CT_MPFR_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MPFR_ARCHIVE_FORMATS=".tar.xz .tar.bz2 .tar.gz .zip"
+CT_MPFR_SIGNATURE_FORMAT="packed/.asc"
+CT_COMP_LIBS_NCURSES=y
+CT_COMP_LIBS_NCURSES_PKG_KSYM="NCURSES"
+CT_NCURSES_DIR_NAME="ncurses"
+CT_NCURSES_PKG_NAME="ncurses"
+CT_NCURSES_SRC_RELEASE=y
+# CT_NCURSES_SRC_DEVEL is not set
+# CT_NCURSES_SRC_CUSTOM is not set
+CT_NCURSES_PATCH_GLOBAL=y
+# CT_NCURSES_PATCH_BUNDLED is not set
+# CT_NCURSES_PATCH_LOCAL is not set
+# CT_NCURSES_PATCH_BUNDLED_LOCAL is not set
+# CT_NCURSES_PATCH_LOCAL_BUNDLED is not set
+# CT_NCURSES_PATCH_NONE is not set
+CT_NCURSES_PATCH_ORDER="global"
+CT_NCURSES_V_6_5=y
+# CT_NCURSES_V_6_4 is not set
+# CT_NCURSES_V_6_2 is not set
+# CT_NCURSES_V_6_1 is not set
+# CT_NCURSES_V_6_0 is not set
+CT_NCURSES_VERSION="6.5"
+CT_NCURSES_MIRRORS="https://invisible-mirror.net/archives/ncurses $(CT_Mirrors GNU ncurses)"
+CT_NCURSES_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_NCURSES_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_NCURSES_ARCHIVE_FORMATS=".tar.gz"
+CT_NCURSES_SIGNATURE_FORMAT="packed/.asc"
+# CT_NCURSES_NEW_ABI is not set
+CT_NCURSES_HOST_CONFIG_ARGS=""
+CT_NCURSES_HOST_DISABLE_DB=y
+CT_NCURSES_HOST_FALLBACKS="linux,xterm,xterm-color,xterm-256color,vt100"
+CT_NCURSES_TARGET_CONFIG_ARGS=""
+# CT_NCURSES_TARGET_DISABLE_DB is not set
+CT_NCURSES_TARGET_FALLBACKS=""
+CT_NCURSES_EXTRA_CFLAGS="-std=gnu17"
+CT_COMP_LIBS_ZLIB=y
+CT_COMP_LIBS_ZLIB_PKG_KSYM="ZLIB"
+CT_ZLIB_DIR_NAME="zlib"
+CT_ZLIB_PKG_NAME="zlib"
+CT_ZLIB_SRC_RELEASE=y
+# CT_ZLIB_SRC_DEVEL is not set
+# CT_ZLIB_SRC_CUSTOM is not set
+CT_ZLIB_PATCH_GLOBAL=y
+# CT_ZLIB_PATCH_BUNDLED is not set
+# CT_ZLIB_PATCH_LOCAL is not set
+# CT_ZLIB_PATCH_BUNDLED_LOCAL is not set
+# CT_ZLIB_PATCH_LOCAL_BUNDLED is not set
+# CT_ZLIB_PATCH_NONE is not set
+CT_ZLIB_PATCH_ORDER="global"
+CT_ZLIB_V_1_3_1=y
+# CT_ZLIB_V_1_2_13 is not set
+CT_ZLIB_VERSION="1.3.1"
+CT_ZLIB_MIRRORS="https://github.com/madler/zlib/releases/download/v${CT_ZLIB_VERSION} https://www.zlib.net/"
+CT_ZLIB_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ZLIB_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ZLIB_ARCHIVE_FORMATS=".tar.xz .tar.gz"
+CT_ZLIB_SIGNATURE_FORMAT="packed/.asc"
+CT_COMP_LIBS_ZSTD=y
+CT_COMP_LIBS_ZSTD_PKG_KSYM="ZSTD"
+CT_ZSTD_DIR_NAME="zstd"
+CT_ZSTD_PKG_NAME="zstd"
+CT_ZSTD_SRC_RELEASE=y
+# CT_ZSTD_SRC_DEVEL is not set
+# CT_ZSTD_SRC_CUSTOM is not set
+CT_ZSTD_PATCH_GLOBAL=y
+# CT_ZSTD_PATCH_BUNDLED is not set
+# CT_ZSTD_PATCH_LOCAL is not set
+# CT_ZSTD_PATCH_BUNDLED_LOCAL is not set
+# CT_ZSTD_PATCH_LOCAL_BUNDLED is not set
+# CT_ZSTD_PATCH_NONE is not set
+CT_ZSTD_PATCH_ORDER="global"
+CT_ZSTD_V_1_5_7=y
+# CT_ZSTD_V_1_5_6 is not set
+# CT_ZSTD_V_1_5_5 is not set
+# CT_ZSTD_V_1_5_2 is not set
+CT_ZSTD_VERSION="1.5.7"
+CT_ZSTD_MIRRORS="https://github.com/facebook/zstd/releases/download/v${CT_ZSTD_VERSION} https://downloads.sourceforge.net/project/zstandard.mirror/v${CT_ZSTD_VERSION}"
+CT_ZSTD_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_ZSTD_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_ZSTD_ARCHIVE_FORMATS=".tar.gz"
+CT_ZSTD_SIGNATURE_FORMAT="packed/.sig"
+CT_ALL_COMP_LIBS_CHOICES="CLOOG EXPAT GETTEXT GMP GNUPRUMCU ISL LIBELF LIBICONV MPC MPFR NCURSES NEWLIB_NANO PICOLIBC ZLIB ZSTD"
+CT_LIBICONV_NEEDED=y
+CT_GETTEXT_NEEDED=y
+CT_GMP_NEEDED=y
+CT_MPFR_NEEDED=y
+CT_ISL_NEEDED=y
+CT_MPC_NEEDED=y
+CT_NCURSES_NEEDED=y
+CT_ZLIB_NEEDED=y
+CT_ZSTD_NEEDED=y
+CT_LIBICONV=y
+CT_GETTEXT=y
+CT_GMP=y
+CT_MPFR=y
+CT_ISL=y
+CT_MPC=y
+CT_NCURSES=y
+CT_ZLIB=y
+CT_ZSTD=y
+# end of Companion libraries
+
+#
+# Companion tools
+#
+# CT_COMP_TOOLS_FOR_HOST is not set
+# CT_COMP_TOOLS_AUTOCONF is not set
+# CT_COMP_TOOLS_AUTOMAKE is not set
+# CT_COMP_TOOLS_BISON is not set
+# CT_COMP_TOOLS_DTC is not set
+# CT_COMP_TOOLS_LIBTOOL is not set
+# CT_COMP_TOOLS_M4 is not set
+CT_COMP_TOOLS_MAKE=y
+CT_COMP_TOOLS_MAKE_PKG_KSYM="MAKE"
+CT_MAKE_DIR_NAME="make"
+CT_MAKE_PKG_NAME="make"
+CT_MAKE_SRC_RELEASE=y
+# CT_MAKE_SRC_DEVEL is not set
+# CT_MAKE_SRC_CUSTOM is not set
+CT_MAKE_PATCH_GLOBAL=y
+# CT_MAKE_PATCH_BUNDLED is not set
+# CT_MAKE_PATCH_LOCAL is not set
+# CT_MAKE_PATCH_BUNDLED_LOCAL is not set
+# CT_MAKE_PATCH_LOCAL_BUNDLED is not set
+# CT_MAKE_PATCH_NONE is not set
+CT_MAKE_PATCH_ORDER="global"
+CT_MAKE_V_4_3=y
+CT_MAKE_VERSION="4.3"
+CT_MAKE_MIRRORS="$(CT_Mirrors GNU make)"
+CT_MAKE_ARCHIVE_FILENAME="@{pkg_name}-@{version}"
+CT_MAKE_ARCHIVE_DIRNAME="@{pkg_name}-@{version}"
+CT_MAKE_ARCHIVE_FORMATS=".tar.lz .tar.gz"
+CT_MAKE_SIGNATURE_FORMAT="packed/.sig"
+CT_MAKE_4_4_or_older=y
+CT_MAKE_older_than_4_4=y
+CT_MAKE_REQUIRE_older_than_4_4=y
+CT_MAKE_4_3_or_later=y
+CT_MAKE_4_3_or_older=y
+CT_MAKE_GMAKE_SYMLINK=y
+CT_MAKE_GNUMAKE_SYMLINK=y
+CT_ALL_COMP_TOOLS_CHOICES="AUTOCONF AUTOMAKE BISON DTC LIBTOOL M4 MAKE"
+# end of Companion tools
+
+#
+# Test suite
+#
+# CT_TEST_SUITE_GCC is not set
+# end of Test suite

--- a/builder/images/base-linuxriscv64/gen-implib.sh
+++ b/builder/images/base-linuxriscv64/gen-implib.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+if [[ $# != 2 ]]; then
+    echo "Invalid arguments"
+    exit 1
+fi
+IN="$1"
+OUT="$2"
+
+TMPDIR="$(mktemp -d)"
+trap "rm -rf '$TMPDIR'" EXIT
+cd "$TMPDIR"
+
+set -x
+python3 /opt/implib/implib-gen.py --target riscv64-linux-gnu --dlopen --lazy-load --verbose "$IN"
+${FFBUILD_CROSS_PREFIX}gcc $CFLAGS -fvisibility=hidden -Wa,--noexecstack -DIMPLIB_HIDDEN_SHIMS -c *.tramp.S *.init.c
+${FFBUILD_CROSS_PREFIX}ar -rcs "$OUT" *.tramp.o *.init.o

--- a/builder/images/base-linuxriscv64/toolchain.cmake
+++ b/builder/images/base-linuxriscv64/toolchain.cmake
@@ -1,0 +1,16 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+set(triple riscv64-ffbuild-linux-gnu)
+
+set(CMAKE_C_COMPILER ${triple}-gcc)
+set(CMAKE_CXX_COMPILER ${triple}-g++)
+set(CMAKE_RANLIB ${triple}-gcc-ranlib)
+set(CMAKE_AR ${triple}-gcc-ar)
+
+set(CMAKE_SYSROOT /opt/ct-ng/${triple}/sysroot)
+set(CMAKE_FIND_ROOT_PATH /opt/ct-ng /opt/ct-ng/${triple}/sysroot /opt/ffbuild)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

--- a/builder/scripts.d/25-fftw3f.sh
+++ b/builder/scripts.d/25-fftw3f.sh
@@ -33,7 +33,10 @@ ffbuild_dockerbuild() {
         myconf+=(
             --enable-neon
         )
-    else
+    elif [[ $TARGET == linuxriscv64 ]]; then
+        # RISC-V: no SIMD yet (vector extension support pending)
+        :
+    elif [[ $TARGET == linux64 || $TARGET == win64 ]]; then
         myconf+=(
             --enable-sse2
             --enable-avx

--- a/builder/scripts.d/25-openssl.sh
+++ b/builder/scripts.d/25-openssl.sh
@@ -48,6 +48,11 @@ ffbuild_dockerbuild() {
             --cross-compile-prefix="$FFBUILD_CROSS_PREFIX"
             linux-aarch64
         )
+    elif [[ $TARGET == linuxriscv64 ]]; then
+        myconf+=(
+            --cross-compile-prefix="$FFBUILD_CROSS_PREFIX"
+            linux64-riscv64
+        )
     elif [[ $TARGET == mac* ]]; then
         if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
             myconf+=(

--- a/builder/scripts.d/45-x11/60-libglvnd.sh
+++ b/builder/scripts.d/45-x11/60-libglvnd.sh
@@ -18,7 +18,6 @@ ffbuild_dockerbuild() {
         --prefix="$FFBUILD_PREFIX"
         --buildtype=release
         --default-library=static
-        -Dasm=enabled
         -Dx11=enabled
         -Degl=true
         -Dglx=enabled
@@ -26,6 +25,13 @@ ffbuild_dockerbuild() {
         -Dgles2=true
         -Dheaders=true
     )
+
+    if [[ $TARGET == linuxriscv64 ]]; then
+        # No RISC-V assembly stubs in libglvnd yet
+        myconf+=(-Dasm=disabled)
+    else
+        myconf+=(-Dasm=enabled)
+    fi
 
     if [[ $TARGET == linux* ]]; then
         myconf+=(

--- a/builder/scripts.d/50-amf.sh
+++ b/builder/scripts.d/50-amf.sh
@@ -18,6 +18,7 @@ ffbuild_dockerbuild() {
 }
 
 ffbuild_configure() {
+    [[ $TARGET == linuxriscv64 ]] && return 0
     echo --enable-amf
 }
 

--- a/builder/scripts.d/50-ffnvcodec.sh
+++ b/builder/scripts.d/50-ffnvcodec.sh
@@ -16,6 +16,7 @@ ffbuild_dockerbuild() {
 }
 
 ffbuild_configure() {
+    [[ $TARGET == linuxriscv64 ]] && return 0
     echo --enable-ffnvcodec --enable-cuda --enable-cuda-llvm --enable-cuvid --enable-nvdec --enable-nvenc
 }
 

--- a/builder/scripts.d/50-libvpl.sh
+++ b/builder/scripts.d/50-libvpl.sh
@@ -30,6 +30,7 @@ ffbuild_dockerbuild() {
 }
 
 ffbuild_configure() {
+    [[ $TARGET == linuxriscv64 ]] && return 0
     echo --enable-libvpl
 }
 

--- a/builder/scripts.d/50-libvpx.sh
+++ b/builder/scripts.d/50-libvpx.sh
@@ -43,6 +43,11 @@ ffbuild_dockerbuild() {
             --target=arm64-linux-gcc
         )
         export CROSS="$FFBUILD_CROSS_PREFIX"
+    elif [[ $TARGET == linuxriscv64 ]]; then
+        myconf+=(
+            --target=generic-gnu
+        )
+        export CROSS="$FFBUILD_CROSS_PREFIX"
     elif [[ $TARGET == mac* ]]; then
         if [ "$MACOS_BUILDER_CPU_ARCH" = "arm64" ] && [ "$TARGET" = "mac64" ]; then
             myconf+=(

--- a/builder/scripts.d/50-vaapi/50-libva.sh
+++ b/builder/scripts.d/50-vaapi/50-libva.sh
@@ -51,6 +51,17 @@ ffbuild_dockerbuild() {
             -Dwith_glx=no
             -Dwith_wayland=no
         )
+    elif [[ $TARGET == linuxriscv64 ]]; then
+        myconf+=(
+            --cross-file=/cross.meson
+            --default-library=shared
+            --sysconfdir="/etc"
+            -Ddriverdir="/usr/lib/riscv64-linux-gnu/dri"
+            -Ddisable_drm=false
+            -Dwith_x11=yes
+            -Dwith_glx=no
+            -Dwith_wayland=no
+        )
     else
         echo "Unknown target"
         return -1

--- a/builder/variants/linuxriscv64-gpl.sh
+++ b/builder/variants/linuxriscv64-gpl.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+source "$(dirname "$BASH_SOURCE")"/default-install.sh
+source "$(dirname "$BASH_SOURCE")"/defaults-gpl.sh

--- a/cross-riscv64.meson
+++ b/cross-riscv64.meson
@@ -1,0 +1,15 @@
+[binaries]
+c = '/usr/bin/riscv64-linux-gnu-gcc'
+cpp = '/usr/bin/riscv64-linux-gnu-g++'
+ar = '/usr/bin/riscv64-linux-gnu-gcc-ar'
+ld = '/usr/bin/riscv64-linux-gnu-ld'
+strip = '/usr/bin/riscv64-linux-gnu-strip'
+ranlib = '/usr/bin/riscv64-linux-gnu-gcc-ranlib'
+nm = '/usr/bin/riscv64-linux-gnu-gcc-nm'
+pkg-config = 'pkg-config'
+
+[host_machine]
+system = 'linux'
+cpu_family = 'riscv64'
+cpu = 'riscv64'
+endian = 'little'

--- a/debian/control
+++ b/debian/control
@@ -53,7 +53,7 @@ Build-Depends:
  nasm
 
 Package: jellyfin-ffmpeg8
-Architecture: amd64 arm64
+Architecture: amd64 arm64 riscv64
 Multi-Arch: foreign
 Replaces: jellyfin-ffmpeg, jellyfin-ffmpeg5, jellyfin-ffmpeg6, jellyfin-ffmpeg7
 Conflicts: jellyfin-ffmpeg, jellyfin-ffmpeg5, jellyfin-ffmpeg6, jellyfin-ffmpeg7

--- a/debian/rules
+++ b/debian/rules
@@ -67,6 +67,24 @@ CONFIG_ARM64 := --arch=arm64 \
 	--enable-rkmpp \
 	--enable-rkrga \
 
+CONFIG_RISCV64 := --arch=riscv64 \
+	--cross-prefix=/usr/bin/riscv64-linux-gnu- \
+	--enable-cross-compile \
+	--disable-ffnvcodec \
+	--disable-cuda \
+	--disable-cuda-llvm \
+	--disable-cuvid \
+	--disable-nvdec \
+	--disable-nvenc \
+	--disable-amf \
+	--disable-libvpl \
+	--disable-vaapi \
+	--disable-vulkan \
+	--disable-libshaderc \
+	--disable-libplacebo \
+	--disable-opencl \
+	--disable-libdrm \
+
 HOST_ARCH := $(shell arch)
 BUILD_ARCH := ${DEB_HOST_MULTIARCH}
 ifeq ($(BUILD_ARCH),x86_64-linux-gnu)
@@ -76,6 +94,10 @@ endif
 ifeq ($(BUILD_ARCH),aarch64-linux-gnu)
 	# Cross-building ARM64 on AMD64
 	CONFIG += $(CONFIG_ARM64)
+endif
+ifeq ($(BUILD_ARCH),riscv64-linux-gnu)
+	# Cross-building RISC-V on AMD64
+	CONFIG += $(CONFIG_RISCV64)
 endif
 
 %:

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -24,6 +24,12 @@ prepare_extra_common() {
             CMAKE_TOOLCHAIN_OPT="-DCMAKE_TOOLCHAIN_FILE=${SOURCE_DIR}/toolchain-${ARCH}.cmake"
             MESON_CROSS_OPT="--cross-file=${SOURCE_DIR}/cross-${ARCH}.meson"
         ;;
+        'riscv64')
+            CROSS_PREFIX_OPT="riscv64-linux-gnu-"
+            CROSS_OPT="--host=riscv64-linux-gnu CC=riscv64-linux-gnu-gcc CXX=riscv64-linux-gnu-g++"
+            CMAKE_TOOLCHAIN_OPT="-DCMAKE_TOOLCHAIN_FILE=${SOURCE_DIR}/toolchain-${ARCH}.cmake"
+            MESON_CROSS_OPT="--cross-file=${SOURCE_DIR}/cross-${ARCH}.meson"
+        ;;
     esac
 
     # ICONV
@@ -194,6 +200,8 @@ prepare_extra_common() {
     pushd fftw-${fftw3_ver}
     if [ "${ARCH}" = "amd64" ]; then
         fftw3_optimizations="--enable-sse2 --enable-avx --enable-avx-128-fma --enable-avx2 --enable-avx512"
+    elif [ "${ARCH}" = "riscv64" ]; then
+        fftw3_optimizations=""
     else
         fftw3_optimizations="--enable-neon"
     fi
@@ -729,6 +737,40 @@ EOF
     done
 }
 
+# Prepare the cross-toolchain for riscv64
+prepare_crossbuild_env_riscv64() {
+    # Prepare the Ubuntu-specific cross-build requirements
+    if [[ $( lsb_release -i -s ) == "Debian" ]]; then
+        CODENAME="$( lsb_release -c -s )"
+        echo "deb [arch=amd64] ${DEBIAN_ADDR} ${CODENAME}-backports main restricted universe multiverse" >> /etc/apt/sources.list
+        echo "deb [arch=riscv64] ${DEBIAN_ADDR} ${CODENAME}-backports main restricted universe multiverse" >> /etc/apt/sources.list
+    fi
+    if [[ $( lsb_release -i -s ) == "Ubuntu" ]]; then
+        CODENAME="$( lsb_release -c -s )"
+        # Remove the default sources
+        rm -f /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources
+        # Add arch-specific list files
+        cat <<EOF > /etc/apt/sources.list.d/amd64.list
+deb [arch=amd64] ${UBUNTU_ARCHIVE_ADDR} ${CODENAME} main restricted universe multiverse
+deb [arch=amd64] ${UBUNTU_ARCHIVE_ADDR} ${CODENAME}-updates main restricted universe multiverse
+deb [arch=amd64] ${UBUNTU_ARCHIVE_ADDR} ${CODENAME}-backports main restricted universe multiverse
+deb [arch=amd64] ${UBUNTU_ARCHIVE_ADDR} ${CODENAME}-security main restricted universe multiverse
+EOF
+        cat <<EOF > /etc/apt/sources.list.d/riscv64.list
+deb [arch=riscv64] ${UBUNTU_PORTS_ADDR} ${CODENAME} main restricted universe multiverse
+deb [arch=riscv64] ${UBUNTU_PORTS_ADDR} ${CODENAME}-updates main restricted universe multiverse
+deb [arch=riscv64] ${UBUNTU_PORTS_ADDR} ${CODENAME}-backports main restricted universe multiverse
+deb [arch=riscv64] ${UBUNTU_PORTS_ADDR} ${CODENAME}-security main restricted universe multiverse
+EOF
+    fi
+    # Add riscv64 architecture
+    dpkg --add-architecture riscv64
+    apt-get update && apt-get dist-upgrade -y
+    # Install dependencies
+    ln -fs /usr/share/zoneinfo/America/Toronto /etc/localtime
+    yes | apt-get install -y -o Dpkg::Options::="--force-overwrite" -o APT::Immediate-Configure=0 gcc-riscv64-linux-gnu g++-riscv64-linux-gnu binutils-riscv64-linux-gnu bison flex libtool gdb sharutils netbase libmpc-dev libmpfr-dev autogen expect chrpath zip libc6-dev:riscv64 linux-libc-dev:riscv64 libgcc1:riscv64 libgcc-s1:riscv64 libstdc++6:riscv64 libatomic1:riscv64
+}
+
 # Set the architecture-specific options
 case ${ARCH} in
     'amd64')
@@ -745,6 +787,15 @@ case ${ARCH} in
         CONFIG_SITE="/etc/dpkg-cross/cross-config.${ARCH}"
         DEP_ARCH_OPT="--host-arch arm64"
         BUILD_ARCH_OPT="-aarm64"
+    ;;
+    'riscv64')
+        prepare_crossbuild_env_riscv64
+        prepare_extra_common
+        CONFIG_SITE="/etc/dpkg-cross/cross-config.${ARCH}"
+        DEP_ARCH_OPT="--host-arch riscv64"
+        BUILD_ARCH_OPT="-ariscv64"
+        # RISC-V needs libatomic for 128-bit atomic operations
+        export LDFLAGS="${LDFLAGS} -latomic -Wl,--as-needed"
     ;;
 esac
 

--- a/toolchain-riscv64.cmake
+++ b/toolchain-riscv64.cmake
@@ -1,0 +1,13 @@
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR riscv64)
+
+set(CMAKE_C_COMPILER riscv64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER riscv64-linux-gnu-g++)
+set(CMAKE_RANLIB riscv64-linux-gnu-gcc-ranlib)
+set(CMAKE_AR riscv64-linux-gnu-gcc-ar)
+
+set(CMAKE_FIND_ROOT_PATH /usr/bin /usr/lib/jellyfin-ffmpeg /usr/riscv64-linux-gnu)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
…upport

Portable build (cross-compiled via crosstool-ng):
- Add builder/images/base-linuxriscv64/ with Dockerfile, ct-ng-config, gen-implib.sh, cross.meson, toolchain.cmake
- Add builder/variants/linuxriscv64-gpl.sh variant file
- Add build-linux-riscv64 build script
- Add cross-riscv64.meson and toolchain-riscv64.cmake top-level files
- Clear STAGE_CFLAGS (-fvisibility=hidden is shared-lib only and breaks configure scripts for static builds)
- Keep sysroot static libs so cross-compiler can link test programs
- Add -fvisibility=hidden to gen-implib.sh directly (prevents trampoline symbol leakage between X11 import libraries)

crosstool-ng config for RISC-V GCC 15.2.0:
- glibc 2.42, binutils 2.46.0, Linux headers 6.1.100

CI / debian build:
- Add riscv64 to build_portable_linux, jammy/noble/resolute CI jobs
- Add jammy-riscv64 to build.yaml packages list
- Add riscv64 cross-compilation to build, docker-build.sh, debian/rules
- Fix libatomic.so.1: install libatomic1:riscv64, add -latomic LDFLAGS (RISC-V needs libatomic for 128-bit atomics)

Architecture-specific build fixes:
- FFTW3: add linuxriscv64 arch case (no SSE/AVX SIMD)
- libglvnd: disable asm for riscv64 (no RISC-V stubs)
- libva: add linuxriscv64 target (DRM+X11, riscv64 driver path)

FFmpeg configure:
- Disable GPU-hardware features: ffnvcodec/cuda/nvenc (NVIDIA), amf (AMD), libvpl (Intel) — no RISC-V GPU hardware
- Keep: libplacebo, vulkan, shaderc, opencl (libs exist at build time)

<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->