### PR TITLE
[WIP] Add HW caps detection and usage monitoring to ffprobe

### DIFF
--- a/debian/patches/0098-add-hw-caps-detection-and-usage-monitoring-to-ffprobe.patch
+++ b/debian/patches/0098-add-hw-caps-detection-and-usage-monitoring-to-ffprobe.patch
@@ -1,0 +1,9726 @@
+Index: FFmpeg/compat/cuda/dynlink_loader.h
+===================================================================
+--- FFmpeg.orig/compat/cuda/dynlink_loader.h
++++ FFmpeg/compat/cuda/dynlink_loader.h
+@@ -30,4 +30,291 @@
+ 
+ #include <ffnvcodec/dynlink_loader.h>
+ 
++#if defined(_WIN32) || defined(__CYGWIN__)
++#   define CUDA_LIBNAME "nvcuda.dll"
++#   define NVML_LIBNAME "nvml.dll"
++#   define NVML_LIBNAME2 "%ProgramW6432%\\NVIDIA Corporation\\NVSMI\\nvml.dll"
++#else
++#   define CUDA_LIBNAME "libcuda.so.1"
++#   define NVML_LIBNAME "libnvidia-ml.so.1"
++#   define NVML_LIBNAME2 NULL
++#endif
++
++#if defined(_WIN32) || defined(__CYGWIN__)
++#   define NVML_API_CALL __stdcall
++#else
++#   define NVML_API_CALL
++#endif
++
++#define LOAD_LIBRARY2(l, path1, path2)                               \
++    do {                                                             \
++        char *path2_ = (char *)(path2);                              \
++        if (!((l) = FFNV_LOAD_FUNC(path1))) {                        \
++            FFNV_LOG_FUNC(logctx, "Cannot load %s\n", path1);        \
++            if (!(path2_)) {                                         \
++                ret = -1;                                            \
++                goto error;                                          \
++            }                                                        \
++            if (!((l) = FFNV_LOAD_FUNC(path2_))) {                   \
++                FFNV_LOG_FUNC(logctx, "Cannot load %s\n", path2_);   \
++                ret = -1;                                            \
++                goto error;                                          \
++            }                                                        \
++            FFNV_DEBUG_LOG_FUNC(logctx, "Loaded lib: %s\n", path2_); \
++        }                                                            \
++        FFNV_DEBUG_LOG_FUNC(logctx, "Loaded lib: %s\n", path1);      \
++    } while (0)
++
++#define LOAD_SYMBOL(fun, tp, symbol)                             \
++    do {                                                         \
++        if (!((f->fun) = (tp*)FFNV_SYM_FUNC(f->lib, symbol))) {  \
++            FFNV_LOG_FUNC(logctx, "Cannot load %s\n", symbol);   \
++            ret = -1;                                            \
++            goto error;                                          \
++        }                                                        \
++        FFNV_DEBUG_LOG_FUNC(logctx, "Loaded sym: %s\n", symbol); \
++    } while (0)
++
++#define LOAD_SYMBOL_OPT(fun, tp, symbol)                                      \
++    do {                                                                      \
++        if (!((f->fun) = (tp*)FFNV_SYM_FUNC(f->lib, symbol))) {               \
++            FFNV_DEBUG_LOG_FUNC(logctx, "Cannot load optional %s\n", symbol); \
++        } else {                                                              \
++            FFNV_DEBUG_LOG_FUNC(logctx, "Loaded sym: %s\n", symbol);          \
++        }                                                                     \
++    } while (0)
++
++#define GENERIC_LOAD_FUNC_PREAMBLE(T, n, N, NN) \
++    T *f;                                       \
++    int ret;                                    \
++                                                \
++    n##_free_functions(functions);              \
++                                                \
++    f = *functions = (T*)calloc(1, sizeof(*f)); \
++    if (!f)                                     \
++        return -1;                              \
++                                                \
++    LOAD_LIBRARY2(f->lib, N, NN);
++
++#define GENERIC_LOAD_FUNC_FINALE(n) \
++    return 0;                       \
++error:                              \
++    n##_free_functions(functions);  \
++    return ret;
++
++#define GENERIC_FREE_FUNC()                \
++    if (!functions)                        \
++        return;                            \
++    if (*functions && (*functions)->lib)   \
++        FFNV_FREE_FUNC((*functions)->lib); \
++    free(*functions);                      \
++    *functions = NULL;
++
++#ifdef FFNV_DYNLINK_CUDA_H
++#   ifndef CU_UUID_HAS_BEEN_DEFINED
++typedef struct CUuuid_st {
++    char bytes[16];
++} CUuuid;
++#   endif
++
++typedef CUresult CUDAAPI ff_tcuInit(unsigned int Flags);
++typedef CUresult CUDAAPI ff_tcuDriverGetVersion(int *driverVersion);
++typedef CUresult CUDAAPI ff_tcuDeviceGetCount(int *count);
++typedef CUresult CUDAAPI ff_tcuDeviceTotalMem(size_t *bytes, CUdevice dev);
++typedef CUresult CUDAAPI ff_tcuGetErrorName(CUresult error, const char** pstr);
++typedef CUresult CUDAAPI ff_tcuGetErrorString(CUresult error, const char** pstr);
++typedef CUresult CUDAAPI ff_tcuDeviceGetUuid(CUuuid *uuid, CUdevice dev);
++typedef CUresult CUDAAPI ff_tcuDeviceGetUuid_v2(CUuuid *uuid, CUdevice dev);
++typedef CUresult CUDAAPI ff_tcuDeviceGetLuid(char* luid, unsigned int* deviceNodeMask, CUdevice dev);
++typedef CUresult CUDAAPI ff_tcuDeviceGetByPCIBusId(CUdevice* dev, const char* pciBusId);
++typedef CUresult CUDAAPI ff_tcuDeviceGetPCIBusId(char* pciBusId, int len, CUdevice dev);
++
++typedef struct CudaFunctionsExt {
++    ff_tcuInit *cuInit;
++    ff_tcuDriverGetVersion *cuDriverGetVersion;
++    ff_tcuDeviceGetCount *cuDeviceGetCount;
++    ff_tcuDeviceTotalMem *cuDeviceTotalMem;
++    ff_tcuGetErrorName *cuGetErrorName;
++    ff_tcuGetErrorString *cuGetErrorString;
++    ff_tcuDeviceGetUuid *cuDeviceGetUuid;
++    ff_tcuDeviceGetUuid_v2 *cuDeviceGetUuid_v2;
++    ff_tcuDeviceGetLuid *cuDeviceGetLuid;
++    ff_tcuDeviceGetByPCIBusId *cuDeviceGetByPCIBusId;
++    ff_tcuDeviceGetPCIBusId *cuDeviceGetPCIBusId;
++
++    FFNV_LIB_HANDLE lib;
++} CudaFunctionsExt;
++
++static inline void cuda_ext_free_functions(CudaFunctionsExt **functions)
++{
++    GENERIC_FREE_FUNC();
++}
++
++static inline int cuda_ext_load_functions(CudaFunctionsExt **functions, void *logctx)
++{
++    GENERIC_LOAD_FUNC_PREAMBLE(CudaFunctionsExt, cuda_ext, CUDA_LIBNAME, NULL);
++
++    LOAD_SYMBOL(cuInit, ff_tcuInit, "cuInit");
++    LOAD_SYMBOL(cuDriverGetVersion, ff_tcuDriverGetVersion, "cuDriverGetVersion");
++    LOAD_SYMBOL(cuDeviceGetCount, ff_tcuDeviceGetCount, "cuDeviceGetCount");
++    LOAD_SYMBOL(cuDeviceTotalMem, ff_tcuDeviceTotalMem, "cuDeviceTotalMem_v2");
++    LOAD_SYMBOL(cuGetErrorName, ff_tcuGetErrorName, "cuGetErrorName");
++    LOAD_SYMBOL(cuGetErrorString, ff_tcuGetErrorString, "cuGetErrorString");
++    LOAD_SYMBOL_OPT(cuDeviceGetUuid, ff_tcuDeviceGetUuid, "cuDeviceGetUuid");
++    LOAD_SYMBOL_OPT(cuDeviceGetUuid_v2, ff_tcuDeviceGetUuid_v2, "cuDeviceGetUuid_v2");
++    LOAD_SYMBOL_OPT(cuDeviceGetLuid, ff_tcuDeviceGetLuid, "cuDeviceGetLuid");
++    LOAD_SYMBOL_OPT(cuDeviceGetByPCIBusId, ff_tcuDeviceGetByPCIBusId, "cuDeviceGetByPCIBusId");
++    LOAD_SYMBOL_OPT(cuDeviceGetPCIBusId, ff_tcuDeviceGetPCIBusId, "cuDeviceGetPCIBusId");
++
++    GENERIC_LOAD_FUNC_FINALE(cuda_ext);
++}
++
++#if !defined(NVML_API_VERSION) || defined(NVML_API_VERSION) && (NVML_API_VERSION < 11)
++#   ifndef NVML_API_VERSION
++typedef enum nvmlReturn_enum {
++    NVML_SUCCESS = 0
++} nvmlReturn_t;
++
++typedef struct nvmlDevice_st* nvmlDevice_t;
++
++typedef struct nvmlUtilization_st {
++    unsigned int gpu;
++    unsigned int memory;
++} nvmlUtilization_t;
++
++typedef struct nvmlMemory_st
++{
++    unsigned long long total;
++    unsigned long long free;
++    unsigned long long used;
++} nvmlMemory_t;
++
++typedef unsigned int nvmlPcieUtilCounter_t;
++#   endif
++
++typedef unsigned int nvmlDeviceArchitecture_t;
++
++#   define NVML_INIT_FLAG_NO_GPUS                              1  //!< Don't fail nvmlInit() when no GPUs are found
++#   define NVML_INIT_FLAG_NO_ATTACH                            2  //!< Don't attach GPUs
++#   define NVML_DEVICE_ARCH_KEPLER                             2  //!< Devices based on the NVIDIA Kepler architecture
++#   define NVML_DEVICE_ARCH_MAXWELL                            3  //!< Devices based on the NVIDIA Maxwell architecture
++#   define NVML_DEVICE_ARCH_PASCAL                             4  //!< Devices based on the NVIDIA Pascal architecture
++#   define NVML_DEVICE_ARCH_VOLTA                              5  //!< Devices based on the NVIDIA Volta architecture
++#   define NVML_DEVICE_ARCH_TURING                             6  //!< Devices based on the NVIDIA Turing architecture
++#   define NVML_DEVICE_ARCH_AMPERE                             7  //!< Devices based on the NVIDIA Ampere architecture
++#   define NVML_DEVICE_ARCH_ADA                                8  //!< Devices based on the NVIDIA Ada architecture
++#   define NVML_DEVICE_ARCH_HOPPER                             9  //!< Devices based on the NVIDIA Hopper architecture
++#   define NVML_DEVICE_ARCH_BLACKWELL                         10  //!< Devices based on the NVIDIA Blackwell architecture
++#   define NVML_DEVICE_ARCH_UNKNOWN                   0xffffffff  //!< Anything else, presumably something newer
++#   define NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE             80  //!< Buffer size guaranteed to be large enough for nvmlSystemGetDriverVersion
++#   define NVML_SYSTEM_NVML_VERSION_BUFFER_SIZE               80  //!< Buffer size guaranteed to be large enough for nvmlSystemGetNVMLVersion
++#   endif
++
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlInit(void);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlInitWithFlags(unsigned int flags);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlShutdown(void);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlSystemGetCudaDriverVersion(int* cudaDriverVersion);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlSystemGetDriverVersion(char* version, unsigned int length);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlSystemGetNVMLVersion(char* version, unsigned int length);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetHandleByIndex(unsigned int index, nvmlDevice_t* device);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetHandleByUUID(const char* uuid, nvmlDevice_t* device);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetHandleByPciBusId(const char* pciBusId, nvmlDevice_t* device);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetCount(unsigned int* deviceCount);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetName(nvmlDevice_t device, char* name, unsigned int length);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetIndex(nvmlDevice_t device, unsigned int* index);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetUUID(nvmlDevice_t device, char* uuid, unsigned int length);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetArchitecture(nvmlDevice_t device, nvmlDeviceArchitecture_t* arch);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetNumGpuCores(nvmlDevice_t device, unsigned int* numCores);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetMinorNumber(nvmlDevice_t device, unsigned int* minorNumber);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t* memory);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetUtilizationRates(nvmlDevice_t device, nvmlUtilization_t* utilization);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetDecoderUtilization(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetEncoderUtilization(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetEncoderStats(nvmlDevice_t device, unsigned int* sessionCount, unsigned int* averageFps, unsigned int* averageLatency);
++typedef nvmlReturn_t NVML_API_CALL ff_tnvmlDeviceGetPcieThroughput(nvmlDevice_t device, nvmlPcieUtilCounter_t counter, unsigned int* value);
++typedef const char*  NVML_API_CALL ff_tnvmlErrorString(nvmlReturn_t result);
++
++typedef struct NvmlFunctionsExt {
++    ff_tnvmlInit *nvmlInit;
++    ff_tnvmlInitWithFlags *nvmlInitWithFlags;
++    ff_tnvmlShutdown *nvmlShutdown;
++    ff_tnvmlSystemGetCudaDriverVersion *nvmlSystemGetCudaDriverVersion;
++    ff_tnvmlSystemGetDriverVersion *nvmlSystemGetDriverVersion;
++    ff_tnvmlSystemGetNVMLVersion *nvmlSystemGetNVMLVersion;
++    ff_tnvmlDeviceGetHandleByIndex *nvmlDeviceGetHandleByIndex;
++    ff_tnvmlDeviceGetHandleByUUID *nvmlDeviceGetHandleByUUID;
++    ff_tnvmlDeviceGetHandleByPciBusId *nvmlDeviceGetHandleByPciBusId;
++    ff_tnvmlDeviceGetHandleByPciBusId *nvmlDeviceGetHandleByPciBusId_v2;
++    ff_tnvmlDeviceGetCount *nvmlDeviceGetCount;
++    ff_tnvmlDeviceGetName *nvmlDeviceGetName;
++    ff_tnvmlDeviceGetIndex *nvmlDeviceGetIndex;
++    ff_tnvmlDeviceGetUUID *nvmlDeviceGetUUID;
++    ff_tnvmlDeviceGetArchitecture *nvmlDeviceGetArchitecture;
++    ff_tnvmlDeviceGetNumGpuCores *nvmlDeviceGetNumGpuCores;
++    ff_tnvmlDeviceGetMinorNumber *nvmlDeviceGetMinorNumber;
++    ff_tnvmlDeviceGetMemoryInfo *nvmlDeviceGetMemoryInfo;
++    ff_tnvmlDeviceGetUtilizationRates *nvmlDeviceGetUtilizationRates;
++    ff_tnvmlDeviceGetDecoderUtilization *nvmlDeviceGetDecoderUtilization;
++    ff_tnvmlDeviceGetEncoderUtilization *nvmlDeviceGetEncoderUtilization;
++    ff_tnvmlDeviceGetEncoderStats *nvmlDeviceGetEncoderStats;
++    ff_tnvmlDeviceGetPcieThroughput *nvmlDeviceGetPcieThroughput;
++    ff_tnvmlErrorString *nvmlErrorString;
++
++    FFNV_LIB_HANDLE lib;
++} NvmlFunctionsExt;
++
++static inline void nvml_ext_free_functions(NvmlFunctionsExt **functions)
++{
++    GENERIC_FREE_FUNC();
++}
++
++static inline int nvml_ext_load_functions(NvmlFunctionsExt **functions, void *logctx)
++{
++#   if defined(_WIN32) || defined(__CYGWIN__)
++    char nvml_libname_2[512];
++    DWORD len = ExpandEnvironmentStringsA(NVML_LIBNAME2, nvml_libname_2, sizeof(nvml_libname_2));
++
++    GENERIC_LOAD_FUNC_PREAMBLE(NvmlFunctionsExt, nvml_ext, NVML_LIBNAME, (len ? nvml_libname_2 : NULL));
++#   else
++    GENERIC_LOAD_FUNC_PREAMBLE(NvmlFunctionsExt, nvml_ext, NVML_LIBNAME, NVML_LIBNAME2);
++#   endif
++    LOAD_SYMBOL(nvmlInit, ff_tnvmlInit, "nvmlInit_v2");
++    LOAD_SYMBOL_OPT(nvmlInitWithFlags, ff_tnvmlInitWithFlags, "nvmlInitWithFlags");
++    LOAD_SYMBOL(nvmlShutdown, ff_tnvmlShutdown, "nvmlShutdown");
++    LOAD_SYMBOL_OPT(nvmlSystemGetCudaDriverVersion, ff_tnvmlSystemGetCudaDriverVersion, "nvmlSystemGetCudaDriverVersion");
++    LOAD_SYMBOL(nvmlSystemGetDriverVersion, ff_tnvmlSystemGetDriverVersion, "nvmlSystemGetDriverVersion");
++    LOAD_SYMBOL(nvmlSystemGetNVMLVersion, ff_tnvmlSystemGetNVMLVersion, "nvmlSystemGetNVMLVersion");
++    LOAD_SYMBOL(nvmlDeviceGetHandleByIndex, ff_tnvmlDeviceGetHandleByIndex, "nvmlDeviceGetHandleByIndex");
++    LOAD_SYMBOL(nvmlDeviceGetHandleByUUID, ff_tnvmlDeviceGetHandleByUUID, "nvmlDeviceGetHandleByUUID");
++    LOAD_SYMBOL(nvmlDeviceGetHandleByPciBusId, ff_tnvmlDeviceGetHandleByPciBusId, "nvmlDeviceGetHandleByPciBusId");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetHandleByPciBusId_v2, ff_tnvmlDeviceGetHandleByPciBusId, "nvmlDeviceGetHandleByPciBusId_v2");
++    LOAD_SYMBOL(nvmlDeviceGetCount, ff_tnvmlDeviceGetCount, "nvmlDeviceGetCount");
++    LOAD_SYMBOL(nvmlDeviceGetName, ff_tnvmlDeviceGetName, "nvmlDeviceGetName");
++    LOAD_SYMBOL(nvmlDeviceGetIndex, ff_tnvmlDeviceGetIndex, "nvmlDeviceGetIndex");
++    LOAD_SYMBOL(nvmlDeviceGetUUID, ff_tnvmlDeviceGetUUID, "nvmlDeviceGetUUID");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetArchitecture, ff_tnvmlDeviceGetArchitecture, "nvmlDeviceGetArchitecture");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetNumGpuCores, ff_tnvmlDeviceGetNumGpuCores, "nvmlDeviceGetNumGpuCores");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetMinorNumber, ff_tnvmlDeviceGetMinorNumber, "nvmlDeviceGetMinorNumber");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetMemoryInfo, ff_tnvmlDeviceGetMemoryInfo, "nvmlDeviceGetMemoryInfo");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetUtilizationRates, ff_tnvmlDeviceGetUtilizationRates, "nvmlDeviceGetUtilizationRates");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetDecoderUtilization, ff_tnvmlDeviceGetDecoderUtilization, "nvmlDeviceGetDecoderUtilization");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetEncoderUtilization, ff_tnvmlDeviceGetEncoderUtilization, "nvmlDeviceGetEncoderUtilization");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetEncoderStats, ff_tnvmlDeviceGetEncoderStats, "nvmlDeviceGetEncoderStats");
++    LOAD_SYMBOL_OPT(nvmlDeviceGetPcieThroughput, ff_tnvmlDeviceGetPcieThroughput, "nvmlDeviceGetPcieThroughput");
++    LOAD_SYMBOL(nvmlErrorString, ff_tnvmlErrorString, "nvmlErrorString");
++
++    GENERIC_LOAD_FUNC_FINALE(nvml_ext);
++}
++#endif
++
++#undef GENERIC_LOAD_FUNC_PREAMBLE
++#undef LOAD_LIBRARY2
++#undef LOAD_SYMBOL
++#undef LOAD_SYMBOL_OPT
++#undef GENERIC_LOAD_FUNC_FINALE
++#undef GENERIC_FREE_FUNC
++#undef CUDA_LIBNAME
++#undef NVML_LIBNAME
++#undef NVML_LIBNAME2
++
+ #endif /* COMPAT_CUDA_DYNLINK_LOADER_H */
+Index: FFmpeg/configure
+===================================================================
+--- FFmpeg.orig/configure
++++ FFmpeg/configure
+@@ -2569,6 +2569,10 @@ SYSTEM_FUNCS="
+ "
+ 
+ SYSTEM_LIBRARIES="
++    advapi32
++    cfgmgr32
++    ole32
++    pdh
+     bcrypt
+     vaapi_drm
+     vaapi_x11
+@@ -2611,6 +2615,7 @@ TOOLCHAIN_FEATURES="
+ 
+ TYPES_LIST="
+     DPI_AWARENESS_CONTEXT
++    IDXGIAdapter3
+     IDXGIOutput5
+     __x_ABI_CWindows_CGraphics_CCapture_CIGraphicsCaptureSession5
+     IDirect3DDxgiInterfaceAccess
+@@ -4359,7 +4364,7 @@ ffplay_deps="avcodec avformat avfilter s
+ ffplay_select="crop_filter transpose_filter hflip_filter vflip_filter rotate_filter"
+ ffplay_suggest="shell32 libplacebo vulkan"
+ ffprobe_deps="avcodec avformat"
+-ffprobe_suggest="shell32"
++ffprobe_suggest="advapi32 cfgmgr32 ole32 shell32 pdh"
+ 
+ # documentation
+ podpages_deps="perl"
+@@ -7074,6 +7079,8 @@ check_lib bcrypt   "windows.h bcrypt.h"
+ check_lib ole32    "windows.h objbase.h"  CoTaskMemFree        -lole32
+ check_lib shell32  "windows.h shellapi.h" CommandLineToArgvW   -lshell32
+ check_lib psapi    "windows.h psapi.h"    GetProcessMemoryInfo -lpsapi
++check_lib cfgmgr32 "windows.h cfgmgr32.h" CM_Get_Version       -lcfgmgr32
++check_lib pdh      "windows.h pdh.h"      PdhCloseQuery        -lpdh
+ 
+ check_lib android android/native_window.h ANativeWindow_acquire -landroid
+ check_lib mediandk "stdint.h media/NdkMediaFormat.h" AMediaFormat_new -lmediandk
+@@ -7135,6 +7142,7 @@ check_type "windows.h dxva.h" "DXVA_PicP
+ check_type "windows.h dxgi1_2.h" "DXGI_OUTDUPL_FRAME_INFO"
+ check_type "windows.h dxgi1_2.h" "IDXGIOutput1"
+ check_type "windows.h dxgi1_5.h" "IDXGIOutput5"
++check_type "windows.h dxgi1_4.h" "IDXGIAdapter3"
+ check_type "windows.h d3d11.h" "ID3D11VideoDecoder"
+ check_type "windows.h d3d11.h" "ID3D11VideoContext"
+ check_type "windows.h d3d11.h" "ID3D11VideoProcessor"
+Index: FFmpeg/fftools/Makefile
+===================================================================
+--- FFmpeg.orig/fftools/Makefile
++++ FFmpeg/fftools/Makefile
+@@ -39,6 +39,16 @@ OBJS-ffmpeg +=                  \
+     $(RESOBJS)                        \
+ 
+ OBJS-ffprobe +=                       \
++    fftools/ffprobe_hw.o              \
++    fftools/ffprobe_hw_vaapi.o        \
++    fftools/ffprobe_hw_dxgi.o         \
++    fftools/ffprobe_hw_cuda.o         \
++    fftools/ffprobe_hw_qsv.o          \
++    fftools/ffprobe_hw_amf.o          \
++    fftools/ffprobe_hw_mf.o           \
++    fftools/ffprobe_hw_rkmpp.o        \
++    fftools/ffprobe_hw_opencl.o       \
++    fftools/ffprobe_hw_vulkan.o       \
+     fftools/textformat/avtextformat.o \
+     fftools/textformat/tf_compact.o   \
+     fftools/textformat/tf_default.o   \
+Index: FFmpeg/fftools/ffprobe.c
+===================================================================
+--- FFmpeg.orig/fftools/ffprobe.c
++++ FFmpeg/fftools/ffprobe.c
+@@ -70,6 +70,9 @@
+ 
+ #include "libavutil/thread.h"
+ 
++#include "ffprobe.h"
++#include "ffprobe_hw.h"
++
+ // attached as opaque_ref to packets/frames
+ typedef struct FrameData {
+     int64_t pkt_pos;
+@@ -136,6 +139,11 @@ static const char *data_codec_name = NUL
+ static const char *subtitle_codec_name = NULL;
+ static const char *video_codec_name = NULL;
+ 
++static int do_show_hwaccel = 0;
++static enum AVHWDeviceType hwaccel_type = AV_HWDEVICE_TYPE_NONE;
++static int hwaccel_flags = FFPROBE_HW_DEFAULT_PRINT_FLAGS;
++static char *hwaccel_device = NULL;
++
+ #define SHOW_OPTIONAL_FIELDS_AUTO       -1
+ #define SHOW_OPTIONAL_FIELDS_NEVER       0
+ #define SHOW_OPTIONAL_FIELDS_ALWAYS      1
+@@ -167,75 +175,6 @@ static int find_stream_info  = 1;
+ 
+ /* section structure definition */
+ 
+-typedef enum {
+-    SECTION_ID_CHAPTER,
+-    SECTION_ID_CHAPTER_TAGS,
+-    SECTION_ID_CHAPTERS,
+-    SECTION_ID_ERROR,
+-    SECTION_ID_FORMAT,
+-    SECTION_ID_FORMAT_TAGS,
+-    SECTION_ID_FRAME,
+-    SECTION_ID_FRAMES,
+-    SECTION_ID_FRAME_TAGS,
+-    SECTION_ID_FRAME_SIDE_DATA_LIST,
+-    SECTION_ID_FRAME_SIDE_DATA,
+-    SECTION_ID_FRAME_SIDE_DATA_TIMECODE_LIST,
+-    SECTION_ID_FRAME_SIDE_DATA_TIMECODE,
+-    SECTION_ID_FRAME_SIDE_DATA_COMPONENT_LIST,
+-    SECTION_ID_FRAME_SIDE_DATA_COMPONENT,
+-    SECTION_ID_FRAME_SIDE_DATA_PIECE_LIST,
+-    SECTION_ID_FRAME_SIDE_DATA_PIECE,
+-    SECTION_ID_FRAME_LOG,
+-    SECTION_ID_FRAME_LOGS,
+-    SECTION_ID_LIBRARY_VERSION,
+-    SECTION_ID_LIBRARY_VERSIONS,
+-    SECTION_ID_PACKET,
+-    SECTION_ID_PACKET_TAGS,
+-    SECTION_ID_PACKETS,
+-    SECTION_ID_PACKETS_AND_FRAMES,
+-    SECTION_ID_PACKET_SIDE_DATA_LIST,
+-    SECTION_ID_PACKET_SIDE_DATA,
+-    SECTION_ID_PIXEL_FORMAT,
+-    SECTION_ID_PIXEL_FORMAT_FLAGS,
+-    SECTION_ID_PIXEL_FORMAT_COMPONENT,
+-    SECTION_ID_PIXEL_FORMAT_COMPONENTS,
+-    SECTION_ID_PIXEL_FORMATS,
+-    SECTION_ID_PROGRAM_STREAM_DISPOSITION,
+-    SECTION_ID_PROGRAM_STREAM_TAGS,
+-    SECTION_ID_PROGRAM,
+-    SECTION_ID_PROGRAM_STREAMS,
+-    SECTION_ID_PROGRAM_STREAM,
+-    SECTION_ID_PROGRAM_TAGS,
+-    SECTION_ID_PROGRAM_VERSION,
+-    SECTION_ID_PROGRAMS,
+-    SECTION_ID_STREAM_GROUP_STREAM_DISPOSITION,
+-    SECTION_ID_STREAM_GROUP_STREAM_TAGS,
+-    SECTION_ID_STREAM_GROUP,
+-    SECTION_ID_STREAM_GROUP_COMPONENTS,
+-    SECTION_ID_STREAM_GROUP_COMPONENT,
+-    SECTION_ID_STREAM_GROUP_SUBCOMPONENTS,
+-    SECTION_ID_STREAM_GROUP_SUBCOMPONENT,
+-    SECTION_ID_STREAM_GROUP_PIECES,
+-    SECTION_ID_STREAM_GROUP_PIECE,
+-    SECTION_ID_STREAM_GROUP_SUBPIECES,
+-    SECTION_ID_STREAM_GROUP_SUBPIECE,
+-    SECTION_ID_STREAM_GROUP_BLOCKS,
+-    SECTION_ID_STREAM_GROUP_BLOCK,
+-    SECTION_ID_STREAM_GROUP_STREAMS,
+-    SECTION_ID_STREAM_GROUP_STREAM,
+-    SECTION_ID_STREAM_GROUP_DISPOSITION,
+-    SECTION_ID_STREAM_GROUP_TAGS,
+-    SECTION_ID_STREAM_GROUPS,
+-    SECTION_ID_ROOT,
+-    SECTION_ID_STREAM,
+-    SECTION_ID_STREAM_DISPOSITION,
+-    SECTION_ID_STREAMS,
+-    SECTION_ID_STREAM_TAGS,
+-    SECTION_ID_STREAM_SIDE_DATA_LIST,
+-    SECTION_ID_STREAM_SIDE_DATA,
+-    SECTION_ID_SUBTITLE,
+-} SectionID;
+-
+ static const char *get_packet_side_data_type(const void *data)
+ {
+     const AVPacketSideData *sd = (const AVPacketSideData *)data;
+@@ -259,7 +198,7 @@ static const char *get_stream_group_type
+     return av_x_if_null(avformat_stream_group_name(stg->type), "unknown");
+ }
+ 
+-static const AVTextFormatSection sections[] = {
++const AVTextFormatSection sections[] = {
+     [SECTION_ID_CHAPTERS] =           { SECTION_ID_CHAPTERS, "chapters", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_CHAPTER, -1 } },
+     [SECTION_ID_CHAPTER] =            { SECTION_ID_CHAPTER, "chapter", 0, { SECTION_ID_CHAPTER_TAGS, -1 } },
+     [SECTION_ID_CHAPTER_TAGS] =       { SECTION_ID_CHAPTER_TAGS, "tags", AV_TEXTFORMAT_SECTION_FLAG_HAS_VARIABLE_FIELDS, { -1 }, .element_name = "tag", .unique_name = "chapter_tags" },
+@@ -321,7 +260,7 @@ static const AVTextFormatSection section
+     [SECTION_ID_ROOT] =               { SECTION_ID_ROOT, "root", AV_TEXTFORMAT_SECTION_FLAG_IS_WRAPPER,
+                                         { SECTION_ID_CHAPTERS, SECTION_ID_FORMAT, SECTION_ID_FRAMES, SECTION_ID_PROGRAMS, SECTION_ID_STREAM_GROUPS, SECTION_ID_STREAMS,
+                                           SECTION_ID_PACKETS, SECTION_ID_ERROR, SECTION_ID_PROGRAM_VERSION, SECTION_ID_LIBRARY_VERSIONS,
+-                                          SECTION_ID_PIXEL_FORMATS, -1} },
++                                          SECTION_ID_PIXEL_FORMATS, SECTION_ID_HWACCEL_DEVICES, -1} },
+     [SECTION_ID_STREAMS] =            { SECTION_ID_STREAMS, "streams", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_STREAM, -1 } },
+     [SECTION_ID_STREAM] =             { SECTION_ID_STREAM, "stream", 0, { SECTION_ID_STREAM_DISPOSITION, SECTION_ID_STREAM_TAGS, SECTION_ID_STREAM_SIDE_DATA_LIST, -1 } },
+     [SECTION_ID_STREAM_DISPOSITION] = { SECTION_ID_STREAM_DISPOSITION, "disposition", 0, { -1 }, .unique_name = "stream_disposition" },
+@@ -329,6 +268,61 @@ static const AVTextFormatSection section
+     [SECTION_ID_STREAM_SIDE_DATA_LIST] ={ SECTION_ID_STREAM_SIDE_DATA_LIST, "side_data_list", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_STREAM_SIDE_DATA, -1 }, .element_name = "side_data", .unique_name = "stream_side_data_list" },
+     [SECTION_ID_STREAM_SIDE_DATA] =     { SECTION_ID_STREAM_SIDE_DATA, "side_data", AV_TEXTFORMAT_SECTION_FLAG_HAS_TYPE|AV_TEXTFORMAT_SECTION_FLAG_HAS_VARIABLE_FIELDS, { -1 }, .unique_name = "stream_side_data", .element_name = "side_datum", .get_type = get_packet_side_data_type },
+     [SECTION_ID_SUBTITLE] =           { SECTION_ID_SUBTITLE, "subtitle", 0, { -1 } },
++
++
++    [SECTION_ID_HWACCEL_DEVICES] =    { SECTION_ID_HWACCEL_DEVICES, "hwaccel_devices", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_HWACCEL_DEVICE, -1 } },
++    [SECTION_ID_HWACCEL_DEVICE] =     { SECTION_ID_HWACCEL_DEVICE, "hwaccel_device", 0,
++                                        { SECTION_ID_DEVICE_PATH_DRM, SECTION_ID_DEVICE_INDEX_D3D11VA, SECTION_ID_DEVICE_INDEX_CUDA,
++                                          SECTION_ID_DEVICE_INFO_DRM, SECTION_ID_DEVICE_INFO_VAAPI, SECTION_ID_DEVICE_INFO_D3D11VA, SECTION_ID_DEVICE_INFO_QSV,
++                                          SECTION_ID_DEVICE_INFO_OPENCL, SECTION_ID_DEVICE_INFO_VULKAN, SECTION_ID_DEVICE_INFO_CUDA, SECTION_ID_DEVICE_INFO_AMF,
++                                          SECTION_ID_DEVICE_UTIL_DRM, SECTION_ID_DEVICE_UTIL_D3D11VA, SECTION_ID_DEVICE_UTIL_CUDA,
++                                          SECTION_ID_DEVICE_DECODERS_VAAPI, SECTION_ID_DEVICE_DECODERS_D3D11VA, SECTION_ID_DEVICE_DECODERS_QSV, SECTION_ID_DEVICE_DECODERS_CUDA, SECTION_ID_DEVICE_DECODERS_RKMPP,
++                                          SECTION_ID_DEVICE_ENCODERS_VAAPI, SECTION_ID_DEVICE_ENCODERS_QSV, SECTION_ID_DEVICE_ENCODERS_CUDA, SECTION_ID_DEVICE_ENCODERS_AMF,
++                                          SECTION_ID_DEVICE_ENCODERS_MF, SECTION_ID_DEVICE_ENCODERS_RKMPP, SECTION_ID_DEVICE_FILTERS_VAAPI, SECTION_ID_DEVICE_FILTERS_QSV, SECTION_ID_DEVICE_FILTERS_RKMPP, -1 } },
++
++    [SECTION_ID_DEVICE_PATH_DRM] =         { SECTION_ID_DEVICE_PATH_DRM,         "device_path_drm",      0, { -1 } },
++    [SECTION_ID_DEVICE_INDEX_D3D11VA] =    { SECTION_ID_DEVICE_INDEX_D3D11VA,    "device_index_d3d11va", 0, { -1 } },
++    [SECTION_ID_DEVICE_INDEX_CUDA] =       { SECTION_ID_DEVICE_INDEX_CUDA,       "device_index_cuda",    0, { -1 } },
++
++    [SECTION_ID_DEVICE_INFO_DRM] =         { SECTION_ID_DEVICE_INFO_DRM,         "device_info_drm",      0, { -1 } },
++    [SECTION_ID_DEVICE_INFO_VAAPI] =       { SECTION_ID_DEVICE_INFO_VAAPI,       "device_info_vaapi",    0, { -1 } },
++    [SECTION_ID_DEVICE_INFO_D3D11VA] =     { SECTION_ID_DEVICE_INFO_D3D11VA,     "device_info_d3d11va",  0, { -1 } },
++    [SECTION_ID_DEVICE_INFO_QSV] =         { SECTION_ID_DEVICE_INFO_QSV,         "device_info_qsv",      0, { -1 } },
++    [SECTION_ID_DEVICE_INFO_OPENCL] =      { SECTION_ID_DEVICE_INFO_OPENCL,      "device_info_opencl",   0, { -1 } },
++    [SECTION_ID_DEVICE_INFO_VULKAN] =      { SECTION_ID_DEVICE_INFO_VULKAN,      "device_info_vulkan",   0, { -1 } },
++    [SECTION_ID_DEVICE_INFO_CUDA] =        { SECTION_ID_DEVICE_INFO_CUDA,        "device_info_cuda",     0, { -1 } },
++    [SECTION_ID_DEVICE_INFO_AMF] =         { SECTION_ID_DEVICE_INFO_AMF,         "device_info_amf",      0, { -1 } },
++
++    [SECTION_ID_DEVICE_UTIL_DRM] =         { SECTION_ID_DEVICE_UTIL_DRM,         "device_util_drm",      0, { -1 } },
++    [SECTION_ID_DEVICE_UTIL_D3D11VA] =     { SECTION_ID_DEVICE_UTIL_D3D11VA,     "device_util_d3d11va",  0, { -1 } },
++    [SECTION_ID_DEVICE_UTIL_CUDA] =        { SECTION_ID_DEVICE_UTIL_CUDA,        "device_util_cuda",     0, { -1 } },
++
++    [SECTION_ID_DEVICE_DECODERS_VAAPI] =   { SECTION_ID_DEVICE_DECODERS_VAAPI,   "device_decoders_vaapi",   AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_DECODER, -1 } },
++    [SECTION_ID_DEVICE_DECODERS_D3D11VA] = { SECTION_ID_DEVICE_DECODERS_D3D11VA, "device_decoders_d3d11va", AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_DECODER, -1 } },
++    [SECTION_ID_DEVICE_DECODERS_QSV] =     { SECTION_ID_DEVICE_DECODERS_QSV,     "device_decoders_qsv",     AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_DECODER, -1 } },
++    [SECTION_ID_DEVICE_DECODERS_CUDA] =    { SECTION_ID_DEVICE_DECODERS_CUDA,    "device_decoders_cuda",    AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_DECODER, -1 } },
++    [SECTION_ID_DEVICE_DECODERS_RKMPP] =   { SECTION_ID_DEVICE_DECODERS_RKMPP,   "device_decoders_rkmpp",   AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_DECODER, -1 } },
++    [SECTION_ID_DEVICE_DECODER] =          { SECTION_ID_DEVICE_DECODER,          "device_decoder", 0, { SECTION_ID_DEVICE_PROFILES, SECTION_ID_DEVICE_PIX_FMTS, -1 } },
++
++    [SECTION_ID_DEVICE_ENCODERS_VAAPI] =   { SECTION_ID_DEVICE_ENCODERS_VAAPI,   "device_encoders_vaapi",   AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_ENCODER, -1 } },
++    [SECTION_ID_DEVICE_ENCODERS_QSV] =     { SECTION_ID_DEVICE_ENCODERS_QSV,     "device_encoders_qsv",     AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_ENCODER, -1 } },
++    [SECTION_ID_DEVICE_ENCODERS_CUDA] =    { SECTION_ID_DEVICE_ENCODERS_CUDA,    "device_encoders_cuda",    AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_ENCODER, -1 } },
++    [SECTION_ID_DEVICE_ENCODERS_AMF] =     { SECTION_ID_DEVICE_ENCODERS_AMF,     "device_encoders_amf",     AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_ENCODER, -1 } },
++    [SECTION_ID_DEVICE_ENCODERS_MF] =      { SECTION_ID_DEVICE_ENCODERS_MF,      "device_encoders_mf",      AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_ENCODER, -1 } },
++    [SECTION_ID_DEVICE_ENCODERS_RKMPP] =   { SECTION_ID_DEVICE_ENCODERS_RKMPP,   "device_encoders_rkmpp",   AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_ENCODER, -1 } },
++    [SECTION_ID_DEVICE_ENCODER] =          { SECTION_ID_DEVICE_ENCODER,          "device_encoder", 0, { SECTION_ID_DEVICE_PROFILES, SECTION_ID_DEVICE_PIX_FMTS, SECTION_ID_DEVICE_PRESETS, -1 } },
++
++    [SECTION_ID_DEVICE_FILTERS_VAAPI] =    { SECTION_ID_DEVICE_FILTERS_VAAPI,    "device_filters_vaapi",    AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_FILTER, -1 } },
++    [SECTION_ID_DEVICE_FILTERS_QSV] =      { SECTION_ID_DEVICE_FILTERS_QSV,      "device_filters_qsv",      AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_FILTER, -1 } },
++    [SECTION_ID_DEVICE_FILTERS_RKMPP] =    { SECTION_ID_DEVICE_FILTERS_RKMPP,    "device_filters_rkmpp",    AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_FILTER, -1 } },
++    [SECTION_ID_DEVICE_FILTER] =           { SECTION_ID_DEVICE_FILTER,           "device_filter",  0, { SECTION_ID_DEVICE_PIX_FMTS, -1 } },
++
++    [SECTION_ID_DEVICE_PROFILES] =         { SECTION_ID_DEVICE_PROFILES,         "profiles",   AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_PROFILE, -1 } },
++    [SECTION_ID_DEVICE_PROFILE] =          { SECTION_ID_DEVICE_PROFILE,          "profile", 0, { -1 } },
++    [SECTION_ID_DEVICE_PIX_FMTS] =         { SECTION_ID_DEVICE_PIX_FMTS,         "pix_fmts",   AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_PIX_FMT, -1 } },
++    [SECTION_ID_DEVICE_PIX_FMT] =          { SECTION_ID_DEVICE_PIX_FMT,          "pix_fmt", 0, { -1 } },
++    [SECTION_ID_DEVICE_PRESETS] =          { SECTION_ID_DEVICE_PRESETS,          "presets",    AV_TEXTFORMAT_SECTION_FLAG_IS_ARRAY, { SECTION_ID_DEVICE_PRESET, -1 } },
++    [SECTION_ID_DEVICE_PRESET] =           { SECTION_ID_DEVICE_PRESET,           "preset",  0, { -1 } },
+ };
+ 
+ typedef struct EntrySelection {
+@@ -2875,8 +2869,8 @@ static int opt_format(void *optctx, cons
+     return 0;
+ }
+ 
+-static inline void mark_section_show_entries(SectionID section_id,
+-                                             int show_all_entries, AVDictionary *entries)
++void mark_section_show_entries(SectionID section_id,
++                               int show_all_entries, AVDictionary *entries)
+ {
+     EntrySelection *selection = &selected_entries[section_id];
+ 
+@@ -3234,6 +3228,78 @@ static int opt_show_versions(void *optct
+     return 0;
+ }
+ 
++static const char *const hwaccel_type_names[] = {
++    [AV_HWDEVICE_TYPE_VAAPI]   = "vaapi",
++    [AV_HWDEVICE_TYPE_D3D11VA] = "d3d11va",
++    [AV_HWDEVICE_TYPE_CUDA]    = "cuda",
++    [AV_HWDEVICE_TYPE_QSV]     = "qsv",
++    [AV_HWDEVICE_TYPE_AMF]     = "amf",
++    [AV_HWDEVICE_TYPE_RKMPP]   = "rkmpp",
++};
++
++static int opt_show_hwaccel(void *optctx, const char *opt, const char *arg)
++{
++    for (unsigned i = 0; i < FF_ARRAY_ELEMS(hwaccel_type_names); i++) {
++        if (hwaccel_type_names[i] && !strcmp(hwaccel_type_names[i], arg)) {
++            hwaccel_type = i; break;
++        }
++    }
++    if (hwaccel_type == AV_HWDEVICE_TYPE_NONE) {
++        av_log(NULL, AV_LOG_ERROR, "hwaccel type '%s' is not supported!\n", arg);
++        av_log(NULL, AV_LOG_ERROR, "Available types are: vaapi, d3d11va, cuda, qsv, amf, rkmpp\n");
++        return AVERROR(EINVAL);
++    }
++
++    mark_section_show_entries(SECTION_ID_HWACCEL_DEVICES, 1, NULL);
++
++    return 0;
++}
++
++static int opt_hwaccel_flags(void* optctx, const char *opt, const char *arg)
++{
++    static const AVOption hwaccel_flags_opts[] = {
++        { "hwaccel_flags", NULL, 0, AV_OPT_TYPE_FLAGS, { .i64 = 0 }, INT64_MIN, INT64_MAX,        .unit = "flags" },
++        { "all",           NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_ALL_PRINT_FLAGS     }, .unit = "flags" },
++        { "dev",           NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_FLAG_PRINT_DEV      }, .unit = "flags" },
++        { "dec",           NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_FLAG_PRINT_DEC      }, .unit = "flags" },
++        { "enc",           NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_FLAG_PRINT_ENC      }, .unit = "flags" },
++        { "vpp",           NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_FLAG_PRINT_VPP      }, .unit = "flags" },
++        { "ocl",           NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_FLAG_PRINT_OPT_OCL  }, .unit = "flags" },
++        { "vk",            NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_FLAG_PRINT_OPT_VK   }, .unit = "flags" },
++        { "dx11",          NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_FLAG_PRINT_OPT_DX11 }, .unit = "flags" },
++        { "subdev",        NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_FLAG_PRINT_SUB_DEV  }, .unit = "flags" },
++        { "util",          NULL, 0, AV_OPT_TYPE_CONST, { .i64 = FFPROBE_HW_FLAG_PRINT_UTIL     }, .unit = "flags" },
++        { NULL },
++    };
++    static const AVClass class = {
++        .class_name = "hwaccelflags",
++        .item_name  = av_default_item_name,
++        .option     = hwaccel_flags_opts,
++        .version    = LIBAVUTIL_VERSION_INT,
++    };
++    const struct {
++        const AVClass *av_class;
++    } ctx = { &class };
++
++    if ((av_opt_eval_flags((void *)&ctx, &hwaccel_flags_opts[0], arg, &hwaccel_flags)) < 0) {
++        av_log(NULL, AV_LOG_ERROR, "hwaccel flags '%s' is not supported!\n", arg);
++        av_log(NULL, AV_LOG_ERROR, "Available flags are: all, dev, dec, enc, vpp, ocl, vk, dx11, subdev, util\n");
++        return AVERROR(EINVAL);
++    }
++
++    hwaccel_flags &= FFPROBE_HW_ALL_PRINT_FLAGS;
++
++    if (!(hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) &&
++        !(hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEC) &&
++        !(hwaccel_flags & FFPROBE_HW_FLAG_PRINT_ENC) &&
++        !(hwaccel_flags & FFPROBE_HW_FLAG_PRINT_VPP) &&
++        !(hwaccel_flags & FFPROBE_HW_FLAG_PRINT_UTIL)) {
++        hwaccel_flags |= FFPROBE_HW_DEFAULT_PRINT_FLAGS;
++    }
++
++    return 0;
++}
++
+ #define DEFINE_OPT_SHOW_SECTION(section, target_section_id)             \
+     static int opt_show_##section(void *optctx, const char *opt, const char *arg) \
+     {                                                                   \
+@@ -3306,6 +3372,11 @@ static const OptionDef real_options[] =
+     { "c",                     OPT_TYPE_FUNC, OPT_FUNC_ARG, { .func_arg = opt_codec}, "force decoder", "decoder_name" },
+     { "codec",                 OPT_TYPE_FUNC, OPT_FUNC_ARG, { .func_arg = opt_codec}, "alias for -c (force decoder)", "decoder_name" },
+     { "only_first_vframe",     OPT_TYPE_BOOL,        0, { &only_show_first_video_frame }, "only show first video frame when show_frames is used" },
++    { "show_hwaccel",          OPT_TYPE_FUNC, OPT_FUNC_ARG, { .func_arg = &opt_show_hwaccel },
++        "show details of the given hwaccel type (available types are: vaapi, d3d11va, cuda, qsv, amf, rkmpp)" },
++    { "hwaccel_flags",         OPT_TYPE_FUNC, OPT_FUNC_ARG, { .func_arg = &opt_hwaccel_flags },
++        "set hwaccel flags for showing (available flags are: all, dev, dec, enc, vpp, ocl, vk, dx11, subdev, util)" },
++    { "hwaccel_device",        OPT_TYPE_STRING,      0, { &hwaccel_device }, "set a hwaccel device for showing" },
+     { NULL, },
+ };
+ 
+@@ -3323,6 +3394,16 @@ static inline int check_section_show_ent
+     return 0;
+ }
+ 
++static void ffprobe_show_hwaccel(AVTextFormatContext *tfc,
++                                 enum AVHWDeviceType hwaccel_type_opt,
++                                 int hwaccel_flags_opt,
++                                 const char *hwaccel_device_opt)
++{
++    avtext_print_section_header(tfc, NULL, SECTION_ID_HWACCEL_DEVICES);
++    ffprobe_show_hwaccel_internal(tfc, hwaccel_type_opt, hwaccel_flags_opt, hwaccel_device_opt);
++    avtext_print_section_footer(tfc);
++}
++
+ #define SET_DO_SHOW(id, varname) do {                                   \
+         if (check_section_show_entries(SECTION_ID_##id))                \
+             do_show_##varname = 1;                                      \
+@@ -3391,6 +3472,8 @@ int main(int argc, char **argv)
+     SET_DO_SHOW(STREAM_GROUP_STREAM_TAGS, stream_tags);
+     SET_DO_SHOW(PACKET_TAGS, packet_tags);
+ 
++    SET_DO_SHOW(HWACCEL_DEVICES, hwaccel);
++
+     if (do_bitexact && (do_show_program_version || do_show_library_versions)) {
+         av_log(NULL, AV_LOG_ERROR,
+                "-bitexact and -show_program_version or -show_library_versions "
+@@ -3463,10 +3546,12 @@ int main(int argc, char **argv)
+             ffprobe_show_library_versions(tctx);
+         if (do_show_pixel_formats)
+             ffprobe_show_pixel_formats(tctx);
++        if (do_show_hwaccel)
++            ffprobe_show_hwaccel(tctx, hwaccel_type, hwaccel_flags, hwaccel_device);
+ 
+         if (!input_filename &&
+             ((do_show_format || do_show_programs || do_show_stream_groups || do_show_streams || do_show_chapters || do_show_packets || do_show_error) ||
+-             (!do_show_program_version && !do_show_library_versions && !do_show_pixel_formats))) {
++             (!do_show_program_version && !do_show_library_versions && !do_show_pixel_formats && !do_show_hwaccel))) {
+             show_usage();
+             av_log(NULL, AV_LOG_ERROR, "You have to specify one input file.\n");
+             av_log(NULL, AV_LOG_ERROR, "Use -h to get full help or, even better, run 'man %s'.\n", program_name);
+Index: FFmpeg/fftools/ffprobe.h
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe.h
+@@ -0,0 +1,145 @@
++/*
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#ifndef FFTOOLS_FFPROBE_H
++#define FFTOOLS_FFPROBE_H
++
++#include "textformat/avtextformat.h"
++
++typedef enum {
++    SECTION_ID_CHAPTER,
++    SECTION_ID_CHAPTER_TAGS,
++    SECTION_ID_CHAPTERS,
++    SECTION_ID_ERROR,
++    SECTION_ID_FORMAT,
++    SECTION_ID_FORMAT_TAGS,
++    SECTION_ID_FRAME,
++    SECTION_ID_FRAMES,
++    SECTION_ID_FRAME_TAGS,
++    SECTION_ID_FRAME_SIDE_DATA_LIST,
++    SECTION_ID_FRAME_SIDE_DATA,
++    SECTION_ID_FRAME_SIDE_DATA_TIMECODE_LIST,
++    SECTION_ID_FRAME_SIDE_DATA_TIMECODE,
++    SECTION_ID_FRAME_SIDE_DATA_COMPONENT_LIST,
++    SECTION_ID_FRAME_SIDE_DATA_COMPONENT,
++    SECTION_ID_FRAME_SIDE_DATA_PIECE_LIST,
++    SECTION_ID_FRAME_SIDE_DATA_PIECE,
++    SECTION_ID_FRAME_LOG,
++    SECTION_ID_FRAME_LOGS,
++    SECTION_ID_LIBRARY_VERSION,
++    SECTION_ID_LIBRARY_VERSIONS,
++    SECTION_ID_PACKET,
++    SECTION_ID_PACKET_TAGS,
++    SECTION_ID_PACKETS,
++    SECTION_ID_PACKETS_AND_FRAMES,
++    SECTION_ID_PACKET_SIDE_DATA_LIST,
++    SECTION_ID_PACKET_SIDE_DATA,
++    SECTION_ID_PIXEL_FORMAT,
++    SECTION_ID_PIXEL_FORMAT_FLAGS,
++    SECTION_ID_PIXEL_FORMAT_COMPONENT,
++    SECTION_ID_PIXEL_FORMAT_COMPONENTS,
++    SECTION_ID_PIXEL_FORMATS,
++    SECTION_ID_PROGRAM_STREAM_DISPOSITION,
++    SECTION_ID_PROGRAM_STREAM_TAGS,
++    SECTION_ID_PROGRAM,
++    SECTION_ID_PROGRAM_STREAMS,
++    SECTION_ID_PROGRAM_STREAM,
++    SECTION_ID_PROGRAM_TAGS,
++    SECTION_ID_PROGRAM_VERSION,
++    SECTION_ID_PROGRAMS,
++    SECTION_ID_STREAM_GROUP_STREAM_DISPOSITION,
++    SECTION_ID_STREAM_GROUP_STREAM_TAGS,
++    SECTION_ID_STREAM_GROUP,
++    SECTION_ID_STREAM_GROUP_COMPONENTS,
++    SECTION_ID_STREAM_GROUP_COMPONENT,
++    SECTION_ID_STREAM_GROUP_SUBCOMPONENTS,
++    SECTION_ID_STREAM_GROUP_SUBCOMPONENT,
++    SECTION_ID_STREAM_GROUP_PIECES,
++    SECTION_ID_STREAM_GROUP_PIECE,
++    SECTION_ID_STREAM_GROUP_SUBPIECES,
++    SECTION_ID_STREAM_GROUP_SUBPIECE,
++    SECTION_ID_STREAM_GROUP_BLOCKS,
++    SECTION_ID_STREAM_GROUP_BLOCK,
++    SECTION_ID_STREAM_GROUP_STREAMS,
++    SECTION_ID_STREAM_GROUP_STREAM,
++    SECTION_ID_STREAM_GROUP_DISPOSITION,
++    SECTION_ID_STREAM_GROUP_TAGS,
++    SECTION_ID_STREAM_GROUPS,
++    SECTION_ID_ROOT,
++    SECTION_ID_STREAM,
++    SECTION_ID_STREAM_DISPOSITION,
++    SECTION_ID_STREAMS,
++    SECTION_ID_STREAM_TAGS,
++    SECTION_ID_STREAM_SIDE_DATA_LIST,
++    SECTION_ID_STREAM_SIDE_DATA,
++    SECTION_ID_SUBTITLE,
++
++    SECTION_ID_HWACCEL_DEVICES,
++    SECTION_ID_HWACCEL_DEVICE,
++
++    SECTION_ID_DEVICE_PATH_DRM,
++    SECTION_ID_DEVICE_INDEX_D3D11VA,
++    SECTION_ID_DEVICE_INDEX_CUDA,
++
++    SECTION_ID_DEVICE_INFO_DRM,
++    SECTION_ID_DEVICE_INFO_VAAPI,
++    SECTION_ID_DEVICE_INFO_D3D11VA,
++    SECTION_ID_DEVICE_INFO_QSV,
++    SECTION_ID_DEVICE_INFO_OPENCL,
++    SECTION_ID_DEVICE_INFO_VULKAN,
++    SECTION_ID_DEVICE_INFO_CUDA,
++    SECTION_ID_DEVICE_INFO_AMF,
++
++    SECTION_ID_DEVICE_UTIL_DRM,
++    SECTION_ID_DEVICE_UTIL_D3D11VA,
++    SECTION_ID_DEVICE_UTIL_CUDA,
++
++    SECTION_ID_DEVICE_DECODERS_VAAPI,
++    SECTION_ID_DEVICE_DECODERS_D3D11VA,
++    SECTION_ID_DEVICE_DECODERS_QSV,
++    SECTION_ID_DEVICE_DECODERS_CUDA,
++    SECTION_ID_DEVICE_DECODERS_RKMPP,
++    SECTION_ID_DEVICE_DECODER,
++
++    SECTION_ID_DEVICE_ENCODERS_VAAPI,
++    SECTION_ID_DEVICE_ENCODERS_QSV,
++    SECTION_ID_DEVICE_ENCODERS_CUDA,
++    SECTION_ID_DEVICE_ENCODERS_AMF,
++    SECTION_ID_DEVICE_ENCODERS_MF,
++    SECTION_ID_DEVICE_ENCODERS_RKMPP,
++    SECTION_ID_DEVICE_ENCODER,
++
++    SECTION_ID_DEVICE_FILTERS_VAAPI,
++    SECTION_ID_DEVICE_FILTERS_QSV,
++    SECTION_ID_DEVICE_FILTERS_RKMPP,
++    SECTION_ID_DEVICE_FILTER,
++
++    SECTION_ID_DEVICE_PROFILES,
++    SECTION_ID_DEVICE_PROFILE,
++    SECTION_ID_DEVICE_PIX_FMTS,
++    SECTION_ID_DEVICE_PIX_FMT,
++    SECTION_ID_DEVICE_PRESETS,
++    SECTION_ID_DEVICE_PRESET,
++} SectionID;
++
++extern const AVTextFormatSection sections[];
++
++void mark_section_show_entries(SectionID section_id,
++                               int show_all_entries, AVDictionary *entries);
++
++#endif /* FFTOOLS_FFPROBE_H */
+Index: FFmpeg/fftools/ffprobe_hw.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw.c
+@@ -0,0 +1,540 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include <errno.h>
++#include <stdlib.h>
++
++#include "ffprobe_hw_internal.h"
++
++av_unused static void get_hwaccel_device_index(int *device_idx, const char *hwaccel_device)
++{
++    if (!device_idx)
++        return;
++
++    *device_idx = -1;
++
++    if (hwaccel_device) {
++        char *end_ptr = NULL;
++        long val = strtol(hwaccel_device, &end_ptr, 10);
++
++        if (hwaccel_device == end_ptr ||
++            *end_ptr != '\0'          ||
++            errno == ERANGE           ||
++            val < 0                   ||
++            val > FFPROBE_HW_MAX_DEV_NUM) {
++            *device_idx = -1;
++        } else
++            *device_idx = (int)val;
++    }
++}
++
++#if CONFIG_CUDA
++static int print_cuda_based_all(AVTextFormatContext *tfc,
++                                HwDeviceRefs *refs, int hwaccel_flags)
++{
++    unsigned i;
++    int nvml_ret = AVERROR_EXTERNAL;
++    if (!refs || !tfc)
++        return AVERROR(EINVAL);
++
++    for (i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs[i].cuda_ref; i++);
++    if (!i)
++        return 0;
++
++    /* Init NVML for the optional version info */
++    if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) ||
++        (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_UTIL))
++        nvml_ret = init_nvml_driver_version();
++
++    mark_section_show_entries(SECTION_ID_HWACCEL_DEVICE, 1, NULL);
++
++    for (i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs[i].cuda_ref; i++) {
++        avtext_print_section_header(tfc, NULL, SECTION_ID_HWACCEL_DEVICE);
++
++        /* CUDA based device index */
++        print_int("device_index_cuda", refs[i].device_index_cuda);
++
++        /* CUDA device info */
++        if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV)
++            print_cuda_device_info(tfc, refs[i].cuda_ref, nvml_ret);
++
++        /* CUDA device util */
++        if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_UTIL)
++            print_cuda_device_util(tfc, refs[i].cuda_ref, nvml_ret);
++
++        /* CUDA decoder info */
++        if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEC)
++            print_cuda_decoder_info(tfc, refs[i].cuda_ref);
++
++        /* CUDA encoder info */
++        if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_ENC)
++            print_cuda_encoder_info(tfc, refs[i].cuda_ref);
++
++#   if CONFIG_D3D11VA
++        /* DXGI/D3D11VA based device index */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_DX11) && refs[i].d3d11va_ref)
++            print_int("device_index_d3d11va", refs[i].device_index_dxgi);
++
++        /* D3D11VA device info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_DX11))
++            print_d3d11va_device_info(tfc, refs[i].d3d11va_ref);
++
++        /* D3D11VA device util */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_UTIL) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_DX11))
++            print_d3d11va_device_util(tfc, refs[i].d3d11va_ref);
++
++        /* D3D11VA decoder info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEC) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_DX11))
++            print_d3d11va_decoder_info(tfc, refs[i].d3d11va_ref);
++#   endif
++
++        avtext_print_section_footer(tfc); // SECTION_ID_HWACCEL_DEVICE
++    }
++
++    return 0;
++}
++#endif
++
++static int show_cuda_info(AVTextFormatContext *tfc, HwDeviceRefs *refs,
++                          int hwaccel_flags, const char *hwaccel_device)
++{
++    av_unused int device_idx = -1;
++    int ret = 0;
++    if (!tfc || !refs)
++        return AVERROR(EINVAL);
++
++#if CONFIG_CUDA
++    get_hwaccel_device_index(&device_idx, hwaccel_device);
++
++    ret = create_cuda_devices(refs, device_idx);
++    if (ret < 0)
++        goto exit;
++
++#   if CONFIG_D3D11VA
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_DX11)
++        create_derive_d3d11va_devices_from_cuda(refs);
++#   endif
++
++    print_cuda_based_all(tfc, refs, hwaccel_flags);
++exit:
++    uninit_cuvid_functions();
++    uninit_nvenc_functions();
++    uninit_cuda_functions();
++    uninit_nvml_functions();
++#endif
++    return ret;
++}
++
++#if CONFIG_D3D11VA
++static int print_dxgi_based_all(AVTextFormatContext *tfc,
++                                HwDeviceRefs *refs,
++                                int hwaccel_flags, int mf_only)
++{
++    unsigned i;
++    if (!tfc || !refs)
++        return AVERROR(EINVAL);
++
++    for (i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs[i].d3d11va_ref; i++);
++    if (!i)
++        return 0;
++
++    mark_section_show_entries(SECTION_ID_HWACCEL_DEVICE, 1, NULL);
++
++    for (i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs[i].d3d11va_ref; i++) {
++        avtext_print_section_header(tfc, NULL, SECTION_ID_HWACCEL_DEVICE);
++
++        /* DXGI/D3D11VA based device index */
++        print_int("device_index_d3d11va", refs[i].device_index_dxgi);
++
++        /* D3D11VA device info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_SUB_DEV))
++            print_d3d11va_device_info(tfc, refs[i].d3d11va_ref);
++
++        /* D3D11VA device util */
++        if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_UTIL)
++            print_d3d11va_device_util(tfc, refs[i].d3d11va_ref);
++
++        /* D3D11VA decoder info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEC) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_SUB_DEV))
++            print_d3d11va_decoder_info(tfc, refs[i].d3d11va_ref);
++
++        if (!mf_only && refs[i].device_vendor_id == FFPROBE_HW_VENDOR_ID_INTEL) {
++            /* QSV device info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV)
++                print_qsv_device_info(tfc, refs[i].qsv_ref);
++
++            /* QSV decoder info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEC)
++                print_qsv_decoder_info(tfc, refs[i].qsv_ref);
++
++            /* QSV encoder info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_ENC)
++                print_qsv_encoder_info(tfc, refs[i].qsv_ref);
++
++            /* QSV vpp info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_VPP)
++                print_qsv_vpp_info(tfc, refs[i].qsv_ref);
++        }
++
++        if (!mf_only && refs[i].device_vendor_id == FFPROBE_HW_VENDOR_ID_AMD &&
++            ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) ||
++             (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_ENC))) {
++            /* Create internal AMF device from D3D11VA */
++            create_derive_amf_device_from_d3d11va(refs[i].d3d11va_ref,
++                                                  refs[i].amf_dll_path);
++
++            /* AMF device info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV)
++                print_amf_device_info_from_d3d11va(tfc);
++
++            /* AMF encoder info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_ENC)
++                print_amf_encoder_info_from_d3d11va(tfc);
++
++            uninit_amf_functions();
++        }
++
++        if (mf_only && (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_ENC)) {
++            /* Create internal MF device from D3D11VA */
++            create_derive_mf_device_from_d3d11va(refs[i].d3d11va_ref);
++
++            /* MF encoder info */
++            print_mf_encoder_info_from_d3d11va(tfc, refs[i].device_luid_dxgi);
++
++            uninit_mf_functions();
++        }
++
++        /* OPENCL device info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_OCL))
++            print_opencl_device_info(tfc, refs[i].opencl_ref);
++
++        avtext_print_section_footer(tfc); // SECTION_ID_HWACCEL_DEVICE
++    }
++
++    return 0;
++}
++#endif
++
++#if CONFIG_LIBDRM
++static int print_drm_based_all(AVTextFormatContext *tfc,
++                               HwDeviceRefs *refs, int hwaccel_flags)
++{
++    unsigned i;
++    if (!tfc || !refs)
++        return AVERROR(EINVAL);
++
++    for (i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs[i].drm_ref; i++);
++    if (!i)
++        return 0;
++
++    for (i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs[i].drm_ref; i++) {
++        if (!refs[i].vaapi_ref)
++            continue;
++        if (!refs[i].qsv_ref && !(hwaccel_flags & FFPROBE_HW_FLAG_PRINT_SUB_DEV))
++            continue;
++
++        mark_section_show_entries(SECTION_ID_HWACCEL_DEVICE, 1, NULL);
++        avtext_print_section_header(tfc, NULL, SECTION_ID_HWACCEL_DEVICE);
++
++        /* DRM based device path */
++        print_str("device_path_drm", refs[i].device_path_drm);
++
++        /* DRM device info */
++        if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV)
++            print_drm_device_info(tfc, refs[i].drm_ref);
++#   if 0
++        /* DRM device util */
++        if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_UTIL)
++            print_drm_device_util(tfc, refs[i].drm_ref);
++#   endif
++        /* VAAPI device info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_SUB_DEV))
++            print_vaapi_device_info(tfc, refs[i].vaapi_ref,
++                                         refs[i].drm_ref);
++        /* VAAPI decoder info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEC) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_SUB_DEV))
++            print_vaapi_decoder_info(tfc, refs[i].vaapi_ref);
++
++        /* VAAPI encoder info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_ENC) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_SUB_DEV))
++            print_vaapi_encoder_info(tfc, refs[i].vaapi_ref);
++
++        /* VAAPI vpp info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_VPP) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_SUB_DEV))
++            print_vaapi_vpp_info(tfc, refs[i].vaapi_ref);
++
++        if (refs[i].device_vendor_id == FFPROBE_HW_VENDOR_ID_INTEL) {
++            /* QSV device info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV)
++                print_qsv_device_info(tfc, refs[i].qsv_ref);
++
++            /* QSV decoder info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEC)
++                print_qsv_decoder_info(tfc, refs[i].qsv_ref);
++
++            /* QSV encoder info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_ENC)
++                print_qsv_encoder_info(tfc, refs[i].qsv_ref);
++
++            /* QSV vpp info */
++            if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_VPP)
++                print_qsv_vpp_info(tfc, refs[i].qsv_ref);
++        }
++
++        /* OPENCL device info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_OCL))
++            print_opencl_device_info(tfc, refs[i].opencl_ref);
++
++        /* VULKAN device info */
++        if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) &&
++            (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_VK))
++            print_vulkan_device_info(tfc, refs[i].vulkan_ref);
++
++        avtext_print_section_footer(tfc); // SECTION_ID_HWACCEL_DEVICE
++    }
++
++    return 0;
++}
++#endif
++
++static int show_vaapi_info(AVTextFormatContext *tfc, HwDeviceRefs *refs,
++                           int hwaccel_flags, const char *hwaccel_device)
++{
++    int ret = 0;
++    if (!tfc || !refs)
++        return AVERROR(EINVAL);
++
++#if (CONFIG_LIBDRM && CONFIG_VAAPI && HAVE_VAAPI_DRM)
++    ret = create_drm_devices(refs, hwaccel_device);
++    if (ret < 0)
++        return ret;
++
++    create_derive_vaapi_devices_from_drm(refs);
++
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_OCL)
++        create_derive_opencl_devices_from_vaapi(refs);
++
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_VK)
++        create_derive_vulkan_devices_from_drm(refs);
++
++    print_drm_based_all(tfc, refs, (hwaccel_flags | FFPROBE_HW_FLAG_PRINT_SUB_DEV));
++
++    uninit_udev_functions();
++#endif
++    return ret;
++}
++
++static int show_d3d11va_info(AVTextFormatContext *tfc, HwDeviceRefs *refs,
++                             int hwaccel_flags, const char *hwaccel_device)
++{
++    av_unused int device_idx = -1;
++    int ret = 0;
++    if (!tfc || !refs)
++        return AVERROR(EINVAL);
++
++#if CONFIG_D3D11VA
++    get_hwaccel_device_index(&device_idx, hwaccel_device);
++
++    ret = create_d3d11va_devices(refs, device_idx);
++    if (ret < 0)
++        return ret;
++
++    print_dxgi_based_all(tfc, refs, (hwaccel_flags | FFPROBE_HW_FLAG_PRINT_SUB_DEV), 1);
++#endif
++    return ret;
++}
++
++static int show_qsv_info(AVTextFormatContext *tfc, HwDeviceRefs *refs,
++                         int hwaccel_flags, const char *hwaccel_device)
++{
++    av_unused int device_idx = -1;
++    int ret = 0;
++    if (!tfc || !refs)
++        return AVERROR(EINVAL);
++
++#if CONFIG_D3D11VA
++    get_hwaccel_device_index(&device_idx, hwaccel_device);
++
++    ret = create_d3d11va_devices_with_filter(refs, FFPROBE_HW_VENDOR_ID_INTEL, -1, NULL, device_idx);
++    if (ret < 0)
++        return ret;
++
++    create_derive_qsv_devices_from_d3d11va(refs);
++
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_OCL)
++        create_derive_opencl_devices_from_d3d11va(refs);
++
++    print_dxgi_based_all(tfc, refs, hwaccel_flags, 0);
++#elif (CONFIG_LIBDRM && CONFIG_VAAPI && HAVE_VAAPI_DRM)
++    ret = create_drm_devices_with_filter(refs, FFPROBE_HW_VENDOR_ID_INTEL, hwaccel_device);
++    if (ret < 0)
++        return ret;
++
++    create_derive_vaapi_devices_from_drm(refs);
++    create_derive_qsv_devices_from_vaapi(refs);
++
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_OCL)
++        create_derive_opencl_devices_from_vaapi(refs);
++
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_VK)
++        create_derive_vulkan_devices_from_drm(refs);
++
++    print_drm_based_all(tfc, refs, hwaccel_flags);
++
++    uninit_udev_functions();
++#endif
++    return ret;
++}
++
++static int show_amf_info(AVTextFormatContext *tfc, HwDeviceRefs *refs,
++                         int hwaccel_flags, const char *hwaccel_device)
++{
++    av_unused int device_idx = -1;
++    int ret = 0;
++    if (!tfc || !refs)
++        return AVERROR(EINVAL);
++
++#if CONFIG_D3D11VA
++    get_hwaccel_device_index(&device_idx, hwaccel_device);
++
++    ret = create_d3d11va_devices_with_filter(refs, FFPROBE_HW_VENDOR_ID_AMD, -1, NULL, device_idx);
++    if (ret < 0)
++        return ret;
++
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_OCL)
++        create_derive_opencl_devices_from_d3d11va(refs);
++
++    print_dxgi_based_all(tfc, refs, (hwaccel_flags | FFPROBE_HW_FLAG_PRINT_SUB_DEV), 0);
++#endif
++    return ret;
++}
++
++static int show_rkmpp_info(AVTextFormatContext *tfc, HwDeviceRefs *refs,
++                           int hwaccel_flags, const char *hwaccel_device)
++{
++    int ret = 0;
++    if (!tfc || !refs)
++        return AVERROR(EINVAL);
++
++#if CONFIG_RKMPP
++    ret = create_rkmpp_device(refs);
++    if (ret < 0 || !refs[0].rkmpp_ref)
++        return AVERROR(ENOSYS);
++
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_OCL)
++        create_derive_opencl_devices_from_rkmpp(refs);
++
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_VK)
++        create_derive_vulkan_devices_from_rkmpp(refs);
++
++    mark_section_show_entries(SECTION_ID_HWACCEL_DEVICE, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_HWACCEL_DEVICE);
++    print_str("device_tree_rkmpp", refs[0].device_tree_rkmpp);
++
++    /* RKMPP decoder info */
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEC)
++        print_rkmpp_decoder_info(tfc, refs[0].device_tree_rkmpp);
++
++    /* RKMPP encoder info */
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_ENC)
++        print_rkmpp_encoder_info(tfc, refs[0].device_tree_rkmpp);
++
++    /* RKMPP vpp info */
++    if (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_VPP)
++        print_rkmpp_vpp_info(tfc, refs[0].device_tree_rkmpp);
++
++    /* OPENCL device info */
++    if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) &&
++        (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_OCL))
++        print_opencl_device_info(tfc, refs[0].opencl_ref);
++
++    /* VULKAN device info */
++    if ((hwaccel_flags & FFPROBE_HW_FLAG_PRINT_DEV) &&
++        (hwaccel_flags & FFPROBE_HW_FLAG_PRINT_OPT_VK))
++        print_vulkan_device_info(tfc, refs[0].vulkan_ref);
++
++    avtext_print_section_footer(tfc); // SECTION_ID_HWACCEL_DEVICE
++#endif
++    return ret;
++}
++
++void ffprobe_show_hwaccel_internal(AVTextFormatContext *tfc,
++                                   enum AVHWDeviceType hwaccel_type,
++                                   int hwaccel_flags,
++                                   const char *hwaccel_device)
++{
++    HwDeviceRefs refs[FFPROBE_HW_MAX_DEV_NUM] = { 0 };
++
++    if (!tfc)
++        return;
++
++    switch (hwaccel_type) {
++    case AV_HWDEVICE_TYPE_VAAPI:
++        show_vaapi_info(tfc, refs, hwaccel_flags, hwaccel_device);
++        break;
++    case AV_HWDEVICE_TYPE_D3D11VA:
++        show_d3d11va_info(tfc, refs, hwaccel_flags, hwaccel_device);
++        break;
++    case AV_HWDEVICE_TYPE_CUDA:
++        show_cuda_info(tfc, refs, hwaccel_flags, hwaccel_device);
++        break;
++    case AV_HWDEVICE_TYPE_QSV:
++        show_qsv_info(tfc, refs, hwaccel_flags, hwaccel_device);
++        break;
++    case AV_HWDEVICE_TYPE_AMF:
++        show_amf_info(tfc, refs, hwaccel_flags, hwaccel_device);
++        break;
++    case AV_HWDEVICE_TYPE_RKMPP:
++        show_rkmpp_info(tfc, refs, hwaccel_flags, hwaccel_device);
++        break;
++    default:
++        return;
++    }
++
++    for (unsigned i = 0; i < FF_ARRAY_ELEMS(refs); i++) {
++        if (refs[i].drm_ref)
++            av_buffer_unref(&refs[i].drm_ref);
++        if (refs[i].vaapi_ref)
++            av_buffer_unref(&refs[i].vaapi_ref);
++        if (refs[i].d3d11va_ref)
++            av_buffer_unref(&refs[i].d3d11va_ref);
++        if (refs[i].cuda_ref)
++            av_buffer_unref(&refs[i].cuda_ref);
++        if (refs[i].qsv_ref)
++            av_buffer_unref(&refs[i].qsv_ref);
++        if (refs[i].rkmpp_ref)
++            av_buffer_unref(&refs[i].rkmpp_ref);
++        if (refs[i].opencl_ref)
++            av_buffer_unref(&refs[i].opencl_ref);
++        if (refs[i].vulkan_ref)
++            av_buffer_unref(&refs[i].vulkan_ref);
++    }
++}
+Index: FFmpeg/fftools/ffprobe_hw.h
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw.h
+@@ -0,0 +1,59 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#ifndef FFTOOLS_FFPROBE_HW_H
++#define FFTOOLS_FFPROBE_HW_H
++
++#include "textformat/avtextformat.h"
++#include "libavutil/hwcontext.h"
++
++#define FFPROBE_HW_FLAG_PRINT_DEV       (1 << 0)
++#define FFPROBE_HW_FLAG_PRINT_DEC       (1 << 1)
++#define FFPROBE_HW_FLAG_PRINT_ENC       (1 << 2)
++#define FFPROBE_HW_FLAG_PRINT_VPP       (1 << 3)
++#define FFPROBE_HW_FLAG_PRINT_OPT_OCL   (1 << 4)
++#define FFPROBE_HW_FLAG_PRINT_OPT_VK    (1 << 5)
++#define FFPROBE_HW_FLAG_PRINT_OPT_DX11  (1 << 6)
++#define FFPROBE_HW_FLAG_PRINT_SUB_DEV   (1 << 7)
++#define FFPROBE_HW_FLAG_PRINT_UTIL      (1 << 8)
++
++#define FFPROBE_HW_ALL_PRINT_FLAGS \
++    (FFPROBE_HW_FLAG_PRINT_DEV | \
++     FFPROBE_HW_FLAG_PRINT_DEC | \
++     FFPROBE_HW_FLAG_PRINT_ENC | \
++     FFPROBE_HW_FLAG_PRINT_VPP | \
++     FFPROBE_HW_FLAG_PRINT_OPT_OCL  | \
++     FFPROBE_HW_FLAG_PRINT_OPT_VK   | \
++     FFPROBE_HW_FLAG_PRINT_OPT_DX11 | \
++     FFPROBE_HW_FLAG_PRINT_SUB_DEV  | \
++     FFPROBE_HW_FLAG_PRINT_UTIL)
++
++#define FFPROBE_HW_DEFAULT_PRINT_FLAGS \
++    (FFPROBE_HW_FLAG_PRINT_DEV | \
++     FFPROBE_HW_FLAG_PRINT_DEC | \
++     FFPROBE_HW_FLAG_PRINT_ENC | \
++     FFPROBE_HW_FLAG_PRINT_VPP)
++
++void ffprobe_show_hwaccel_internal(AVTextFormatContext *tfc,
++                                   enum AVHWDeviceType hwaccel_type,
++                                   int hwaccel_flags,
++                                   const char *hwaccel_device);
++
++#endif /* FFTOOLS_FFPROBE_HW_H */
+Index: FFmpeg/fftools/ffprobe_hw_amf.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_amf.c
+@@ -0,0 +1,508 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "ffprobe_hw_internal.h"
++#include "libavutil/wchar_filename.h"
++
++#if (CONFIG_AMF && CONFIG_D3D11VA)
++#   include <AMF/core/Factory.h>
++#   include <AMF/components/VideoEncoderVCE.h>
++#   include <AMF/components/VideoEncoderHEVC.h>
++#   include <AMF/components/VideoEncoderAV1.h>
++
++#   define COBJMACROS
++#   include <windows.h>
++#   include <initguid.h>
++#   include <d3d11.h>
++#   include <dxgi1_2.h>
++#   include "libavutil/hwcontext_d3d11va.h"
++#   include "compat/w32dlfcn.h"
++#endif
++
++#if (CONFIG_AMF && CONFIG_D3D11VA)
++amf_handle         amf_lib = NULL;
++AMFInit_Fn         amf_init_fn = NULL;
++AMFQueryVersion_Fn amf_ver_fn = NULL;
++amf_uint64         amf_ver = 0;
++AMFFactory        *amf_factory = NULL;
++AMFContext        *amf_ctx = NULL;
++
++typedef struct AmfEncCap {
++    const wchar_t *cap_val;
++    const char    *cap_str;
++} AmfEncCap;
++
++typedef struct AmfEncMode {
++    const char               *name;
++    const enum AVCodecID      codec;
++    const wchar_t            *comp_name;
++    const int                *profiles;
++    const enum AVPixelFormat *formats;
++    const AmfEncCap          *caps;
++    const size_t              nb_caps;
++} AmfEncMode;
++
++static const int enc_profiles_h264[] = {
++    AV_PROFILE_H264_BASELINE,
++    AV_PROFILE_H264_CONSTRAINED_BASELINE,
++    AV_PROFILE_H264_MAIN,
++    AV_PROFILE_H264_HIGH,
++    AV_PROFILE_UNKNOWN
++};
++static const int enc_profiles_hevc[] = {
++    AV_PROFILE_HEVC_MAIN,
++    AV_PROFILE_HEVC_MAIN_10,
++    AV_PROFILE_UNKNOWN
++};
++static const int enc_profiles_av1[] = {
++    AV_PROFILE_AV1_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++
++static const enum AVPixelFormat enc_formats_8_10_yuv_rgb[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_YUV420P,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_BGR0,
++    AV_PIX_FMT_RGB0,
++    AV_PIX_FMT_BGRA,
++    AV_PIX_FMT_ARGB,
++    AV_PIX_FMT_RGBA,
++    AV_PIX_FMT_X2BGR10,
++    AV_PIX_FMT_NONE
++};
++
++static const AmfEncCap enc_caps_h264[] = {
++    { AMF_VIDEO_ENCODER_CAP_MAX_BITRATE,                     "max_bitrate"                },
++    { AMF_VIDEO_ENCODER_CAP_NUM_OF_STREAMS,                  "num_of_streams"             },
++    { AMF_VIDEO_ENCODER_CAP_MAX_PROFILE,                     "max_profile"                },
++    { AMF_VIDEO_ENCODER_CAP_MAX_LEVEL,                       "max_level"                  },
++    { AMF_VIDEO_ENCODER_CAP_BFRAMES,                         "bframes"                    },
++    { AMF_VIDEO_ENCODER_CAP_MIN_REFERENCE_FRAMES,            "min_reference_frames"       },
++    { AMF_VIDEO_ENCODER_CAP_MAX_REFERENCE_FRAMES,            "max_reference_frames"       },
++    { AMF_VIDEO_ENCODER_CAP_MAX_TEMPORAL_LAYERS,             "max_temporal_layers"        },
++    { AMF_VIDEO_ENCODER_CAP_FIXED_SLICE_MODE,                "fixed_slice_mode"           },
++    { AMF_VIDEO_ENCODER_CAP_NUM_OF_HW_INSTANCES,             "num_of_hw_instances"        },
++    { AMF_VIDEO_ENCODER_CAP_COLOR_CONVERSION,                "color_conversion"           },
++    { AMF_VIDEO_ENCODER_CAP_PRE_ANALYSIS,                    "pre_analysis"               },
++    { AMF_VIDEO_ENCODER_CAP_ROI,                             "roi"                        },
++    { AMF_VIDEO_ENCODER_CAP_MAX_THROUGHPUT,                  "max_throughput"             },
++    { AMF_VIDEO_ENCODER_CAP_REQUESTED_THROUGHPUT,            "requested_throughput"       },
++    { AMF_VIDEO_ENCODER_CAP_QUERY_TIMEOUT_SUPPORT,           "query_timeout_support"      },
++    { AMF_VIDEO_ENCODER_CAP_SUPPORT_SLICE_OUTPUT,            "support_slice_output"       },
++    { AMF_VIDEO_ENCODER_CAP_SUPPORT_SMART_ACCESS_VIDEO,      "support_smart_access_video" },
++};
++static const AmfEncCap enc_caps_hevc[] = {
++    { AMF_VIDEO_ENCODER_HEVC_CAP_MAX_BITRATE,                "max_bitrate"                },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_NUM_OF_STREAMS,             "num_of_streams"             },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_MAX_PROFILE,                "max_profile"                },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_MAX_TIER,                   "max_tier"                   },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_MAX_LEVEL,                  "max_level"                  },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_MIN_REFERENCE_FRAMES,       "min_reference_frames"       },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_MAX_REFERENCE_FRAMES,       "max_reference_frames"       },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_MAX_TEMPORAL_LAYERS,        "max_temporal_layers"        },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_NUM_OF_HW_INSTANCES,        "num_of_hw_instances"        },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_COLOR_CONVERSION,           "color_conversion"           },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_PRE_ANALYSIS,               "pre_analysis"               },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_ROI,                        "roi"                        },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_MAX_THROUGHPUT,             "max_throughput"             },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_REQUESTED_THROUGHPUT,       "requested_throughput"       },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_QUERY_TIMEOUT_SUPPORT,      "query_timeout_support"      },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_SUPPORT_SLICE_OUTPUT,       "support_slice_output"       },
++    { AMF_VIDEO_ENCODER_HEVC_CAP_SUPPORT_SMART_ACCESS_VIDEO, "support_smart_access_video" },
++};
++static const AmfEncCap enc_caps_av1[] = {
++    { AMF_VIDEO_ENCODER_AV1_CAP_NUM_OF_HW_INSTANCES,         "num_of_hw_instances"        },
++    { AMF_VIDEO_ENCODER_AV1_CAP_MAX_THROUGHPUT,              "max_throughput"             },
++    { AMF_VIDEO_ENCODER_AV1_CAP_REQUESTED_THROUGHPUT,        "requested_throughput"       },
++    { AMF_VIDEO_ENCODER_AV1_CAP_COLOR_CONVERSION,            "color_conversion"           },
++    { AMF_VIDEO_ENCODER_AV1_CAP_PRE_ANALYSIS,                "pre_analysis"               },
++    { AMF_VIDEO_ENCODER_AV1_CAP_MAX_BITRATE,                 "max_bitrate"                },
++    { AMF_VIDEO_ENCODER_AV1_CAP_MAX_PROFILE,                 "max_profile"                },
++    { AMF_VIDEO_ENCODER_AV1_CAP_MAX_LEVEL,                   "max_level"                  },
++    { AMF_VIDEO_ENCODER_AV1_CAP_MAX_NUM_TEMPORAL_LAYERS,     "max_num_temporal_layers"    },
++    { AMF_VIDEO_ENCODER_AV1_CAP_MAX_NUM_LTR_FRAMES,          "max_num_ltr_frames"         },
++    { AMF_VIDEO_ENCODER_AV1_CAP_SUPPORT_TILE_OUTPUT,         "support_tile_output"        },
++    { AMF_VIDEO_ENCODER_AV1_CAP_BFRAMES,                     "bframes"                    },
++    { AMF_VIDEO_ENCODER_AV1_CAP_SUPPORT_SMART_ACCESS_VIDEO,  "support_smart_access_video" },
++    { AMF_VIDEO_ENCODER_AV1_CAP_WIDTH_ALIGNMENT_FACTOR,      "width_alignment_factor"     },
++    { AMF_VIDEO_ENCODER_AV1_CAP_HEIGHT_ALIGNMENT_FACTOR,     "height_alignment_factor"    },
++};
++
++static const AmfEncMode amfenc_modes[] = {
++    { "AMF H.264 Encoder", AV_CODEC_ID_H264, AMFVideoEncoderVCE_AVC,
++        enc_profiles_h264, enc_formats_8_10_yuv_rgb, enc_caps_h264, FF_ARRAY_ELEMS(enc_caps_h264) },
++    { "AMF HEVC Encoder",  AV_CODEC_ID_HEVC, AMFVideoEncoder_HEVC,
++        enc_profiles_hevc, enc_formats_8_10_yuv_rgb, enc_caps_hevc, FF_ARRAY_ELEMS(enc_caps_hevc) },
++    { "AMF AV1 Encoder",   AV_CODEC_ID_AV1,  AMFVideoEncoder_AV1,
++        enc_profiles_av1,  enc_formats_8_10_yuv_rgb, enc_caps_av1,  FF_ARRAY_ELEMS(enc_caps_av1)  },
++    { NULL, 0, NULL, NULL, NULL, NULL, 0 },
++};
++#endif
++
++int init_amf_functions(const wchar_t *amf_dll_path)
++{
++    int ret = AVERROR(ENOSYS);
++#if (CONFIG_AMF && CONFIG_D3D11VA)
++    AMF_RESULT res = AMF_OK;
++
++    if (amf_dll_path) {
++        char *amf_dll_path_utf8 = NULL;
++
++        if (!wchartoutf8(amf_dll_path, &amf_dll_path_utf8)) {
++            amf_lib = dlopen(amf_dll_path_utf8, RTLD_NOW | RTLD_LOCAL);
++            av_free(amf_dll_path_utf8);
++        }
++    }
++    if (!amf_lib) {
++        amf_lib = dlopen(AMF_DLL_NAMEA, RTLD_NOW | RTLD_LOCAL);
++        if (!amf_lib)
++            return AVERROR(ENOSYS);
++    }
++
++    if (!amf_ver_fn) {
++        amf_ver_fn = (AMFQueryVersion_Fn)dlsym(amf_lib, AMF_QUERY_VERSION_FUNCTION_NAME);
++        if (!amf_ver_fn) {
++            ret = AVERROR(ENOSYS);
++            goto exit;
++        }
++        res = amf_ver_fn(&amf_ver);
++        if (res != AMF_OK) {
++            ret = AVERROR(ENOSYS);
++            goto exit;
++        }
++    }
++
++    if (!amf_init_fn) {
++        amf_init_fn = (AMFInit_Fn)dlsym(amf_lib, AMF_INIT_FUNCTION_NAME);
++        if (!amf_init_fn) {
++            ret = AVERROR(ENOSYS);
++            goto exit;
++        }
++    }
++
++    if (!amf_factory) {
++        res = amf_init_fn(AMF_FULL_VERSION, &amf_factory);
++        if (res != AMF_OK) {
++            ret = AVERROR(ENOSYS);
++            goto exit;
++        }
++    }
++
++    if (amf_ctx) {
++        amf_ctx->pVtbl->Terminate(amf_ctx);
++        amf_ctx->pVtbl->Release(amf_ctx);
++        amf_ctx = NULL;
++    }
++
++    res = amf_factory->pVtbl->CreateContext(amf_factory, &amf_ctx);
++    if (res != AMF_OK) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    return 0;
++exit:
++    uninit_amf_functions();
++#endif
++    return ret;
++}
++
++void uninit_amf_functions(void)
++{
++#if (CONFIG_AMF && CONFIG_D3D11VA)
++    if (amf_ctx) {
++        amf_ctx->pVtbl->Terminate(amf_ctx);
++        amf_ctx->pVtbl->Release(amf_ctx);
++        amf_ctx = NULL;
++    }
++    if (amf_lib) {
++        dlclose(amf_lib);
++        amf_lib = NULL;
++        amf_init_fn = NULL;
++        amf_ver_fn = NULL;
++    }
++    amf_ver = 0;
++    amf_factory = NULL;
++#endif
++}
++
++int create_derive_amf_device_from_d3d11va(AVBufferRef *d3d11va_ref, const wchar_t *amf_dll_path)
++{
++    int ret = AVERROR(ENOSYS);
++#if (CONFIG_AMF && CONFIG_D3D11VA)
++    AVHWDeviceContext    *dev_ctx = NULL;
++    AVD3D11VADeviceContext *hwctx = NULL;
++    AMF_RESULT res = AMF_OK;
++
++    if (!d3d11va_ref)
++        return AVERROR(EINVAL);
++    if ((ret = init_amf_functions(amf_dll_path)) < 0)
++        goto exit;
++
++    dev_ctx = (AVHWDeviceContext*)d3d11va_ref->data;
++    hwctx = dev_ctx->hwctx;
++
++    res = amf_ctx->pVtbl->InitDX11(amf_ctx, hwctx->device, AMF_DX11_1);
++    if (res != AMF_OK && res != AMF_ALREADY_INITIALIZED) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++    return 0;
++exit:
++#endif
++    return ret;
++}
++
++int print_amf_device_info_from_d3d11va(AVTextFormatContext *tfc)
++{
++#if (CONFIG_AMF && CONFIG_D3D11VA)
++    static const amf_uint64 api_ver = AMF_FULL_VERSION;
++
++    if (!tfc || !amf_ctx)
++        return AVERROR(EINVAL);
++
++    mark_section_show_entries(SECTION_ID_DEVICE_INFO_AMF, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_INFO_AMF);
++
++    print_int("device_amf_impl_version_major", AMF_GET_MAJOR_VERSION(amf_ver));
++    print_int("device_amf_impl_version_minor", AMF_GET_MINOR_VERSION(amf_ver));
++    print_int("device_amf_impl_version_sub_minor", AMF_GET_SUBMINOR_VERSION(amf_ver));
++    print_int("device_amf_impl_version_build", AMF_GET_BUILD_VERSION(amf_ver));
++    print_int("device_amf_api_version_major", AMF_GET_MAJOR_VERSION(api_ver));
++    print_int("device_amf_api_version_minor", AMF_GET_MINOR_VERSION(api_ver));
++    print_int("device_amf_api_version_sub_minor", AMF_GET_SUBMINOR_VERSION(api_ver));
++    print_int("device_amf_api_version_build", AMF_GET_BUILD_VERSION(api_ver));
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_INFO_AMF
++#endif
++    return 0;
++}
++
++#if (CONFIG_AMF && CONFIG_D3D11VA)
++static int amf_map_av_to_amfenc_profile(enum AVCodecID codec, int profile)
++{
++    if (codec == AV_CODEC_ID_H264) {
++        switch (profile) {
++        case AV_PROFILE_H264_BASELINE:             return AMF_VIDEO_ENCODER_PROFILE_BASELINE;
++        case AV_PROFILE_H264_CONSTRAINED_BASELINE: return AMF_VIDEO_ENCODER_PROFILE_CONSTRAINED_BASELINE;
++        case AV_PROFILE_H264_MAIN:                 return AMF_VIDEO_ENCODER_PROFILE_MAIN;
++        case AV_PROFILE_H264_HIGH:                 return AMF_VIDEO_ENCODER_PROFILE_HIGH;
++        }
++    } else if (codec == AV_CODEC_ID_HEVC) {
++        switch (profile) {
++        case AV_PROFILE_HEVC_MAIN:    return AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN;
++        case AV_PROFILE_HEVC_MAIN_10: return AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN_10;
++        }
++    } else if (codec == AV_CODEC_ID_AV1) {
++        switch (profile) {
++        case AV_PROFILE_AV1_MAIN:     return AMF_VIDEO_ENCODER_AV1_PROFILE_MAIN;
++        }
++    }
++
++    return -1;
++}
++
++static AMF_SURFACE_FORMAT amf_map_av_to_amf_surface_format(enum AVPixelFormat pix_fmt)
++{
++    switch (pix_fmt) {
++    case AV_PIX_FMT_YUV420P: return AMF_SURFACE_YUV420P;
++    case AV_PIX_FMT_NV12:    return AMF_SURFACE_NV12;
++    case AV_PIX_FMT_P010:    return AMF_SURFACE_P010;
++    case AV_PIX_FMT_YUYV422: return AMF_SURFACE_YUY2;
++    case AV_PIX_FMT_GRAY8:   return AMF_SURFACE_GRAY8;
++    case AV_PIX_FMT_BGR0:    return AMF_SURFACE_BGRA;
++    case AV_PIX_FMT_RGB0:    return AMF_SURFACE_RGBA;
++    case AV_PIX_FMT_BGRA:    return AMF_SURFACE_BGRA;
++    case AV_PIX_FMT_ARGB:    return AMF_SURFACE_ARGB;
++    case AV_PIX_FMT_RGBA:    return AMF_SURFACE_RGBA;
++    case AV_PIX_FMT_X2BGR10: return AMF_SURFACE_R10G10B10A2;
++    default:                 return AMF_SURFACE_UNKNOWN;
++    }
++}
++#endif
++
++int print_amf_encoder_info_from_d3d11va(AVTextFormatContext *tfc)
++{
++#if (CONFIG_AMF && CONFIG_D3D11VA)
++    AMF_RESULT res = AMF_OK;
++    int header_printed = 0;
++    unsigned i, j, k;
++
++    if (!tfc || !amf_ctx || !amf_factory)
++        return AVERROR(EINVAL);
++
++    for (i = 0; amfenc_modes[i].name; i++) {
++        int header2_printed = 0;
++        int header3_printed = 0;
++        AMFComponent *encoder = NULL;
++        AMFCaps *encoder_caps = NULL;
++        AMFIOCaps *input_caps = NULL;
++        const AmfEncMode *mode = &amfenc_modes[i];
++        int max_depth = 8;
++        amf_int64 max_profile = -1;
++        amf_int32 num_formats = 0;
++
++        if (!mode->comp_name || !mode->formats || !mode->caps)
++            continue;
++
++        res = amf_factory->pVtbl->CreateComponent(amf_factory, amf_ctx, mode->comp_name, &encoder);
++        if (res != AMF_OK || !encoder)
++            continue;
++
++        if (!header_printed) {
++            mark_section_show_entries(SECTION_ID_DEVICE_ENCODERS_AMF, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_ENCODERS_AMF);
++            header_printed = 1;
++        }
++
++        mark_section_show_entries(SECTION_ID_DEVICE_ENCODER, 1, NULL);
++        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_ENCODER);
++        print_str("codec_name", avcodec_get_name(mode->codec));
++        print_int("codec_id", mode->codec);
++        print_str("codec_desc", mode->name);
++
++        res = encoder->pVtbl->GetCaps(encoder, &encoder_caps);
++        if (res == AMF_OK && encoder_caps) {
++            res = encoder_caps->pVtbl->GetInputCaps(encoder_caps, &input_caps);
++            if (res == AMF_OK && input_caps) {
++                amf_int32 min_w = 0, max_w = 0;
++                amf_int32 min_h = 0, max_h = 0;
++                amf_int32 vert_align = 0;
++                amf_bool interlaced_support = 0;
++
++                input_caps->pVtbl->GetWidthRange(input_caps, &min_w, &max_w);
++                input_caps->pVtbl->GetHeightRange(input_caps, &min_h, &max_h);
++                print_int("min_width",  min_w);
++                print_int("min_height", min_h);
++                print_int("max_width",  max_w);
++                print_int("max_height", max_h);
++                vert_align = input_caps->pVtbl->GetVertAlign(input_caps);
++                print_int("vertical_align", vert_align);
++                interlaced_support = input_caps->pVtbl->IsInterlacedSupported(input_caps);
++                print_int("interlaced_support", interlaced_support);
++
++                num_formats = input_caps->pVtbl->GetNumOfFormats(input_caps);
++            }
++
++            for (j = 0; j < mode->nb_caps; j++) {
++                AMFVariantStruct val = { 0 };
++
++                res = encoder_caps->pVtbl->GetProperty(encoder_caps, mode->caps[j].cap_val, &val);
++                if (res == AMF_OK) {
++                    if (val.type == AMF_VARIANT_BOOL)
++                        print_int(mode->caps[j].cap_str, val.boolValue);
++                    else if (val.type == AMF_VARIANT_INT64) {
++                        print_int(mode->caps[j].cap_str, val.int64Value);
++
++                        if (!wcscmp(mode->caps[j].cap_val, AMF_VIDEO_ENCODER_CAP_MAX_PROFILE) ||
++                            !wcscmp(mode->caps[j].cap_val, AMF_VIDEO_ENCODER_HEVC_CAP_MAX_PROFILE) ||
++                            !wcscmp(mode->caps[j].cap_val, AMF_VIDEO_ENCODER_AV1_CAP_MAX_PROFILE)) {
++                            max_profile = val.int64Value;
++                        }
++                    }
++                    AMFVariantClear(&val);
++                }
++            }
++
++            /* Formats */
++            for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++                AMF_SURFACE_FORMAT surface_format = AMF_SURFACE_UNKNOWN;
++
++                if (!num_formats)
++                    break;
++
++                surface_format = amf_map_av_to_amf_surface_format(mode->formats[j]);
++                if (surface_format == AMF_SURFACE_UNKNOWN)
++                    continue;
++
++                for (k = 0; k < num_formats; k++) {
++                    AMF_SURFACE_FORMAT input_format = AMF_SURFACE_UNKNOWN;
++                    amf_bool is_native = 0;
++
++                    res = input_caps->pVtbl->GetFormatAt(input_caps, k, &input_format, &is_native);
++                    if (res != AMF_OK)
++                        continue;
++
++                    if (surface_format == input_format) {
++                        const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(mode->formats[j]);
++
++                        if (desc)
++                            max_depth = FFMAX(FFMIN(desc->comp[0].depth, 12), max_depth);
++
++                        if (!header2_printed) {
++                            mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                            header2_printed = 1;
++                        }
++                        mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++                        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++                        print_str("format_name", av_get_pix_fmt_name(mode->formats[j]));
++                        print_int("format_id", mode->formats[j]);
++                        print_int("is_native", is_native);
++                        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++                        break;
++                    }
++                }
++            }
++            if (header2_printed)
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++            /* Profiles */
++            for (j = 0; mode->profiles[j] != AV_PROFILE_UNKNOWN; j++) {
++                const int amf_profile = amf_map_av_to_amfenc_profile(mode->codec, mode->profiles[j]);
++
++                /* Fixup legacy drivers */
++                if (mode->codec == AV_CODEC_ID_HEVC && max_depth >= 10)
++                    max_profile = AMF_VIDEO_ENCODER_HEVC_PROFILE_MAIN_10;
++
++                if (amf_profile >= 0 && max_profile >= 0 && amf_profile <= max_profile) {
++                    if (!header3_printed) {
++                        mark_section_show_entries(SECTION_ID_DEVICE_PROFILES, 1, NULL);
++                        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILES);
++                        header3_printed = 1;
++                    }
++                    mark_section_show_entries(SECTION_ID_DEVICE_PROFILE, 1, NULL);
++                    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILE);
++                    print_str("profile_name", avcodec_profile_name(mode->codec, mode->profiles[j]));
++                    print_int("profile_id", mode->profiles[j]);
++                    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILE
++                }
++            }
++            if (header3_printed)
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILES
++
++            if (input_caps)
++                input_caps->pVtbl->Release(input_caps);
++        }
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_ENCODER
++
++        if (encoder_caps)
++            encoder_caps->pVtbl->Release(encoder_caps);
++        if (encoder) {
++            encoder->pVtbl->Terminate(encoder);
++            encoder->pVtbl->Release(encoder);
++        }
++    }
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_ENCODERS_AMF
++#endif
++    return 0;
++}
+Index: FFmpeg/fftools/ffprobe_hw_cuda.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_cuda.c
+@@ -0,0 +1,1305 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "ffprobe_hw_internal.h"
++
++#if CONFIG_CUDA
++#   define CHECK_CU(x) FF_CUDA_CHECK_DL(NULL, cu, x)
++#   define CHECK_CU_EXT(x) FF_CUDA_CHECK_DL(NULL, cu_ext, x)
++#   define CHECK_ML(x) FF_NVML_CHECK_DL(NULL, nvml_ext, x)
++#   include "libavutil/cuda_check.h"
++#   include "libavutil/hwcontext_cuda_internal.h"
++#endif
++
++#if CONFIG_CUDA
++static CudaFunctionsExt *cu_ext = NULL;
++static NvmlFunctionsExt *nvml_ext = NULL;
++static char drv_ver[NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE+1] = { 0 };
++static char nvml_ver[NVML_SYSTEM_NVML_VERSION_BUFFER_SIZE+1] = { 0 };
++
++static const struct {
++    const int   attr_val;
++    const char *attr_str;
++} cuda_device_attrs[] = {
++    { 13 /* CU_DEVICE_ATTRIBUTE_CLOCK_RATE */,               "device_clock_rate"               },
++    { 14 /* CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT */,        "device_texture_alignment"        },
++    { 16 /* CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT */,     "device_multiprocessor_count"     },
++    { 18 /* CU_DEVICE_ATTRIBUTE_INTEGRATED */,               "device_integrated"               },
++    { 19 /* CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY */,      "device_can_map_host_memory"      },
++    { 20 /* CU_DEVICE_ATTRIBUTE_COMPUTE_MODE */,             "device_compute_mode"             },
++    { 31 /* CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS */,       "device_concurrent_kernels"       },
++    { 33 /* CU_DEVICE_ATTRIBUTE_PCI_BUS_ID */,               "device_pci_bus_id"               },
++    { 34 /* CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID */,            "device_pci_device_id"            },
++    { 35 /* CU_DEVICE_ATTRIBUTE_TCC_DRIVER */,               "device_tcc_driver"               },
++    { 36 /* CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE */,        "device_memory_clock_rate"        },
++    { 37 /* CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH */,  "device_global_memory_bus_width"  },
++    { 40 /* CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT */,       "device_async_engine_count"       },
++    { 41 /* CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING */,       "device_unified_addressing"       },
++    { 50 /* CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID */,            "device_pci_domain_id"            },
++    { 51 /* CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT */,  "device_texture_pitch_alignment"  },
++    { 75 /* CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR */, "device_compute_capability_major" },
++    { 76 /* CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR */, "device_compute_capability_minor" },
++    { 83 /* CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY */,           "device_managed_memory"           },
++    { 84 /* CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD */,          "device_multi_gpu_board"          },
++    { 85 /* CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID */, "device_multi_gpu_board_group_id" },
++};
++#endif
++
++#if (CONFIG_CUDA && (CONFIG_CUVID || CONFIG_NVDEC))
++#   if defined(NVDECAPI_MAJOR_VERSION) && defined(NVDECAPI_MINOR_VERSION)
++#   define NVDECAPI_CHECK_VERSION(major, minor) \
++        ((major) < NVDECAPI_MAJOR_VERSION || \
++         ((major) == NVDECAPI_MAJOR_VERSION && \
++          (minor) <= NVDECAPI_MINOR_VERSION))
++#   else
++/* version macros were added in SDK 8.1 ffnvcodec */
++#   define NVDECAPI_CHECK_VERSION(major, minor) \
++        ((major) < 8 || ((major) == 8 && (minor) <= 0))
++#   endif
++
++static CuvidFunctions *cuvid = NULL;
++
++typedef struct CuvidMode {
++    const char               *name;
++    const enum AVCodecID      codec;
++    const enum AVPixelFormat *formats;
++} CuvidMode;
++
++static const enum AVPixelFormat dec_formats_8_420[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat dec_formats_8_10_420[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat dec_formats_8_10_420_422[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_P210,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat dec_formats_8_12_420[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++#   if !FF_API_NVDEC_OLD_PIX_FMTS
++    AV_PIX_FMT_P012,
++#   else
++    AV_PIX_FMT_P016,
++#   endif
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat dec_formats_8_12_420_422_444[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,
++    AV_PIX_FMT_YUV444P,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_P210,
++#   if !FF_API_NVDEC_OLD_PIX_FMTS
++    AV_PIX_FMT_P012,
++    AV_PIX_FMT_P212,
++    AV_PIX_FMT_YUV444P10MSB,
++    AV_PIX_FMT_YUV444P12MSB,
++#   else
++    AV_PIX_FMT_P016,
++    AV_PIX_FMT_P216,
++    AV_PIX_FMT_YUV444P16,
++#   endif
++    AV_PIX_FMT_NONE
++};
++
++static const CuvidMode cuvid_modes[] = {
++    { "NVDEC/CUVID MPEG-1 Decoder", AV_CODEC_ID_MPEG1VIDEO, dec_formats_8_420            },
++    { "NVDEC/CUVID MPEG-2 Decoder", AV_CODEC_ID_MPEG2VIDEO, dec_formats_8_420            },
++    { "NVDEC/CUVID MPEG-4 Decoder", AV_CODEC_ID_MPEG4,      dec_formats_8_420            },
++    { "NVDEC/CUVID VC-1 Decoder",   AV_CODEC_ID_VC1,        dec_formats_8_420            },
++    { "NVDEC/CUVID H.264 Decoder",  AV_CODEC_ID_H264,       dec_formats_8_10_420_422     },
++    { "NVDEC/CUVID MJPEG Decoder",  AV_CODEC_ID_MJPEG,      dec_formats_8_420            },
++    { "NVDEC/CUVID HEVC Decoder",   AV_CODEC_ID_HEVC,       dec_formats_8_12_420_422_444 },
++    { "NVDEC/CUVID VP8 Decoder",    AV_CODEC_ID_VP8,        dec_formats_8_420            },
++    { "NVDEC/CUVID VP9 Decoder",    AV_CODEC_ID_VP9,        dec_formats_8_12_420         },
++    { "NVDEC/CUVID AV1 Decoder",    AV_CODEC_ID_AV1,        dec_formats_8_10_420         },
++    { NULL, 0, NULL },
++};
++#endif
++
++#if (CONFIG_CUDA && CONFIG_NVENC)
++#   define NVENCAPI_CHECK_VERSION(major, minor) \
++        ((major) < NVENCAPI_MAJOR_VERSION || \
++         ((major) == NVENCAPI_MAJOR_VERSION && \
++          (minor) <= NVENCAPI_MINOR_VERSION))
++
++static NvencFunctions *nvenc = NULL;
++static NV_ENCODE_API_FUNCTION_LIST nvenc_fns;
++
++typedef struct NvencMode {
++    const char               *name;
++    const enum AVCodecID      codec;
++    const int                *profiles;
++    const enum AVPixelFormat *formats;
++} NvencMode;
++
++static const int enc_profiles_h264[] = {
++    AV_PROFILE_H264_BASELINE,
++    AV_PROFILE_H264_MAIN,
++    AV_PROFILE_H264_HIGH,
++    AV_PROFILE_H264_HIGH_10,
++    AV_PROFILE_H264_HIGH_422,
++    AV_PROFILE_H264_HIGH_444_PREDICTIVE,
++    AV_PROFILE_UNKNOWN
++};
++static const int enc_profiles_hevc[] = {
++    AV_PROFILE_HEVC_MAIN,
++    AV_PROFILE_HEVC_MAIN_10,
++    AV_PROFILE_HEVC_REXT,
++    AV_PROFILE_UNKNOWN
++};
++static const int enc_profiles_av1[]  = {
++    AV_PROFILE_AV1_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++
++static const enum AVPixelFormat enc_formats_8_10_yuv_rgb[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,
++    AV_PIX_FMT_YUV420P,
++    AV_PIX_FMT_YUV444P,
++    AV_PIX_FMT_RGB32,
++    AV_PIX_FMT_0RGB32,
++    AV_PIX_FMT_BGR32,
++    AV_PIX_FMT_0BGR32,
++    AV_PIX_FMT_GBRP,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_P016,
++    AV_PIX_FMT_P210,
++    AV_PIX_FMT_P216,
++    AV_PIX_FMT_YUV444P10MSB,
++    AV_PIX_FMT_YUV444P16,
++    AV_PIX_FMT_X2RGB10,
++    AV_PIX_FMT_X2BGR10,
++    AV_PIX_FMT_GBRP10MSB,
++    AV_PIX_FMT_GBRP16,
++    AV_PIX_FMT_NONE
++};
++
++static const NvencMode nvenc_modes[] = {
++    { "NVENC H.264 Encoder", AV_CODEC_ID_H264, enc_profiles_h264, enc_formats_8_10_yuv_rgb },
++    { "NVENC HEVC Encoder",  AV_CODEC_ID_HEVC, enc_profiles_hevc, enc_formats_8_10_yuv_rgb },
++    { "NVENC AV1 Encoder",   AV_CODEC_ID_AV1,  enc_profiles_av1,  enc_formats_8_10_yuv_rgb },
++    { NULL, 0, NULL },
++};
++
++static const struct {
++    const int   cap_val;
++    const char *cap_str;
++} nvenc_codec_caps[] = {
++    { NV_ENC_CAPS_NUM_MAX_BFRAMES,                "max_b_frames"                       },
++    { NV_ENC_CAPS_SUPPORTED_RATECONTROL_MODES,    "rate_control_modes_mask"            },
++    { NV_ENC_CAPS_SUPPORT_FIELD_ENCODING,         "support_field_encoding"             },
++    { NV_ENC_CAPS_SUPPORT_MONOCHROME,             "support_monochrome"                 },
++    { NV_ENC_CAPS_SUPPORT_FMO,                    "support_fmo"                        },
++    { NV_ENC_CAPS_SUPPORT_QPELMV,                 "support_qp_motion_estimation"       },
++    { NV_ENC_CAPS_SUPPORT_BDIRECT_MODE,           "support_bi_direct"                  },
++    { NV_ENC_CAPS_SUPPORT_CABAC,                  "support_cabac"                      },
++    { NV_ENC_CAPS_SUPPORT_ADAPTIVE_TRANSFORM,     "support_adaptive_transform"         },
++    { NV_ENC_CAPS_SUPPORT_STEREO_MVC,             "support_stereo_mvc"                 },
++    { NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS,        "support_max_temporal_layers"        },
++    { NV_ENC_CAPS_SUPPORT_HIERARCHICAL_PFRAMES,   "support_hierarchical_p_frames"      },
++    { NV_ENC_CAPS_SUPPORT_HIERARCHICAL_BFRAMES,   "support_hierarchical_b_frames"      },
++    { NV_ENC_CAPS_LEVEL_MAX,                      "max_level"                          },
++    { NV_ENC_CAPS_LEVEL_MIN,                      "min_level"                          },
++    { NV_ENC_CAPS_SEPARATE_COLOUR_PLANE,          "support_separate_colour_plane"      },
++    { NV_ENC_CAPS_WIDTH_MAX,                      "max_width"                          },
++    { NV_ENC_CAPS_HEIGHT_MAX,                     "max_height"                         },
++    { NV_ENC_CAPS_SUPPORT_TEMPORAL_SVC,           "support_temporal_svc"               },
++    { NV_ENC_CAPS_SUPPORT_DYN_RES_CHANGE,         "support_dyn_res_change"             },
++    { NV_ENC_CAPS_SUPPORT_DYN_BITRATE_CHANGE,     "support_dyn_bitrate_change"         },
++    { NV_ENC_CAPS_SUPPORT_DYN_FORCE_CONSTQP,      "support_dyn_force_const_qp"         },
++    { NV_ENC_CAPS_SUPPORT_DYN_RCMODE_CHANGE,      "support_dyn_rc_mode_change"         },
++    { NV_ENC_CAPS_SUPPORT_SUBFRAME_READBACK,      "support_sub_frame_readback"         },
++    { NV_ENC_CAPS_SUPPORT_CONSTRAINED_ENCODING,   "support_constrained_encoding"       },
++    { NV_ENC_CAPS_SUPPORT_INTRA_REFRESH,          "support_intra_refresh"              },
++    { NV_ENC_CAPS_SUPPORT_CUSTOM_VBV_BUF_SIZE,    "support_custom_vbv_buf_size"        },
++    { NV_ENC_CAPS_SUPPORT_DYNAMIC_SLICE_MODE,     "support_dyn_slice_mode"             },
++    { NV_ENC_CAPS_SUPPORT_REF_PIC_INVALIDATION,   "support_ref_pic_invalidation"       },
++    { NV_ENC_CAPS_PREPROC_SUPPORT,                "pre_proc_mask"                      },
++    { NV_ENC_CAPS_ASYNC_ENCODE_SUPPORT,           "support_async_encode"               },
++    { NV_ENC_CAPS_MB_NUM_MAX,                     "max_mb_per_frame"                   },
++    { NV_ENC_CAPS_MB_PER_SEC_MAX,                 "max_mb_per_sec"                     },
++    { NV_ENC_CAPS_SUPPORT_YUV444_ENCODE,          "support_yuv444_encode"              },
++    { NV_ENC_CAPS_SUPPORT_LOSSLESS_ENCODE,        "support_lossless_encode"            },
++    { NV_ENC_CAPS_SUPPORT_SAO,                    "support_sao"                        },
++    { NV_ENC_CAPS_SUPPORT_MEONLY_MODE,            "support_me_only_mode"               },
++    { NV_ENC_CAPS_SUPPORT_LOOKAHEAD,              "support_lookahead"                  },
++    { NV_ENC_CAPS_SUPPORT_TEMPORAL_AQ,            "support_intra_temporal_aq"          },
++    { NV_ENC_CAPS_SUPPORT_10BIT_ENCODE,           "support_10bit_encode"               },
++    { NV_ENC_CAPS_NUM_MAX_LTR_FRAMES,             "max_ltr_frames"                     },
++    { NV_ENC_CAPS_SUPPORT_WEIGHTED_PREDICTION,    "support_weight_prediction"          },
++#   if NVENCAPI_CHECK_VERSION(8, 1)
++    { NV_ENC_CAPS_DYNAMIC_QUERY_ENCODER_CAPACITY, "support_dyn_query_encoder_capacity" },
++    { NV_ENC_CAPS_SUPPORT_BFRAME_REF_MODE,        "support_bframe_ref_mode"            },
++    { NV_ENC_CAPS_SUPPORT_EMPHASIS_LEVEL_MAP,     "support_emphasis_level_map"         },
++#   endif
++#   if NVENCAPI_CHECK_VERSION(9, 1)
++    { NV_ENC_CAPS_WIDTH_MIN,                      "min_width"                          },
++    { NV_ENC_CAPS_HEIGHT_MIN,                     "min_height"                         },
++    { NV_ENC_CAPS_SUPPORT_MULTIPLE_REF_FRAMES,    "support_multi_ref_frames"           },
++#   endif
++#   if NVENCAPI_CHECK_VERSION(11, 0)
++    { NV_ENC_CAPS_SUPPORT_ALPHA_LAYER_ENCODING,   "support_alpha_layer_encoding"       },
++    { NV_ENC_CAPS_NUM_ENCODER_ENGINES,            "encoder_engines"                    },
++#   endif
++#   if NVENCAPI_CHECK_VERSION(11, 1)
++    { NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH,     "support_single_slice_intra_refresh" },
++#   endif
++#   if NVENCAPI_CHECK_VERSION(12, 1)
++    { NV_ENC_CAPS_DISABLE_ENC_STATE_ADVANCE,      "disable_enc_state_advance"          },
++    { NV_ENC_CAPS_OUTPUT_RECON_SURFACE,           "output_recon_surface"               },
++    { NV_ENC_CAPS_OUTPUT_BLOCK_STATS,             "output_block_stats"                 },
++    { NV_ENC_CAPS_OUTPUT_ROW_STATS,               "output_row_stats"                   },
++#   endif
++#   if NVENCAPI_CHECK_VERSION(12, 2)
++    { NV_ENC_CAPS_SUPPORT_TEMPORAL_FILTER,        "support_temporal_filter"            },
++    { NV_ENC_CAPS_SUPPORT_LOOKAHEAD_LEVEL,        "support_lookahead_level"            },
++    { NV_ENC_CAPS_SUPPORT_UNIDIRECTIONAL_B,       "support_unidirectional_b"           },
++#   endif
++#   if NVENCAPI_CHECK_VERSION(13, 0)
++    { NV_ENC_CAPS_SUPPORT_MVHEVC_ENCODE,          "support_mvhevc_encode"              },
++    { NV_ENC_CAPS_SUPPORT_YUV422_ENCODE,          "support_yuv422_encode"              },
++#   endif
++};
++
++static const struct {
++    const GUID *preset_val;
++    const char *preset_str;
++} nvenc_codec_presets[] = {
++#   if NVENCAPI_CHECK_VERSION(10, 0)
++    { &NV_ENC_PRESET_P1_GUID,                  "p1"         },
++    { &NV_ENC_PRESET_P2_GUID,                  "p2"         },
++    { &NV_ENC_PRESET_P3_GUID,                  "p3"         },
++    { &NV_ENC_PRESET_P4_GUID,                  "p4"         },
++    { &NV_ENC_PRESET_P5_GUID,                  "p5"         },
++    { &NV_ENC_PRESET_P6_GUID,                  "p6"         },
++    { &NV_ENC_PRESET_P7_GUID,                  "p7"         },
++#   else
++    { &NV_ENC_PRESET_DEFAULT_GUID,             "default"    },
++    { &NV_ENC_PRESET_HP_GUID,                  "hp"         },
++    { &NV_ENC_PRESET_HQ_GUID,                  "hq"         },
++    { &NV_ENC_PRESET_BD_GUID,                  "bd"         },
++    { &NV_ENC_PRESET_LOW_LATENCY_DEFAULT_GUID, "ll"         },
++    { &NV_ENC_PRESET_LOW_LATENCY_HQ_GUID,      "llhq"       },
++    { &NV_ENC_PRESET_LOW_LATENCY_HP_GUID,      "llhp"       },
++    { &NV_ENC_PRESET_LOSSLESS_DEFAULT_GUID,    "lossless"   },
++    { &NV_ENC_PRESET_LOSSLESS_HP_GUID,         "losslesshp" },
++#   endif
++};
++#endif
++
++int init_cuda_functions(void)
++{
++#if CONFIG_CUDA
++    int ret = 0;
++
++    if (!cu_ext) {
++        ret = cuda_ext_load_functions(&cu_ext, NULL);
++        if (ret < 0)
++            goto exit;
++
++        ret = CHECK_CU_EXT(cu_ext->cuInit(0));
++        if (ret < 0)
++            goto exit;
++    }
++    return 0;
++exit:
++    if (cu_ext)
++        cuda_ext_free_functions(&cu_ext);
++    return ret;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++void uninit_cuda_functions(void)
++{
++#if CONFIG_CUDA
++    if (cu_ext)
++        cuda_ext_free_functions(&cu_ext);
++#endif
++}
++
++int init_nvml_functions(void)
++{
++#if CONFIG_CUDA
++    int ret = 0;
++
++    if (!nvml_ext) {
++        ret = nvml_ext_load_functions(&nvml_ext, NULL);
++        if (ret < 0)
++            goto exit;
++
++        ret = CHECK_ML(nvml_ext->nvmlInit());
++        if (ret < 0)
++            goto exit;
++    }
++    return 0;
++exit:
++    if (nvml_ext) {
++        CHECK_ML(nvml_ext->nvmlShutdown());
++        nvml_ext_free_functions(&nvml_ext);
++    }
++    return ret;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++void uninit_nvml_functions(void)
++{
++#if CONFIG_CUDA
++    if (nvml_ext) {
++        CHECK_ML(nvml_ext->nvmlShutdown());
++        nvml_ext_free_functions(&nvml_ext);
++    }
++#endif
++}
++
++int init_cuvid_functions(void)
++{
++#if (CONFIG_CUDA && (CONFIG_CUVID || CONFIG_NVDEC))
++    int ret = 0;
++
++    if (!cuvid) {
++        ret = cuvid_load_functions(&cuvid, NULL);
++        if (ret < 0)
++            goto exit;
++    }
++    return 0;
++exit:
++    if (cuvid)
++        cuvid_free_functions(&cuvid);
++    return ret;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++void uninit_cuvid_functions(void)
++{
++#if (CONFIG_CUDA && (CONFIG_CUVID || CONFIG_NVDEC))
++    if (cuvid)
++        cuvid_free_functions(&cuvid);
++#endif
++}
++
++int init_nvenc_functions(void)
++{
++#if (CONFIG_CUDA && CONFIG_NVENC)
++    int ret = 0;
++    uint32_t max_ver = 0;
++    NVENCSTATUS err = 0;
++
++    if (!nvenc) {
++        ret = nvenc_load_functions(&nvenc, NULL);
++        if (ret < 0)
++            goto exit;
++
++        err = nvenc->NvEncodeAPIGetMaxSupportedVersion(&max_ver);
++        if (err != NV_ENC_SUCCESS) {
++            ret = AVERROR(ENOSYS);
++            goto exit;
++        }
++
++        av_log(NULL, AV_LOG_DEBUG, "Loaded Nvenc version %d.%d\n",
++               max_ver >> 4, max_ver & 0xF);
++
++        if ((NVENCAPI_MAJOR_VERSION << 4 | NVENCAPI_MINOR_VERSION) > max_ver) {
++            av_log(NULL, AV_LOG_DEBUG, "Driver does not support the required Nvenc API version. "
++                   "Required: %d.%d Found: %d.%d\n",
++                   NVENCAPI_MAJOR_VERSION, NVENCAPI_MINOR_VERSION,
++                   max_ver >> 4, max_ver & 0xF);
++            ret = AVERROR(ENOSYS);
++            goto exit;
++        }
++
++        nvenc_fns.version = NV_ENCODE_API_FUNCTION_LIST_VER;
++        err = nvenc->NvEncodeAPICreateInstance(&nvenc_fns);
++        if (err != NV_ENC_SUCCESS) {
++            av_log(NULL, AV_LOG_DEBUG, "Failed to create Nvenc instance\n");
++            ret = AVERROR(ENOSYS);
++            goto exit;
++        }
++    }
++    return 0;
++exit:
++    if (nvenc)
++        nvenc_free_functions(&nvenc);
++    return ret;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++void uninit_nvenc_functions(void)
++{
++#if (CONFIG_CUDA && CONFIG_NVENC)
++    if (nvenc)
++        nvenc_free_functions(&nvenc);
++#endif
++}
++
++/* CUDA */
++int create_cuda_devices(HwDeviceRefs *refs, int device_idx)
++{
++#if CONFIG_CUDA
++    unsigned i, j;
++    const int start_idx = device_idx < 0 ? 0 : device_idx;
++    int n = 0, ret = 0;
++    char ibuf[4];
++
++    if ((ret = init_cuda_functions()) < 0)
++        goto exit;
++
++    ret = CHECK_CU_EXT(cu_ext->cuDeviceGetCount(&n));
++    if (ret < 0)
++        goto exit;
++
++    if (n <= 0) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    n = FFMIN(n, FFPROBE_HW_MAX_DEV_NUM);
++    for (i = start_idx, j = 0; i < n && refs; i++) {
++        snprintf(ibuf, sizeof(ibuf), "%d", i);
++        ret = av_hwdevice_ctx_create(&refs[j].cuda_ref, AV_HWDEVICE_TYPE_CUDA,
++                                     ibuf, NULL, 0);
++        if (ret < 0) {
++            if (device_idx < 0) continue;
++            else break;
++        }
++
++        refs[j].device_index_cuda = i;
++        refs[j].device_vendor_id  = FFPROBE_HW_VENDOR_ID_NVIDIA;
++        j++;
++
++        /* Filter by the requested device index */
++        if (device_idx >= 0)
++            break;
++    }
++
++    ret = 0;
++
++exit:
++    return ret;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++/* CUDA -> D3D11VA */
++void create_derive_d3d11va_devices_from_cuda(HwDeviceRefs *refs)
++{
++#if (CONFIG_CUDA && CONFIG_D3D11VA)
++    int ret = 0;
++
++    if (!refs)
++        return;
++    if ((ret = init_cuda_functions()) < 0)
++        return;
++    if (!cu_ext->cuDeviceGetLuid)
++        return;
++
++    for (unsigned i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs[i].cuda_ref; i++) {
++        AVHWDeviceContext *dev_ctx = NULL;
++        AVCUDADeviceContext *hwctx = NULL;
++        CudaFunctions *cu = NULL;
++        char cuda_luid[8] = { 0 };
++        int is_tcc_drv = 0;
++        unsigned node_mask = 0;
++
++        dev_ctx = (AVHWDeviceContext*)refs[i].cuda_ref->data;
++        if (!dev_ctx)
++            continue;
++
++        hwctx = dev_ctx->hwctx;
++        cu = hwctx->internal->cuda_dl;
++
++        /* Values are undefined on TCC and non-Windows platforms */
++        ret = CHECK_CU(cu->cuDeviceGetAttribute(&is_tcc_drv,
++                                                35 /* CU_DEVICE_ATTRIBUTE_TCC_DRIVER */,
++                                                hwctx->internal->cuda_device));
++        if (ret < 0 || is_tcc_drv)
++            continue;
++
++        ret = CHECK_CU_EXT(cu_ext->cuDeviceGetLuid(cuda_luid, &node_mask,
++                                                   hwctx->internal->cuda_device));
++        if (ret < 0)
++            continue;
++
++        create_d3d11va_devices_with_filter(refs, FFPROBE_HW_VENDOR_ID_NVIDIA, i, cuda_luid, -1);
++    }
++#endif
++}
++
++int init_nvml_driver_version(void)
++{
++#if CONFIG_CUDA
++    int ret = 0;
++
++    if ((ret = init_nvml_functions()) < 0)
++        return ret;
++
++    ret = CHECK_ML(nvml_ext->nvmlSystemGetDriverVersion(drv_ver,
++                                                        NVML_SYSTEM_DRIVER_VERSION_BUFFER_SIZE));
++    if (ret < 0)
++        return ret;
++
++    ret = CHECK_ML(nvml_ext->nvmlSystemGetNVMLVersion(nvml_ver,
++                                                      NVML_SYSTEM_NVML_VERSION_BUFFER_SIZE));
++    if (ret < 0)
++        return ret;
++
++    return 0;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++int print_cuda_device_info(AVTextFormatContext *tfc, AVBufferRef *cuda_ref, int nvml_ret)
++{
++#if CONFIG_CUDA
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVCUDADeviceContext *hwctx = NULL;
++    CudaFunctions *cu = NULL;
++    CUdevice dev;
++    CUuuid cuda_uuid = { 0 };
++    int has_uuid = 0;
++    int val, cuda_ver = 0, ret = 0;
++    char device_name[256] = { 0 };
++    char uuid_buf[32+4+1] = { 0 };
++    size_t device_memory = 0;
++
++    if (!tfc || !cuda_ref)
++        return AVERROR(EINVAL);
++
++    if ((ret = init_cuda_functions()) < 0)
++        return AVERROR(ENOSYS);
++
++    dev_ctx = (AVHWDeviceContext*)cuda_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++    cu = hwctx->internal->cuda_dl;
++    dev = hwctx->internal->cuda_device;
++
++    ret = CHECK_CU(cu->cuDeviceGetName(device_name, sizeof(device_name), dev));
++    if (ret < 0)
++        return ret;
++
++    ret = CHECK_CU_EXT(cu_ext->cuDriverGetVersion(&cuda_ver));
++    if (ret < 0)
++        return ret;
++
++    ret = CHECK_CU_EXT(cu_ext->cuDeviceTotalMem(&device_memory, dev));
++    if (ret < 0)
++        return ret;
++
++    if (cu_ext->cuDeviceGetUuid_v2) {
++        ret = CHECK_CU_EXT(cu_ext->cuDeviceGetUuid_v2(&cuda_uuid, dev));
++        if (!ret)
++            has_uuid = 1;
++    } else if (cu_ext->cuDeviceGetUuid) {
++        ret = CHECK_CU_EXT(cu_ext->cuDeviceGetUuid(&cuda_uuid, dev));
++        if (!ret)
++            has_uuid = 1;
++    }
++
++    mark_section_show_entries(SECTION_ID_DEVICE_INFO_CUDA, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_INFO_CUDA);
++
++    print_str("device_name", device_name);
++    if (!nvml_ret) {
++        print_str("device_driver_version", drv_ver);
++        print_str("device_nvml_version", nvml_ver);
++    }
++    print_int("device_cuda_version", cuda_ver);
++    if (has_uuid) {
++        const uint8_t *u = (const uint8_t*)cuda_uuid.bytes;
++
++        snprintf(
++            uuid_buf, sizeof(uuid_buf),
++            "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
++            u[0], u[1], u[2],  u[3],  u[4],  u[5],  u[6],  u[7],
++            u[8], u[9], u[10], u[11], u[12], u[13], u[14], u[15]
++        );
++        print_str("device_uuid", uuid_buf);
++    }
++    print_int("device_memory", device_memory);
++
++    for (unsigned i = 0; i < FF_ARRAY_ELEMS(cuda_device_attrs); i++) {
++        val = 0;
++        if (cuda_device_attrs[i].attr_val <= 0)
++            break;
++        ret = CHECK_CU(cu->cuDeviceGetAttribute(&val, cuda_device_attrs[i].attr_val, dev));
++        if (!ret)
++            print_int(cuda_device_attrs[i].attr_str, val);
++    }
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_INFO_CUDA
++
++    return ret;
++#else
++    return 0;
++#endif
++}
++
++int print_cuda_device_util(AVTextFormatContext *tfc, AVBufferRef *cuda_ref, int nvml_ret)
++{
++#if CONFIG_CUDA
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVCUDADeviceContext *hwctx = NULL;
++    CudaFunctions *cu = NULL;
++    CUdevice dev;
++    CUuuid cuda_uuid = { 0 };
++    nvmlDevice_t nvml_dev = NULL;
++    int ret = 0;
++    char device_name[256] = { 0 };
++    char uuid_buf[4+32+4+1] = { 0 };
++
++    if (!tfc || !cuda_ref || nvml_ret < 0)
++        return AVERROR(EINVAL);
++
++    if ((ret = init_cuda_functions()) < 0)
++        return AVERROR(ENOSYS);
++
++    dev_ctx = (AVHWDeviceContext*)cuda_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++    cu = hwctx->internal->cuda_dl;
++    dev = hwctx->internal->cuda_device;
++
++    ret = CHECK_CU(cu->cuDeviceGetName(device_name, sizeof(device_name), dev));
++    if (ret < 0)
++        return ret;
++
++    if (cu_ext->cuDeviceGetUuid_v2) {
++        ret = CHECK_CU_EXT(cu_ext->cuDeviceGetUuid_v2(&cuda_uuid, dev));
++        if (ret < 0)
++            return ret;
++    } else if (cu_ext->cuDeviceGetUuid) {
++        ret = CHECK_CU_EXT(cu_ext->cuDeviceGetUuid(&cuda_uuid, dev));
++        if (ret < 0)
++            return ret;
++    }
++
++    for (unsigned i = 0; i < 2; i++) {
++        const uint8_t *u = (const uint8_t*)cuda_uuid.bytes;
++
++        snprintf(
++            uuid_buf, sizeof(uuid_buf),
++            "%s%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
++            (i ? "MIG-" : "GPU-"),
++            u[0], u[1], u[2],  u[3],  u[4],  u[5],  u[6],  u[7],
++            u[8], u[9], u[10], u[11], u[12], u[13], u[14], u[15]
++        );
++        ret = CHECK_ML(nvml_ext->nvmlDeviceGetHandleByUUID(uuid_buf, &nvml_dev));
++        if (!ret)
++            break;
++    }
++    if (!nvml_dev)
++        return AVERROR(ENOSYS);
++
++    mark_section_show_entries(SECTION_ID_DEVICE_UTIL_CUDA, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_UTIL_CUDA);
++
++    print_str("device_name", device_name);
++    print_str("device_uuid", uuid_buf);
++
++    if (nvml_ext->nvmlDeviceGetMemoryInfo) {
++        nvmlMemory_t memory_info = { 0 };
++
++        ret = CHECK_ML(nvml_ext->nvmlDeviceGetMemoryInfo(nvml_dev, &memory_info));
++        if (!ret) {
++            print_int("device_memory_total", memory_info.total);
++            print_int("device_memory_used", memory_info.used);
++            print_int("device_memory_free", memory_info.free);
++        }
++    }
++    if (nvml_ext->nvmlDeviceGetUtilizationRates) {
++        nvmlUtilization_t util = { 0 };
++
++        ret = CHECK_ML(nvml_ext->nvmlDeviceGetUtilizationRates(nvml_dev, &util));
++        if (!ret) {
++            print_int("device_gpu_utilization", util.gpu);
++            print_int("device_memory_utilization", util.memory);
++        }
++    }
++    if (nvml_ext->nvmlDeviceGetDecoderUtilization) {
++        unsigned dec_util = 0, sample_us = 0;
++
++        ret = CHECK_ML(nvml_ext->nvmlDeviceGetDecoderUtilization(nvml_dev, &dec_util, &sample_us));
++        if (!ret)
++            print_int("device_decoder_utilization", dec_util);
++    }
++    if (nvml_ext->nvmlDeviceGetEncoderUtilization) {
++        unsigned enc_util = 0, sample_us = 0;
++
++        ret = CHECK_ML(nvml_ext->nvmlDeviceGetEncoderUtilization(nvml_dev, &enc_util, &sample_us));
++        if (!ret)
++            print_int("device_encoder_utilization", enc_util);
++    }
++    if (nvml_ext->nvmlDeviceGetEncoderStats) {
++        unsigned sessions = 0, avg_fps = 0, avg_latency = 0;
++
++        ret = CHECK_ML(nvml_ext->nvmlDeviceGetEncoderStats(nvml_dev, &sessions, &avg_fps, &avg_latency));
++        if (!ret) {
++            print_int("device_encoder_sessions", sessions);
++            print_int("device_encoder_avg_fps", avg_fps);
++            print_int("device_encoder_avg_latency", avg_latency);
++        }
++    }
++    if (nvml_ext->nvmlDeviceGetPcieThroughput) {
++        unsigned util = 0;
++        static const struct {
++            nvmlPcieUtilCounter_t pcie_util_val;
++            const char           *pcie_util_str;
++        } params[] = {
++            { 0 /* NVML_PCIE_UTIL_TX_BYTES */, "device_pcie_tx_throughput" },
++            { 1 /* NVML_PCIE_UTIL_RX_BYTES */, "device_pcie_rx_throughput" },
++        };
++
++        for (unsigned i = 0; i < FF_ARRAY_ELEMS(params); i++) {
++            ret = CHECK_ML(nvml_ext->nvmlDeviceGetPcieThroughput(nvml_dev, params[i].pcie_util_val, &util));
++            if (!ret)
++                print_int(params[i].pcie_util_str, util);
++        }
++    }
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_UTIL_CUDA
++
++    return ret;
++#else
++    return 0;
++#endif
++}
++
++#if (CONFIG_CUDA && (CONFIG_CUVID || CONFIG_NVDEC))
++static int cuda_map_av_to_cuvid_codec(enum AVCodecID codec)
++{
++    switch (codec) {
++    case AV_CODEC_ID_MPEG1VIDEO: return cudaVideoCodec_MPEG1;
++    case AV_CODEC_ID_MPEG2VIDEO: return cudaVideoCodec_MPEG2;
++    case AV_CODEC_ID_MPEG4:      return cudaVideoCodec_MPEG4;
++    case AV_CODEC_ID_VC1:        return cudaVideoCodec_VC1;
++    case AV_CODEC_ID_H264:       return cudaVideoCodec_H264;
++    case AV_CODEC_ID_MJPEG:      return cudaVideoCodec_JPEG;
++    case AV_CODEC_ID_HEVC:       return cudaVideoCodec_HEVC;
++    case AV_CODEC_ID_VP8:        return cudaVideoCodec_VP8;
++    case AV_CODEC_ID_VP9:        return cudaVideoCodec_VP9;
++#   if NVDECAPI_CHECK_VERSION(11, 0)
++    case AV_CODEC_ID_AV1:        return cudaVideoCodec_AV1;
++#   endif
++    default:                     return -1;
++    }
++}
++
++static int cuda_map_av_to_cuvid_chroma(enum AVPixelFormat pix_fmt)
++{
++    switch (pix_fmt) {
++    case AV_PIX_FMT_NV12:         /* fallthrough */
++    case AV_PIX_FMT_P010:         /* fallthrough */
++    case AV_PIX_FMT_P012:         /* fallthrough */
++    case AV_PIX_FMT_P016:      return cudaVideoChromaFormat_420;
++    case AV_PIX_FMT_NV16:         /* fallthrough */
++    case AV_PIX_FMT_P210:         /* fallthrough */
++    case AV_PIX_FMT_P212:         /* fallthrough */
++    case AV_PIX_FMT_P216:      return cudaVideoChromaFormat_422;
++    case AV_PIX_FMT_YUV444P:      /* fallthrough */
++    case AV_PIX_FMT_YUV444P10MSB: /* fallthrough */
++    case AV_PIX_FMT_YUV444P12MSB: /* fallthrough */
++    case AV_PIX_FMT_YUV444P16: return cudaVideoChromaFormat_444;
++    default:                   return -1;
++    }
++}
++
++static int cuda_map_av_to_cuvid_surface(enum AVPixelFormat pix_fmt)
++{
++    switch (pix_fmt) {
++    case AV_PIX_FMT_NV12:      return cudaVideoSurfaceFormat_NV12;
++    case AV_PIX_FMT_P010:         /* fallthrough */
++    case AV_PIX_FMT_P012:         /* fallthrough */
++    case AV_PIX_FMT_P016:      return cudaVideoSurfaceFormat_P016;
++#   if NVDECAPI_CHECK_VERSION(13, 0)
++    case AV_PIX_FMT_NV16:      return cudaVideoSurfaceFormat_NV16;
++    case AV_PIX_FMT_P210:         /* fallthrough */
++    case AV_PIX_FMT_P212:         /* fallthrough */
++    case AV_PIX_FMT_P216:      return cudaVideoSurfaceFormat_P216;
++#   endif
++#   if NVDECAPI_CHECK_VERSION(9, 0)
++    case AV_PIX_FMT_YUV444P:   return cudaVideoSurfaceFormat_YUV444;
++    case AV_PIX_FMT_YUV444P10MSB: /* fallthrough */
++    case AV_PIX_FMT_YUV444P12MSB: /* fallthrough */
++    case AV_PIX_FMT_YUV444P16: return cudaVideoSurfaceFormat_YUV444_16Bit;
++#   endif
++    default:                   return -1;
++    }
++}
++#endif
++
++int print_cuda_decoder_info(AVTextFormatContext *tfc, AVBufferRef *cuda_ref)
++{
++#if (CONFIG_CUDA && (CONFIG_CUVID || CONFIG_NVDEC))
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVCUDADeviceContext *hwctx = NULL;
++    CUVIDDECODECAPS caps = { 0 };
++    CudaFunctions *cu = NULL;
++    CUcontext dummy;
++    int header_printed = 0;
++    int ret = 0;
++    unsigned i, j;
++
++    if (!tfc || !cuda_ref)
++        return AVERROR(EINVAL);
++
++    if ((ret = init_cuvid_functions()) < 0)
++        return AVERROR(ENOSYS);
++
++    if (!cuvid->cuvidGetDecoderCaps)
++        return AVERROR(ENOSYS);
++
++    dev_ctx = (AVHWDeviceContext*)cuda_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++    cu = hwctx->internal->cuda_dl;
++
++    ret = CHECK_CU(cu->cuCtxPushCurrent(hwctx->cuda_ctx));
++    if (ret < 0)
++        return ret;
++
++    for (i = 0; cuvid_modes[i].name; i++) {
++        int header2_printed = 0;
++        const CuvidMode *mode = &cuvid_modes[i];
++
++        if (!mode->formats)
++            continue;
++
++        caps.eCodecType = cuda_map_av_to_cuvid_codec(mode->codec);
++        if (caps.eCodecType < 0)
++            continue;
++
++        for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++            int surface = -1;
++            const int format = mode->formats[j];
++            const AVPixFmtDescriptor *desc;
++
++            surface = cuda_map_av_to_cuvid_surface(format);
++            if (surface < 0)
++                continue;
++
++            desc = av_pix_fmt_desc_get(format);
++            caps.nBitDepthMinus8 = FFMIN(desc->comp[0].depth, 12) - 8;
++            caps.eChromaFormat = cuda_map_av_to_cuvid_chroma(format);
++            if (caps.eChromaFormat < 0)
++                continue;
++
++            ret = CHECK_CU(cuvid->cuvidGetDecoderCaps(&caps));
++            if (ret < 0)
++                continue;
++
++            if (!caps.bIsSupported || !(caps.nOutputFormatMask & (1 << surface)))
++                continue;
++
++            if (!header_printed) {
++                mark_section_show_entries(SECTION_ID_DEVICE_DECODERS_CUDA, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_DECODERS_CUDA);
++                header_printed = 1;
++            }
++
++            if (!header2_printed) {
++                mark_section_show_entries(SECTION_ID_DEVICE_DECODER, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_DECODER);
++                print_str("codec_name", avcodec_get_name(mode->codec));
++                print_int("codec_id", mode->codec);
++                print_str("codec_desc", mode->name);
++                print_int("min_width", caps.nMinWidth);
++                print_int("min_height", caps.nMinHeight);
++                print_int("max_width", caps.nMaxWidth);
++                print_int("max_height", caps.nMaxHeight);
++                print_int("max_mb_count", caps.nMaxMBCount);
++                mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                header2_printed = 1;
++            }
++
++            mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++            print_str("format_name", av_get_pix_fmt_name(format));
++            print_int("format_id", format);
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++        }
++
++        if (header2_printed) {
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_DECODER
++        }
++    }
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_DECODERS_CUDA
++
++    CHECK_CU(cu->cuCtxPopCurrent(&dummy));
++#endif
++    return 0;
++}
++
++#if (CONFIG_CUDA && CONFIG_NVENC)
++static GUID cuda_map_av_to_nvenc_codec_guid(enum AVCodecID codec)
++{
++    static const GUID g = { 0 };
++
++    switch (codec) {
++    case AV_CODEC_ID_H264: return NV_ENC_CODEC_H264_GUID;
++    case AV_CODEC_ID_HEVC: return NV_ENC_CODEC_HEVC_GUID;
++#   if NVENCAPI_CHECK_VERSION(12, 0)
++    case AV_CODEC_ID_AV1:  return NV_ENC_CODEC_AV1_GUID;
++#   endif
++    default:               return g;
++    }
++}
++
++static GUID cuda_map_av_to_nvenc_profile_guid(enum AVCodecID codec, int profile)
++{
++    static const GUID g = { 0 };
++
++    if (codec == AV_CODEC_ID_H264) {
++        switch (profile) {
++        case AV_PROFILE_H264_BASELINE:            return NV_ENC_H264_PROFILE_BASELINE_GUID;
++        case AV_PROFILE_H264_MAIN:                return NV_ENC_H264_PROFILE_MAIN_GUID;
++        case AV_PROFILE_H264_HIGH:                return NV_ENC_H264_PROFILE_HIGH_GUID;
++#   if NVENCAPI_CHECK_VERSION(13, 0)
++        case AV_PROFILE_H264_HIGH_10:             return NV_ENC_H264_PROFILE_HIGH_10_GUID;
++        case AV_PROFILE_H264_HIGH_422:            return NV_ENC_H264_PROFILE_HIGH_422_GUID;
++#   endif
++        case AV_PROFILE_H264_HIGH_444_PREDICTIVE: return NV_ENC_H264_PROFILE_HIGH_444_GUID;
++        }
++    } else if (codec == AV_CODEC_ID_HEVC) {
++        switch (profile) {
++        case AV_PROFILE_HEVC_MAIN:    return NV_ENC_HEVC_PROFILE_MAIN_GUID;
++        case AV_PROFILE_HEVC_MAIN_10: return NV_ENC_HEVC_PROFILE_MAIN10_GUID;
++        case AV_PROFILE_HEVC_REXT:    return NV_ENC_HEVC_PROFILE_FREXT_GUID;
++        }
++    } else if (codec == AV_CODEC_ID_AV1) {
++        switch (profile) {
++#   if NVENCAPI_CHECK_VERSION(12, 0)
++        case AV_PROFILE_AV1_MAIN:      return NV_ENC_AV1_PROFILE_MAIN_GUID;
++#   endif
++        }
++    }
++
++    return g;
++}
++
++static NV_ENC_BUFFER_FORMAT cuda_map_av_to_nvenc_buffer_format(enum AVPixelFormat pix_fmt)
++{
++    switch (pix_fmt) {
++    case AV_PIX_FMT_NV12:      return NV_ENC_BUFFER_FORMAT_NV12;
++#   if NVENCAPI_CHECK_VERSION(13, 0)
++    case AV_PIX_FMT_NV16:      return NV_ENC_BUFFER_FORMAT_NV16;
++#   endif
++    case AV_PIX_FMT_YUV420P:   return NV_ENC_BUFFER_FORMAT_YV12;
++    case AV_PIX_FMT_P010:      /* fallthrough */
++    case AV_PIX_FMT_P016:      return NV_ENC_BUFFER_FORMAT_YUV420_10BIT;
++#   if NVENCAPI_CHECK_VERSION(13, 0)
++    case AV_PIX_FMT_P210:      /* fallthrough */
++    case AV_PIX_FMT_P216:      return NV_ENC_BUFFER_FORMAT_P210;
++#   endif
++    case AV_PIX_FMT_GBRP:      /* fallthrough */
++    case AV_PIX_FMT_YUV444P:   return NV_ENC_BUFFER_FORMAT_YUV444;
++    case AV_PIX_FMT_GBRP10MSB:
++    case AV_PIX_FMT_GBRP16:    /* fallthrough */
++    case AV_PIX_FMT_YUV444P10MSB:
++    case AV_PIX_FMT_YUV444P16: return NV_ENC_BUFFER_FORMAT_YUV444_10BIT;
++    case AV_PIX_FMT_0RGB32:    /* fallthrough */
++    case AV_PIX_FMT_RGB32:     return NV_ENC_BUFFER_FORMAT_ARGB;
++    case AV_PIX_FMT_0BGR32:    /* fallthrough */
++    case AV_PIX_FMT_BGR32:     return NV_ENC_BUFFER_FORMAT_ABGR;
++    case AV_PIX_FMT_X2RGB10:   return NV_ENC_BUFFER_FORMAT_ARGB10;
++    case AV_PIX_FMT_X2BGR10:   return NV_ENC_BUFFER_FORMAT_ABGR10;
++    default:                   return NV_ENC_BUFFER_FORMAT_UNDEFINED;
++    }
++}
++#endif
++
++int print_cuda_encoder_info(AVTextFormatContext *tfc, AVBufferRef *cuda_ref)
++{
++#if (CONFIG_CUDA && CONFIG_NVENC)
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVCUDADeviceContext *hwctx = NULL;
++    CudaFunctions *cu = NULL;
++    CUdevice dev;
++    CUcontext dummy;
++    unsigned i, j, k;
++    unsigned major = 0, minor = 0;
++    int val, ret = 0;
++    int header_printed = 0;
++    void *nvenc_hdl = NULL;
++    NVENCSTATUS err = 0;
++    unsigned codec_cnt = 0;
++    GUID *codec_list = NULL;
++
++    if (!tfc || !cuda_ref)
++        return AVERROR(EINVAL);
++
++    if ((ret = init_cuda_functions()) < 0)
++        return AVERROR(ENOSYS);
++
++    if ((ret = init_nvenc_functions()) < 0)
++        return AVERROR(ENOSYS);
++
++    dev_ctx = (AVHWDeviceContext*)cuda_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++    cu = hwctx->internal->cuda_dl;
++    dev = hwctx->internal->cuda_device;
++
++    ret = CHECK_CU(cu->cuDeviceComputeCapability(&major, &minor, dev));
++    if (ret < 0)
++        return ret;
++
++    if (((major << 4) | minor) < 0x30 /* NVENC_CAP */)
++        return AVERROR(EINVAL);
++
++    ret = CHECK_CU(cu->cuCtxPushCurrent(hwctx->cuda_ctx));
++    if (ret < 0)
++        return ret;
++
++    {
++        NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS params = {
++            .version    = NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER,
++            .apiVersion = NVENCAPI_VERSION,
++            .deviceType = NV_ENC_DEVICE_TYPE_CUDA,
++            .device     = hwctx->cuda_ctx,
++        };
++
++        err = nvenc_fns.nvEncOpenEncodeSessionEx(&params, &nvenc_hdl);
++        if (err != NV_ENC_SUCCESS) {
++            nvenc_hdl = NULL;
++            av_log(NULL, AV_LOG_DEBUG, "Nvenc OpenEncodeSessionEx failed\n");
++            ret = AVERROR(ENOSYS);
++            goto exit;
++        }
++    }
++
++    err = nvenc_fns.nvEncGetEncodeGUIDCount(nvenc_hdl, &codec_cnt);
++    if (err != NV_ENC_SUCCESS || !codec_cnt) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    codec_list = av_malloc_array(codec_cnt, sizeof(*codec_list));
++    if (!codec_list) {
++        av_free(codec_list);
++        ret = AVERROR(EINVAL);
++        goto exit;
++    }
++
++    err = nvenc_fns.nvEncGetEncodeGUIDs(nvenc_hdl, codec_list, codec_cnt, &codec_cnt);
++    if (err != NV_ENC_SUCCESS) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    for (i = 0; nvenc_modes[i].name; i++) {
++        int supported = 0;
++        int header2_printed = 0;
++        int header3_printed = 0;
++        int header4_printed = 0;
++        unsigned profile_cnt, fmt_cnt, preset_cnt;
++        GUID *profile_list = NULL, *preset_list = NULL;
++        NV_ENC_BUFFER_FORMAT *fmt_list = NULL;
++        const NvencMode *mode = &nvenc_modes[i];
++        const GUID codec_guid = cuda_map_av_to_nvenc_codec_guid(mode->codec);
++
++        for (const GUID *g = &codec_list[0]; !supported && g < &codec_list[codec_cnt]; g++) {
++            supported = !memcmp(g, &codec_guid, sizeof(*g));
++        }
++        if (!supported)
++            continue;
++
++        if (!mode->formats)
++            continue;
++
++        if (!header_printed) {
++            mark_section_show_entries(SECTION_ID_DEVICE_ENCODERS_CUDA, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_ENCODERS_CUDA);
++            header_printed = 1;
++        }
++
++        mark_section_show_entries(SECTION_ID_DEVICE_ENCODER, 1, NULL);
++        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_ENCODER);
++        print_str("codec_name", avcodec_get_name(mode->codec));
++        print_int("codec_id", mode->codec);
++        print_str("codec_desc", mode->name);
++
++        for (j = 0; j < FF_ARRAY_ELEMS(nvenc_codec_caps); j++) {
++            NV_ENC_CAPS_PARAM params = {
++                .version     = NV_ENC_CAPS_PARAM_VER,
++                .capsToQuery = nvenc_codec_caps[j].cap_val,
++            };
++
++            val = 0;
++            err = nvenc_fns.nvEncGetEncodeCaps(nvenc_hdl, codec_guid, &params, &val);
++            if (err == NV_ENC_SUCCESS)
++                print_int(nvenc_codec_caps[j].cap_str, val);
++        }
++
++        /* Profiles */
++        err = nvenc_fns.nvEncGetEncodeProfileGUIDCount(nvenc_hdl, codec_guid, &profile_cnt);
++        if (err == NV_ENC_SUCCESS && profile_cnt) {
++            profile_list = av_malloc_array(profile_cnt, sizeof(*profile_list));
++            if (profile_list)
++                err = nvenc_fns.nvEncGetEncodeProfileGUIDs(nvenc_hdl, codec_guid,
++                                                           profile_list, profile_cnt, &profile_cnt);
++        }
++        for (j = 0; mode->profiles[j] != AV_PROFILE_UNKNOWN; j++) {
++            GUID profile_guid = { 0 };
++
++            if (!profile_cnt || !profile_list || err != NV_ENC_SUCCESS)
++                break;
++
++            profile_guid = cuda_map_av_to_nvenc_profile_guid(mode->codec, mode->profiles[j]);
++            for (const GUID *g = &profile_list[0]; g < &profile_list[profile_cnt]; g++) {
++                if (!memcmp(g, &profile_guid, sizeof(*g))) {
++                    if (!header2_printed) {
++                        mark_section_show_entries(SECTION_ID_DEVICE_PROFILES, 1, NULL);
++                        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILES);
++                        header2_printed = 1;
++                    }
++                    mark_section_show_entries(SECTION_ID_DEVICE_PROFILE, 1, NULL);
++                    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILE);
++                    print_str("profile_name", avcodec_profile_name(mode->codec, mode->profiles[j]));
++                    print_int("profile_id", mode->profiles[j]);
++                    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILE
++                    break;
++                }
++            }
++        }
++        if (header2_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILES
++
++        /* Formats */
++        err = nvenc_fns.nvEncGetInputFormatCount(nvenc_hdl, codec_guid, &fmt_cnt);
++        if (err == NV_ENC_SUCCESS && fmt_cnt) {
++            fmt_list = av_malloc_array(fmt_cnt, sizeof(*fmt_list));
++            if (fmt_list)
++                err = nvenc_fns.nvEncGetInputFormats(nvenc_hdl, codec_guid,
++                                                     fmt_list, fmt_cnt, &fmt_cnt);
++        }
++        for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++            int buffer_format = NV_ENC_BUFFER_FORMAT_UNDEFINED;
++
++            if (!fmt_cnt || !fmt_list || err != NV_ENC_SUCCESS)
++                break;
++
++            buffer_format = cuda_map_av_to_nvenc_buffer_format(mode->formats[j]);
++            if (buffer_format == NV_ENC_BUFFER_FORMAT_UNDEFINED)
++                continue;
++
++            for (k = 0; k < fmt_cnt; k++) {
++                if (buffer_format == fmt_list[k]) {
++                    if (!header3_printed) {
++                        mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                        header3_printed = 1;
++                    }
++                    mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++                    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++                    print_str("format_name", av_get_pix_fmt_name(mode->formats[j]));
++                    print_int("format_id", mode->formats[j]);
++                    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++                    break;
++                }
++            }
++        }
++        if (header3_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++        /* Presets */
++        err = nvenc_fns.nvEncGetEncodePresetCount(nvenc_hdl, codec_guid, &preset_cnt);
++        if (err == NV_ENC_SUCCESS && preset_cnt) {
++            preset_list = av_malloc_array(preset_cnt, sizeof(*preset_list));
++            if (preset_list)
++                err = nvenc_fns.nvEncGetEncodePresetGUIDs(nvenc_hdl, codec_guid,
++                                                          preset_list, preset_cnt, &preset_cnt);
++        }
++        for (j = 0; j < FF_ARRAY_ELEMS(nvenc_codec_presets); j++) {
++            if (!preset_cnt || !preset_list || err != NV_ENC_SUCCESS)
++                break;
++
++            for (const GUID *g = &preset_list[0]; g < &preset_list[preset_cnt]; g++) {
++                if (!memcmp(g, nvenc_codec_presets[j].preset_val, sizeof(*g))) {
++                    if (!header4_printed) {
++                        mark_section_show_entries(SECTION_ID_DEVICE_PRESETS, 1, NULL);
++                        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PRESETS);
++                        header4_printed = 1;
++                    }
++                    mark_section_show_entries(SECTION_ID_DEVICE_PRESET, 1, NULL);
++                    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PRESET);
++                    print_str("preset_name", nvenc_codec_presets[j].preset_str);
++                    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PRESET
++                    break;
++                }
++            }
++        }
++        if (header4_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PRESETS
++
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_ENCODER
++
++        if (profile_list)
++            av_free(profile_list);
++        if (fmt_list)
++            av_free(fmt_list);
++        if (preset_list)
++            av_free(preset_list);
++    }
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_ENCODERS_CUDA
++
++exit:
++    if (codec_list)
++        av_free(codec_list);
++    if (nvenc_hdl)
++        nvenc_fns.nvEncDestroyEncoder(nvenc_hdl);
++
++    CHECK_CU(cu->cuCtxPopCurrent(&dummy));
++    return ret;
++#else
++    return 0;
++#endif
++}
+Index: FFmpeg/fftools/ffprobe_hw_dxgi.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_dxgi.c
+@@ -0,0 +1,1464 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "ffprobe_hw_internal.h"
++
++#if CONFIG_D3D11VA
++#   define COBJMACROS
++#   include <windows.h>
++#   include <wctype.h>
++#   include <initguid.h>
++#   include <d3d11.h>
++#   include <dxgi1_2.h>
++#   include "libavutil/hwcontext_d3d11va.h"
++#   include "libavutil/wchar_filename.h"
++#   include "compat/w32dlfcn.h"
++#endif
++
++#if CONFIG_D3D11VA
++#   if HAVE_IDXGIADAPTER3 && HAVE_PDH
++#       include <dxgi1_4.h>
++#       include <pdh.h>
++#       define FFPROBE_HW_DXGI1_4_PDH_HELPER
++#   endif
++#endif
++
++#if CONFIG_D3D11VA && CONFIG_AMF && !HAVE_UWP
++#   if HAVE_ADVAPI32 && HAVE_CFGMGR32 && HAVE_OLE32
++#       include <cfgmgr32.h>
++#       include <devguid.h>
++#       define FFPROBE_HW_WDDM_VERSION_HELPER
++#       define FFPROBE_HW_AMF_DLL_HELPER
++#   endif
++#endif
++
++#if CONFIG_D3D11VA
++typedef struct DxvaMode {
++    const char               *name;
++    const enum AVCodecID      codec;
++    const int                *profiles;
++    const enum AVPixelFormat *formats;
++    const GUID               *guid;
++    const unsigned            legacy;
++} DxvaMode;
++
++static const int prof_mpeg2_main[] = {
++    AV_PROFILE_MPEG2_SIMPLE,
++    AV_PROFILE_MPEG2_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++static const int prof_h264_high[] = {
++    AV_PROFILE_H264_CONSTRAINED_BASELINE,
++    AV_PROFILE_H264_MAIN,
++    AV_PROFILE_H264_HIGH,
++    AV_PROFILE_UNKNOWN
++};
++static const int prof_vc1_advanced[] = {
++    AV_PROFILE_VC1_SIMPLE,
++    AV_PROFILE_VC1_MAIN,
++    AV_PROFILE_VC1_ADVANCED,
++    AV_PROFILE_UNKNOWN
++};
++static const int prof_hevc_main[] = {
++    AV_PROFILE_HEVC_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++static const int prof_hevc_main10[] = {
++    AV_PROFILE_HEVC_MAIN_10,
++    AV_PROFILE_UNKNOWN
++};
++static const int prof_hevc_rext[] = {
++    AV_PROFILE_HEVC_REXT,
++    AV_PROFILE_UNKNOWN
++};
++static const int prof_vp9_profile0[] = {
++    AV_PROFILE_VP9_0,
++    AV_PROFILE_UNKNOWN
++};
++static const int prof_vp9_profile2[] = {
++    AV_PROFILE_VP9_2,
++    AV_PROFILE_UNKNOWN
++};
++static const int prof_av1_profile0[] = {
++    AV_PROFILE_AV1_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++
++static const enum AVPixelFormat formats_8_420[]    = { AV_PIX_FMT_NV12, AV_PIX_FMT_NONE };
++static const enum AVPixelFormat formats_10_420[]   = { AV_PIX_FMT_P010, AV_PIX_FMT_NONE };
++static const enum AVPixelFormat formats_8_10_420[] = { AV_PIX_FMT_P010, AV_PIX_FMT_NV12, AV_PIX_FMT_NONE };
++static const enum AVPixelFormat formats_12_420[]   = { AV_PIX_FMT_P012, AV_PIX_FMT_NONE };
++static const enum AVPixelFormat formats_8_10_422[] = { AV_PIX_FMT_Y210, AV_PIX_FMT_YUYV422, AV_PIX_FMT_NONE };
++static const enum AVPixelFormat formats_12_422[]   = { AV_PIX_FMT_Y212, AV_PIX_FMT_NONE };
++static const enum AVPixelFormat formats_8_444[]    = { AV_PIX_FMT_VUYX, AV_PIX_FMT_NONE };
++static const enum AVPixelFormat formats_10_444[]   = { AV_PIX_FMT_XV30, AV_PIX_FMT_NONE };
++static const enum AVPixelFormat formats_12_444[]   = { AV_PIX_FMT_XV36, AV_PIX_FMT_NONE };
++
++DEFINE_GUID(ff_DXVA_ModeMPEG2_VLD,                 0xee27417f,0x5e28,0x4e65,0xbe,0xea,0x1d,0x26,0xb5,0x08,0xad,0xc9);
++DEFINE_GUID(ff_DXVA_ModeMPEG2and1_VLD,             0x86695f12,0x340e,0x4f04,0x9f,0xd3,0x92,0x53,0xdd,0x32,0x74,0x60);
++DEFINE_GUID(ff_DXVA_ModeH264_E,                    0x1b81be68,0xa0c7,0x11d3,0xb9,0x84,0x00,0xc0,0x4f,0x2e,0x73,0xc5);
++DEFINE_GUID(ff_DXVA_ModeH264_F,                    0x1b81be69,0xa0c7,0x11d3,0xb9,0x84,0x00,0xc0,0x4f,0x2e,0x73,0xc5);
++DEFINE_GUID(ff_DXVA_ModeH264_E_Intel,              0x604F8E68,0x4951,0x4C54,0x88,0xFE,0xAB,0xD2,0x5C,0x15,0xB3,0xD6);
++DEFINE_GUID(ff_DXVA_ModeVC1_D,                     0x1b81beA3,0xa0c7,0x11d3,0xb9,0x84,0x00,0xc0,0x4f,0x2e,0x73,0xc5);
++DEFINE_GUID(ff_DXVA_ModeVC1_D2010,                 0x1b81beA4,0xa0c7,0x11d3,0xb9,0x84,0x00,0xc0,0x4f,0x2e,0x73,0xc5);
++DEFINE_GUID(ff_DXVA_ModeHEVC_VLD_Main,             0x5b11d51b,0x2f4c,0x4452,0xbc,0xc3,0x09,0xf2,0xa1,0x16,0x0c,0xc0);
++DEFINE_GUID(ff_DXVA_ModeHEVC_VLD_Main10,           0x107af0e0,0xef1a,0x4d19,0xab,0xa8,0x67,0xa1,0x63,0x07,0x3d,0x13);
++DEFINE_GUID(ff_DXVA_ModeHEVC_VLD_Main12_Intel,     0x8ff8a3aa,0xc456,0x4132,0xb6,0xef,0x69,0xd9,0xdd,0x72,0x57,0x1d);
++DEFINE_GUID(ff_DXVA_ModeHEVC_VLD_Main422_10_Intel, 0xe484dcb8,0xcac9,0x4859,0x99,0xf5,0x5c,0x0d,0x45,0x06,0x90,0x89);
++DEFINE_GUID(ff_DXVA_ModeHEVC_VLD_Main422_12_Intel, 0xc23dd857,0x874b,0x423c,0xb6,0xe0,0x82,0xce,0xaa,0x9b,0x11,0x8a);
++DEFINE_GUID(ff_DXVA_ModeHEVC_VLD_Main444_Intel,    0x41a5af96,0xe415,0x4b0c,0x9d,0x03,0x90,0x78,0x58,0xe2,0x3e,0x78);
++DEFINE_GUID(ff_DXVA_ModeHEVC_VLD_Main444_10_Intel, 0x6a6a81ba,0x912a,0x485d,0xb5,0x7f,0xcc,0xd2,0xd3,0x7b,0x8d,0x94);
++DEFINE_GUID(ff_DXVA_ModeHEVC_VLD_Main444_12_Intel, 0x5b08e35d,0x0c66,0x4c51,0xa6,0xf1,0x89,0xd0,0x0c,0xb2,0xc1,0x97);
++DEFINE_GUID(ff_DXVA_ModeVP9_VLD_Profile0,          0x463707f8,0xa1d0,0x4585,0x87,0x6d,0x83,0xaa,0x6d,0x60,0xb8,0x9e);
++DEFINE_GUID(ff_DXVA_ModeVP9_VLD_10bit_Profile2,    0xa4c749ef,0x6ecf,0x48aa,0x84,0x48,0x50,0xa7,0xa1,0x16,0x5f,0xf7);
++DEFINE_GUID(ff_DXVA_ModeAV1_VLD_Profile0,          0xb8be4ccb,0xcf53,0x46ba,0x8d,0x59,0xd6,0xb8,0xa6,0xda,0x5d,0x2a);
++
++static const DxvaMode dxva_modes[] = {
++#   define MAP(n, c, p, f, g, l) { n, AV_CODEC_ID_ ## c, p, f, g, l }
++    MAP("D3D11VA MPEG-2 Decoder",             MPEG2VIDEO, prof_mpeg2_main,      formats_8_420, &ff_DXVA_ModeMPEG2_VLD,                 1),
++    MAP("D3D11VA MPEG-2 and MPEG-1 Decoder",  MPEG2VIDEO, prof_mpeg2_main,      formats_8_420, &ff_DXVA_ModeMPEG2and1_VLD,             1),
++    MAP("D3D11VA H.264 Decoder, NoFGT",             H264, prof_h264_high,       formats_8_420, &ff_DXVA_ModeH264_E,                    0),
++    MAP("D3D11VA H.264 Decoder, FGT",               H264, prof_h264_high,       formats_8_420, &ff_DXVA_ModeH264_F,                    1),
++    MAP("D3D11VA H.264 Decoder, NoFGT (Intel)",     H264, prof_h264_high,       formats_8_420, &ff_DXVA_ModeH264_E_Intel,              1),
++    MAP("D3D11VA VC-1 Decoder",                      VC1, prof_vc1_advanced,    formats_8_420, &ff_DXVA_ModeVC1_D,                     1),
++    MAP("D3D11VA VC-1 Decoder (2010)",               VC1, prof_vc1_advanced,    formats_8_420, &ff_DXVA_ModeVC1_D2010,                 1),
++    MAP("D3D11VA HEVC Decoder, Main",               HEVC, prof_hevc_main,       formats_8_420, &ff_DXVA_ModeHEVC_VLD_Main,             0),
++    MAP("D3D11VA HEVC Decoder, Main10",             HEVC, prof_hevc_main10,    formats_10_420, &ff_DXVA_ModeHEVC_VLD_Main10,           0),
++    MAP("D3D11VA HEVC Decoder, Main12 (Intel)",     HEVC, prof_hevc_rext,      formats_12_420, &ff_DXVA_ModeHEVC_VLD_Main12_Intel,     0),
++    MAP("D3D11VA HEVC Decoder, Main422_10 (Intel)", HEVC, prof_hevc_rext,    formats_8_10_422, &ff_DXVA_ModeHEVC_VLD_Main422_10_Intel, 0),
++    MAP("D3D11VA HEVC Decoder, Main422_12 (Intel)", HEVC, prof_hevc_rext,      formats_12_422, &ff_DXVA_ModeHEVC_VLD_Main422_12_Intel, 0),
++    MAP("D3D11VA HEVC Decoder, Main444 (Intel)",    HEVC, prof_hevc_rext,       formats_8_444, &ff_DXVA_ModeHEVC_VLD_Main444_Intel,    0),
++    MAP("D3D11VA HEVC Decoder, Main444_10 (Intel)", HEVC, prof_hevc_rext,      formats_10_444, &ff_DXVA_ModeHEVC_VLD_Main444_10_Intel, 0),
++    MAP("D3D11VA HEVC Decoder, Main444_12 (Intel)", HEVC, prof_hevc_rext,      formats_12_444, &ff_DXVA_ModeHEVC_VLD_Main444_12_Intel, 0),
++    MAP("D3D11VA VP9 Decoder, Profile 0",            VP9, prof_vp9_profile0,    formats_8_420, &ff_DXVA_ModeVP9_VLD_Profile0,          0),
++    MAP("D3D11VA VP9 Decoder, Profile 2",            VP9, prof_vp9_profile2,   formats_10_420, &ff_DXVA_ModeVP9_VLD_10bit_Profile2,    0),
++    MAP("D3D11VA AV1 Decoder, Profile 0",            AV1, prof_av1_profile0, formats_8_10_420, &ff_DXVA_ModeAV1_VLD_Profile0,          0),
++    MAP(NULL, NONE, NULL, NULL, NULL, 0),
++#   undef MAP
++};
++
++static DXGI_FORMAT d3d11va_map_av_to_dxgi_format(enum AVPixelFormat pix_fmt)
++{
++    switch (pix_fmt) {
++    case AV_PIX_FMT_NV12:    return DXGI_FORMAT_NV12;
++    case AV_PIX_FMT_P010:    return DXGI_FORMAT_P010;
++    case AV_PIX_FMT_P012:    return DXGI_FORMAT_P016;
++    case AV_PIX_FMT_YUYV422: return DXGI_FORMAT_YUY2;
++    case AV_PIX_FMT_Y210:    return DXGI_FORMAT_Y210;
++    case AV_PIX_FMT_Y212:    return DXGI_FORMAT_Y216;
++    case AV_PIX_FMT_VUYX:    return DXGI_FORMAT_AYUV;
++    case AV_PIX_FMT_XV30:    return DXGI_FORMAT_Y410;
++    case AV_PIX_FMT_XV36:    return DXGI_FORMAT_Y416;
++    case AV_PIX_FMT_YUV420P: return DXGI_FORMAT_420_OPAQUE;
++    default:                 return DXGI_FORMAT_UNKNOWN;
++    }
++}
++#endif
++
++#if CONFIG_D3D11VA
++#   if !HAVE_UWP
++typedef UINT ff_D3DKMT_HANDLE;
++
++#       pragma pack(push, 8)
++typedef struct _ff_D3DKMT_OPENADAPTERFROMLUID {
++    LUID             AdapterLuid;
++    ff_D3DKMT_HANDLE hAdapter;
++} ff_D3DKMT_OPENADAPTERFROMLUID;
++
++typedef struct _ff_D3DKMT_CLOSEADAPTER {
++    ff_D3DKMT_HANDLE hAdapter;
++} ff_D3DKMT_CLOSEADAPTER;
++
++typedef struct _ff_D3DKMT_QUERYADAPTERINFO {
++    ff_D3DKMT_HANDLE hAdapter;
++    UINT             Type;               // KMTQUERYADAPTERINFOTYPE value
++    VOID            *pPrivateDriverData;
++    UINT             PrivateDriverDataSize;
++} ff_D3DKMT_QUERYADAPTERINFO;
++
++typedef struct _ff_D3DKMT_ADAPTERTYPE {
++    union {
++        struct {
++            UINT RenderSupported            : 1;
++            UINT DisplaySupported           : 1;
++            UINT SoftwareDevice             : 1;
++            UINT PostDevice                 : 1;
++            UINT HybridDiscrete             : 1;
++            UINT HybridIntegrated           : 1;
++            UINT IndirectDisplayDevice      : 1;
++            UINT Paravirtualized            : 1;
++            UINT ACGSupported               : 1;
++            UINT SupportSetTimingsFromVidPn : 1;
++            UINT Detachable                 : 1;
++            UINT ComputeOnly                : 1;
++            UINT Prototype                  : 1;
++            UINT RuntimePowerManagement     : 1;
++            UINT Reserved                   : 18;
++        };
++        UINT Value;
++    };
++} ff_D3DKMT_ADAPTERTYPE;
++#       pragma pack(pop)
++
++typedef LONG (APIENTRY *PFN_D3DKMT_OPEN_ADAPTER_FROM_LUID)(ff_D3DKMT_OPENADAPTERFROMLUID *);
++typedef LONG (APIENTRY *PFN_D3DKMT_CLOSE_ADAPTER)(const ff_D3DKMT_CLOSEADAPTER *);
++typedef LONG (APIENTRY *PFN_D3DKMT_QUERY_ADAPTER_INFO)(const ff_D3DKMT_QUERYADAPTERINFO *);
++
++static int load_d3dkmt_functions(PFN_D3DKMT_OPEN_ADAPTER_FROM_LUID *open_fn,
++                                 PFN_D3DKMT_QUERY_ADAPTER_INFO *query_fn,
++                                 PFN_D3DKMT_CLOSE_ADAPTER *close_fn)
++{
++    static void *gdi32 = NULL;
++    static PFN_D3DKMT_OPEN_ADAPTER_FROM_LUID cached_open = NULL;
++    static PFN_D3DKMT_QUERY_ADAPTER_INFO cached_query = NULL;
++    static PFN_D3DKMT_CLOSE_ADAPTER cached_close = NULL;
++    static int resolved = 0; // 0 = not tried, 1 = succeeded, -1 = failed
++
++    if (!resolved) {
++        gdi32 = dlopen("gdi32.dll", 0);
++        if (gdi32) {
++            cached_open  = (PFN_D3DKMT_OPEN_ADAPTER_FROM_LUID)dlsym(gdi32, "D3DKMTOpenAdapterFromLuid");
++            cached_query = (PFN_D3DKMT_QUERY_ADAPTER_INFO)dlsym(gdi32, "D3DKMTQueryAdapterInfo");
++            cached_close = (PFN_D3DKMT_CLOSE_ADAPTER)dlsym(gdi32, "D3DKMTCloseAdapter");
++        }
++        resolved = (cached_open && cached_query && cached_close) ? 1 : -1;
++    }
++
++    *open_fn  = cached_open;
++    *query_fn = cached_query;
++    *close_fn = cached_close;
++    return resolved == 1;
++}
++#   endif // !HAVE_UWP
++
++static int is_physical_dxgi_adapter(LUID luid)
++{
++#   if !HAVE_UWP
++#       define ff_KMTQAITYPE_ADAPTERTYPE 15
++#       define ff_STATUS_SUCCESS_LOCAL   0L
++    PFN_D3DKMT_OPEN_ADAPTER_FROM_LUID d3dkmt_open;
++    PFN_D3DKMT_QUERY_ADAPTER_INFO d3dkmt_query;
++    PFN_D3DKMT_CLOSE_ADAPTER d3dkmt_close;
++    ff_D3DKMT_OPENADAPTERFROMLUID open_adapter = { 0 };
++    ff_D3DKMT_CLOSEADAPTER close_adapter = { 0 };
++    ff_D3DKMT_QUERYADAPTERINFO query = { 0 };
++    ff_D3DKMT_ADAPTERTYPE adapter_type = { 0 };
++    int is_phy_adapter = 1; // default: assume physical on any failure
++
++    if (!load_d3dkmt_functions(&d3dkmt_open, &d3dkmt_query, &d3dkmt_close))
++        return is_phy_adapter;
++
++    open_adapter.AdapterLuid = luid;
++    if (d3dkmt_open(&open_adapter) != ff_STATUS_SUCCESS_LOCAL)
++        return is_phy_adapter;
++
++    query.hAdapter = open_adapter.hAdapter;
++    query.Type = ff_KMTQAITYPE_ADAPTERTYPE;
++    query.pPrivateDriverData = &adapter_type;
++    query.PrivateDriverDataSize = sizeof(adapter_type);
++
++    if (d3dkmt_query(&query) == ff_STATUS_SUCCESS_LOCAL) {
++        if (adapter_type.SoftwareDevice ||
++            adapter_type.IndirectDisplayDevice)
++            is_phy_adapter = 0;
++    }
++
++    close_adapter.hAdapter = open_adapter.hAdapter;
++    d3dkmt_close(&close_adapter);
++
++    return is_phy_adapter;
++#   else // !HAVE_UWP
++    return 1;
++#   endif
++}
++#endif
++
++#if CONFIG_D3D11VA
++static int find_amf_dll_for_dxgi_adapter(DXGI_ADAPTER_DESC desc, wchar_t *out_path, size_t out_len)
++{
++#   ifdef FFPROBE_HW_AMF_DLL_HELPER
++#       if ARCH_X86_64 || ARCH_AARCH64
++#           define FFPROBE_HW_AMF_DLL_NAME L"amfrt64.dll"
++#       else
++#           define FFPROBE_HW_AMF_DLL_NAME L"amfrt32.dll"
++#       endif
++    CONFIGRET cr;
++    ULONG device_id_list_size = 0;
++    WCHAR *device_id_list = NULL;
++    WCHAR *begin, *end;
++    WCHAR display_guid[39];
++    WCHAR dev_id[32];
++    int found = 0;
++    int ret = 0;
++
++    if (desc.VendorId != FFPROBE_HW_VENDOR_ID_AMD)
++        return AVERROR(EINVAL);
++
++    if (!out_path || !out_len)
++        return AVERROR(EINVAL);
++
++    swprintf(dev_id, FF_ARRAY_ELEMS(dev_id), L"DEV_%04X", desc.DeviceId);
++
++    if (StringFromGUID2(&GUID_DEVCLASS_DISPLAY, display_guid,
++                        FF_ARRAY_ELEMS(display_guid)) == 0) {
++        av_log(NULL, AV_LOG_DEBUG, "AMF_DLL: StringFromGUID2 failed\n");
++        return AVERROR(ENOSYS);
++    }
++
++    do {
++        cr = CM_Get_Device_ID_List_SizeW(&device_id_list_size, display_guid,
++                                         CM_GETIDLIST_FILTER_CLASS |
++                                         CM_GETIDLIST_FILTER_PRESENT);
++        if (cr != CR_SUCCESS) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "AMF_DLL: CM_Get_Device_ID_List_SizeW failed '%lu'\n", cr);
++            ret = AVERROR(ENOSYS);
++            goto done;
++        }
++
++        av_freep(&device_id_list);
++        device_id_list = av_malloc(device_id_list_size * sizeof(*device_id_list));
++        if (!device_id_list) {
++            ret = AVERROR(ENOMEM);
++            goto done;
++        }
++
++        cr = CM_Get_Device_ID_ListW(display_guid, device_id_list, device_id_list_size,
++                                    CM_GETIDLIST_FILTER_CLASS |
++                                    CM_GETIDLIST_FILTER_PRESENT);
++    } while (cr == CR_BUFFER_SMALL);
++
++    if (cr != CR_SUCCESS) {
++        av_log(NULL, AV_LOG_DEBUG,
++               "AMF_DLL: CM_Get_Device_ID_ListW failed '%lu'\n", cr);
++        ret = AVERROR(ENOSYS);
++        goto done;
++    }
++
++    begin = device_id_list;
++    end   = begin + device_id_list_size;
++
++    for (; (begin < end) && *begin; begin += wcslen(begin) + 1) {
++        DEVINST dev_inst;
++        HKEY hkey;
++        WCHAR upper[MAX_DEVICE_ID_LEN];
++        WCHAR um_driver[MAX_PATH * 2];
++        WCHAR candidate[MAX_PATH * 2];
++        WCHAR *sep;
++        DWORD um_size = sizeof(um_driver);
++        size_t k;
++
++        wcsncpy(upper, begin, FF_ARRAY_ELEMS(upper) - 1);
++        upper[FF_ARRAY_ELEMS(upper) - 1] = L'\0';
++        for (k = 0; upper[k]; k++)
++            upper[k] = towupper(upper[k]);
++
++        if (!wcsstr(upper, dev_id))
++            continue;
++
++        cr = CM_Locate_DevNodeW(&dev_inst, begin, CM_LOCATE_DEVNODE_NORMAL);
++        if (cr != CR_SUCCESS) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "AMF_DLL: CM_Locate_DevNodeW failed '%lu'\n", cr);
++            continue;
++        }
++
++        cr = CM_Open_DevNode_Key(dev_inst, KEY_READ, 0,
++                                 RegDisposition_OpenExisting,
++                                 &hkey, CM_REGISTRY_SOFTWARE);
++        if (cr != CR_SUCCESS) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "AMF_DLL: CM_Open_DevNode_Key failed '%lu'\n", cr);
++            continue;
++        }
++
++        if (RegQueryValueExW(hkey, L"UserModeDriverName", NULL, NULL,
++                             (LPBYTE)um_driver, &um_size) != ERROR_SUCCESS) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "AMF_DLL: UserModeDriverName query failed '%lu'\n", GetLastError());
++            RegCloseKey(hkey);
++            continue;
++        }
++        RegCloseKey(hkey);
++
++        um_driver[FF_ARRAY_ELEMS(um_driver) - 1] = L'\0';
++
++        sep = wcsrchr(um_driver, L'\\');
++        if (!sep) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "AMF_DLL: unexpected UserModeDriverName format '%ls'\n", um_driver);
++            continue;
++        }
++        *sep = L'\0';
++
++        /* candidate path: <driverstore_folder>\amfrt64.dll */
++        if (swprintf(candidate, FF_ARRAY_ELEMS(candidate),
++                     L"%ls\\" FFPROBE_HW_AMF_DLL_NAME, um_driver) < 0) {
++            av_log(NULL, AV_LOG_DEBUG, "AMF_DLL: path too long\n");
++            continue;
++        }
++
++        if (GetFileAttributesW(candidate) == INVALID_FILE_ATTRIBUTES) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "AMF_DLL: not found at '%ls'\n", candidate);
++            continue;
++        }
++
++        wcsncpy(out_path, candidate, out_len - 1);
++        out_path[out_len - 1] = L'\0';
++        if (wcslen(candidate) >= out_len) {
++            av_log(NULL, AV_LOG_DEBUG, "AMF_DLL: output buffer too small\n");
++            ret = AVERROR(ERANGE);
++            goto done;
++        }
++
++        av_log(NULL, AV_LOG_DEBUG, "AMF_DLL: found at '%ls'\n", candidate);
++        found = 1;
++        break;
++    }
++
++    if (!found && !ret) {
++        av_log(NULL, AV_LOG_DEBUG,
++               "AMF_DLL: not found for device '%04X'\n", desc.DeviceId);
++        ret = AVERROR(ENOSYS);
++    }
++
++done:
++    av_freep(&device_id_list);
++    return ret;
++#       undef FFPROBE_HW_AMF_DLL_NAME
++#   else // FFPROBE_HW_AMF_DLL_HELPER
++    return AVERROR(ENOSYS);
++#   endif
++}
++#endif
++
++int create_d3d11va_devices(HwDeviceRefs *refs, int device_idx)
++{
++    return create_d3d11va_devices_with_filter(refs, -1, -1, NULL, device_idx);
++}
++
++#if CONFIG_D3D11VA
++typedef HRESULT(WINAPI *PFN_CREATE_DXGI_FACTORY)(REFIID riid, void **ppFactory);
++static PFN_CREATE_DXGI_FACTORY mCreateDXGIFactory = NULL;
++#endif
++
++int create_d3d11va_devices_with_filter(HwDeviceRefs *refs, int vendor_id,
++                                       int idx_luid, const char *luid, int device_idx)
++{
++#if CONFIG_D3D11VA
++    int ret = 0;
++    const int start_idx = device_idx < 0 ? 0 : device_idx;
++    unsigned i, j;
++    char ibuf[4];
++    HRESULT hr;
++    DXGI_ADAPTER_DESC desc;
++    IDXGIFactory2 *pDXGIFactory = NULL;
++    IDXGIAdapter *pDXGIAdapter = NULL;
++#   if !HAVE_UWP
++    HANDLE dxgilib;
++
++    if (!mCreateDXGIFactory) {
++        dxgilib = dlopen("dxgi.dll", 0);
++        if (!dxgilib)
++            return AVERROR(ENOSYS);
++
++        mCreateDXGIFactory = (PFN_CREATE_DXGI_FACTORY)GetProcAddress(dxgilib, "CreateDXGIFactory1");
++    }
++#   else
++    if (!mCreateDXGIFactory)
++        mCreateDXGIFactory = (PFN_CREATE_DXGI_FACTORY)CreateDXGIFactory1;
++#   endif
++    if (!mCreateDXGIFactory)
++        return AVERROR(ENOSYS);
++
++    hr = mCreateDXGIFactory(&IID_IDXGIFactory2, (void**)&pDXGIFactory);
++    if (FAILED(hr))
++        return AVERROR(ENOSYS);
++
++    for (i = start_idx, j = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs; i++) {
++        hr = IDXGIFactory2_EnumAdapters(pDXGIFactory, i, &pDXGIAdapter);
++        if (FAILED(hr)) {
++            if (device_idx < 0) continue;
++            else break;
++        }
++
++        hr = IDXGIAdapter2_GetDesc(pDXGIAdapter, &desc);
++        if (pDXGIAdapter)
++            IDXGIAdapter_Release(pDXGIAdapter);
++
++        /* Filter out 'Microsoft Basic Render Driver' */
++        if (SUCCEEDED(hr) &&
++            desc.VendorId == FFPROBE_HW_VENDOR_ID_MICROSOFT) {
++            if (device_idx < 0) continue;
++            else break;
++        }
++
++        /* Filter out RDP/indirect/software adapters */
++        if (SUCCEEDED(hr) && !is_physical_dxgi_adapter(desc.AdapterLuid)) {
++            if (device_idx < 0) continue;
++            else break;
++        }
++
++        /* Filter out by the requested vendor id */
++        if (SUCCEEDED(hr) && vendor_id > 0 && desc.VendorId != vendor_id) {
++            if (device_idx < 0) continue;
++            else break;
++        }
++
++        /* Filter by the requested LUID on Windows from CUDA */
++        if (SUCCEEDED(hr) && idx_luid >= 0 && luid && device_idx < 0) {
++            const LUID dxgi_luid = desc.AdapterLuid;
++            const size_t lo_size = sizeof(dxgi_luid.LowPart);
++            const size_t hi_size = sizeof(dxgi_luid.HighPart);
++
++            if (!memcmp(&dxgi_luid.LowPart, luid, lo_size) &&
++                !memcmp(&dxgi_luid.HighPart, luid + lo_size, hi_size)) {
++                snprintf(ibuf, sizeof(ibuf), "%d", i);
++                av_hwdevice_ctx_create(&refs[idx_luid].d3d11va_ref,
++                                       AV_HWDEVICE_TYPE_D3D11VA,
++                                       ibuf, NULL, 0);
++                break;
++            } else
++                continue;
++        }
++
++        snprintf(ibuf, sizeof(ibuf), "%d", i);
++        ret = av_hwdevice_ctx_create(&refs[j].d3d11va_ref,
++                                     AV_HWDEVICE_TYPE_D3D11VA,
++                                     ibuf, NULL, 0);
++        if (ret < 0) {
++            if (device_idx < 0) continue;
++            else break;
++        }
++
++        if (desc.VendorId == FFPROBE_HW_VENDOR_ID_AMD) {
++            find_amf_dll_for_dxgi_adapter(desc, refs[j].amf_dll_path,
++                                          FF_ARRAY_ELEMS(refs[j].amf_dll_path));
++        }
++        refs[j].device_index_dxgi = i;
++        refs[j].device_luid_dxgi  = ((uint64_t)desc.AdapterLuid.HighPart << 32) |
++                                     (uint64_t)desc.AdapterLuid.LowPart;
++        refs[j].device_vendor_id  = desc.VendorId;
++        j++;
++
++        /* Filter by the requested device index */
++        if (device_idx >= 0)
++            break;
++    }
++
++    IDXGIFactory2_Release(pDXGIFactory);
++    return 0;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++/* D3D11VA -> QSV */
++void create_derive_qsv_devices_from_d3d11va(HwDeviceRefs *refs)
++{
++    for (unsigned i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs && refs[i].d3d11va_ref; i++) {
++        if (refs[i].device_vendor_id != FFPROBE_HW_VENDOR_ID_INTEL)
++            continue;
++        av_hwdevice_ctx_create_derived(&refs[i].qsv_ref, AV_HWDEVICE_TYPE_QSV,
++                                       refs[i].d3d11va_ref, 0);
++    }
++}
++
++/* D3D11VA -> OPENCL */
++void create_derive_opencl_devices_from_d3d11va(HwDeviceRefs *refs)
++{
++    for (unsigned i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs && refs[i].d3d11va_ref; i++) {
++        if (!(refs[i].device_vendor_id == FFPROBE_HW_VENDOR_ID_INTEL ||
++              refs[i].device_vendor_id == FFPROBE_HW_VENDOR_ID_AMD))
++            continue;
++        av_hwdevice_ctx_create_derived(&refs[i].opencl_ref, AV_HWDEVICE_TYPE_OPENCL,
++                                       refs[i].d3d11va_ref, 0);
++    }
++}
++
++#if CONFIG_D3D11VA
++static int print_d3d11va_driver_version(AVTextFormatContext *tfc, DXGI_ADAPTER_DESC desc)
++{
++#   ifdef FFPROBE_HW_WDDM_VERSION_HELPER
++    CONFIGRET cr;
++    ULONG device_id_list_size = 0;
++    WCHAR *device_id_list = NULL;
++    WCHAR *begin, *end;
++    WCHAR display_guid[39];
++    WCHAR dev_id[64];
++    int found = 0;
++    int ret = 0;
++
++    if (!tfc)
++        return AVERROR(EINVAL);
++
++    swprintf(dev_id, FF_ARRAY_ELEMS(dev_id),
++             L"VEN_%04X&DEV_%04X&SUBSYS_%08X&REV_%02X",
++             desc.VendorId, desc.DeviceId, desc.SubSysId, desc.Revision);
++
++    if (StringFromGUID2(&GUID_DEVCLASS_DISPLAY, display_guid,
++                        FF_ARRAY_ELEMS(display_guid)) == 0) {
++        av_log(NULL, AV_LOG_DEBUG, "WDDM: StringFromGUID2 failed\n");
++        return AVERROR(ENOSYS);
++    }
++
++    do {
++        cr = CM_Get_Device_ID_List_SizeW(&device_id_list_size, display_guid,
++                                         CM_GETIDLIST_FILTER_CLASS |
++                                         CM_GETIDLIST_FILTER_PRESENT);
++        if (cr != CR_SUCCESS) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "WDDM: CM_Get_Device_ID_List_SizeW failed '%lu'\n", cr);
++            ret = AVERROR(ENOSYS);
++            goto done;
++        }
++
++        av_freep(&device_id_list);
++        device_id_list = av_malloc(device_id_list_size * sizeof(*device_id_list));
++        if (!device_id_list) {
++            ret = AVERROR(ENOMEM);
++            goto done;
++        }
++
++        cr = CM_Get_Device_ID_ListW(display_guid, device_id_list, device_id_list_size,
++                                    CM_GETIDLIST_FILTER_CLASS |
++                                    CM_GETIDLIST_FILTER_PRESENT);
++    } while (cr == CR_BUFFER_SMALL);
++
++    if (cr != CR_SUCCESS) {
++        av_log(NULL, AV_LOG_DEBUG,
++               "WDDM: CM_Get_Device_ID_ListW failed '%lu'\n", cr);
++        ret = AVERROR(ENOSYS);
++        goto done;
++    }
++
++    begin = device_id_list;
++    end   = begin + device_id_list_size;
++
++    for (; (begin < end) && *begin; begin += wcslen(begin) + 1) {
++        DEVINST dev_inst;
++        HKEY hkey;
++        WCHAR upper[MAX_DEVICE_ID_LEN];
++        WCHAR ver_str[64];
++        DWORD ver_size = sizeof(ver_str);
++        DWORD type = 0;
++        int model, feature, revision, build;
++        size_t k;
++
++        wcsncpy(upper, begin, FF_ARRAY_ELEMS(upper) - 1);
++        upper[FF_ARRAY_ELEMS(upper) - 1] = L'\0';
++        for (k = 0; upper[k]; k++)
++            upper[k] = towupper(upper[k]);
++
++        if (!wcsstr(upper, dev_id))
++            continue;
++
++        cr = CM_Locate_DevNodeW(&dev_inst, begin, CM_LOCATE_DEVNODE_NORMAL);
++        if (cr != CR_SUCCESS) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "WDDM: CM_Locate_DevNodeW failed '%lu'\n", cr);
++            continue;
++        }
++
++        cr = CM_Open_DevNode_Key(dev_inst, KEY_READ, 0,
++                                 RegDisposition_OpenExisting,
++                                 &hkey, CM_REGISTRY_SOFTWARE);
++        if (cr != CR_SUCCESS) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "WDDM: CM_Open_DevNode_Key failed '%lu'\n", cr);
++            continue;
++        }
++
++        if (RegQueryValueExW(hkey, L"DriverVersion", NULL, &type,
++                             (LPBYTE)ver_str, &ver_size) != ERROR_SUCCESS ||
++            type != REG_SZ) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "WDDM: DriverVersion query failed '%lu'\n", GetLastError());
++            RegCloseKey(hkey);
++            continue;
++        }
++        RegCloseKey(hkey);
++
++        /* https://learn.microsoft.com/en-us/windows-hardware/drivers/display/wddm-2-1-features */
++        if (swscanf(ver_str, L"%d.%d.%d.%d",
++                    &model, &feature, &revision, &build) != 4) {
++            av_log(NULL, AV_LOG_DEBUG,
++                   "WDDM: DriverVersion '%ls' doesn't match expected format\n", ver_str);
++            continue;
++        }
++
++        print_int("device_wddm_model_version", model);
++        print_int("device_wddm_d3d_feature_level", feature);
++        print_int("device_wddm_vendor_revision", revision);
++        print_int("device_wddm_vendor_build", build);
++
++        found = 1;
++        break;
++    }
++
++    if (!found && !ret) {
++        av_log(NULL, AV_LOG_DEBUG,
++               "WDDM: driver version not found for device VEN_%04X&DEV_%04X\n",
++               desc.VendorId, desc.DeviceId);
++        ret = AVERROR(ENOSYS);
++    }
++
++done:
++    av_freep(&device_id_list);
++    return ret;
++#   else // FFPROBE_HW_WDDM_VERSION_HELPER
++    return 0;
++#   endif
++}
++#endif
++
++int print_d3d11va_device_info(AVTextFormatContext *tfc, AVBufferRef *d3d11va_ref)
++{
++#if CONFIG_D3D11VA
++    AVHWDeviceContext    *dev_ctx = NULL;
++    AVD3D11VADeviceContext *hwctx = NULL;
++    IDXGIDevice     *pDXGIDevice = NULL;
++    IDXGIAdapter   *pDXGIAdapter = NULL;
++    DXGI_ADAPTER_DESC desc = { 0 };
++    D3D_FEATURE_LEVEL level = 0;
++    D3D11_FEATURE_DATA_D3D11_OPTIONS data = { 0 };
++    D3D11_FEATURE_DATA_D3D11_OPTIONS2 data2 = { 0 };
++    HRESULT hr;
++    char device_desc[128*3+1] = { 0 };
++    int uma = -1, ext_sharing = -1, ret = 0;
++
++    if (!tfc || !d3d11va_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)d3d11va_ref->data;
++    hwctx = dev_ctx->hwctx;
++
++    hr = ID3D11Device_QueryInterface(hwctx->device, &IID_IDXGIDevice, (void**)&pDXGIDevice);
++    if (FAILED(hr)) {
++        ret = AVERROR(ENOSYS);
++        av_log(NULL, AV_LOG_DEBUG, "ID3D11Device_QueryInterface failed: 0x%08lx\n", hr);
++        goto exit;
++    }
++
++    hr = IDXGIDevice_GetAdapter(pDXGIDevice, &pDXGIAdapter);
++    if (FAILED(hr)) {
++        ret = AVERROR(ENOSYS);
++        av_log(NULL, AV_LOG_DEBUG, "IDXGIDevice_GetAdapter failed: 0x%08lx\n", hr);
++        goto exit;
++    }
++
++    hr = IDXGIAdapter_GetDesc(pDXGIAdapter, &desc);
++    if (FAILED(hr)) {
++        ret = AVERROR(ENOSYS);
++        av_log(NULL, AV_LOG_DEBUG, "IDXGIAdapter_GetDesc failed: 0x%08lx\n", hr);
++        goto exit;
++    }
++
++    level = ID3D11Device_GetFeatureLevel(hwctx->device);
++
++    hr = ID3D11Device_CheckFeatureSupport(hwctx->device,
++                                          D3D11_FEATURE_D3D11_OPTIONS,
++                                          &data, sizeof(data));
++    ext_sharing = SUCCEEDED(hr) && data.ExtendedResourceSharing;
++
++    hr = ID3D11Device_CheckFeatureSupport(hwctx->device,
++                                          D3D11_FEATURE_D3D11_OPTIONS2,
++                                          &data2, sizeof(data2));
++    uma = SUCCEEDED(hr) && data2.UnifiedMemoryArchitecture;
++
++    if (WideCharToMultiByte(CP_UTF8, 0, desc.Description, -1,
++                            device_desc, FF_ARRAY_ELEMS(device_desc),
++                            NULL, NULL) <= 0) {
++        av_strlcpy(device_desc, "Unknown GPU", sizeof(device_desc));
++    } else
++        device_desc[FF_ARRAY_ELEMS(device_desc) - 1] = '\0';
++
++    mark_section_show_entries(SECTION_ID_DEVICE_INFO_D3D11VA, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_INFO_D3D11VA);
++
++    print_str("device_name", device_desc);
++    print_int("device_vid", desc.VendorId);
++    print_int("device_did", desc.DeviceId);
++    print_int("device_subsys_id", desc.SubSysId);
++    print_int("device_revision", desc.Revision);
++    print_int("device_dedicated_video_memory", desc.DedicatedVideoMemory);
++    print_int("device_shared_system_memory", desc.SharedSystemMemory);
++    print_int("device_luid_lo", desc.AdapterLuid.LowPart);
++    print_int("device_luid_hi", desc.AdapterLuid.HighPart);
++    print_int("device_feature_level", level);
++    print_int("device_extended_resource_sharing", ext_sharing);
++    print_int("device_unified_memory_architecture", uma);
++
++    print_d3d11va_driver_version(tfc, desc);
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_INFO_D3D11VA
++
++exit:
++    if (pDXGIAdapter)
++        IDXGIAdapter_Release(pDXGIAdapter);
++    if (pDXGIDevice)
++        IDXGIDevice_Release(pDXGIDevice);
++    return ret;
++#else
++    return 0;
++#endif
++}
++
++#ifdef FFPROBE_HW_DXGI1_4_PDH_HELPER
++static BOOL match_dxgi_adapter_luids(const WCHAR *inst,
++                                     const WCHAR *luid_hi, const WCHAR *luid_lo)
++{
++    WCHAR luid_hi_upper[16], luid_lo_upper[16];
++    DWORD i;
++
++    if (wcsstr(inst, luid_hi) && wcsstr(inst, luid_lo))
++        return TRUE;
++
++    for (i = 0; i < FF_ARRAY_ELEMS(luid_hi_upper) - 1 && luid_hi[i]; i++)
++        luid_hi_upper[i] = towupper(luid_hi[i]);
++    luid_hi_upper[i] = L'\0';
++
++    if (!(wcsstr(inst, luid_hi) || wcsstr(inst, luid_hi_upper)))
++        return FALSE;
++
++    for (i = 0; i < FF_ARRAY_ELEMS(luid_lo_upper) - 1 && luid_lo[i]; i++)
++        luid_lo_upper[i] = towupper(luid_lo[i]);
++    luid_lo_upper[i] = L'\0';
++
++    return wcsstr(inst, luid_lo) || wcsstr(inst, luid_lo_upper);
++}
++
++static BOOL add_dxgi_adapter_memory_counter(PDH_HQUERY query, LUID luid,
++                                            PDH_HCOUNTER *counter, int shared)
++{
++    DWORD buf_size = 0, instance_count = 0;
++    WCHAR path[PDH_MAX_COUNTER_PATH];
++    WCHAR luid_hi[16], luid_lo[16];
++    WCHAR *counter_buf = NULL;
++    WCHAR *instance_buf = NULL;
++    const WCHAR *inst;
++    BOOL found = FALSE;
++    PDH_STATUS st;
++
++    swprintf(luid_hi, FF_ARRAY_ELEMS(luid_hi), L"%08x", (UINT32)luid.HighPart);
++    swprintf(luid_lo, FF_ARRAY_ELEMS(luid_lo), L"%08x", (UINT32)luid.LowPart);
++
++    /* Try uppercase first (most drivers) */
++    swprintf(path, FF_ARRAY_ELEMS(path), (shared ?
++        L"\\GPU Adapter Memory(luid_0x%08X_0x%08X_phys_0)\\Shared Usage" :
++        L"\\GPU Adapter Memory(luid_0x%08X_0x%08X_phys_0)\\Dedicated Usage"),
++        (UINT32)luid.HighPart,
++        (UINT32)luid.LowPart);
++
++    st = PdhAddEnglishCounterW(query, path, 0, counter);
++    if (st == ERROR_SUCCESS)
++        return TRUE;
++
++    /* Fall back: enumerate and match LUID */
++    PdhEnumObjectItemsW(NULL, NULL, L"GPU Adapter Memory",
++        NULL, &buf_size, NULL, &instance_count,
++        PERF_DETAIL_WIZARD, 0);
++
++    counter_buf  = av_malloc(buf_size * sizeof(*counter_buf));
++    instance_buf = av_malloc(instance_count * sizeof(*instance_buf));
++    if (!counter_buf || !instance_buf)
++        goto cleanup;
++
++    st = PdhEnumObjectItemsW(NULL, NULL, L"GPU Adapter Memory",
++                             counter_buf, &buf_size,
++                             instance_buf, &instance_count,
++                             PERF_DETAIL_WIZARD, 0);
++    if (st != ERROR_SUCCESS)
++        goto cleanup;
++
++    inst = instance_buf;
++    while (*inst) {
++        if (match_dxgi_adapter_luids(inst, luid_hi, luid_lo)) {
++            swprintf(path, FF_ARRAY_ELEMS(path), (shared ?
++                L"\\GPU Adapter Memory(%ls)\\Shared Usage" :
++                L"\\GPU Adapter Memory(%ls)\\Dedicated Usage"), inst);
++            st = PdhAddEnglishCounterW(query, path, 0, counter);
++            if (st == ERROR_SUCCESS) {
++                found = TRUE;
++                break;
++            }
++        }
++        inst += wcslen(inst) + 1;
++    }
++
++cleanup:
++    av_free(counter_buf);
++    av_free(instance_buf);
++    return found;
++}
++
++typedef struct {
++    PDH_HCOUNTER handle;
++    WCHAR        path[PDH_MAX_COUNTER_PATH];
++} EngineCounter;
++
++static BOOL is_relevant_engine_type(const WCHAR *inst)
++{
++    const WCHAR engtype[] = L"engtype_";
++    const DWORD engtype_len = FF_ARRAY_ELEMS(engtype) - 1;
++    const WCHAR *p = wcsstr(inst, engtype);
++    if (!p)
++        return FALSE;
++    p += engtype_len;
++
++#   define MATCH(e) (!wcsncmp(p, (e), FF_ARRAY_ELEMS(e) - 1))
++    return (MATCH(L"3D")               ||
++            MATCH(L"VideoDecode")      ||
++            MATCH(L"Video Decode")     ||
++            MATCH(L"VideoEncode")      ||
++            MATCH(L"Video Encode")     ||
++            MATCH(L"VideoCodec")       ||
++            MATCH(L"Video Codec")      ||
++            MATCH(L"VideoProcessing")  ||
++            MATCH(L"Video Processing") ||
++            MATCH(L"Copy")             ||
++            MATCH(L"Compute"));
++#   undef MATCH
++}
++
++static BOOL add_dxgi_adapter_engine_counters(PDH_HQUERY query, LUID luid,
++                                             EngineCounter **counters,
++                                             DWORD *counter_count)
++{
++    DWORD buf_size = 0, instance_count = 0;
++    WCHAR luid_hi[16] = { 0 };
++    WCHAR luid_lo[16] = { 0 };
++    WCHAR *counter_buf = NULL;
++    WCHAR *instance_buf = NULL;
++    const WCHAR *inst;
++    DWORD capacity = 0;
++    BOOL success = FALSE;
++    PDH_STATUS st;
++
++    *counters = NULL;
++    *counter_count = 0;
++
++    swprintf(luid_hi, FF_ARRAY_ELEMS(luid_hi), L"%08x", (UINT32)luid.HighPart);
++    swprintf(luid_lo, FF_ARRAY_ELEMS(luid_lo), L"%08x", (UINT32)luid.LowPart);
++
++    PdhEnumObjectItemsW(NULL, NULL, L"GPU Engine",
++        NULL, &buf_size, NULL, &instance_count,
++        PERF_DETAIL_WIZARD, 0);
++
++    counter_buf  = av_malloc(buf_size * sizeof(*counter_buf));
++    instance_buf = av_malloc(instance_count * sizeof(*instance_buf));
++    if (!counter_buf || !instance_buf)
++        goto cleanup;
++
++    st = PdhEnumObjectItemsW(NULL, NULL, L"GPU Engine",
++                             counter_buf, &buf_size,
++                             instance_buf, &instance_count,
++                             PERF_DETAIL_WIZARD, 0);
++    if (st != ERROR_SUCCESS)
++        goto cleanup;
++
++    inst = instance_buf;
++    while (*inst) {
++        if (is_relevant_engine_type(inst) &&
++            match_dxgi_adapter_luids(inst, luid_hi, luid_lo)) {
++            EngineCounter *ec = NULL;
++
++            if (*counter_count >= capacity) {
++                capacity = capacity ? (capacity * 2) : 8;
++                *counters = av_realloc_array(*counters, capacity,
++                                             sizeof(EngineCounter));
++                if (!*counters)
++                    goto cleanup;
++            }
++
++            ec = &(*counters)[*counter_count];
++            swprintf(ec->path, FF_ARRAY_ELEMS(ec->path),
++                L"\\GPU Engine(%ls)\\Utilization Percentage", inst);
++
++            st = PdhAddEnglishCounterW(query, ec->path, 0, &ec->handle);
++            if (st == ERROR_SUCCESS)
++                (*counter_count)++;
++        }
++        inst += wcslen(inst) + 1;
++    }
++
++    success = TRUE;
++
++cleanup:
++    av_free(counter_buf);
++    av_free(instance_buf);
++    return success;
++}
++
++static void get_dxgi_adapter_engine_type(const WCHAR *path, WCHAR *buf, DWORD buf_len)
++{
++    const WCHAR engtype[] = L"engtype_";
++    const DWORD engtype_len = FF_ARRAY_ELEMS(engtype) - 1;
++    const WCHAR prefix[] = L"device_";
++    const DWORD prefix_len = FF_ARRAY_ELEMS(prefix) - 1;
++    const WCHAR suffix[] = L"_utilization";
++    const DWORD suffix_len = FF_ARRAY_ELEMS(suffix) - 1;
++    const WCHAR *p;
++    DWORD i;
++
++    buf[0] = L'\0';
++
++    p = wcsstr(path, engtype);
++    if (!p)
++        return;
++
++    p += engtype_len;
++
++    if (buf_len < prefix_len + 1)
++        return;
++
++    wcscpy(buf, prefix);
++    i = prefix_len;
++
++    /* Drop spaces and convert to lowercase */
++    while (*p && *p != L')' && i < buf_len - 1) {
++        WCHAR c = *p++;
++
++        if (c == L' ')
++            continue;
++        buf[i++] = towlower(c);
++    }
++    buf[i] = L'\0';
++
++    /* Drop engine type index (engine_N) */
++    while (i > prefix_len && buf[i - 1] >= L'0' && buf[i - 1] <= L'9') i--;
++    if (i > prefix_len && buf[i - 1] == L'_') i--;
++    buf[i] = L'\0';
++
++    if (i + suffix_len + 1 <= buf_len)
++        wcscpy(buf + i, suffix);
++
++    buf[i + suffix_len] = L'\0';
++}
++
++static void print_dxgi_adapter_engine_utilizations(AVTextFormatContext *tfc,
++                                                   EngineCounter *counters,
++                                                   DWORD counter_count)
++{
++    struct {
++        WCHAR  engine_type[256];
++        double val_total;
++        int    active_nodes[32];
++        int    active_node_count;
++    } summary[32] = { 0 };
++    DWORD summary_count = 0;
++    DWORD i, j, k;
++    PDH_STATUS st;
++
++    if (!tfc || !counters || !counter_count)
++        return;
++
++    for (i = 0; i < counter_count; i++) {
++        const WCHAR eng[] = L"_eng_";
++        const DWORD eng_len = FF_ARRAY_ELEMS(eng) - 1;
++        WCHAR engine_type[256] = { 0 };
++        PDH_FMT_COUNTERVALUE val;
++        int current_node_id = -1;
++        const WCHAR *p;
++
++        get_dxgi_adapter_engine_type(counters[i].path, engine_type, FF_ARRAY_ELEMS(engine_type));
++        if (engine_type[0] == L'\0')
++            continue;
++
++        st = PdhGetFormattedCounterValue(counters[i].handle, PDH_FMT_DOUBLE, NULL, &val);
++        if (st != ERROR_SUCCESS)
++            continue;
++
++        p = wcsstr(counters[i].path, eng);
++        if (p)
++            current_node_id = (int)wcstol(p + eng_len, NULL, 10);
++
++        for (j = 0; j < summary_count; j++) {
++            if (wcscmp(summary[j].engine_type, engine_type) == 0) {
++                if (val.doubleValue > 0.0)
++                    summary[j].val_total += val.doubleValue;
++                if (current_node_id != -1) {
++                    for (k = 0; k < (DWORD)summary[j].active_node_count; k++) {
++                        if (summary[j].active_nodes[k] == current_node_id)
++                            break;
++                    }
++                    if (k == (DWORD)summary[j].active_node_count && val.doubleValue > 0.0 &&
++                        summary[j].active_node_count < FF_ARRAY_ELEMS(summary[j].active_nodes)) {
++                        summary[j].active_nodes[summary[j].active_node_count++] = current_node_id;
++                    }
++                }
++                break;
++            }
++        }
++        if (j == summary_count && summary_count < FF_ARRAY_ELEMS(summary)) {
++            wcscpy(summary[summary_count].engine_type, engine_type);
++            summary[summary_count].val_total = val.doubleValue > 0.0 ? val.doubleValue : 0.0;
++            summary[summary_count].active_node_count = 0;
++            if (current_node_id != -1) {
++                summary[summary_count].active_nodes[0] = current_node_id;
++                if (val.doubleValue > 0.0)
++                    summary[summary_count].active_node_count = 1;
++            }
++            summary_count++;
++        }
++    }
++
++    for (j = 0; j < summary_count; j++) {
++        char *engine_type_utf8 = NULL;
++
++        if (!wchartoutf8((wchar_t*)summary[j].engine_type, &engine_type_utf8)) {
++            double avg_val = summary[j].val_total;
++
++            if (summary[j].active_node_count > 0)
++                avg_val /= summary[j].active_node_count;
++
++            print_int(engine_type_utf8, (int)FFMIN(avg_val + 0.5, 100.0));
++            av_free(engine_type_utf8);
++        }
++    }
++}
++#endif
++
++int print_d3d11va_device_util(AVTextFormatContext *tfc, AVBufferRef *d3d11va_ref)
++{
++#ifdef FFPROBE_HW_DXGI1_4_PDH_HELPER
++    AVHWDeviceContext    *dev_ctx = NULL;
++    AVD3D11VADeviceContext *hwctx = NULL;
++    IDXGIDevice      *pDXGIDevice = NULL;
++    IDXGIAdapter    *pDXGIAdapter = NULL;
++    IDXGIAdapter3  *pDXGIAdapter3 = NULL;
++    DXGI_ADAPTER_DESC        desc = { 0 };
++    HRESULT hr;
++    PDH_HQUERY             pQuery = NULL;
++    PDH_HCOUNTER  pMemCounterDgfx = NULL;
++    PDH_HCOUNTER  pMemCounterIgfx = NULL;
++    EngineCounter   *pEngCounters = NULL;
++    DWORD            engine_count = 0;
++    char device_desc[128*3+1] = { 0 };
++    int ret = 0;
++
++    if (!tfc || !d3d11va_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)d3d11va_ref->data;
++    hwctx = dev_ctx->hwctx;
++
++    hr = ID3D11Device_QueryInterface(hwctx->device, &IID_IDXGIDevice, (void**)&pDXGIDevice);
++    if (FAILED(hr)) {
++        ret = AVERROR(ENOSYS);
++        av_log(NULL, AV_LOG_DEBUG, "ID3D11Device_QueryInterface failed: 0x%08lx\n", hr);
++        goto exit;
++    }
++
++    hr = IDXGIDevice_GetAdapter(pDXGIDevice, &pDXGIAdapter);
++    if (FAILED(hr)) {
++        ret = AVERROR(ENOSYS);
++        av_log(NULL, AV_LOG_DEBUG, "IDXGIDevice_GetAdapter failed: 0x%08lx\n", hr);
++        goto exit;
++    }
++
++    hr = IDXGIAdapter_GetDesc(pDXGIAdapter, &desc);
++    if (FAILED(hr)) {
++        ret = AVERROR(ENOSYS);
++        av_log(NULL, AV_LOG_DEBUG, "IDXGIAdapter_GetDesc failed: 0x%08lx\n", hr);
++        goto exit;
++    }
++
++    if (WideCharToMultiByte(CP_UTF8, 0, desc.Description, -1,
++                            device_desc, FF_ARRAY_ELEMS(device_desc),
++                            NULL, NULL) <= 0) {
++        av_strlcpy(device_desc, "Unknown GPU", sizeof(device_desc));
++    } else
++        device_desc[FF_ARRAY_ELEMS(device_desc) - 1] = '\0';
++
++    if (PdhOpenQueryW(NULL, 0, &pQuery) == ERROR_SUCCESS) {
++        if (add_dxgi_adapter_memory_counter(pQuery, desc.AdapterLuid, &pMemCounterDgfx, 0) |
++            add_dxgi_adapter_memory_counter(pQuery, desc.AdapterLuid, &pMemCounterIgfx, 1) |
++            add_dxgi_adapter_engine_counters(pQuery, desc.AdapterLuid, &pEngCounters, &engine_count)) {
++            PdhCollectQueryData(pQuery);
++            Sleep(100);
++            PdhCollectQueryData(pQuery);
++        }
++    }
++
++    mark_section_show_entries(SECTION_ID_DEVICE_UTIL_D3D11VA, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_UTIL_D3D11VA);
++
++    print_str("device_name", device_desc);
++    print_int("device_luid_lo", desc.AdapterLuid.LowPart);
++    print_int("device_luid_hi", desc.AdapterLuid.HighPart);
++    print_int("device_dedicated_video_memory", desc.DedicatedVideoMemory);
++    print_int("device_shared_system_memory", desc.SharedSystemMemory);
++
++    hr = IDXGIAdapter_QueryInterface(pDXGIAdapter, &IID_IDXGIAdapter3, (void**)&pDXGIAdapter3);
++    if (SUCCEEDED(hr)) {
++        DXGI_QUERY_VIDEO_MEMORY_INFO memory_info;
++
++        hr = IDXGIAdapter3_QueryVideoMemoryInfo(pDXGIAdapter3, 0,
++                                                DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &memory_info);
++        if (SUCCEEDED(hr))
++            print_int("device_memory_budget", memory_info.Budget);
++    }
++
++    {
++        PDH_STATUS st;
++        PDH_FMT_COUNTERVALUE mem_val;
++
++        if (pMemCounterDgfx) {
++            st = PdhGetFormattedCounterValue(pMemCounterDgfx, PDH_FMT_LARGE, NULL, &mem_val);
++            if (st == ERROR_SUCCESS)
++                print_int("device_memory_dedicated_usage", mem_val.largeValue);
++        }
++        if (pMemCounterIgfx) {
++            st = PdhGetFormattedCounterValue(pMemCounterIgfx, PDH_FMT_LARGE, NULL, &mem_val);
++            if (st == ERROR_SUCCESS)
++                print_int("device_memory_shared_usage", mem_val.largeValue);
++        }
++        if (pEngCounters && engine_count > 0)
++            print_dxgi_adapter_engine_utilizations(tfc, pEngCounters, engine_count);
++    }
++
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_UTIL_D3D11VA
++
++exit:
++    av_free(pEngCounters);
++    if (pQuery != NULL)
++        PdhCloseQuery(pQuery); // Also free counters
++    if (pDXGIAdapter3)
++        IDXGIAdapter3_Release(pDXGIAdapter3);
++    if (pDXGIAdapter)
++        IDXGIAdapter_Release(pDXGIAdapter);
++    if (pDXGIDevice)
++        IDXGIDevice_Release(pDXGIDevice);
++    return ret;
++#else
++    return 0;
++#endif
++}
++
++#if CONFIG_D3D11VA
++static int check_d3d11va_decoder_config(ID3D11VideoDevice *video_device,
++                                        D3D11_VIDEO_DECODER_DESC desc,
++                                        enum AVCodecID codec)
++{
++    unsigned i, cfg_cnt = 0;
++    D3D11_VIDEO_DECODER_CONFIG *cfg_list = NULL;
++    HRESULT hr;
++
++    hr = ID3D11VideoDevice_GetVideoDecoderConfigCount(video_device, &desc, &cfg_cnt);
++    if (FAILED(hr)) {
++        av_log(NULL, AV_LOG_DEBUG, "ID3D11VideoDevice_GetVideoDecoderConfigCount failed: 0x%08lx\n", hr);
++        return AVERROR(EINVAL);
++    }
++
++    cfg_list = av_malloc_array(cfg_cnt, sizeof(*cfg_list));
++    if (!cfg_list)
++        return AVERROR(ENOMEM);
++
++    for (i = 0; i < cfg_cnt; i++) {
++        D3D11_VIDEO_DECODER_CONFIG *cfg = &cfg_list[i];
++
++        hr = ID3D11VideoDevice_GetVideoDecoderConfig(video_device, &desc, i, cfg);
++        if (FAILED(hr)) {
++            av_log(NULL, AV_LOG_DEBUG, "ID3D11VideoDevice_GetVideoDecoderConfig failed: 0x%08lx\n", hr);
++            av_free(cfg_list);
++            return AVERROR(EINVAL);
++        }
++
++        if (cfg->ConfigBitstreamRaw == 1 ||
++            (codec == AV_CODEC_ID_H264 && cfg->ConfigBitstreamRaw == 2)) {
++            av_free(cfg_list);
++            return 1;
++        }
++    }
++
++    av_free(cfg_list);
++    return 0;
++}
++#endif
++
++int print_d3d11va_decoder_info(AVTextFormatContext *tfc, AVBufferRef *d3d11va_ref)
++{
++#if CONFIG_D3D11VA
++    AVHWDeviceContext    *dev_ctx = NULL;
++    AVD3D11VADeviceContext *hwctx = NULL;
++    HRESULT hr;
++    int header_printed = 0;
++    unsigned i, j, p_cnt = 0;
++    GUID *p_list = NULL;
++
++    if (!tfc || !d3d11va_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)d3d11va_ref->data;
++    hwctx = dev_ctx->hwctx;
++
++    p_cnt = ID3D11VideoDevice_GetVideoDecoderProfileCount(hwctx->video_device);
++    p_list = av_malloc_array(p_cnt, sizeof(*p_list));
++    if (!p_list || !p_cnt) {
++        av_log(NULL, AV_LOG_DEBUG, "ID3D11VideoDevice_GetVideoDecoderProfileCount failed\n");
++        av_free(p_list);
++        return AVERROR(EINVAL);
++    }
++
++    for (i = 0; i < p_cnt; i++) {
++        hr = ID3D11VideoDevice_GetVideoDecoderProfile(hwctx->video_device, i, &p_list[i]);
++        if (FAILED(hr)) {
++            av_log(NULL, AV_LOG_DEBUG, "ID3D11VideoDevice_GetVideoDecoderProfile %u failed\n", i);
++            av_free(p_list);
++            return AVERROR(EINVAL);
++        }
++    }
++
++    for (i = 0; dxva_modes[i].name && dxva_modes[i].guid; i++) {
++        int supported = 0;
++        unsigned min_width = 0, min_height = 0;
++        unsigned max_width = 0, max_height = 0;
++        const DxvaMode *mode = &dxva_modes[i];
++        D3D11_VIDEO_DECODER_DESC desc = { 0 };
++        DXGI_FORMAT dxgi_fmt = DXGI_FORMAT_UNKNOWN;
++
++        if (!mode->formats)
++            continue;
++
++        for (const GUID *g = &p_list[0]; !supported && g < &p_list[p_cnt]; g++) {
++            supported = IsEqualGUID(mode->guid, g);
++        }
++        if (!supported)
++            continue;
++
++        /* Use the most significant format for this profile */
++        dxgi_fmt = d3d11va_map_av_to_dxgi_format(mode->formats[0]);
++        if (dxgi_fmt == DXGI_FORMAT_UNKNOWN)
++            continue;
++
++        desc.Guid = *mode->guid;
++
++        /* Check min res first */
++        for (const HwRes *r = &hw_res_ascend[0]; r->name; r++) {
++            if (mode->legacy && (r->width > 4096 || r->height > 4096))
++                break;
++
++            desc.SampleWidth  = r->width;
++            desc.SampleHeight = r->height;
++            desc.OutputFormat = dxgi_fmt;
++
++            if (check_d3d11va_decoder_config(hwctx->video_device, desc, mode->codec) == 1) {
++                min_width  = r->width;
++                min_height = r->height;
++                break;
++            }
++        }
++        if (!min_width || !min_height)
++            continue;
++
++        /* Test rest formats for this profile, bail out directly if any fails */
++        for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++            desc.SampleWidth  = min_width;
++            desc.SampleHeight = min_height;
++            desc.OutputFormat = d3d11va_map_av_to_dxgi_format(mode->formats[j]);
++
++            if (check_d3d11va_decoder_config(hwctx->video_device, desc, mode->codec) != 1) {
++                min_width = min_height = 0;
++                break;
++            }
++        }
++        if (!min_width || !min_height)
++            continue;
++
++        /* Check max res */
++        for (const HwRes *r = &hw_res_ascend[FF_ARRAY_ELEMS(hw_res_ascend) - 1]; r >= &hw_res_ascend[0]; r--) {
++            if (!r->name)
++                continue;
++            if (r->width <= min_width && r->height <= min_height) {
++                max_width  = r->width;
++                max_height = r->height;
++                break;
++            }
++            if (mode->legacy && (r->width > 4096 || r->height > 4096))
++                continue;
++
++            desc.SampleWidth  = r->width;
++            desc.SampleHeight = r->height;
++            desc.OutputFormat = dxgi_fmt;
++
++            if (check_d3d11va_decoder_config(hwctx->video_device, desc, mode->codec) == 1) {
++                max_width  = r->width;
++                max_height = r->height;
++                break;
++            }
++        }
++        if (!max_width || !max_height)
++            continue;
++
++        if (!header_printed) {
++            mark_section_show_entries(SECTION_ID_DEVICE_DECODERS_D3D11VA, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_DECODERS_D3D11VA);
++            header_printed = 1;
++        }
++
++        mark_section_show_entries(SECTION_ID_DEVICE_DECODER, 1, NULL);
++        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_DECODER);
++        print_str("codec_name", avcodec_get_name(mode->codec));
++        print_int("codec_id", mode->codec);
++        print_str("codec_desc", mode->name);
++        print_int("min_width", min_width);
++        print_int("min_height", min_height);
++        print_int("max_width", max_width);
++        print_int("max_height", max_height);
++
++        /* Formats */
++        if (mode->formats) {
++            mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++            for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++                print_str("format_name", av_get_pix_fmt_name(mode->formats[j]));
++                print_int("format_id", mode->formats[j]);
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++            }
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++        }
++
++        /* Profiles */
++        if (mode->profiles) {
++            mark_section_show_entries(SECTION_ID_DEVICE_PROFILES, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILES);
++            for (j = 0; mode->profiles[j] != AV_PROFILE_UNKNOWN; j++) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PROFILE, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILE);
++                print_str("profile_name", avcodec_profile_name(mode->codec, mode->profiles[j]));
++                print_int("profile_id", mode->profiles[j]);
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILE
++            }
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILES
++        }
++
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_DECODER
++    }
++
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_DECODERS_D3D11VA
++#endif
++    return 0;
++}
+Index: FFmpeg/fftools/ffprobe_hw_internal.h
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_internal.h
+@@ -0,0 +1,180 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#ifndef FFTOOLS_FFPROBE_HW_INTERNAL_H
++#define FFTOOLS_FFPROBE_HW_INTERNAL_H
++
++#include "config.h"
++#include "config_components.h"
++
++#include "textformat/avtextformat.h"
++#include "libavcodec/avcodec.h"
++#include "libavutil/hwcontext.h"
++#include "libavutil/pixdesc.h"
++
++#include "ffprobe.h"
++#include "ffprobe_hw.h"
++
++#define print_int(k, v) avtext_print_integer(tfc, k, v, 0)
++#define print_str(k, v) avtext_print_string(tfc, k, v, 0)
++
++#define FFPROBE_HW_MAX_DEV_NUM 16
++
++#define FFPROBE_HW_VENDOR_ID_AMD        0x1002
++#define FFPROBE_HW_VENDOR_ID_INTEL      0x8086
++#define FFPROBE_HW_VENDOR_ID_NVIDIA     0x10de
++#define FFPROBE_HW_VENDOR_ID_MICROSOFT  0x1414
++#define FFPROBE_HW_VENDOR_ID_ROCKCHIP   0x1d87
++
++typedef struct HwRes {
++    const char    *name;
++    const unsigned width;
++    const unsigned height;
++} HwRes;
++
++static const HwRes hw_res_ascend[] = {
++    { "16x16",     16,   16   },
++    { "64x64",     64,   64   },
++    { "128x128",   128,  128  },
++    { "144x144",   144,  144  },
++    { "256x256",   256,  256  },
++    { "720x480",   720,  480  },
++    { "1280x720",  1280, 720  },
++    { "2048x1024", 2048, 1024 },
++    { "1920x1080", 1920, 1080 },
++    { "1920x1088", 1920, 1088 },
++    { "2560x1440", 2560, 1440 },
++    { "2048x2048", 2048, 2048 },
++    { "3840x2160", 3840, 2160 },
++    { "4096x2160", 4096, 2160 },
++    { "4096x2304", 4096, 2304 },
++    { "4096x2318", 4096, 2318 },
++    { "3840x3840", 3840, 3840 },
++    { "4080x4080", 4080, 4080 },
++    { "4096x4096", 4096, 4096 },
++    { "7680x4320", 7680, 4320 },
++    { "8192x4320", 8192, 4320 },
++    { "8192x4352", 8192, 4352 },
++    { "8192x8192", 8192, 8192 },
++    { NULL,        0,    0    },
++};
++
++typedef struct HwDeviceRefs {
++    AVBufferRef *drm_ref;
++    char         device_path_drm[4096]; /* PATH_MAX */
++
++    AVBufferRef *vaapi_ref;
++
++    AVBufferRef *d3d11va_ref;
++    int          device_index_dxgi;
++    uint64_t     device_luid_dxgi;
++
++    AVBufferRef *cuda_ref;
++    int          device_index_cuda;
++
++    AVBufferRef *qsv_ref;
++
++    AVBufferRef *rkmpp_ref;
++    char         device_tree_rkmpp[256];
++
++    AVBufferRef *opencl_ref;
++    AVBufferRef *vulkan_ref;
++
++    int          device_vendor_id;
++    wchar_t      amf_dll_path[260*2]; /* MAX_PATH*2 */
++} HwDeviceRefs;
++
++/* DRM */
++int init_udev_functions(void);
++void uninit_udev_functions(void);
++int create_drm_devices(HwDeviceRefs *refs, const char *device_path);
++int create_drm_devices_with_filter(HwDeviceRefs *refs, int vendor_id, const char *device_path);
++void create_derive_vaapi_devices_from_drm(HwDeviceRefs *refs);
++void create_derive_vulkan_devices_from_drm(HwDeviceRefs *refs);
++int print_drm_device_info(AVTextFormatContext *tfc, AVBufferRef *drm_ref);
++
++/* VAAPI */
++void create_derive_qsv_devices_from_vaapi(HwDeviceRefs *refs);
++void create_derive_opencl_devices_from_vaapi(HwDeviceRefs *refs);
++int print_vaapi_device_info(AVTextFormatContext *tfc, AVBufferRef *vaapi_ref, AVBufferRef *drm_ref);
++int print_vaapi_decoder_info(AVTextFormatContext *tfc, AVBufferRef *vaapi_ref);
++int print_vaapi_encoder_info(AVTextFormatContext *tfc, AVBufferRef *vaapi_ref);
++int print_vaapi_vpp_info(AVTextFormatContext *tfc, AVBufferRef *vaapi_ref);
++
++/* DXGI/D3D11VA */
++int create_d3d11va_devices(HwDeviceRefs *refs, int device_idx);
++int create_d3d11va_devices_with_filter(HwDeviceRefs *refs, int vendor_id, int idx_luid, const char *luid, int device_idx);
++void create_derive_qsv_devices_from_d3d11va(HwDeviceRefs *refs);
++void create_derive_opencl_devices_from_d3d11va(HwDeviceRefs *refs);
++int print_d3d11va_device_info(AVTextFormatContext *tfc, AVBufferRef *d3d11va_ref);
++int print_d3d11va_device_util(AVTextFormatContext *tfc, AVBufferRef *d3d11va_ref);
++int print_d3d11va_decoder_info(AVTextFormatContext *tfc, AVBufferRef *d3d11va_ref);
++
++/* CUDA */
++int init_cuda_functions(void);
++void uninit_cuda_functions(void);
++int init_nvml_functions(void);
++void uninit_nvml_functions(void);
++int init_cuvid_functions(void);
++void uninit_cuvid_functions(void);
++int init_nvenc_functions(void);
++void uninit_nvenc_functions(void);
++int init_nvml_driver_version(void);
++int create_cuda_devices(HwDeviceRefs *refs, int device_idx);
++void create_derive_d3d11va_devices_from_cuda(HwDeviceRefs *refs);
++int print_cuda_device_info(AVTextFormatContext *tfc, AVBufferRef *cuda_ref, int nvml_ret);
++int print_cuda_device_util(AVTextFormatContext *tfc, AVBufferRef *cuda_ref, int nvml_ret);
++int print_cuda_decoder_info(AVTextFormatContext *tfc, AVBufferRef *cuda_ref);
++int print_cuda_encoder_info(AVTextFormatContext *tfc, AVBufferRef *cuda_ref);
++
++/* QSV */
++int print_qsv_device_info(AVTextFormatContext *tfc, AVBufferRef *qsv_ref);
++int print_qsv_decoder_info(AVTextFormatContext *tfc, AVBufferRef *qsv_ref);
++int print_qsv_encoder_info(AVTextFormatContext *tfc, AVBufferRef *qsv_ref);
++int print_qsv_vpp_info(AVTextFormatContext *tfc, AVBufferRef *qsv_ref);
++
++/* AMF */
++int init_amf_functions(const wchar_t *amf_dll_path);
++void uninit_amf_functions(void);
++int create_derive_amf_device_from_d3d11va(AVBufferRef *d3d11va_ref, const wchar_t *amf_dll_path);
++int print_amf_device_info_from_d3d11va(AVTextFormatContext *tfc);
++int print_amf_encoder_info_from_d3d11va(AVTextFormatContext *tfc);
++
++/* MF/MFT */
++int init_mf_functions(void);
++void uninit_mf_functions(void);
++int create_derive_mf_device_from_d3d11va(AVBufferRef *d3d11va_ref);
++int print_mf_encoder_info_from_d3d11va(AVTextFormatContext *tfc, uint64_t dxgi_luid);
++
++/* RKMPP */
++int create_rkmpp_device(HwDeviceRefs *refs);
++void create_derive_opencl_devices_from_rkmpp(HwDeviceRefs *refs);
++void create_derive_vulkan_devices_from_rkmpp(HwDeviceRefs *refs);
++int print_rkmpp_decoder_info(AVTextFormatContext *tfc, const char *device_tree);
++int print_rkmpp_encoder_info(AVTextFormatContext *tfc, const char *device_tree);
++int print_rkmpp_vpp_info(AVTextFormatContext *tfc, const char *device_tree);
++
++/* OPENCL */
++int print_opencl_device_info(AVTextFormatContext *tfc, AVBufferRef *opencl_ref);
++
++/* VULKAN */
++int print_vulkan_device_info(AVTextFormatContext *tfc, AVBufferRef *vulkan_ref);
++
++#endif /* FFTOOLS_FFPROBE_HW_INTERNAL_H */
+Index: FFmpeg/fftools/ffprobe_hw_mf.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_mf.c
+@@ -0,0 +1,670 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "ffprobe_hw_internal.h"
++
++#if (CONFIG_MEDIAFOUNDATION && CONFIG_D3D11VA)
++#   define COBJMACROS
++#   include <windows.h>
++#   include <initguid.h>
++#   include <mfapi.h>
++#   include <mferror.h>
++#   include <mfobjects.h>
++#   include <mftransform.h>
++#   include "libavutil/hwcontext_d3d11va.h"
++#   include "compat/w32dlfcn.h"
++#endif
++
++#if (CONFIG_MEDIAFOUNDATION && CONFIG_D3D11VA)
++DEFINE_GUID(ff_MFT_ENUM_ADAPTER_LUID, 0x1d39518c, 0xe220, 0x4da8, 0xa0, 0x7f, 0xba, 0x17, 0x25, 0x52, 0xd6, 0xb1);
++
++typedef struct MFFunctions {
++    HRESULT (WINAPI *MFStartup)(ULONG Version, DWORD dwFlags);
++    HRESULT (WINAPI *MFShutdown)(void);
++    HRESULT (WINAPI *MFCreateMediaType)(IMFMediaType **ppMFType);
++    HRESULT (WINAPI *MFCreateAttributes)(IMFAttributes **ppAttributes,
++                                         UINT32 cbInitialSize);
++    HRESULT (WINAPI *MFCreateDXGIDeviceManager)(UINT *pResetToken,
++                                                IMFDXGIDeviceManager **ppDeviceManager);
++    HRESULT (WINAPI *MFTEnum2)(GUID guidCategory, UINT32 Flags,
++                               const MFT_REGISTER_TYPE_INFO *pInputType,
++                               const MFT_REGISTER_TYPE_INFO *pOutputType,
++                               IMFAttributes *pAttributes,
++                               IMFActivate ***pppActivate,
++                               UINT32 *pcCount);
++} MFFunctions;
++
++static void                 *mf_library = NULL;
++static MFFunctions           mf_functions = { NULL };
++static IMFDXGIDeviceManager *mf_dxgi_manager = NULL;
++static UINT                  mf_reset_token  = 0;
++
++typedef struct MfEncMode {
++    const char               *name;
++    const GUID               *guid;
++    const enum AVCodecID      codec;
++    const int                *profiles;
++    const enum AVPixelFormat *formats;
++    const int                 legacy;
++} MfEncMode;
++
++static const int profiles_h264[] = {
++    AV_PROFILE_H264_BASELINE,
++    AV_PROFILE_H264_MAIN,
++    AV_PROFILE_H264_HIGH,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_hevc[] = {
++    AV_PROFILE_HEVC_MAIN,
++    AV_PROFILE_HEVC_MAIN_10,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_av1[] = {
++    AV_PROFILE_AV1_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++
++static const enum AVPixelFormat formats_8_420[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat formats_8_10_420[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_NONE
++};
++
++static const MfEncMode mfenc_modes[] = {
++    { "MFT Hardware H.264 Encoder", &MFVideoFormat_H264, AV_CODEC_ID_H264, profiles_h264, formats_8_420,    1 },
++    { "MFT Hardware HEVC Encoder",  &MFVideoFormat_HEVC, AV_CODEC_ID_HEVC, profiles_hevc, formats_8_10_420, 0 },
++    { "MFT Hardware AV1 Encoder",   &MFVideoFormat_AV1,  AV_CODEC_ID_AV1,  profiles_av1,  formats_8_10_420, 0 },
++    { NULL, NULL, AV_CODEC_ID_NONE, NULL, NULL, 0 }
++};
++
++enum MfTestType {
++    MF_TEST_BREAK    = -2,
++    MF_TEST_CONTINUE = -1,
++    MF_TEST_SUCCESS  =  0,
++};
++#endif
++
++#if !HAVE_UWP
++#   define LOAD_MF_FUNCTION(func_name) \
++        mf_functions.func_name = (void *)dlsym(mf_library, #func_name); \
++        if (!mf_functions.func_name) { \
++            av_log(NULL, AV_LOG_DEBUG, "DLL mfplat.dll failed to find function " #func_name "\n"); \
++            return AVERROR_UNKNOWN; \
++        }
++#else
++#   define LOAD_MF_FUNCTION(func_name) \
++        mf_functions.func_name = func_name; \
++        if (!mf_functions.func_name) { \
++            av_log(NULL, AV_LOG_DEBUG, "Failed to find function " #func_name "\n"); \
++            return AVERROR_UNKNOWN; \
++        }
++#endif
++
++int init_mf_functions(void)
++{
++#if (CONFIG_MEDIAFOUNDATION && CONFIG_D3D11VA)
++#   if !HAVE_UWP
++    mf_library = dlopen("mfplat.dll", 0);
++    if (!mf_library) {
++        av_log(NULL, AV_LOG_DEBUG, "DLL mfplat.dll failed to open\n");
++        return AVERROR_UNKNOWN;
++    }
++#   endif
++
++    LOAD_MF_FUNCTION(MFStartup);
++    LOAD_MF_FUNCTION(MFShutdown);
++    LOAD_MF_FUNCTION(MFCreateMediaType);
++    LOAD_MF_FUNCTION(MFCreateAttributes);
++    LOAD_MF_FUNCTION(MFCreateDXGIDeviceManager);
++    LOAD_MF_FUNCTION(MFTEnum2);
++
++    if (FAILED(mf_functions.MFStartup(MF_VERSION, MFSTARTUP_LITE))) {
++        av_log(NULL, AV_LOG_DEBUG, "MFStartup failed\n");
++        uninit_mf_functions();
++        return AVERROR_UNKNOWN;
++    }
++    return 0;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++void uninit_mf_functions(void)
++{
++#if (CONFIG_MEDIAFOUNDATION && CONFIG_D3D11VA)
++    if (mf_dxgi_manager) {
++        IMFDXGIDeviceManager_Release(mf_dxgi_manager);
++        mf_dxgi_manager = NULL;
++        mf_reset_token  = 0;
++    }
++    if (mf_functions.MFShutdown)
++        mf_functions.MFShutdown();
++#   if !HAVE_UWP
++    if (mf_library) {
++        dlclose(mf_library);
++        mf_library = NULL;
++    }
++#   endif
++    memset(&mf_functions, 0, sizeof(mf_functions));
++#endif
++}
++
++int create_derive_mf_device_from_d3d11va(AVBufferRef *d3d11va_ref)
++{
++    int ret = AVERROR(ENOSYS);
++#if (CONFIG_MEDIAFOUNDATION && CONFIG_D3D11VA)
++    AVHWDeviceContext      *dev_ctx = NULL;
++    AVD3D11VADeviceContext *hwctx   = NULL;
++    HRESULT hr;
++
++    if (!d3d11va_ref)
++        return AVERROR(EINVAL);
++    if ((ret = init_mf_functions()) < 0)
++        goto exit;
++
++    dev_ctx = (AVHWDeviceContext*)d3d11va_ref->data;
++    hwctx = dev_ctx->hwctx;
++
++    hr = mf_functions.MFCreateDXGIDeviceManager(&mf_reset_token, &mf_dxgi_manager);
++    if (FAILED(hr)) {
++        av_log(NULL, AV_LOG_DEBUG, "MFCreateDXGIDeviceManager failed: 0x%08lx\n", hr);
++        ret = AVERROR_EXTERNAL;
++        goto exit;
++    }
++
++    hr = IMFDXGIDeviceManager_ResetDevice(mf_dxgi_manager,
++                                          (IUnknown*)hwctx->device, mf_reset_token);
++    if (FAILED(hr)) {
++        av_log(NULL, AV_LOG_DEBUG, "IMFDXGIDeviceManager_ResetDevice failed: 0x%08lx\n", hr);
++        ret = AVERROR_EXTERNAL;
++        goto exit;
++    }
++
++    return 0;
++
++exit:
++    if (mf_dxgi_manager) {
++        IMFDXGIDeviceManager_Release(mf_dxgi_manager);
++        mf_dxgi_manager = NULL;
++        mf_reset_token = 0;
++    }
++#endif
++    return ret;
++}
++
++#if (CONFIG_MEDIAFOUNDATION && CONFIG_D3D11VA)
++enum ff_eAVEncH264VProfile {
++    ff_eAVEncH264VProfile_Base   = 66,
++    ff_eAVEncH264VProfile_Main   = 77,
++    ff_eAVEncH264VProfile_High   = 100,
++    ff_eAVEncH264VProfile_High10 = 110,
++};
++
++enum ff_eAVEncH265VProfile {
++    ff_eAVEncH265VProfile_Main_420_8  = 1,
++    ff_eAVEncH265VProfile_Main_420_10 = 2,
++};
++
++enum ff_eAVEncAV1VProfile {
++    ff_eAVEncAV1VProfile_Main_420_8  = 1,
++    ff_eAVEncAV1VProfile_Main_420_10 = 2,
++};
++
++static unsigned mf_map_av_to_default_mf_profile(enum AVCodecID codec, int profile)
++{
++    if (codec == AV_CODEC_ID_H264) {
++        switch (profile) {
++        case AV_PROFILE_H264_BASELINE: return ff_eAVEncH264VProfile_Base;
++        case AV_PROFILE_H264_MAIN:     return ff_eAVEncH264VProfile_Main;
++        case AV_PROFILE_H264_HIGH:     return ff_eAVEncH264VProfile_High;
++        case AV_PROFILE_H264_HIGH_10:  return ff_eAVEncH264VProfile_High10;
++        }
++    } else if (codec == AV_CODEC_ID_HEVC) {
++        switch (profile) {
++        case AV_PROFILE_HEVC_MAIN:    return ff_eAVEncH265VProfile_Main_420_8;
++        case AV_PROFILE_HEVC_MAIN_10: return ff_eAVEncH265VProfile_Main_420_10;
++        }
++    } else if (codec == AV_CODEC_ID_AV1) {
++        switch (profile) {
++        case AV_PROFILE_AV1_MAIN: return ff_eAVEncAV1VProfile_Main_420_8;
++        }
++    }
++
++    return 0;
++}
++
++static const GUID *mf_map_mf_profile_to_mf_format_guid(const GUID *codec, unsigned profile)
++{
++    if (!codec)
++        return NULL;
++
++    if (IsEqualGUID(&MFVideoFormat_H264, codec)) {
++        switch (profile) {
++        case ff_eAVEncH264VProfile_Base:
++        case ff_eAVEncH264VProfile_Main:
++        case ff_eAVEncH264VProfile_High:   return &MFVideoFormat_NV12;
++        case ff_eAVEncH264VProfile_High10: return &MFVideoFormat_P010;
++        }
++    } else if (IsEqualGUID(&MFVideoFormat_HEVC, codec)) {
++        switch (profile) {
++        case ff_eAVEncH265VProfile_Main_420_8:  return &MFVideoFormat_NV12;
++        case ff_eAVEncH265VProfile_Main_420_10: return &MFVideoFormat_P010;
++        }
++    } else if (IsEqualGUID(&MFVideoFormat_AV1, codec)) {
++        switch (profile) {
++        case ff_eAVEncAV1VProfile_Main_420_8:  return &MFVideoFormat_NV12;
++        case ff_eAVEncAV1VProfile_Main_420_10: return &MFVideoFormat_P010;
++        }
++    }
++
++    return NULL;
++}
++
++static const GUID *mf_map_av_to_mf_format_guid(enum AVPixelFormat pix_fmt) {
++    switch (pix_fmt) {
++    case AV_PIX_FMT_NV12: return &MFVideoFormat_NV12;
++    case AV_PIX_FMT_P010: return &MFVideoFormat_P010;
++    default:              return NULL;
++    }
++}
++
++static enum MfTestType mf_test_params(IMFActivate *pActivate,
++                                      IMFTransform **ppMFT,
++                                      const GUID *codec,
++                                      UINT32 width, UINT32 height,
++                                      UINT32 profile)
++{
++    IMFMediaType *out_type = NULL;
++    IMFMediaType  *in_type = NULL;
++    HRESULT hr;
++    enum MfTestType test_ret = MF_TEST_CONTINUE;
++
++    if (!pActivate || !ppMFT)
++        return MF_TEST_BREAK;
++
++    if (*ppMFT) {
++        IMFTransform_SetOutputType(*ppMFT, 0, NULL, 0);
++        IMFTransform_SetInputType(*ppMFT, 0, NULL, 0);
++        IMFTransform_ProcessMessage(*ppMFT, MFT_MESSAGE_COMMAND_FLUSH, 0);
++    } else {
++        IMFAttributes *attrs = NULL;
++
++        IMFActivate_ShutdownObject(pActivate);
++        if (FAILED(IMFActivate_ActivateObject(pActivate, &IID_IMFTransform,
++                                              (void**)ppMFT))) {
++            IMFActivate_ShutdownObject(pActivate);
++            return MF_TEST_BREAK;
++        }
++
++        if (SUCCEEDED(IMFTransform_GetAttributes(*ppMFT, &attrs))) {
++            UINT32 is_mft_async = 0, is_d3d11_aware = 0;
++
++            IMFAttributes_GetUINT32(attrs, &MF_TRANSFORM_ASYNC, &is_mft_async);
++            IMFAttributes_GetUINT32(attrs, &MF_SA_D3D11_AWARE, &is_d3d11_aware);
++
++            hr = IMFAttributes_SetUINT32(attrs, &MF_TRANSFORM_ASYNC_UNLOCK, TRUE);
++            IMFAttributes_Release(attrs);
++
++            if (!is_mft_async || !is_d3d11_aware || FAILED(hr)) {
++                if (!is_mft_async)
++                    av_log(NULL, AV_LOG_DEBUG, "MF_TRANSFORM_ASYNC unsupported\n");
++                if (!is_d3d11_aware)
++                    av_log(NULL, AV_LOG_DEBUG, "MF_SA_D3D11_AWARE unsupported\n");
++                if (FAILED(hr))
++                    av_log(NULL, AV_LOG_DEBUG, "MF_TRANSFORM_ASYNC_UNLOCK failed\n");
++
++                test_ret = MF_TEST_BREAK;
++                goto fail;
++            }
++        } else {
++            test_ret = MF_TEST_BREAK;
++            goto fail;
++        }
++
++        IMFTransform_ProcessMessage(*ppMFT, MFT_MESSAGE_COMMAND_FLUSH, 0);
++        if (FAILED(IMFTransform_ProcessMessage(*ppMFT, MFT_MESSAGE_SET_D3D_MANAGER,
++                                               (ULONG_PTR)mf_dxgi_manager))) {
++            av_log(NULL, AV_LOG_DEBUG, "MFT_MESSAGE_SET_D3D_MANAGER failed\n");
++            test_ret = MF_TEST_BREAK;
++            goto fail;
++        }
++    }
++
++    if (FAILED(mf_functions.MFCreateMediaType(&out_type)))
++        return MF_TEST_CONTINUE;
++
++#   define SET_MINIMAL_MEDIA_TYPES(type, subtype) do { \
++        IMFMediaType_SetGUID((type), &MF_MT_MAJOR_TYPE, &MFMediaType_Video); \
++        IMFMediaType_SetGUID((type), &MF_MT_SUBTYPE, (subtype)); \
++        IMFMediaType_SetUINT64((type), &MF_MT_FRAME_SIZE, ((UINT64)width << 32) | height); \
++        IMFMediaType_SetUINT64((type), &MF_MT_FRAME_RATE, ((UINT64)25 << 32) | 1); \
++        IMFMediaType_SetUINT32((type), &MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive); \
++    } while (0)
++
++    SET_MINIMAL_MEDIA_TYPES(out_type, codec);
++
++    IMFMediaType_SetUINT32(out_type, &MF_MT_AVG_BITRATE, 4000000);
++    if (profile > 0)
++        IMFAttributes_SetUINT32(out_type, &MF_MT_MPEG2_PROFILE, profile);
++
++    hr = IMFTransform_SetOutputType(*ppMFT, 0, out_type, 0);
++    if (out_type)
++        IMFMediaType_Release(out_type);
++
++    if (FAILED(hr)) {
++        test_ret = MF_TEST_CONTINUE;
++        goto fail;
++    }
++
++    if (profile > 0) {
++        IMFMediaType *pType = NULL;
++        DWORD index = 0;
++        BOOL success = FALSE;
++
++        if (FAILED(mf_functions.MFCreateMediaType(&in_type)))
++            return MF_TEST_CONTINUE;
++
++        while (SUCCEEDED(IMFTransform_GetInputAvailableType(*ppMFT, 0, index++, &pType))) {
++            GUID input_format = { 0 };
++
++            if (SUCCEEDED(IMFAttributes_GetGUID(pType, &MF_MT_SUBTYPE, &input_format))) {
++                const GUID *format = mf_map_mf_profile_to_mf_format_guid(codec, profile);
++
++                if (!format || !IsEqualGUID(&input_format, format)) {
++                    if (pType) {
++                        IMFMediaType_Release(pType);
++                        pType = NULL;
++                    }
++                    continue;
++                }
++
++                SET_MINIMAL_MEDIA_TYPES(in_type, &input_format);
++
++                hr = IMFTransform_SetInputType(*ppMFT, 0, in_type, 0);
++                if (FAILED(hr)) {
++                    if (pType)
++                        IMFMediaType_Release(pType);
++                    if (in_type)
++                        IMFMediaType_Release(in_type);
++                    test_ret = MF_TEST_CONTINUE;
++                    goto fail;
++                }
++                success = TRUE;
++                break;
++            }
++            if (pType) {
++                IMFMediaType_Release(pType);
++                pType = NULL;
++            }
++        }
++        if (in_type)
++            IMFMediaType_Release(in_type);
++        if (success != TRUE)
++            return MF_TEST_CONTINUE;
++    }
++#   undef SET_MINIMAL_MEDIA_TYPES
++
++    return MF_TEST_SUCCESS;
++
++fail:
++    if (*ppMFT) {
++        IMFTransform_ProcessMessage(*ppMFT, MFT_MESSAGE_SET_D3D_MANAGER,
++                                    (ULONG_PTR)NULL);
++        IMFTransform_Release(*ppMFT);
++        *ppMFT = NULL;
++    }
++    return test_ret;
++}
++#endif
++
++int print_mf_encoder_info_from_d3d11va(AVTextFormatContext *tfc, uint64_t dxgi_luid)
++{
++#if (CONFIG_MEDIAFOUNDATION && CONFIG_D3D11VA)
++    IMFAttributes* pEnumAttrs = NULL;
++    LUID mft_enum_luid = {
++        .LowPart  = (DWORD)(dxgi_luid & 0xFFFFFFFF),
++        .HighPart = (LONG)(dxgi_luid >> 32)
++    };
++    HRESULT hr;
++    int header_printed = 0;
++    int i, j;
++
++#   if !HAVE_UWP
++    if (!mf_library)
++        return AVERROR(ENOSYS);
++#   endif
++    if (!mf_dxgi_manager)
++        return AVERROR(ENOSYS);
++
++    hr = mf_functions.MFCreateAttributes(&pEnumAttrs, 1);
++    if (FAILED(hr))
++        return AVERROR_UNKNOWN;
++
++    hr = IMFAttributes_SetBlob(pEnumAttrs, &ff_MFT_ENUM_ADAPTER_LUID,
++                               (const UINT8*)&mft_enum_luid, sizeof(mft_enum_luid));
++    if (FAILED(hr)) {
++        IMFAttributes_Release(pEnumAttrs);
++        return AVERROR_UNKNOWN;
++    }
++
++    for (i = 0; mfenc_modes[i].name && mfenc_modes[i].guid; i++) {
++        IMFActivate** ppActivates = NULL;
++        UINT32 activate_count = 0;
++        UINT32 activate_idx = 0;
++        IMFTransform* pMFT = NULL;
++        const MfEncMode* mode = &mfenc_modes[i];
++        MFT_REGISTER_TYPE_INFO output_type_info = {
++            .guidMajorType = MFMediaType_Video,
++            .guidSubtype   = *(mode->guid)
++        };
++        unsigned min_width = 0, min_height = 0;
++        unsigned max_width = 0, max_height = 0;
++        char mft_desc[128*3+1] = { 0 };
++        int mft_has_desc = 0;
++        int header2_printed = 0;
++        int header3_printed = 0;
++        enum MfTestType test_ret = MF_TEST_SUCCESS;
++
++        if (!mode->formats)
++            continue;
++
++        hr = mf_functions.MFTEnum2(MFT_CATEGORY_VIDEO_ENCODER,
++                                   (MFT_ENUM_FLAG_SORTANDFILTER | MFT_ENUM_FLAG_HARDWARE),
++                                   NULL, &output_type_info, pEnumAttrs,
++                                   &ppActivates, &activate_count);
++        if (FAILED(hr) || !ppActivates || !activate_count) {
++            if (ppActivates)
++                CoTaskMemFree(ppActivates);
++            continue;
++        }
++
++        /* Check min res */
++        for (const HwRes *r = &hw_res_ascend[0]; r->name; r++) {
++            if (mode->legacy && (r->width > 4096 || r->height > 4096))
++                break;
++
++            test_ret = mf_test_params(ppActivates[0], &pMFT, mode->guid, r->width, r->height, 0);
++            if (test_ret != MF_TEST_SUCCESS) {
++                if (test_ret == MF_TEST_BREAK) break;
++                else continue;
++            }
++            min_width  = r->width;
++            min_height = r->height;
++            break;
++        }
++        if (!min_width || !min_height)
++            goto next;
++
++        /* Check max res */
++        for (const HwRes *r = &hw_res_ascend[FF_ARRAY_ELEMS(hw_res_ascend) - 1]; r >= &hw_res_ascend[0]; r--) {
++            if (!r->name)
++                continue;
++            if (r->width <= min_width && r->height <= min_height) {
++                max_width  = r->width;
++                max_height = r->height;
++                break;
++            }
++            if (mode->legacy && (r->width > 4096 || r->height > 4096))
++                continue;
++
++            test_ret = mf_test_params(ppActivates[0], &pMFT, mode->guid, r->width, r->height, 0);
++            if (test_ret != MF_TEST_SUCCESS) {
++                if (test_ret == MF_TEST_BREAK) break;
++                else continue;
++            }
++            max_width  = r->width;
++            max_height = r->height;
++            break;
++        }
++        if (!max_width || !max_height)
++            goto next;
++
++        if (!pMFT)
++            goto next;
++
++        {
++            WCHAR *mft_desc_w = NULL;
++            UINT32 mft_desc_w_len = 0;
++
++            hr = IMFActivate_GetAllocatedString(ppActivates[0],
++                                                &MFT_FRIENDLY_NAME_Attribute,
++                                                &mft_desc_w, &mft_desc_w_len);
++            if (SUCCEEDED(hr) && mft_desc_w && mft_desc_w_len) {
++                int written_bytes = WideCharToMultiByte(
++                    CP_UTF8, 0, mft_desc_w, -1,
++                    mft_desc, FF_ARRAY_ELEMS(mft_desc),
++                    NULL, NULL
++                );
++                mft_has_desc = written_bytes > 0;
++                mft_desc[FF_ARRAY_ELEMS(mft_desc) - 1] = '\0';
++            }
++            CoTaskMemFree(mft_desc_w);
++        }
++
++        if (!header_printed) {
++            mark_section_show_entries(SECTION_ID_DEVICE_ENCODERS_MF, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_ENCODERS_MF);
++            header_printed = 1;
++        }
++
++        mark_section_show_entries(SECTION_ID_DEVICE_ENCODER, 1, NULL);
++        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_ENCODER);
++        print_str("codec_name", avcodec_get_name(mode->codec));
++        print_int("codec_id", mode->codec);
++        print_str("codec_desc", mode->name);
++        if (mft_has_desc)
++            print_str("mft_desc", mft_desc);
++
++        print_int("min_width",  min_width);
++        print_int("min_height", min_height);
++        print_int("max_width",  max_width);
++        print_int("max_height", max_height);
++
++        /* Formats */
++        for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++            const GUID *format = mf_map_av_to_mf_format_guid(mode->formats[j]);
++            IMFMediaType *pType = NULL;
++            DWORD index = 0;
++
++            if (!format)
++                continue;
++
++            while (SUCCEEDED(IMFTransform_GetInputAvailableType(pMFT, 0, index++, &pType))) {
++                GUID input_format = { 0 };
++
++                if (SUCCEEDED(IMFAttributes_GetGUID(pType, &MF_MT_SUBTYPE, &input_format))) {
++                    if (IsEqualGUID(&input_format, format)) {
++                        if (!header2_printed) {
++                            mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                            header2_printed = 1;
++                        }
++                        mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++                        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++                        print_str("format_name", av_get_pix_fmt_name(mode->formats[j]));
++                        print_int("format_id", mode->formats[j]);
++                        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++
++                        if (pType) {
++                            IMFMediaType_Release(pType);
++                            pType = NULL;
++                        }
++                        break;
++                    }
++                }
++                if (pType) {
++                    IMFMediaType_Release(pType);
++                    pType = NULL;
++                }
++            }
++        }
++        if (header2_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++        /* Profiles */
++        for (j = 0; mode->profiles[j] != AV_PROFILE_UNKNOWN; j++) {
++            const UINT32 profile = mf_map_av_to_default_mf_profile(mode->codec, mode->profiles[j]);
++
++            if (!profile)
++                continue;
++
++            test_ret = mf_test_params(ppActivates[0], &pMFT, mode->guid, min_width, min_height, profile);
++            if (test_ret != MF_TEST_SUCCESS) {
++                if (test_ret == MF_TEST_BREAK) break;
++                else continue;
++            }
++            if (!header3_printed) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PROFILES, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILES);
++                header3_printed = 1;
++            }
++            mark_section_show_entries(SECTION_ID_DEVICE_PROFILE, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILE);
++            print_str("profile_name", avcodec_profile_name(mode->codec, mode->profiles[j]));
++            print_int("profile_id", mode->profiles[j]);
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILE
++        }
++        if (header3_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILES
++
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_ENCODER
++
++next:
++        if (pMFT)
++            IMFTransform_Release(pMFT);
++
++        for (activate_idx = 0; activate_idx < activate_count; activate_idx++) {
++            if (ppActivates[activate_idx])
++                IMFActivate_Release(ppActivates[activate_idx]);
++        }
++        CoTaskMemFree(ppActivates);
++    }
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_ENCODERS_MF
++
++    if (pEnumAttrs)
++        IMFAttributes_Release(pEnumAttrs);
++#endif
++    return 0;
++}
+Index: FFmpeg/fftools/ffprobe_hw_opencl.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_opencl.c
+@@ -0,0 +1,223 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "ffprobe_hw_internal.h"
++
++#if CONFIG_OPENCL
++#   include "libavutil/hwcontext_opencl.h"
++#endif
++
++#if CONFIG_OPENCL
++typedef enum {
++    TYPE_STR,
++    TYPE_UINT,
++    TYPE_ULONG,
++    TYPE_SIZE_T
++} OpenclAttrType;
++
++typedef struct {
++    const cl_uint        attr_val;
++    const char          *attr_str;
++    const OpenclAttrType attr_type;
++} OpenclAttr;
++
++static const OpenclAttr opencl_platform_attrs[] = {
++    { CL_PLATFORM_NAME,                                 "device_platform_name",                          TYPE_STR    },
++    { CL_PLATFORM_VENDOR,                               "device_platform_vendor_name",                   TYPE_STR    },
++    { CL_PLATFORM_VERSION,                              "device_platform_version",                       TYPE_STR    },
++    { CL_PLATFORM_PROFILE,                              "device_platform_profile",                       TYPE_STR    },
++    { CL_PLATFORM_EXTENSIONS,                           "device_platform_extensions",                    TYPE_STR    },
++};
++static const OpenclAttr opencl_device_attrs[] = {
++    { CL_DEVICE_NAME,                                   "device_name",                                   TYPE_STR    },
++    { CL_DEVICE_VENDOR,                                 "device_vendor_name",                            TYPE_STR    },
++    { CL_DEVICE_VERSION,                                "device_version",                                TYPE_STR    },
++    { CL_DEVICE_OPENCL_C_VERSION,                       "device_opencl_c_version",                       TYPE_STR    },
++    { CL_DEVICE_VENDOR_ID,                              "device_vendor_id",                              TYPE_UINT   },
++    { CL_DEVICE_TYPE,                                   "device_type",                                   TYPE_ULONG  },
++    { CL_DEVICE_PROFILE,                                "device_profile",                                TYPE_STR    },
++    { CL_DRIVER_VERSION,                                "device_driver_version",                         TYPE_STR    },
++    { CL_DEVICE_MAX_COMPUTE_UNITS,                      "device_max_compute_units",                      TYPE_UINT   },
++    { CL_DEVICE_MAX_WORK_GROUP_SIZE,                    "device_max_work_group_size",                    TYPE_SIZE_T },
++    { CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS,               "device_max_work_item_dimensions",               TYPE_UINT   },
++    { CL_DEVICE_MAX_CLOCK_FREQUENCY,                    "device_max_clock_frequency",                    TYPE_UINT   },
++#   ifdef CL_VERSION_2_1
++    { CL_DEVICE_MAX_NUM_SUB_GROUPS,                     "device_max_num_sub_groups",                     TYPE_UINT   },
++    { CL_DEVICE_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS, "device_sub_group_independent_forward_progress", TYPE_UINT   },
++#   endif
++    { CL_DEVICE_SINGLE_FP_CONFIG,                       "device_single_fp_config",                       TYPE_ULONG  },
++    { CL_DEVICE_DOUBLE_FP_CONFIG,                       "device_double_fp_config",                       TYPE_ULONG  },
++    { CL_DEVICE_GLOBAL_MEM_SIZE,                        "device_global_mem_size",                        TYPE_ULONG  },
++    { CL_DEVICE_MAX_MEM_ALLOC_SIZE,                     "device_max_mem_alloc_size",                     TYPE_ULONG  },
++    { CL_DEVICE_LOCAL_MEM_SIZE,                         "device_local_mem_size",                         TYPE_ULONG  },
++    { CL_DEVICE_LOCAL_MEM_TYPE,                         "device_local_mem_type",                         TYPE_UINT   },
++    { CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE,               "device_max_constant_buffer_size",               TYPE_ULONG  },
++    { CL_DEVICE_MAX_CONSTANT_ARGS,                      "device_max_constant_args",                      TYPE_UINT   },
++    { CL_DEVICE_MAX_PARAMETER_SIZE,                     "device_max_parameter_size",                     TYPE_SIZE_T },
++    { CL_DEVICE_GLOBAL_MEM_CACHELINE_SIZE,              "device_global_mem_cacheline_size",              TYPE_UINT   },
++    { CL_DEVICE_GLOBAL_MEM_CACHE_SIZE,                  "device_global_mem_cache_size",                  TYPE_ULONG  },
++    { CL_DEVICE_GLOBAL_MEM_CACHE_TYPE,                  "device_global_mem_cache_type",                  TYPE_UINT   },
++    { CL_DEVICE_IMAGE_SUPPORT,                          "device_image_support",                          TYPE_UINT   },
++    { CL_DEVICE_IMAGE2D_MAX_WIDTH,                      "device_image2d_max_width",                      TYPE_SIZE_T },
++    { CL_DEVICE_IMAGE2D_MAX_HEIGHT,                     "device_image2d_max_height",                     TYPE_SIZE_T },
++    { CL_DEVICE_IMAGE3D_MAX_WIDTH,                      "device_image3d_max_width",                      TYPE_SIZE_T },
++    { CL_DEVICE_IMAGE3D_MAX_HEIGHT,                     "device_image3d_max_height",                     TYPE_SIZE_T },
++    { CL_DEVICE_IMAGE3D_MAX_DEPTH,                      "device_image3d_max_depth",                      TYPE_SIZE_T },
++    { CL_DEVICE_IMAGE_MAX_BUFFER_SIZE,                  "device_image_max_buffer_size",                  TYPE_SIZE_T },
++    { CL_DEVICE_IMAGE_MAX_ARRAY_SIZE,                   "device_image_max_array_size",                   TYPE_SIZE_T },
++    { CL_DEVICE_MAX_READ_IMAGE_ARGS,                    "device_max_read_image_args",                    TYPE_UINT   },
++    { CL_DEVICE_MAX_WRITE_IMAGE_ARGS,                   "device_max_write_image_args",                   TYPE_UINT   },
++    { CL_DEVICE_MAX_SAMPLERS,                           "device_max_samplers",                           TYPE_UINT   },
++#   ifdef CL_VERSION_2_0
++    { CL_DEVICE_MAX_READ_WRITE_IMAGE_ARGS,              "device_max_read_write_image_args",              TYPE_UINT   },
++#   endif
++    { CL_DEVICE_MEM_BASE_ADDR_ALIGN,                    "device_mem_base_addr_align",                    TYPE_UINT   },
++    { CL_DEVICE_MIN_DATA_TYPE_ALIGN_SIZE,               "device_min_data_type_align_size",               TYPE_UINT   },
++    { CL_DEVICE_IMAGE_PITCH_ALIGNMENT,                  "device_image_pitch_alignment",                  TYPE_UINT   },
++    { CL_DEVICE_IMAGE_BASE_ADDRESS_ALIGNMENT,           "device_image_base_address_alignment",           TYPE_UINT   },
++    { CL_DEVICE_EXECUTION_CAPABILITIES,                 "device_execution_capabilities",                 TYPE_ULONG  },
++    { CL_DEVICE_QUEUE_PROPERTIES,                       "device_queue_properties",                       TYPE_ULONG  },
++    { CL_DEVICE_PROFILING_TIMER_RESOLUTION,             "device_profiling_timer_resolution",             TYPE_SIZE_T },
++    { CL_DEVICE_ENDIAN_LITTLE,                          "device_endian_little",                          TYPE_UINT   },
++    { CL_DEVICE_AVAILABLE,                              "device_available",                              TYPE_UINT   },
++    { CL_DEVICE_COMPILER_AVAILABLE,                     "device_compiler_available",                     TYPE_UINT   },
++    { CL_DEVICE_PRINTF_BUFFER_SIZE,                     "device_printf_buffer_size",                     TYPE_SIZE_T },
++#   ifdef CL_VERSION_2_1
++    { CL_DEVICE_IL_VERSION,                             "device_il_version",                             TYPE_STR    },
++#   endif
++#   ifdef CL_VERSION_2_0
++    { CL_DEVICE_SVM_CAPABILITIES,                       "device_svm_capabilities",                       TYPE_ULONG  },
++    { CL_DEVICE_MAX_GLOBAL_VARIABLE_SIZE,               "device_max_global_variable_size",               TYPE_SIZE_T },
++    { CL_DEVICE_GLOBAL_VARIABLE_PREFERRED_TOTAL_SIZE,   "device_global_variable_preferred_total_size",   TYPE_SIZE_T },
++#   endif
++#   ifdef CL_VERSION_2_0
++    { CL_DEVICE_QUEUE_ON_DEVICE_PROPERTIES,             "device_queue_on_device_properties",             TYPE_ULONG  },
++    { CL_DEVICE_QUEUE_ON_DEVICE_PREFERRED_SIZE,         "device_queue_on_device_preferred_size",         TYPE_UINT   },
++    { CL_DEVICE_QUEUE_ON_DEVICE_MAX_SIZE,               "device_queue_on_device_max_size",               TYPE_UINT   },
++    { CL_DEVICE_MAX_ON_DEVICE_QUEUES,                   "device_max_on_device_queues",                   TYPE_UINT   },
++    { CL_DEVICE_MAX_ON_DEVICE_EVENTS,                   "device_max_on_device_events",                   TYPE_UINT   },
++    { CL_DEVICE_MAX_PIPE_ARGS,                          "device_max_pipe_args",                          TYPE_UINT   },
++    { CL_DEVICE_PIPE_MAX_ACTIVE_RESERVATIONS,           "device_pipe_max_active_reservations",           TYPE_UINT   },
++    { CL_DEVICE_PIPE_MAX_PACKET_SIZE,                   "device_pipe_max_packet_size",                   TYPE_UINT   },
++#   endif
++#   ifdef CL_VERSION_2_0
++    { CL_DEVICE_PREFERRED_PLATFORM_ATOMIC_ALIGNMENT,    "device_preferred_platform_atomic_alignment",    TYPE_UINT   },
++    { CL_DEVICE_PREFERRED_GLOBAL_ATOMIC_ALIGNMENT,      "device_preferred_global_atomic_alignment",      TYPE_UINT   },
++    { CL_DEVICE_PREFERRED_LOCAL_ATOMIC_ALIGNMENT,       "device_preferred_local_atomic_alignment",       TYPE_UINT   },
++#   endif
++    { CL_DEVICE_EXTENSIONS,                             "device_extensions",                             TYPE_STR    },
++};
++#endif
++
++int print_opencl_device_info(AVTextFormatContext *tfc, AVBufferRef *opencl_ref)
++{
++#if CONFIG_OPENCL
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVOpenCLDeviceContext *hwctx = NULL;
++    cl_platform_id platform_id;
++    cl_device_id device_id;
++    cl_int cle;
++    int ret = 0;
++
++    if (!tfc || !opencl_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)opencl_ref->data;
++    hwctx = dev_ctx->hwctx;
++    device_id = hwctx->device_id;
++
++    cle = clGetDeviceInfo(device_id, CL_DEVICE_PLATFORM,
++                          sizeof(platform_id), &platform_id, NULL);
++    if (cle != CL_SUCCESS)
++        return AVERROR(ENOSYS);
++
++    mark_section_show_entries(SECTION_ID_DEVICE_INFO_OPENCL, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_INFO_OPENCL);
++
++    /* Platform */
++    for (unsigned i = 0; i < FF_ARRAY_ELEMS(opencl_platform_attrs); i++) {
++        void *str = NULL;
++        size_t size = 0;
++
++        cle = clGetPlatformInfo(platform_id, opencl_platform_attrs[i].attr_val, 0, NULL, &size);
++        if (cle != CL_SUCCESS)
++            continue;
++
++        str = av_mallocz(size);
++        if (!str)
++            continue;
++
++        cle = clGetPlatformInfo(platform_id, opencl_platform_attrs[i].attr_val, size, str, &size);
++        if (cle == CL_SUCCESS) {
++            if (opencl_platform_attrs[i].attr_type == TYPE_STR) {
++                if (strlen((char*)str) + 1 != size) continue;
++                print_str(opencl_platform_attrs[i].attr_str, (char*)str);
++            }
++        }
++        av_free(str);
++    }
++
++    /* Device */
++    for (unsigned i = 0; i < FF_ARRAY_ELEMS(opencl_device_attrs); i++) {
++        void *str = NULL;
++        size_t size = 0;
++        int64_t val = 0;
++
++        cle = clGetDeviceInfo(device_id, opencl_device_attrs[i].attr_val, 0, NULL, &size);
++        if (cle != CL_SUCCESS)
++            continue;
++
++        str = av_mallocz(size);
++        if (!str)
++            continue;
++
++        cle = clGetDeviceInfo(device_id, opencl_device_attrs[i].attr_val, size, str, &size);
++        if (cle == CL_SUCCESS) {
++            switch (opencl_device_attrs[i].attr_type) {
++            case TYPE_STR:
++                if (strlen((char*)str) + 1 != size) continue;
++                print_str(opencl_device_attrs[i].attr_str, (char*)str);
++                break;
++            case TYPE_UINT:
++                val = (int64_t)(*(cl_uint*)str);
++                print_int(opencl_device_attrs[i].attr_str, val);
++                break;
++            case TYPE_SIZE_T:
++                val = (int64_t)(*(size_t*)str);
++                print_int(opencl_device_attrs[i].attr_str, val);
++                break;
++            case TYPE_ULONG:
++                val = (int64_t)(*(cl_ulong*)str);
++                print_int(opencl_device_attrs[i].attr_str, val);
++                break;
++            default:
++                break;
++            }
++        }
++        av_free(str);
++    }
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_INFO_OPENCL
++
++    return ret;
++#else
++    return 0;
++#endif
++}
+Index: FFmpeg/fftools/ffprobe_hw_qsv.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_qsv.c
+@@ -0,0 +1,1659 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "ffprobe_hw_internal.h"
++
++#if CONFIG_QSV
++#   include <mfxvideo.h>
++#   include <mfxjpeg.h>
++#   include <mfxvp8.h>
++#   include "libavutil/hwcontext_qsv.h"
++#endif
++
++#if CONFIG_QSV
++#   define QSV_VERSION_ATLEAST(MAJOR, MINOR) \
++        (MFX_VERSION_MAJOR > (MAJOR) || \
++         MFX_VERSION_MAJOR == (MAJOR) && \
++         MFX_VERSION_MINOR >= (MINOR))
++
++#   define QSV_RUNTIME_VERSION_ATLEAST(MFX_VERSION, MAJOR, MINOR) \
++        ((MFX_VERSION).Major > (MAJOR) || \
++         ((MFX_VERSION).Major == (MAJOR) && \
++          (MFX_VERSION).Minor >= (MINOR)))
++
++#   define QSV_MFX_PROFILE_H264_CONSTRAINTS \
++        (MFX_PROFILE_AVC_CONSTRAINT_SET0 | \
++         MFX_PROFILE_AVC_CONSTRAINT_SET1 | \
++         MFX_PROFILE_AVC_CONSTRAINT_SET2 | \
++         MFX_PROFILE_AVC_CONSTRAINT_SET3 | \
++         MFX_PROFILE_AVC_CONSTRAINT_SET4 | \
++         MFX_PROFILE_AVC_CONSTRAINT_SET5)
++
++typedef struct QsvDecMode {
++    const char               *name;
++    const enum AVCodecID      codec;
++    const int                *profiles;
++    const enum AVPixelFormat *formats;
++    const unsigned            legacy;
++} QsvDecMode;
++
++static const int profiles_mpeg2[] = {
++    AV_PROFILE_MPEG2_SIMPLE,
++    AV_PROFILE_MPEG2_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_vc1[] = {
++    AV_PROFILE_VC1_SIMPLE,
++    AV_PROFILE_VC1_MAIN,
++    AV_PROFILE_VC1_ADVANCED,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_h264[] = {
++    AV_PROFILE_H264_BASELINE,
++    AV_PROFILE_H264_CONSTRAINED_BASELINE,
++    AV_PROFILE_H264_MAIN,
++    AV_PROFILE_H264_HIGH,
++    AV_PROFILE_H264_HIGH_10,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_hevc[] = {
++    AV_PROFILE_HEVC_MAIN,
++    AV_PROFILE_HEVC_MAIN_10,
++    AV_PROFILE_HEVC_REXT,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_vp9[] = {
++    AV_PROFILE_VP9_0,
++    AV_PROFILE_VP9_1,
++    AV_PROFILE_VP9_2,
++    AV_PROFILE_VP9_3,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_av1[] = {
++    AV_PROFILE_AV1_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_vvc[] = {
++    AV_PROFILE_VVC_MAIN_10,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_mjpeg[] = {
++    AV_PROFILE_MJPEG_HUFFMAN_BASELINE_DCT,
++    AV_PROFILE_UNKNOWN
++};
++
++static const enum AVPixelFormat dec_formats_8_420[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat dec_formats_8_420_422[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_YUYV422,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat dec_formats_8_10_420[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat dec_formats_8_12_420_444[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_P012,
++    AV_PIX_FMT_VUYX,
++    AV_PIX_FMT_XV30,
++    AV_PIX_FMT_XV36,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat dec_formats_8_12_420_422_444[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_P012,
++    AV_PIX_FMT_YUYV422,
++    AV_PIX_FMT_Y210,
++    AV_PIX_FMT_Y212,
++    AV_PIX_FMT_VUYX,
++    AV_PIX_FMT_XV30,
++    AV_PIX_FMT_XV36,
++    AV_PIX_FMT_NONE
++};
++
++static const QsvDecMode qsvdec_modes[] = {
++    { "QSV MPEG-2 Decoder", AV_CODEC_ID_MPEG2VIDEO, profiles_mpeg2, dec_formats_8_420,            1 },
++    { "QSV VC-1 Decoder",   AV_CODEC_ID_VC1,        profiles_vc1,   dec_formats_8_420,            1 },
++    { "QSV H.264 Decoder",  AV_CODEC_ID_H264,       profiles_h264,  dec_formats_8_10_420,         1 },
++    { "QSV HEVC Decoder",   AV_CODEC_ID_HEVC,       profiles_hevc,  dec_formats_8_12_420_422_444, 0 },
++#   ifndef _WIN32
++    { "QSV VP8 Decoder",    AV_CODEC_ID_VP8,        NULL,           dec_formats_8_420,            1 },
++#   endif
++    { "QSV VP9 Decoder",    AV_CODEC_ID_VP9,        profiles_vp9,   dec_formats_8_12_420_444,     0 },
++    { "QSV AV1 Decoder",    AV_CODEC_ID_AV1,        profiles_av1,   dec_formats_8_10_420,         0 },
++    { "QSV VVC Decoder",    AV_CODEC_ID_VVC,        profiles_vvc,   dec_formats_8_10_420,         0 },
++    { "QSV MJPEG Decoder",  AV_CODEC_ID_MJPEG,      profiles_mjpeg, dec_formats_8_420_422,        0 },
++    { NULL, 0, NULL, NULL, 0 },
++};
++
++typedef struct QsvEncMode {
++    const char                *name;
++    const enum AVCodecID       codec;
++    const int                 *profiles;
++    const enum AVPixelFormat  *formats;
++    const unsigned short      *rc_modes;
++    const unsigned             low_power;
++    const unsigned             legacy;
++} QsvEncMode;
++
++static const enum AVPixelFormat enc_formats_8_420_rgb[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_BGRA,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat enc_formats_8_420_422_rgb[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_YUYV422,
++    AV_PIX_FMT_BGRA,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat enc_formats_8_10_420_rgb[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_BGRA,
++    AV_PIX_FMT_X2RGB10,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat enc_formats_8_10_420_444[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_VUYX,
++    AV_PIX_FMT_XV30,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat enc_formats_8_10_420_422_444_rgb[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_YUYV422,
++    AV_PIX_FMT_Y210,
++    AV_PIX_FMT_VUYX,
++    AV_PIX_FMT_XV30,
++    AV_PIX_FMT_BGRA,
++    AV_PIX_FMT_X2RGB10,
++    AV_PIX_FMT_NONE
++};
++static const unsigned short enc_rc_modes_h26x[] = {
++    MFX_RATECONTROL_CQP,
++    MFX_RATECONTROL_CBR,
++    MFX_RATECONTROL_VBR,
++    MFX_RATECONTROL_QVBR,
++    MFX_RATECONTROL_ICQ,
++    0
++};
++static const unsigned short enc_rc_modes_av1[] = {
++    MFX_RATECONTROL_CQP,
++    MFX_RATECONTROL_CBR,
++    MFX_RATECONTROL_VBR,
++    MFX_RATECONTROL_ICQ,
++    0
++};
++static const unsigned short enc_rc_modes_vp9[] = {
++    MFX_RATECONTROL_CQP,
++    MFX_RATECONTROL_CBR,
++    MFX_RATECONTROL_VBR,
++    0
++};
++
++static const QsvEncMode qsvenc_modes[] = {
++    { "QSV H.264 Encoder",             AV_CODEC_ID_H264,  profiles_h264,  enc_formats_8_420_rgb,            enc_rc_modes_h26x, 0, 1 },
++    { "QSV H.264 Encoder (Low-Power)", AV_CODEC_ID_H264,  profiles_h264,  enc_formats_8_420_rgb,            enc_rc_modes_h26x, 1, 1 },
++    { "QSV HEVC Encoder",              AV_CODEC_ID_HEVC,  profiles_hevc,  enc_formats_8_10_420_422_444_rgb, enc_rc_modes_h26x, 0, 0 },
++    { "QSV HEVC Encoder (Low-Power)",  AV_CODEC_ID_HEVC,  profiles_hevc,  enc_formats_8_10_420_422_444_rgb, enc_rc_modes_h26x, 1, 0 },
++    { "QSV AV1 Encoder (Low-Power)",   AV_CODEC_ID_AV1,   profiles_av1,   enc_formats_8_10_420_rgb,         enc_rc_modes_av1,  1, 0 },
++    { "QSV VP9 Encoder (Low-Power)",   AV_CODEC_ID_VP9,   profiles_vp9,   enc_formats_8_10_420_444,         enc_rc_modes_vp9,  1, 0 },
++    { "QSV MJPEG Encoder",             AV_CODEC_ID_MJPEG, profiles_mjpeg, enc_formats_8_420_422_rgb,        NULL,              0, 0 },
++    { NULL, 0, NULL, NULL, NULL, 0, 0 },
++};
++
++enum QsvVppType {
++    QSV_VPP_SCALE,
++    QSV_VPP_DEINT,
++    QSV_VPP_OVERLAY,
++    QSV_VPP_ROTATE,
++    QSV_VPP_FLIP,
++    QSV_VPP_DENOISE,
++    QSV_VPP_DETAIL,
++    QSV_VPP_FRAMERATE,
++    QSV_VPP_PROCAMP,
++    QSV_VPP_TONEMAP,
++    QSV_VPP_NONE,
++};
++
++typedef struct QsvVppMode {
++    const char               *name;
++    const enum QsvVppType     vpp;
++    const enum AVPixelFormat *formats;
++} QsvVppMode;
++
++static const enum AVPixelFormat vpp_formats_10_12_420_422_444[] = {
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_P012,
++    AV_PIX_FMT_Y210,
++    AV_PIX_FMT_Y212,
++    AV_PIX_FMT_XV30,
++    AV_PIX_FMT_XV36,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat vpp_formats_8_10_12_420_422_444_rgb[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_P010,
++    AV_PIX_FMT_P012,
++    AV_PIX_FMT_YUYV422,
++    AV_PIX_FMT_Y210,
++    AV_PIX_FMT_Y212,
++    AV_PIX_FMT_VUYX,
++    AV_PIX_FMT_XV30,
++    AV_PIX_FMT_XV36,
++    AV_PIX_FMT_BGRA,
++    AV_PIX_FMT_NONE
++};
++
++static const QsvVppMode qsvvpp_modes[] = {
++    { "QSV VPP Scale Filter",       QSV_VPP_SCALE,     vpp_formats_8_10_12_420_422_444_rgb },
++    { "QSV VPP Deinterlace Filter", QSV_VPP_DEINT,     vpp_formats_8_10_12_420_422_444_rgb },
++    { "QSV VPP Overlay Filter",     QSV_VPP_OVERLAY,   vpp_formats_8_10_12_420_422_444_rgb },
++    { "QSV VPP Rotate Filter",      QSV_VPP_ROTATE,    vpp_formats_8_10_12_420_422_444_rgb },
++    { "QSV VPP Flip Filter",        QSV_VPP_FLIP,      vpp_formats_8_10_12_420_422_444_rgb },
++    { "QSV VPP Denoise Filter",     QSV_VPP_DENOISE,   vpp_formats_8_10_12_420_422_444_rgb },
++    { "QSV VPP Detail Filter",      QSV_VPP_DETAIL,    vpp_formats_8_10_12_420_422_444_rgb },
++    { "QSV VPP Framerate Filter",   QSV_VPP_FRAMERATE, vpp_formats_8_10_12_420_422_444_rgb },
++    { "QSV VPP Procamp Filter",     QSV_VPP_PROCAMP,   vpp_formats_8_10_12_420_422_444_rgb },
++    { "QSV VPP Tonemap Filter",     QSV_VPP_TONEMAP,   vpp_formats_10_12_420_422_444       },
++    { NULL, QSV_VPP_NONE, NULL },
++};
++
++enum QsvTestType {
++    QSV_TEST_BREAK    = -2,
++    QSV_TEST_CONTINUE = -1,
++    QSV_TEST_SUCCESS  =  0,
++};
++#endif
++
++int print_qsv_device_info(AVTextFormatContext *tfc, AVBufferRef *qsv_ref)
++{
++#if CONFIG_QSV
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVQSVDeviceContext *hwctx = NULL;
++    mfxStatus sts;
++    mfxIMPL impl;
++    mfxVersion ver = { 0 };
++    mfxPlatform platform = { 0 };
++
++    if (!tfc || !qsv_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)qsv_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++
++    sts = MFXQueryIMPL(hwctx->session, &impl);
++    if (sts != MFX_ERR_NONE)
++        return AVERROR(ENOSYS);
++
++    sts = MFXQueryVersion(hwctx->session, &ver);
++    if (sts != MFX_ERR_NONE)
++        return AVERROR(ENOSYS);
++
++    mark_section_show_entries(SECTION_ID_DEVICE_INFO_QSV, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_INFO_QSV);
++
++    print_int("device_mfx_impl", impl);
++    print_int("device_mfx_impl_version_major", ver.Major);
++    print_int("device_mfx_impl_version_minor", ver.Minor);
++    print_int("device_mfx_api_version_major", MFX_VERSION_MAJOR);
++    print_int("device_mfx_api_version_minor", MFX_VERSION_MINOR);
++
++    sts = MFXVideoCORE_QueryPlatform(hwctx->session, &platform);
++    if (sts == MFX_ERR_NONE) {
++        print_int("device_mfx_platfrom_code_name", platform.CodeName);
++        print_int("device_mfx_platfrom_device_id", platform.DeviceId);
++        print_int("device_mfx_platfrom_media_adapter_type", platform.MediaAdapterType);
++    }
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_INFO_QSV
++#endif
++    return 0;
++}
++
++#if CONFIG_QSV
++static int qsv_map_av_to_mfx_codec(enum AVCodecID codec)
++{
++    switch (codec) {
++    case AV_CODEC_ID_H264:       return MFX_CODEC_AVC;
++    case AV_CODEC_ID_HEVC:       return MFX_CODEC_HEVC;
++    case AV_CODEC_ID_MPEG1VIDEO:
++    case AV_CODEC_ID_MPEG2VIDEO: return MFX_CODEC_MPEG2;
++    case AV_CODEC_ID_VC1:        return MFX_CODEC_VC1;
++    case AV_CODEC_ID_VP8:        return MFX_CODEC_VP8;
++    case AV_CODEC_ID_MJPEG:      return MFX_CODEC_JPEG;
++    case AV_CODEC_ID_VP9:        return MFX_CODEC_VP9;
++#   if QSV_VERSION_ATLEAST(1, 34)
++    case AV_CODEC_ID_AV1:        return MFX_CODEC_AV1;
++#   endif
++#   if QSV_VERSION_ATLEAST(2, 11)
++    case AV_CODEC_ID_VVC:        return MFX_CODEC_VVC;
++#   endif
++    default:                     return -1;
++    }
++}
++
++static uint32_t qsv_map_av_to_mfx_fourcc(enum AVPixelFormat pix_fmt)
++{
++    switch (pix_fmt) {
++    case AV_PIX_FMT_NV12:    return MFX_FOURCC_NV12;
++    case AV_PIX_FMT_YUYV422: return MFX_FOURCC_YUY2;
++    case AV_PIX_FMT_VUYX:    return MFX_FOURCC_AYUV;
++    case AV_PIX_FMT_P010:    return MFX_FOURCC_P010;
++    case AV_PIX_FMT_Y210:    return MFX_FOURCC_Y210;
++    case AV_PIX_FMT_XV30:    return MFX_FOURCC_Y410;
++#   if QSV_VERSION_ATLEAST(1, 31)
++    case AV_PIX_FMT_P012:    return MFX_FOURCC_P016;
++    case AV_PIX_FMT_Y212:    return MFX_FOURCC_Y216;
++    case AV_PIX_FMT_XV36:    return MFX_FOURCC_Y416;
++#   endif
++    case AV_PIX_FMT_BGRA:    return MFX_FOURCC_RGB4;
++    case AV_PIX_FMT_X2RGB10: return MFX_FOURCC_A2RGB10;
++    default:                 return 0;
++    }
++}
++
++static int qsv_map_av_to_mfx_chroma(enum AVPixelFormat pix_fmt)
++{
++    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(pix_fmt);
++    return MFX_CHROMAFORMAT_YUV420 +
++        !desc->log2_chroma_w + !desc->log2_chroma_h;
++}
++
++static unsigned short qsv_map_av_to_mfx_profile(enum AVCodecID codec, int profile)
++{
++    if (codec == AV_CODEC_ID_MPEG2VIDEO) {
++        switch (profile) {
++        case AV_PROFILE_MPEG2_SIMPLE: return MFX_PROFILE_MPEG2_SIMPLE;
++        case AV_PROFILE_MPEG2_MAIN:   return MFX_PROFILE_MPEG2_MAIN;
++        case AV_PROFILE_MPEG2_HIGH:   return MFX_PROFILE_MPEG2_HIGH;
++        }
++    } else if (codec == AV_CODEC_ID_VC1) {
++        switch (profile) {
++        case AV_PROFILE_VC1_SIMPLE:   return MFX_PROFILE_VC1_SIMPLE;
++        case AV_PROFILE_VC1_MAIN:     return MFX_PROFILE_VC1_MAIN;
++        case AV_PROFILE_VC1_ADVANCED: return MFX_PROFILE_VC1_ADVANCED;
++        }
++    } else if (codec == AV_CODEC_ID_H264) {
++        switch (profile) {
++        case AV_PROFILE_H264_BASELINE:             return MFX_PROFILE_AVC_BASELINE;
++        case AV_PROFILE_H264_CONSTRAINED_BASELINE: return MFX_PROFILE_AVC_CONSTRAINED_BASELINE;
++        case AV_PROFILE_H264_MAIN:                 return MFX_PROFILE_AVC_MAIN;
++        case AV_PROFILE_H264_EXTENDED:             return MFX_PROFILE_AVC_EXTENDED;
++        case AV_PROFILE_H264_HIGH:                 return MFX_PROFILE_AVC_HIGH;
++        case AV_PROFILE_H264_HIGH_10:              return MFX_PROFILE_AVC_HIGH10;
++        case AV_PROFILE_H264_HIGH_422:             return MFX_PROFILE_AVC_HIGH_422;
++        }
++    } else if (codec == AV_CODEC_ID_HEVC) {
++        switch (profile) {
++        case AV_PROFILE_HEVC_MAIN:    return MFX_PROFILE_HEVC_MAIN;
++        case AV_PROFILE_HEVC_MAIN_10: return MFX_PROFILE_HEVC_MAIN10;
++        case AV_PROFILE_HEVC_REXT:    return MFX_PROFILE_HEVC_REXT;
++        }
++    } else if (codec == AV_CODEC_ID_VP9) {
++        switch (profile) {
++        case AV_PROFILE_VP9_0:        return MFX_PROFILE_VP9_0;
++        case AV_PROFILE_VP9_1:        return MFX_PROFILE_VP9_1;
++        case AV_PROFILE_VP9_2:        return MFX_PROFILE_VP9_2;
++        case AV_PROFILE_VP9_3:        return MFX_PROFILE_VP9_3;
++        }
++    } else if (codec == AV_CODEC_ID_AV1) {
++#   if QSV_VERSION_ATLEAST(1, 34)
++        switch (profile) {
++        case AV_PROFILE_AV1_MAIN:         return MFX_PROFILE_AV1_MAIN;
++        case AV_PROFILE_AV1_HIGH:         return MFX_PROFILE_AV1_HIGH;
++        case AV_PROFILE_AV1_PROFESSIONAL: return MFX_PROFILE_AV1_PRO;
++        }
++#   endif
++    } else if (codec == AV_CODEC_ID_VVC) {
++#   if QSV_VERSION_ATLEAST(2, 11)
++        switch (profile) {
++        case AV_PROFILE_VVC_MAIN_10: return MFX_PROFILE_VVC_MAIN10;
++        }
++#   endif
++    } else if (codec == AV_CODEC_ID_MJPEG) {
++        switch (profile) {
++        case AV_PROFILE_MJPEG_HUFFMAN_BASELINE_DCT: return MFX_PROFILE_JPEG_BASELINE;
++        }
++    }
++
++    return MFX_PROFILE_UNKNOWN;
++}
++
++static void qsv_set_default_mfx_profile_level(unsigned short *mfx_profile,
++                                              unsigned short *mfx_level,
++                                              enum AVCodecID codec,
++                                              unsigned short bit_depth,
++                                              unsigned short mfx_chroma)
++{
++    if (!mfx_profile || !mfx_level)
++        return;
++
++    switch (codec) {
++    case AV_CODEC_ID_MPEG2VIDEO:
++        *mfx_profile = MFX_PROFILE_MPEG2_MAIN;
++        *mfx_level = MFX_LEVEL_MPEG2_HIGH;
++        break;
++    case AV_CODEC_ID_VC1:
++        *mfx_profile = MFX_PROFILE_VC1_ADVANCED;
++        *mfx_level = MFX_LEVEL_VC1_4;
++        break;
++    case AV_CODEC_ID_H264:
++        *mfx_profile = (bit_depth <= 10 && mfx_chroma == MFX_CHROMAFORMAT_YUV422) ?
++            MFX_PROFILE_AVC_HIGH_422 :
++            (bit_depth == 10 ? MFX_PROFILE_AVC_HIGH10 : MFX_PROFILE_AVC_HIGH);
++        *mfx_level = MFX_LEVEL_AVC_52;
++        break;
++    case AV_CODEC_ID_HEVC:
++        *mfx_profile = (bit_depth <= 10 && mfx_chroma == MFX_CHROMAFORMAT_YUV420) ?
++            (bit_depth == 10 ? MFX_PROFILE_HEVC_MAIN10 : MFX_PROFILE_HEVC_MAIN) :
++            MFX_PROFILE_HEVC_REXT;
++        *mfx_level = MFX_LEVEL_HEVC_62;
++        break;
++    case AV_CODEC_ID_VP8:
++        *mfx_profile = MFX_PROFILE_VP8_3;
++        *mfx_level = MFX_LEVEL_UNKNOWN;
++        break;
++    case AV_CODEC_ID_VP9:
++        *mfx_profile = (mfx_chroma == MFX_CHROMAFORMAT_YUV420) ?
++            (bit_depth < 10 ? MFX_PROFILE_VP9_0 : MFX_PROFILE_VP9_2) :
++            (bit_depth < 10 ? MFX_PROFILE_VP9_1 : MFX_PROFILE_VP9_3);
++        *mfx_level = MFX_LEVEL_UNKNOWN;
++        break;
++#   if QSV_VERSION_ATLEAST(1, 34)
++    case AV_CODEC_ID_AV1:
++        *mfx_profile = MFX_PROFILE_AV1_MAIN;
++        *mfx_level = MFX_LEVEL_AV1_63;
++        break;
++#   endif
++#   if QSV_VERSION_ATLEAST(2, 11)
++    case AV_CODEC_ID_VVC:
++        *mfx_profile = MFX_PROFILE_VVC_MAIN10;
++        *mfx_level = MFX_LEVEL_VVC_63;
++        break;
++#   endif
++    case AV_CODEC_ID_MJPEG:
++        *mfx_profile = MFX_PROFILE_JPEG_BASELINE;
++        *mfx_level = MFX_LEVEL_UNKNOWN;
++        break;
++    default:
++        *mfx_profile = MFX_PROFILE_UNKNOWN;
++        *mfx_level = MFX_LEVEL_UNKNOWN;
++        break;
++    }
++}
++
++static int qsv_check_comp_shift(enum AVPixelFormat pix_fmt)
++{
++    int first = -1;
++    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(pix_fmt);
++
++    for (int i = 0; desc && i < desc->nb_components; i++) {
++        if (desc->comp[i].step > 0) {
++            if (desc->comp[i].shift <= 0 ||
++                (first >= 0 && desc->comp[i].shift != first))
++                return 0;
++            first = desc->comp[i].shift;
++        }
++    }
++    return first > 0;
++}
++
++static enum QsvTestType qsv_test_mfx_dec_params(mfxSession mfx_session,
++                                                mfxVideoParam mfx_params,
++                                                mfxVideoParam *mfx_params_out,
++                                                int do_init_test)
++{
++    mfxFrameAllocRequest mfx_alloc_req = { 0 };
++    mfxStatus sts;
++
++    if (!mfx_params_out)
++        return QSV_TEST_CONTINUE;
++
++    mfx_params_out->mfx.CodecId = mfx_params.mfx.CodecId;
++
++    sts = MFXVideoDECODE_Query(mfx_session, &mfx_params, mfx_params_out);
++    if (sts != MFX_ERR_NONE && sts != MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
++        return QSV_TEST_CONTINUE;
++
++    sts = MFXVideoDECODE_QueryIOSurf(mfx_session, &mfx_params, &mfx_alloc_req);
++    if (sts != MFX_ERR_NONE && sts != MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
++        return QSV_TEST_CONTINUE;
++
++    if (!do_init_test)
++        return QSV_TEST_SUCCESS;
++
++    sts = MFXVideoDECODE_Init(mfx_session, &mfx_params);
++    MFXVideoDECODE_Close(mfx_session);
++    if (sts != MFX_ERR_NONE && sts != MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
++        return QSV_TEST_CONTINUE;
++
++    return QSV_TEST_SUCCESS;
++}
++#endif
++
++int print_qsv_decoder_info(AVTextFormatContext *tfc, AVBufferRef *qsv_ref)
++{
++#if CONFIG_QSV
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVQSVDeviceContext *hwctx = NULL;
++    mfxVersion ver = { 0 };
++    mfxPlatform platform = { 0 };
++    mfxStatus sts;
++    int header_printed = 0;
++    int do_init_test = 0;
++    unsigned i, j;
++
++    if (!tfc || !qsv_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)qsv_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++
++    sts = MFXQueryVersion(hwctx->session, &ver);
++    if (sts != MFX_ERR_NONE)
++        return AVERROR(ENOSYS);
++
++    do_init_test = !QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 255);
++
++    MFXVideoCORE_QueryPlatform(hwctx->session, &platform);
++
++    for (i = 0; qsvdec_modes[i].name; i++) {
++        mfxVideoParam mfx_params = { 0 };
++        uint32_t mfx_fourcc = 0;
++        int mfx_codec = -1;
++        const QsvDecMode *mode = &qsvdec_modes[i];
++        const AVPixFmtDescriptor *desc = NULL;
++        enum AVPixelFormat format = AV_PIX_FMT_NONE;
++        unsigned min_width = 0, min_height = 0;
++        unsigned max_width = 0, max_height = 0;
++        unsigned short max_profile = MFX_PROFILE_UNKNOWN;
++        unsigned short max_chroma = MFX_CHROMAFORMAT_YUV420;
++        int header2_printed = 0;
++        int header3_printed = 0;
++        enum QsvTestType test_ret = QSV_TEST_SUCCESS;
++        int do_init_test_dec = do_init_test | (mode->codec == AV_CODEC_ID_MPEG2VIDEO);
++
++        if (platform.CodeName > 0) {
++            switch (mode->codec) {
++            case AV_CODEC_ID_HEVC: { if (platform.CodeName <  6) continue; } break; /* CHERRYTRAIL */
++            case AV_CODEC_ID_VP9:  { if (platform.CodeName <  8) continue; } break; /* APOLLOLAKE  */
++            case AV_CODEC_ID_AV1:  { if (platform.CodeName < 40) continue; } break; /* TIGERLAKE   */
++            case AV_CODEC_ID_VVC:  { if (platform.CodeName < 53) continue; } break; /* LUNARLAKE   */
++            }
++        }
++
++        if (!mode->formats)
++            continue;
++
++        mfx_codec = qsv_map_av_to_mfx_codec(mode->codec);
++        if (mfx_codec < 0)
++            continue;
++
++        /* Use the most basic format for this codec */
++        format = mode->formats[0];
++        desc = av_pix_fmt_desc_get(format);
++        if (!desc)
++            continue;
++        mfx_fourcc = qsv_map_av_to_mfx_fourcc(format);
++        if (!mfx_fourcc)
++            continue;
++
++        mfx_params.mfx.CodecId = mfx_codec;
++        mfx_params.mfx.FrameInfo.BitDepthLuma = FFMIN(desc->comp[0].depth, 12);
++        mfx_params.mfx.FrameInfo.BitDepthChroma = mfx_params.mfx.FrameInfo.BitDepthLuma;
++        mfx_params.mfx.FrameInfo.Shift = qsv_check_comp_shift(format);
++        mfx_params.mfx.FrameInfo.FourCC = mfx_fourcc;
++        mfx_params.mfx.FrameInfo.FrameRateExtN = 25;
++        mfx_params.mfx.FrameInfo.FrameRateExtD = 1;
++        mfx_params.mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
++        mfx_params.mfx.FrameInfo.ChromaFormat = qsv_map_av_to_mfx_chroma(format);
++        mfx_params.AsyncDepth = 1;
++        mfx_params.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
++
++        qsv_set_default_mfx_profile_level(&mfx_params.mfx.CodecProfile,
++                                          &mfx_params.mfx.CodecLevel,
++                                          mode->codec,
++                                          mfx_params.mfx.FrameInfo.BitDepthLuma,
++                                          mfx_params.mfx.FrameInfo.ChromaFormat);
++
++        if (!QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 9)) {
++            mfx_params.mfx.FrameInfo.BitDepthLuma   = 0;
++            mfx_params.mfx.FrameInfo.BitDepthChroma = 0;
++            mfx_params.mfx.FrameInfo.Shift          = 0;
++        }
++
++        /* Check min res first */
++        for (const HwRes *r = &hw_res_ascend[0]; r->name; r++) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            if (mode->legacy && (r->width > 4096 || r->height > 4096))
++                break;
++
++            mfx_params.mfx.FrameInfo.Width  = r->width;
++            mfx_params.mfx.FrameInfo.Height = r->height;
++
++            test_ret = qsv_test_mfx_dec_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test_dec);
++            if (test_ret != QSV_TEST_SUCCESS) {
++                if (test_ret == QSV_TEST_BREAK) break;
++                else continue;
++            }
++            min_width  = r->width;
++            min_height = r->height;
++            break;
++        }
++        if (!min_width || !min_height)
++            continue;
++
++        /* Check max res */
++        for (const HwRes *r = &hw_res_ascend[FF_ARRAY_ELEMS(hw_res_ascend) - 1]; r >= &hw_res_ascend[0]; r--) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            if (!r->name)
++                continue;
++            if (r->width <= min_width && r->height <= min_height) {
++                max_width  = r->width;
++                max_height = r->height;
++                break;
++            }
++            if (mode->legacy && (r->width > 4096 || r->height > 4096))
++                continue;
++
++            mfx_params.mfx.FrameInfo.Width  = r->width;
++            mfx_params.mfx.FrameInfo.Height = r->height;
++
++            test_ret = qsv_test_mfx_dec_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test_dec);
++            if (test_ret != QSV_TEST_SUCCESS) {
++                if (test_ret == QSV_TEST_BREAK) break;
++                else continue;
++            }
++            max_width  = r->width;
++            max_height = r->height;
++            break;
++        }
++        if (!max_width || !max_height)
++            continue;
++
++        if (!header_printed) {
++            mark_section_show_entries(SECTION_ID_DEVICE_DECODERS_QSV, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_DECODERS_QSV);
++            header_printed = 1;
++        }
++
++        mark_section_show_entries(SECTION_ID_DEVICE_DECODER, 1, NULL);
++        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_DECODER);
++        print_str("codec_name", avcodec_get_name(mode->codec));
++        print_int("codec_id", mode->codec);
++        print_str("codec_desc", mode->name);
++        print_int("min_width", min_width);
++        print_int("min_height", min_height);
++        print_int("max_width", max_width);
++        print_int("max_height", max_height);
++
++        /* Formats */
++        for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            format = mode->formats[j];
++            desc = av_pix_fmt_desc_get(format);
++            if (!desc)
++                continue;
++            mfx_fourcc = qsv_map_av_to_mfx_fourcc(format);
++            if (!mfx_fourcc)
++                continue;
++            if (!j)
++                goto skip;
++
++            mfx_params.mfx.FrameInfo.Width  = min_width;
++            mfx_params.mfx.FrameInfo.Height = min_height;
++            mfx_params.mfx.FrameInfo.BitDepthLuma = FFMIN(desc->comp[0].depth, 12);
++            mfx_params.mfx.FrameInfo.BitDepthChroma = mfx_params.mfx.FrameInfo.BitDepthLuma;
++            mfx_params.mfx.FrameInfo.Shift = qsv_check_comp_shift(format);
++            mfx_params.mfx.FrameInfo.FourCC = mfx_fourcc;
++            mfx_params.mfx.FrameInfo.ChromaFormat = qsv_map_av_to_mfx_chroma(format);
++
++            qsv_set_default_mfx_profile_level(&mfx_params.mfx.CodecProfile,
++                                              &mfx_params.mfx.CodecLevel,
++                                              mode->codec,
++                                              mfx_params.mfx.FrameInfo.BitDepthLuma,
++                                              mfx_params.mfx.FrameInfo.ChromaFormat);
++
++            if (!QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 9)) {
++                mfx_params.mfx.FrameInfo.BitDepthLuma   = 0;
++                mfx_params.mfx.FrameInfo.BitDepthChroma = 0;
++                mfx_params.mfx.FrameInfo.Shift          = 0;
++            }
++
++            test_ret = qsv_test_mfx_dec_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test_dec);
++            if (test_ret != QSV_TEST_SUCCESS) {
++                if (test_ret == QSV_TEST_BREAK) break;
++                else continue;
++            }
++skip:
++            if (!header2_printed) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                header2_printed = 1;
++            }
++
++            max_profile = FFMAX(mfx_params.mfx.CodecProfile, max_profile);
++            max_chroma  = FFMAX(mfx_params.mfx.FrameInfo.ChromaFormat, max_chroma);
++
++            mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++            print_str("format_name", av_get_pix_fmt_name(format));
++            print_int("format_id", format);
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++        }
++        if (header2_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++        /* Profiles */
++        for (j = 0; mode->profiles && mode->profiles[j] != AV_PROFILE_UNKNOWN; j++) {
++            unsigned short mfx_profile = qsv_map_av_to_mfx_profile(mode->codec, mode->profiles[j]);
++
++            if (mode->codec == AV_CODEC_ID_H264)
++                mfx_profile &= ~QSV_MFX_PROFILE_H264_CONSTRAINTS;
++            if (mode->codec == AV_CODEC_ID_VP9 &&
++                max_chroma == MFX_CHROMAFORMAT_YUV420 && !(mfx_profile & 1))
++                continue;
++
++            if (mfx_profile > 0 && max_profile > 0 && mfx_profile <= max_profile) {
++                if (!header3_printed) {
++                    mark_section_show_entries(SECTION_ID_DEVICE_PROFILES, 1, NULL);
++                    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILES);
++                    header3_printed = 1;
++                }
++                mark_section_show_entries(SECTION_ID_DEVICE_PROFILE, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILE);
++                print_str("profile_name", avcodec_profile_name(mode->codec, mode->profiles[j]));
++                print_int("profile_id", mode->profiles[j]);
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILE
++            }
++        }
++        if (header3_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILES
++
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_DECODER
++    }
++
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_DECODERS_QSV
++#endif
++    return 0;
++}
++
++#if CONFIG_QSV
++static void qsv_set_default_mfx_enc_rc_params(mfxVideoParam* mfx_params,
++                                              unsigned short mfx_rc_mode)
++{
++    if (!mfx_params)
++        return;
++
++    mfx_params->mfx.RateControlMethod  = 0;
++    mfx_params->mfx.QPI                = 0;
++    mfx_params->mfx.QPP                = 0;
++    mfx_params->mfx.QPB                = 0;
++    mfx_params->mfx.ICQQuality         = 0;
++    mfx_params->mfx.BRCParamMultiplier = 0;
++    mfx_params->mfx.TargetKbps         = 0;
++    mfx_params->mfx.MaxKbps            = 0;
++    mfx_params->mfx.BufferSizeInKB     = 0;
++    mfx_params->mfx.InitialDelayInKB   = 0;
++
++    switch (mfx_rc_mode) {
++    case MFX_RATECONTROL_CBR:
++    case MFX_RATECONTROL_VBR:
++    case MFX_RATECONTROL_QVBR:
++        {
++            mfxU32 target_kbps = 4000;
++            mfxU32 max_kbps    = target_kbps << (mfx_rc_mode != MFX_RATECONTROL_CBR);
++            mfxU32 buf_size    = (max_kbps * 2) / 8;
++            mfxU32 init_delay  = buf_size / 2;
++            mfxU32 max_val     = FFMAX(FFMAX3(target_kbps, max_kbps, buf_size), init_delay);
++            mfxU16 multiplier  = (max_val + 0x10000) / 0x10000;
++
++            multiplier = FFMAX(multiplier, 1);
++            mfx_params->mfx.RateControlMethod  = mfx_rc_mode;
++            mfx_params->mfx.BRCParamMultiplier = multiplier;
++            mfx_params->mfx.TargetKbps         = (mfxU16)(target_kbps / multiplier);
++            mfx_params->mfx.MaxKbps            = (mfxU16)(max_kbps / multiplier);
++            mfx_params->mfx.BufferSizeInKB     = (mfxU16)(buf_size / multiplier);
++            mfx_params->mfx.InitialDelayInKB   = (mfxU16)(init_delay / multiplier);
++        }
++        break;
++    case MFX_RATECONTROL_CQP:
++        mfx_params->mfx.RateControlMethod = mfx_rc_mode;
++        mfx_params->mfx.QPI =
++        mfx_params->mfx.QPP =
++        mfx_params->mfx.QPB = 26;
++        break;
++    case MFX_RATECONTROL_ICQ:
++        mfx_params->mfx.RateControlMethod = mfx_rc_mode;
++        mfx_params->mfx.ICQQuality = 23;
++        break;
++    }
++}
++
++static enum QsvTestType qsv_test_mfx_enc_params(mfxSession mfx_session,
++                                                mfxVideoParam mfx_params,
++                                                mfxVideoParam *mfx_params_out,
++                                                int do_init_test)
++{
++    mfxFrameAllocRequest mfx_alloc_req = { 0 };
++    mfxStatus sts;
++
++    if (!mfx_params_out)
++        return QSV_TEST_CONTINUE;
++
++    mfx_params_out->mfx.CodecId = mfx_params.mfx.CodecId;
++
++    sts = MFXVideoENCODE_Query(mfx_session, &mfx_params, mfx_params_out);
++    if (sts != MFX_ERR_NONE && sts != MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
++        return QSV_TEST_CONTINUE;
++    else if (mfx_params.mfx.LowPower != mfx_params_out->mfx.LowPower)
++        return QSV_TEST_BREAK;
++
++    sts = MFXVideoENCODE_QueryIOSurf(mfx_session, &mfx_params, &mfx_alloc_req);
++    if (sts != MFX_ERR_NONE && sts != MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
++        return QSV_TEST_CONTINUE;
++
++    if (!do_init_test)
++        return QSV_TEST_SUCCESS;
++
++    sts = MFXVideoENCODE_Init(mfx_session, &mfx_params);
++    MFXVideoENCODE_Close(mfx_session);
++    if (sts != MFX_ERR_NONE && sts != MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
++        return QSV_TEST_CONTINUE;
++
++    return QSV_TEST_SUCCESS;
++}
++
++static const char *qsv_map_mfx_rc_mode_to_str(unsigned short mfx_rc_mode, int suffix)
++{
++    switch (mfx_rc_mode) {
++    case MFX_RATECONTROL_CBR:  return suffix ? "cbr_ratecontol"  : "cbr";
++    case MFX_RATECONTROL_VBR:  return suffix ? "vbr_ratecontol"  : "vbr";
++    case MFX_RATECONTROL_CQP:  return suffix ? "cqp_ratecontol"  : "cqp";
++    case MFX_RATECONTROL_ICQ:  return suffix ? "icq_ratecontol"  : "icq";
++    case MFX_RATECONTROL_QVBR: return suffix ? "qvbr_ratecontol" : "qvbr";
++    default:                   return "";
++    }
++}
++#endif
++
++int print_qsv_encoder_info(AVTextFormatContext *tfc, AVBufferRef *qsv_ref)
++{
++#if CONFIG_QSV
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVQSVDeviceContext *hwctx = NULL;
++    mfxVersion ver = { 0 };
++    mfxPlatform platform = { 0 };
++    mfxStatus sts;
++    int header_printed = 0;
++    int do_init_test = 0;
++    unsigned i, j, k;
++
++    if (!tfc || !qsv_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)qsv_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++
++    sts = MFXQueryVersion(hwctx->session, &ver);
++    if (sts != MFX_ERR_NONE)
++        return AVERROR(ENOSYS);
++
++    do_init_test = !QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 255);
++
++    MFXVideoCORE_QueryPlatform(hwctx->session, &platform);
++
++    for (i = 0; qsvenc_modes[i].name; i++) {
++        mfxVideoParam mfx_params = { 0 };
++        uint32_t mfx_fourcc = 0;
++        int mfx_codec = -1;
++        const QsvEncMode *mode = &qsvenc_modes[i];
++        const AVPixFmtDescriptor *desc = NULL;
++        enum AVPixelFormat format = AV_PIX_FMT_NONE;
++        unsigned min_width = 0, min_height = 0;
++        unsigned max_width = 0, max_height = 0;
++        unsigned short max_profile = MFX_PROFILE_UNKNOWN;
++        unsigned short max_chroma = MFX_CHROMAFORMAT_YUV420;
++        int header2_printed = 0;
++        int header3_printed = 0;
++        enum QsvTestType test_ret = QSV_TEST_SUCCESS;
++
++        if (!mode->low_power && mode->codec != AV_CODEC_ID_MJPEG &&
++            (platform.CodeName == 32 || platform.CodeName == 33 || /* JASPERLAKE/ELKHARTLAKE */
++             platform.CodeName == 45 || platform.CodeName == 46 || /* DG2/ATS_M  */
++             platform.CodeName >= 51))                             /* METEORLAKE */
++            continue;
++
++        if (platform.CodeName > 0) {
++            switch (mode->codec) {
++            case AV_CODEC_ID_HEVC: { if (platform.CodeName <   7) continue; } break; /* SKYLAKE       */
++            case AV_CODEC_ID_VP9:  { if (platform.CodeName <  30) continue; } break; /* ICELAKE       */
++            case AV_CODEC_ID_AV1:  { if (platform.CodeName <  45) continue;          /* ARCTICSOUND_P */
++                                     if (platform.CodeName == 50) continue;          /* ALDERLAKE_N   */
++                                     if (platform.CodeName == 55) continue; } break; /* KEEMBAY       */
++            }
++        }
++
++        if (!mode->formats)
++            continue;
++
++        mfx_codec = qsv_map_av_to_mfx_codec(mode->codec);
++        if (mfx_codec < 0)
++            continue;
++
++        /* Use the most basic format for this codec */
++        format = mode->formats[0];
++        desc = av_pix_fmt_desc_get(format);
++        if (!desc)
++            continue;
++        mfx_fourcc = qsv_map_av_to_mfx_fourcc(format);
++        if (!mfx_fourcc)
++            continue;
++
++        mfx_params.mfx.CodecId = mfx_codec;
++        mfx_params.mfx.FrameInfo.BitDepthLuma = FFMIN(desc->comp[0].depth, 10);
++        mfx_params.mfx.FrameInfo.BitDepthChroma = mfx_params.mfx.FrameInfo.BitDepthLuma;
++        mfx_params.mfx.FrameInfo.Shift = qsv_check_comp_shift(format);
++        mfx_params.mfx.FrameInfo.FourCC = mfx_fourcc;
++        mfx_params.mfx.FrameInfo.FrameRateExtN = 25;
++        mfx_params.mfx.FrameInfo.FrameRateExtD = 1;
++        mfx_params.mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
++        mfx_params.mfx.FrameInfo.ChromaFormat = qsv_map_av_to_mfx_chroma(format);
++        mfx_params.AsyncDepth = 1;
++        mfx_params.IOPattern = MFX_IOPATTERN_IN_SYSTEM_MEMORY;
++
++        if (mode->codec == AV_CODEC_ID_MJPEG) {
++            mfx_params.mfx.Interleaved = MFX_SCANTYPE_INTERLEAVED;
++            mfx_params.mfx.Quality = 100;
++        } else {
++            mfx_params.mfx.TargetUsage = MFX_TARGETUSAGE_BALANCED;
++            mfx_params.mfx.LowPower = mode->low_power ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
++            if (!QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 15)) {
++                mfx_params.mfx.LowPower = MFX_CODINGOPTION_UNKNOWN;
++                if (mode->low_power)
++                    continue;
++            }
++            qsv_set_default_mfx_enc_rc_params(&mfx_params, MFX_RATECONTROL_CQP);
++        }
++
++        qsv_set_default_mfx_profile_level(&mfx_params.mfx.CodecProfile,
++                                          &mfx_params.mfx.CodecLevel,
++                                          mode->codec,
++                                          mfx_params.mfx.FrameInfo.BitDepthLuma,
++                                          mfx_params.mfx.FrameInfo.ChromaFormat);
++
++        if (!QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 9)) {
++            mfx_params.mfx.FrameInfo.BitDepthLuma   = 0;
++            mfx_params.mfx.FrameInfo.BitDepthChroma = 0;
++            mfx_params.mfx.FrameInfo.Shift          = 0;
++        }
++
++        /* Check min res first */
++        for (const HwRes *r = &hw_res_ascend[0]; r->name; r++) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            if (mode->legacy && (r->width > 4096 || r->height > 4096))
++                break;
++
++            mfx_params.mfx.FrameInfo.CropW = mfx_params.mfx.FrameInfo.Width  = r->width;
++            mfx_params.mfx.FrameInfo.CropH = mfx_params.mfx.FrameInfo.Height = r->height;
++
++            test_ret = qsv_test_mfx_enc_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++            if (test_ret != QSV_TEST_SUCCESS) {
++                if (test_ret == QSV_TEST_BREAK) break;
++                else continue;
++            }
++            min_width  = r->width;
++            min_height = r->height;
++            break;
++        }
++        if (!min_width || !min_height)
++            continue;
++
++        /* Check max res */
++        for (const HwRes *r = &hw_res_ascend[FF_ARRAY_ELEMS(hw_res_ascend) - 1]; r >= &hw_res_ascend[0]; r--) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            if (!r->name)
++                continue;
++            if (r->width <= min_width && r->height <= min_height) {
++                max_width  = r->width;
++                max_height = r->height;
++                break;
++            }
++            if (mode->legacy && (r->width > 4096 || r->height > 4096))
++                continue;
++
++            mfx_params.mfx.FrameInfo.CropW = mfx_params.mfx.FrameInfo.Width  = r->width;
++            mfx_params.mfx.FrameInfo.CropH = mfx_params.mfx.FrameInfo.Height = r->height;
++
++            test_ret = qsv_test_mfx_enc_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++            if (test_ret != QSV_TEST_SUCCESS) {
++                if (test_ret == QSV_TEST_BREAK) break;
++                else continue;
++            }
++            max_width  = r->width;
++            max_height = r->height;
++            break;
++        }
++        if (!max_width || !max_height)
++            continue;
++
++        if (!header_printed) {
++            mark_section_show_entries(SECTION_ID_DEVICE_ENCODERS_QSV, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_ENCODERS_QSV);
++            header_printed = 1;
++        }
++
++        mark_section_show_entries(SECTION_ID_DEVICE_ENCODER, 1, NULL);
++        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_ENCODER);
++        print_str("codec_name", avcodec_get_name(mode->codec));
++        print_int("codec_id", mode->codec);
++        print_str("codec_desc", mode->name);
++        print_int("min_width", min_width);
++        print_int("min_height", min_height);
++        print_int("max_width", max_width);
++        print_int("max_height", max_height);
++
++        mfx_params.mfx.FrameInfo.CropW = mfx_params.mfx.FrameInfo.Width  = min_width;
++        mfx_params.mfx.FrameInfo.CropH = mfx_params.mfx.FrameInfo.Height = min_height;
++
++        /* Check RC and CO */
++        if (mode->codec != AV_CODEC_ID_MJPEG) {
++            static const struct {
++                const char    *attr_str;
++                const size_t   attr_offset;
++                const unsigned need_brc;
++                const unsigned co_version;
++                const unsigned mfx_ver_major;
++                const unsigned mfx_ver_minor;
++            } mfx_co_attrs[] = {
++                { "enctools_la", offsetof(mfxExtCodingOption2, ExtBRC), 1, 2, 1, 255 },
++                { "mbbrc",       offsetof(mfxExtCodingOption2, MBBRC),  1, 2, 1,   6 },
++            };
++
++            print_int("low_power", mfx_params.mfx.LowPower == MFX_CODINGOPTION_ON);
++
++            for (j = 0; mode->rc_modes && mode->rc_modes[j] != 0; j++) {
++                mfxVideoParam mfx_params_rc = mfx_params;
++                mfxVideoParam mfx_params_rc_out = { 0 };
++
++                test_ret = QSV_TEST_SUCCESS;
++
++                if ((mode->rc_modes[j] == MFX_RATECONTROL_ICQ &&
++                     !QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 8)) ||
++                    (mode->rc_modes[j] == MFX_RATECONTROL_QVBR &&
++                     !QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 11)))
++                    continue;
++
++                if (mode->rc_modes[j] != MFX_RATECONTROL_CQP) {
++                    qsv_set_default_mfx_enc_rc_params(&mfx_params_rc, mode->rc_modes[j]);
++                    test_ret = qsv_test_mfx_enc_params(hwctx->session, mfx_params_rc, &mfx_params_rc_out, do_init_test);
++                }
++
++                print_int(qsv_map_mfx_rc_mode_to_str(mode->rc_modes[j], 1), test_ret == QSV_TEST_SUCCESS);
++                if (test_ret != QSV_TEST_SUCCESS)
++                    continue;
++
++                /* mfxExtCodingOption2 */
++                for (k = 0; k < FF_ARRAY_ELEMS(mfx_co_attrs) && mfx_co_attrs[k].attr_str; k++) {
++                    mfxExtCodingOption2 extco2_in  = { .Header.BufferId = MFX_EXTBUFF_CODING_OPTION2,
++                                                       .Header.BufferSz = sizeof(mfxExtCodingOption2) };
++                    mfxExtCodingOption2 extco2_out = { .Header.BufferId = MFX_EXTBUFF_CODING_OPTION2,
++                                                       .Header.BufferSz = sizeof(mfxExtCodingOption2) };
++                    mfxExtBuffer* mfx_ext_bufs_in[1]  = { (mfxExtBuffer*)&extco2_in  };
++                    mfxExtBuffer* mfx_ext_bufs_out[1] = { (mfxExtBuffer*)&extco2_out };
++                    mfxVideoParam mfx_params_in  = mfx_params_rc;
++                    mfxVideoParam mfx_params_out = { .ExtParam = mfx_ext_bufs_out, .NumExtParam = 1 };
++                    const int is_extbrc = mfx_co_attrs[k].attr_offset == offsetof(mfxExtCodingOption2, ExtBRC);
++                    char full_str[128] = { 0 };
++
++                    if (mfx_co_attrs[k].co_version != 2)
++                        continue;
++                    if (!QSV_RUNTIME_VERSION_ATLEAST(ver, mfx_co_attrs[k].mfx_ver_major,
++                                                          mfx_co_attrs[k].mfx_ver_minor))
++                        continue;
++                    if (mfx_co_attrs[k].need_brc && mode->rc_modes[j] == MFX_RATECONTROL_CQP)
++                        continue;
++                    if (is_extbrc && ((platform.CodeName > 0 && platform.CodeName < 40 /* TIGERLAKE */) ||
++                                       mode->codec == AV_CODEC_ID_VP9 ||
++                                       (mode->rc_modes[j] != MFX_RATECONTROL_CBR &&
++                                        mode->rc_modes[j] != MFX_RATECONTROL_VBR)))
++                        continue;
++
++                    *(mfxU16*)((char*)&extco2_in + mfx_co_attrs[k].attr_offset) = MFX_CODINGOPTION_ON;
++                    if (is_extbrc)
++                        extco2_in.LookAheadDepth = 8;
++
++                    mfx_params_in.ExtParam = mfx_ext_bufs_in;
++                    mfx_params_in.NumExtParam = 1;
++                    test_ret = qsv_test_mfx_enc_params(hwctx->session, mfx_params_in, &mfx_params_out, 1);
++                    if (test_ret == QSV_TEST_SUCCESS) {
++                        mfxU16 attr_out = *(mfxU16*)((char*)&extco2_out + mfx_co_attrs[k].attr_offset);
++
++                        test_ret = (attr_out == MFX_CODINGOPTION_ON) ? QSV_TEST_SUCCESS : QSV_TEST_CONTINUE;
++                        if (is_extbrc && extco2_in.LookAheadDepth != extco2_out.LookAheadDepth)
++                            test_ret = QSV_TEST_CONTINUE;
++                    }
++
++                    snprintf(full_str, sizeof(full_str), "%s_%s",
++                             qsv_map_mfx_rc_mode_to_str(mode->rc_modes[j], 0), mfx_co_attrs[k].attr_str);
++
++                    print_int(full_str, test_ret == QSV_TEST_SUCCESS);
++                }
++            }
++        }
++
++        /* Formats */
++        for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            format = mode->formats[j];
++            desc = av_pix_fmt_desc_get(format);
++            if (!desc)
++                continue;
++            mfx_fourcc = qsv_map_av_to_mfx_fourcc(format);
++            if (!mfx_fourcc)
++                continue;
++            if (!j)
++                goto skip;
++
++            mfx_params.mfx.FrameInfo.BitDepthLuma = FFMIN(desc->comp[0].depth, 10);
++            mfx_params.mfx.FrameInfo.BitDepthChroma = mfx_params.mfx.FrameInfo.BitDepthLuma;
++            mfx_params.mfx.FrameInfo.Shift = qsv_check_comp_shift(format);
++            mfx_params.mfx.FrameInfo.FourCC = mfx_fourcc;
++            mfx_params.mfx.FrameInfo.ChromaFormat = qsv_map_av_to_mfx_chroma(format);
++
++            qsv_set_default_mfx_profile_level(&mfx_params.mfx.CodecProfile,
++                                              &mfx_params.mfx.CodecLevel,
++                                              mode->codec,
++                                              mfx_params.mfx.FrameInfo.BitDepthLuma,
++                                              mfx_params.mfx.FrameInfo.ChromaFormat);
++
++            if (!QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 9)) {
++                mfx_params.mfx.FrameInfo.BitDepthLuma   = 0;
++                mfx_params.mfx.FrameInfo.BitDepthChroma = 0;
++                mfx_params.mfx.FrameInfo.Shift          = 0;
++            }
++
++            test_ret = qsv_test_mfx_enc_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++            if (test_ret != QSV_TEST_SUCCESS) {
++                if (test_ret == QSV_TEST_BREAK) break;
++                else continue;
++            }
++skip:
++            if (!header2_printed) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                header2_printed = 1;
++            }
++
++            max_profile = FFMAX(mfx_params.mfx.CodecProfile, max_profile);
++            max_chroma  = FFMAX(mfx_params.mfx.FrameInfo.ChromaFormat, max_chroma);
++
++            mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++            print_str("format_name", av_get_pix_fmt_name(format));
++            print_int("format_id", format);
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++        }
++        if (header2_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++        /* Profiles */
++        for (j = 0; mode->profiles && mode->profiles[j] != AV_PROFILE_UNKNOWN; j++) {
++            unsigned short mfx_profile = qsv_map_av_to_mfx_profile(mode->codec, mode->profiles[j]);
++
++            if (mode->codec == AV_CODEC_ID_H264)
++                mfx_profile &= ~QSV_MFX_PROFILE_H264_CONSTRAINTS;
++            if (mode->codec == AV_CODEC_ID_VP9 &&
++                max_chroma == MFX_CHROMAFORMAT_YUV420 && !(mfx_profile & 1))
++                continue;
++
++            if (mfx_profile > 0 && max_profile > 0 && mfx_profile <= max_profile) {
++                if (!header3_printed) {
++                    mark_section_show_entries(SECTION_ID_DEVICE_PROFILES, 1, NULL);
++                    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILES);
++                    header3_printed = 1;
++                }
++                mark_section_show_entries(SECTION_ID_DEVICE_PROFILE, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILE);
++                print_str("profile_name", avcodec_profile_name(mode->codec, mode->profiles[j]));
++                print_int("profile_id", mode->profiles[j]);
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILE
++            }
++        }
++        if (header3_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILES
++
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_ENCODER
++    }
++
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_ENCODERS_QSV
++#endif
++    return 0;
++}
++
++#if CONFIG_QSV
++static enum QsvTestType qsv_test_mfx_vpp_params(mfxSession mfx_session,
++                                                mfxVideoParam mfx_params,
++                                                mfxVideoParam *mfx_params_out,
++                                                int do_init_test)
++{
++    mfxFrameAllocRequest mfx_alloc_req[2] = { 0 };
++    mfxStatus sts;
++
++    if (!mfx_params_out)
++        return QSV_TEST_CONTINUE;
++
++    *mfx_params_out = mfx_params;
++
++    sts = MFXVideoVPP_Query(mfx_session, &mfx_params, mfx_params_out);
++    if (sts != MFX_ERR_NONE && sts != MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
++        return QSV_TEST_CONTINUE;
++
++    sts = MFXVideoVPP_QueryIOSurf(mfx_session, &mfx_params, mfx_alloc_req);
++    if (sts != MFX_ERR_NONE && sts != MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
++        return QSV_TEST_CONTINUE;
++
++    if (!do_init_test)
++        return QSV_TEST_SUCCESS;
++
++    sts = MFXVideoVPP_Init(mfx_session, &mfx_params);
++    MFXVideoVPP_Close(mfx_session);
++    if (sts != MFX_ERR_NONE && sts != MFX_WRN_INCOMPATIBLE_VIDEO_PARAM)
++        return QSV_TEST_CONTINUE;
++
++    return QSV_TEST_SUCCESS;
++}
++
++static const char *qsv_map_vpp_type_to_str(enum QsvVppType vpp)
++{
++    switch (vpp) {
++    case QSV_VPP_SCALE:     return "scale";
++    case QSV_VPP_DEINT:     return "deinterlace";
++    case QSV_VPP_OVERLAY:   return "overlay";
++    case QSV_VPP_ROTATE:    return "rotate";
++    case QSV_VPP_FLIP:      return "flip";
++    case QSV_VPP_DENOISE:   return "denoise";
++    case QSV_VPP_DETAIL:    return "detail";
++    case QSV_VPP_FRAMERATE: return "framerate";
++    case QSV_VPP_PROCAMP:   return "procamp";
++    case QSV_VPP_TONEMAP:   return "tonemap";
++    default:                return "";
++    }
++}
++#endif
++
++int print_qsv_vpp_info(AVTextFormatContext *tfc, AVBufferRef *qsv_ref)
++{
++#if CONFIG_QSV
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVQSVDeviceContext *hwctx = NULL;
++    mfxVersion ver = { 0 };
++    mfxStatus sts;
++    int header_printed = 0;
++    int do_init_test = 0;
++    unsigned i, j;
++
++    mfxExtVPPScaling scale_conf = { 0 };
++    mfxExtVPPDeinterlacing deint_conf = {
++        .Mode = MFX_DEINTERLACING_BOB
++    };
++    mfxVPPCompInputStream overlay_inputs[2] = {
++        { 0 },
++        { .GlobalAlpha = 255, .PixelAlphaEnable = 1 }
++    };
++    mfxExtVPPComposite overlay_conf = {
++        .InputStream = overlay_inputs,
++        .NumInputStream = 2
++    };
++    mfxExtVPPRotation rotate_conf = {
++        .Angle = MFX_ANGLE_180
++    };
++    mfxExtVPPMirroring flip_conf = {
++        .Type = MFX_MIRRORING_HORIZONTAL
++    };
++    mfxExtVPPDenoise denoise_conf = {
++        .DenoiseFactor = 1
++    };
++    mfxExtVPPDetail detail_conf = {
++        .DetailFactor = 1
++    };
++    mfxExtVPPFrameRateConversion frc_conf = {
++        .Algorithm = MFX_FRCALGM_FRAME_INTERPOLATION
++    };
++    mfxExtVPPProcAmp procamp_conf = {
++        .Brightness = 1.f,
++        .Contrast = 1.f,
++        .Hue = 1.f,
++        .Saturation = 1.f
++    };
++    mfxExtVideoSignalInfo invsi_conf = {
++        .ColourPrimaries = AVCOL_PRI_BT2020,
++        .TransferCharacteristics = AVCOL_TRC_SMPTE2084,
++        .MatrixCoefficients = AVCOL_SPC_BT2020_NCL,
++        .ColourDescriptionPresent = 1
++    };
++    mfxExtVideoSignalInfo outvsi_conf = {
++        .ColourPrimaries = AVCOL_PRI_BT709,
++        .TransferCharacteristics = AVCOL_TRC_BT709,
++        .MatrixCoefficients = AVCOL_SPC_BT709,
++        .ColourDescriptionPresent = 1
++    };
++    mfxExtMasteringDisplayColourVolume mdcv_conf = {
++        .DisplayPrimariesX = { 13250, 7500, 34000 },
++        .DisplayPrimariesY = { 34500, 3000, 16000 },
++        .WhitePointX = 15635, .WhitePointY = 16450,
++        .MaxDisplayMasteringLuminance = 10000000,
++        .MinDisplayMasteringLuminance = 50
++    };
++    mfxExtContentLightLevelInfo clli_conf = {
++        .MaxContentLightLevel = 1000,
++        .MaxPicAverageLightLevel = 400
++    };
++
++    if (!tfc || !qsv_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)qsv_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++
++    sts = MFXQueryVersion(hwctx->session, &ver);
++    if (sts != MFX_ERR_NONE)
++        return AVERROR(ENOSYS);
++
++    do_init_test = !QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 255);
++
++    for (i = 0; qsvvpp_modes[i].name; i++) {
++        mfxVideoParam mfx_params = { 0 };
++        mfxExtBuffer* mfx_ext_bufs[4] = { NULL };
++        uint32_t mfx_fourcc = 0;
++        const QsvVppMode *mode = &qsvvpp_modes[i];
++        const AVPixFmtDescriptor *desc = NULL;
++        enum AVPixelFormat format = AV_PIX_FMT_NONE;
++        unsigned min_width = 0, min_height = 0;
++        unsigned max_width = 0, max_height = 0;
++        int header2_printed = 0;
++        enum QsvTestType test_ret = QSV_TEST_SUCCESS;
++
++        if (!mode->formats)
++            continue;
++
++        /* Use the most basic format for this vpp */
++        format = mode->formats[0];
++        desc = av_pix_fmt_desc_get(format);
++        if (!desc)
++            continue;
++        mfx_fourcc = qsv_map_av_to_mfx_fourcc(format);
++        if (!mfx_fourcc)
++            continue;
++
++#   define VPP_EXTBUF(id, conf, optional, ver_major, ver_minor) \
++        {                                                                    \
++            if (!QSV_RUNTIME_VERSION_ATLEAST(ver, (ver_major), (ver_minor))) \
++                if (!(optional))                                             \
++                    continue;                                                \
++            if (mfx_params.NumExtParam >= FF_ARRAY_ELEMS(mfx_ext_bufs))      \
++                continue;                                                    \
++            (conf).Header.BufferId                 = (id);                   \
++            (conf).Header.BufferSz                 = sizeof(conf);           \
++            mfx_ext_bufs[mfx_params.NumExtParam++] = (mfxExtBuffer*)&(conf); \
++            mfx_params.ExtParam                    = mfx_ext_bufs;           \
++        }
++
++        switch (mode->vpp) {
++        case QSV_VPP_SCALE:
++            VPP_EXTBUF(MFX_EXTBUFF_VPP_SCALING,                        scale_conf,   1, 1,  19) break;
++        case QSV_VPP_DEINT:
++            VPP_EXTBUF(MFX_EXTBUFF_VPP_DEINTERLACING,                  deint_conf,   0, 1,   8) break;
++        case QSV_VPP_OVERLAY:
++            VPP_EXTBUF(MFX_EXTBUFF_VPP_COMPOSITE,                      overlay_conf, 0, 1,   9) break;
++        case QSV_VPP_ROTATE:
++            VPP_EXTBUF(MFX_EXTBUFF_VPP_ROTATION,                       rotate_conf,  0, 1,  17) break;
++        case QSV_VPP_FLIP:
++            VPP_EXTBUF(MFX_EXTBUFF_VPP_MIRRORING,                      flip_conf,    0, 1,  17) break;
++        case QSV_VPP_DENOISE:
++            VPP_EXTBUF(MFX_EXTBUFF_VPP_DENOISE,                        denoise_conf, 0, 1,   1) break;
++        case QSV_VPP_DETAIL:
++            VPP_EXTBUF(MFX_EXTBUFF_VPP_DETAIL,                         detail_conf,  0, 1,   1) break;
++        case QSV_VPP_FRAMERATE:
++            VPP_EXTBUF(MFX_EXTBUFF_VPP_FRAME_RATE_CONVERSION,          frc_conf,     0, 1,   3) break;
++        case QSV_VPP_PROCAMP:
++            VPP_EXTBUF(MFX_EXTBUFF_VPP_PROCAMP,                        procamp_conf, 0, 1,   1) break;
++        case QSV_VPP_TONEMAP:
++            VPP_EXTBUF(MFX_EXTBUFF_VIDEO_SIGNAL_INFO_IN,               invsi_conf,   0, 1, 255)
++            VPP_EXTBUF(MFX_EXTBUFF_VIDEO_SIGNAL_INFO_OUT,              outvsi_conf,  0, 1, 255)
++            VPP_EXTBUF(MFX_EXTBUFF_MASTERING_DISPLAY_COLOUR_VOLUME_IN, mdcv_conf,    0, 1, 255)
++            VPP_EXTBUF(MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO,           clli_conf,    0, 1, 255) break;
++        default: continue;
++        }
++#   undef VPP_EXTBUF
++
++        mfx_params.vpp.Out.BitDepthLuma   = mfx_params.vpp.In.BitDepthLuma = FFMIN(desc->comp[0].depth, 12);
++        mfx_params.vpp.Out.BitDepthChroma = mfx_params.vpp.In.BitDepthChroma = mfx_params.mfx.FrameInfo.BitDepthLuma;
++        mfx_params.vpp.Out.Shift          = mfx_params.vpp.In.Shift = qsv_check_comp_shift(format);
++        mfx_params.vpp.Out.FourCC         = mfx_params.vpp.In.FourCC = mfx_fourcc;
++        mfx_params.vpp.Out.FrameRateExtN  = mfx_params.vpp.In.FrameRateExtN = 25;
++        mfx_params.vpp.Out.FrameRateExtD  = mfx_params.vpp.In.FrameRateExtD = 1;
++        mfx_params.vpp.Out.PicStruct      = mfx_params.vpp.In.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
++        mfx_params.vpp.Out.ChromaFormat   = mfx_params.vpp.In.ChromaFormat = qsv_map_av_to_mfx_chroma(format);
++
++        if (!QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 9)) {
++            mfx_params.vpp.Out.BitDepthLuma   = mfx_params.vpp.In.BitDepthLuma   = 0;
++            mfx_params.vpp.Out.BitDepthChroma = mfx_params.vpp.In.BitDepthChroma = 0;
++            mfx_params.vpp.Out.Shift          = mfx_params.vpp.In.Shift          = 0;
++        }
++        if (mode->vpp == QSV_VPP_DEINT)
++            mfx_params.vpp.In.PicStruct = MFX_PICSTRUCT_FIELD_TFF;
++        if (mode->vpp == QSV_VPP_FRAMERATE)
++            mfx_params.vpp.Out.FrameRateExtD <<= 1;
++
++        mfx_params.AsyncDepth = 1;
++        mfx_params.IOPattern = MFX_IOPATTERN_IN_SYSTEM_MEMORY | MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
++
++        /* Check min res first */
++        for (const HwRes *r = &hw_res_ascend[0]; r->name; r++) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            overlay_inputs[0].DstW   = overlay_inputs[1].DstW    = r->width;
++            overlay_inputs[0].DstH   = overlay_inputs[1].DstH    = r->height;
++            mfx_params.vpp.In.CropW  = mfx_params.vpp.In.Width   = r->width;
++            mfx_params.vpp.In.CropH  = mfx_params.vpp.In.Height  = r->height;
++            mfx_params.vpp.Out.CropW = mfx_params.vpp.Out.Width  = r->width;
++            mfx_params.vpp.Out.CropH = mfx_params.vpp.Out.Height = r->height;
++
++            test_ret = qsv_test_mfx_vpp_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++            if (test_ret != QSV_TEST_SUCCESS) {
++                if (test_ret == QSV_TEST_BREAK) break;
++                else continue;
++            }
++            min_width  = r->width;
++            min_height = r->height;
++            break;
++        }
++        if (!min_width || !min_height)
++            continue;
++
++        /* Check max res */
++        for (const HwRes *r = &hw_res_ascend[FF_ARRAY_ELEMS(hw_res_ascend) - 1]; r >= &hw_res_ascend[0]; r--) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            if (!r->name)
++                continue;
++            if (r->width <= min_width && r->height <= min_height) {
++                max_width  = r->width;
++                max_height = r->height;
++                break;
++            }
++
++            overlay_inputs[0].DstW   = overlay_inputs[1].DstW    = r->width;
++            overlay_inputs[0].DstH   = overlay_inputs[1].DstH    = r->height;
++            mfx_params.vpp.In.CropW  = mfx_params.vpp.In.Width   = r->width;
++            mfx_params.vpp.In.CropH  = mfx_params.vpp.In.Height  = r->height;
++            mfx_params.vpp.Out.CropW = mfx_params.vpp.Out.Width  = r->width;
++            mfx_params.vpp.Out.CropH = mfx_params.vpp.Out.Height = r->height;
++
++            test_ret = qsv_test_mfx_vpp_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++            if (test_ret != QSV_TEST_SUCCESS) {
++                if (test_ret == QSV_TEST_BREAK) break;
++                else continue;
++            }
++            max_width  = r->width;
++            max_height = r->height;
++            break;
++        }
++        if (!max_width || !max_height)
++            continue;
++
++        if (!header_printed) {
++            mark_section_show_entries(SECTION_ID_DEVICE_FILTERS_QSV, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_FILTERS_QSV);
++            header_printed = 1;
++        }
++
++        mark_section_show_entries(SECTION_ID_DEVICE_FILTER, 1, NULL);
++        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_FILTER);
++        print_str("filter_name", qsv_map_vpp_type_to_str(mode->vpp));
++        print_str("filter_desc", mode->name);
++        print_int("min_width", min_width);
++        print_int("min_height", min_height);
++        print_int("max_width", max_width);
++        print_int("max_height", max_height);
++
++        overlay_inputs[0].DstW   = overlay_inputs[1].DstW    = min_width;
++        overlay_inputs[0].DstH   = overlay_inputs[1].DstH    = min_height;
++        mfx_params.vpp.In.CropW  = mfx_params.vpp.In.Width   = min_width;
++        mfx_params.vpp.In.CropH  = mfx_params.vpp.In.Height  = min_height;
++        mfx_params.vpp.Out.CropW = mfx_params.vpp.Out.Width  = min_width;
++        mfx_params.vpp.Out.CropH = mfx_params.vpp.Out.Height = min_height;
++
++        if (mfx_params.NumExtParam > 0) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            switch (mode->vpp) {
++            case QSV_VPP_SCALE:
++                scale_conf.ScalingMode = MFX_SCALING_MODE_LOWPOWER;
++                test_ret = qsv_test_mfx_vpp_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++                print_int("scale_mode_low_power", test_ret == QSV_TEST_SUCCESS);
++
++                scale_conf.ScalingMode = MFX_SCALING_MODE_QUALITY;
++                test_ret = qsv_test_mfx_vpp_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++                print_int("scale_mode_quality", test_ret == QSV_TEST_SUCCESS);
++
++                scale_conf.ScalingMode = 1001; /* MFX_SCALING_MODE_INTEL_GEN_COMPUTE */
++                test_ret = qsv_test_mfx_vpp_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++                print_int("scale_mode_compute", test_ret == QSV_TEST_SUCCESS);
++
++                scale_conf.ScalingMode = MFX_SCALING_MODE_DEFAULT;
++                break;
++            case QSV_VPP_DEINT:
++                deint_conf.Mode = MFX_DEINTERLACING_ADVANCED;
++                test_ret = qsv_test_mfx_vpp_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++                print_int("deint_mode_bob", 1);
++                print_int("deint_mode_advanced", test_ret == QSV_TEST_SUCCESS);
++
++                deint_conf.Mode = MFX_DEINTERLACING_BOB;
++                break;
++            }
++        }
++
++        /* Formats */
++        for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++            mfxVideoParam mfx_params_out = { 0 };
++
++            format = mode->formats[j];
++            desc = av_pix_fmt_desc_get(format);
++            if (!desc)
++                continue;
++            mfx_fourcc = qsv_map_av_to_mfx_fourcc(format);
++            if (!mfx_fourcc)
++                continue;
++            if (!j)
++                goto skip;
++
++            mfx_params.vpp.Out.BitDepthLuma   = mfx_params.vpp.In.BitDepthLuma = FFMIN(desc->comp[0].depth, 12);
++            mfx_params.vpp.Out.BitDepthChroma = mfx_params.vpp.In.BitDepthChroma = mfx_params.mfx.FrameInfo.BitDepthLuma;
++            mfx_params.vpp.Out.Shift          = mfx_params.vpp.In.Shift = qsv_check_comp_shift(format);
++            mfx_params.vpp.Out.FourCC         = mfx_params.vpp.In.FourCC = mfx_fourcc;
++            mfx_params.vpp.Out.ChromaFormat   = mfx_params.vpp.In.ChromaFormat = qsv_map_av_to_mfx_chroma(format);
++
++            if (!QSV_RUNTIME_VERSION_ATLEAST(ver, 1, 9)) {
++                mfx_params.vpp.Out.BitDepthLuma   = mfx_params.vpp.In.BitDepthLuma   = 0;
++                mfx_params.vpp.Out.BitDepthChroma = mfx_params.vpp.In.BitDepthChroma = 0;
++                mfx_params.vpp.Out.Shift          = mfx_params.vpp.In.Shift          = 0;
++            }
++
++            test_ret = qsv_test_mfx_vpp_params(hwctx->session, mfx_params, &mfx_params_out, do_init_test);
++            if (test_ret != QSV_TEST_SUCCESS) {
++                if (test_ret == QSV_TEST_BREAK) break;
++                else continue;
++            }
++skip:
++            if (!header2_printed) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                header2_printed = 1;
++            }
++            mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++            print_str("format_name", av_get_pix_fmt_name(format));
++            print_int("format_id", format);
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++        }
++        if (header2_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_FILTER
++    }
++
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_FILTERS_QSV
++#endif
++    return 0;
++}
+Index: FFmpeg/fftools/ffprobe_hw_rkmpp.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_rkmpp.c
+@@ -0,0 +1,654 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "ffprobe_hw_internal.h"
++
++#if CONFIG_RKMPP
++#   include <fcntl.h>
++#   if HAVE_UNISTD_H
++#       include <unistd.h>
++#   endif
++#   include <rockchip/rk_mpi.h>
++#   if CONFIG_RKRGA
++#       include <rga/im2d.h>
++#   endif
++#endif
++
++#if CONFIG_RKMPP
++typedef struct RkmppCodecMode {
++    const char               *name;
++    const enum AVCodecID      codec;
++    const int                *profiles;
++    const enum AVPixelFormat *formats;
++} RkmppCodecMode;
++
++static const int profiles_mpeg2[] = {
++    AV_PROFILE_MPEG2_SIMPLE,
++    AV_PROFILE_MPEG2_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_h264[] = {
++    AV_PROFILE_H264_BASELINE,
++    AV_PROFILE_H264_CONSTRAINED_BASELINE,
++    AV_PROFILE_H264_MAIN,
++    AV_PROFILE_H264_HIGH,
++    AV_PROFILE_H264_HIGH_10,
++    AV_PROFILE_H264_HIGH_422,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_hevc[] = {
++    AV_PROFILE_HEVC_MAIN,
++    AV_PROFILE_HEVC_MAIN_10,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_vp9[] = {
++    AV_PROFILE_VP9_0,
++    AV_PROFILE_VP9_2,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_av1[] = {
++    AV_PROFILE_AV1_MAIN,
++    AV_PROFILE_UNKNOWN
++};
++static const int profiles_mjpeg[] = {
++    AV_PROFILE_MJPEG_HUFFMAN_BASELINE_DCT,
++    AV_PROFILE_UNKNOWN
++};
++
++static const enum AVPixelFormat formats_8_420[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat formats_8_420_422_444[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,
++    AV_PIX_FMT_NV24,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat formats_8_10_420[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV15,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat formats_8_10_420_422[] = {
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,
++    AV_PIX_FMT_NV15,
++    AV_PIX_FMT_NV20,
++    AV_PIX_FMT_NONE
++};
++
++static const enum AVPixelFormat formats_h26x_enc[] = {
++    AV_PIX_FMT_YUV420P,
++    AV_PIX_FMT_YUV422P,
++    AV_PIX_FMT_YUV444P,
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,
++    AV_PIX_FMT_NV24,
++    AV_PIX_FMT_YUYV422,
++    AV_PIX_FMT_YVYU422,
++    AV_PIX_FMT_UYVY422,
++    AV_PIX_FMT_RGB24,
++    AV_PIX_FMT_BGR24,
++    AV_PIX_FMT_RGBA,
++    AV_PIX_FMT_BGRA,
++    AV_PIX_FMT_ARGB,
++    AV_PIX_FMT_ABGR,
++    AV_PIX_FMT_NONE
++};
++static const enum AVPixelFormat formats_mjpeg_enc[] = {
++    AV_PIX_FMT_YUV420P,
++    AV_PIX_FMT_YUV422P,  /* RK3576+ only */
++    AV_PIX_FMT_YUV444P,  /* RK3576+ only */
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,     /* RK3576+ only */
++    AV_PIX_FMT_NV24,     /* RK3576+ only */
++    AV_PIX_FMT_YUYV422,
++    AV_PIX_FMT_UYVY422,
++    AV_PIX_FMT_YVYU422,  /* RK3576+ only */
++
++    /* RGB: pre-RK3576 only */
++    AV_PIX_FMT_RGBA,
++    AV_PIX_FMT_BGRA,
++    AV_PIX_FMT_ARGB,
++    AV_PIX_FMT_ABGR,
++    AV_PIX_FMT_NONE,
++};
++
++static const RkmppCodecMode rkmppdec_modes[] = {
++    { "RKMPP MPEG-1 Decoder", AV_CODEC_ID_MPEG1VIDEO, NULL,           formats_8_420         },
++    { "RKMPP MPEG-2 Decoder", AV_CODEC_ID_MPEG2VIDEO, profiles_mpeg2, formats_8_420         },
++    { "RKMPP MPEG-4 Decoder", AV_CODEC_ID_MPEG4,      NULL,           formats_8_420         },
++    { "RKMPP H.264 Decoder",  AV_CODEC_ID_H264,       profiles_h264,  formats_8_10_420_422  },
++    { "RKMPP HEVC Decoder",   AV_CODEC_ID_HEVC,       profiles_hevc,  formats_8_10_420      },
++    { "RKMPP VP8 Decoder",    AV_CODEC_ID_VP8,        NULL,           formats_8_420         },
++    { "RKMPP VP9 Decoder",    AV_CODEC_ID_VP9,        profiles_vp9,   formats_8_10_420      },
++    { "RKMPP AV1 Decoder",    AV_CODEC_ID_AV1,        profiles_av1,   formats_8_10_420      },
++    { "RKMPP MJPEG Decoder",  AV_CODEC_ID_MJPEG,      profiles_mjpeg, formats_8_420_422_444 },
++    { NULL, 0, NULL, NULL },
++};
++
++static const RkmppCodecMode rkmppenc_modes[] = {
++    { "RKMPP H.264 Encoder",  AV_CODEC_ID_H264,       profiles_h264,  formats_h26x_enc      },
++    { "RKMPP HEVC Encoder",   AV_CODEC_ID_HEVC,       profiles_hevc,  formats_h26x_enc      },
++    { "RKMPP MJPEG Encoder",  AV_CODEC_ID_MJPEG,      profiles_mjpeg, formats_mjpeg_enc     },
++    { NULL, 0, NULL, NULL },
++};
++
++#   if CONFIG_RKRGA
++enum RkrgaVppType {
++    RKRGA_VPP_SCALE,
++    RKRGA_VPP_OVERLAY,
++    RKRGA_VPP_ROTATE,
++    RKRGA_VPP_FLIP,
++    RKRGA_VPP_NONE,
++};
++
++typedef struct RkrgaVppMode {
++    const char               *name;
++    const enum RkrgaVppType   vpp;
++    const enum AVPixelFormat *formats;
++} RkrgaVppMode;
++
++static const enum AVPixelFormat formats_vpp[] = {
++    AV_PIX_FMT_YUV420P, /* RGA2 only */
++    AV_PIX_FMT_YUV422P, /* RGA2 only */
++    AV_PIX_FMT_NV12,
++    AV_PIX_FMT_NV16,
++    AV_PIX_FMT_NV24,    /* RGA2-Pro only */
++    AV_PIX_FMT_P010,    /* RGA3 only */
++    AV_PIX_FMT_P210,    /* RGA3 only */
++    AV_PIX_FMT_NV15,    /* RGA2 only input, aka P010 compact */
++    AV_PIX_FMT_NV20,    /* RGA2 only input, aka P210 compact */
++    AV_PIX_FMT_YUYV422,
++    AV_PIX_FMT_YVYU422,
++    AV_PIX_FMT_UYVY422,
++
++    AV_PIX_FMT_RGB24,
++    AV_PIX_FMT_BGR24,
++    AV_PIX_FMT_RGBA,
++    AV_PIX_FMT_BGRA,
++    AV_PIX_FMT_NONE
++};
++
++static const RkrgaVppMode rkrgavpp_modes[] = {
++    { "RKRGA VPP Scale Filter",   RKRGA_VPP_SCALE,   formats_vpp },
++    { "RKRGA VPP Overlay Filter", RKRGA_VPP_OVERLAY, formats_vpp },
++    { "RKRGA VPP Rotate Filter",  RKRGA_VPP_ROTATE,  formats_vpp },
++    { "RKRGA VPP Flip Filter",    RKRGA_VPP_FLIP,    formats_vpp },
++    { NULL, RKRGA_VPP_NONE, NULL },
++};
++#   endif
++#endif
++
++#if CONFIG_RKMPP
++static void read_soc_name(char *name, int size)
++{
++    const char *dt_path = "/proc/device-tree/compatible";
++    int fd = open(dt_path, O_RDONLY);
++
++    if (fd < 0) {
++        av_log(NULL, AV_LOG_DEBUG, "Unable to open '%s' for reading SoC name\n", dt_path);
++    } else {
++        ssize_t soc_name_len = 0;
++
++        snprintf(name, size - 1, "unknown");
++        soc_name_len = read(fd, name, size - 1);
++        if (soc_name_len > 0) {
++            name[soc_name_len] = '\0';
++            /* replacing the termination character to space */
++            for (char *ptr = name;; ptr = name) {
++                ptr += av_strnlen(name, size);
++                if (ptr >= name + soc_name_len - 1)
++                    break;
++                *ptr = ' ';
++            }
++        }
++
++#   if HAVE_UNISTD_H
++        close(fd);
++#   endif
++    }
++}
++#endif
++
++int create_rkmpp_device(HwDeviceRefs *refs)
++{
++#if CONFIG_RKMPP
++    char soc_name[256] = { 0 };
++    int ret = 0;
++    char *device_tree_rkmpp = refs[0].device_tree_rkmpp;
++    const size_t device_tree_rkmpp_sz = FF_ARRAY_ELEMS(refs[0].device_tree_rkmpp);
++
++    read_soc_name(soc_name, sizeof(soc_name));
++
++    if (!strstr(soc_name, "rk35") && !strstr(soc_name, "rk33"))
++        return AVERROR(ENOSYS);
++
++    ret = av_hwdevice_ctx_create(&refs[0].rkmpp_ref, AV_HWDEVICE_TYPE_RKMPP,
++                                 NULL, NULL, 0);
++    if (ret < 0)
++        return AVERROR(ENOSYS);
++
++    refs[0].device_vendor_id = FFPROBE_HW_VENDOR_ID_ROCKCHIP;
++
++    av_strlcpy(device_tree_rkmpp, soc_name, device_tree_rkmpp_sz);
++
++    return ret;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++/* RKMPP -> OPENCL */
++void create_derive_opencl_devices_from_rkmpp(HwDeviceRefs *refs)
++{
++    for (unsigned i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs && refs[i].rkmpp_ref; i++) {
++        if (refs[i].device_vendor_id != FFPROBE_HW_VENDOR_ID_ROCKCHIP)
++            continue;
++        av_hwdevice_ctx_create_derived(&refs[i].opencl_ref, AV_HWDEVICE_TYPE_OPENCL,
++                                       refs[i].rkmpp_ref, 0);
++    }
++}
++
++/* RKMPP -> VULKAN */
++void create_derive_vulkan_devices_from_rkmpp(HwDeviceRefs *refs)
++{
++    for (unsigned i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs && refs[i].rkmpp_ref; i++) {
++        if (refs[i].device_vendor_id != FFPROBE_HW_VENDOR_ID_ROCKCHIP)
++            continue;
++        av_hwdevice_ctx_create_derived(&refs[i].vulkan_ref, AV_HWDEVICE_TYPE_VULKAN,
++                                       refs[i].rkmpp_ref, 0);
++    }
++}
++
++#if CONFIG_RKMPP
++static MppCodingType rkmpp_map_av_to_mpp_coding_type(enum AVCodecID codec)
++{
++    switch (codec) {
++    case AV_CODEC_ID_H264:       return MPP_VIDEO_CodingAVC;
++    case AV_CODEC_ID_HEVC:       return MPP_VIDEO_CodingHEVC;
++    case AV_CODEC_ID_AV1:        return MPP_VIDEO_CodingAV1;
++    case AV_CODEC_ID_VP8:        return MPP_VIDEO_CodingVP8;
++    case AV_CODEC_ID_VP9:        return MPP_VIDEO_CodingVP9;
++    case AV_CODEC_ID_MPEG1VIDEO: /* fallthrough */
++    case AV_CODEC_ID_MPEG2VIDEO: return MPP_VIDEO_CodingMPEG2;
++    case AV_CODEC_ID_MPEG4:      return MPP_VIDEO_CodingMPEG4;
++    case AV_CODEC_ID_MJPEG:      return MPP_VIDEO_CodingMJPEG;
++    default:                     return MPP_VIDEO_CodingUnused;
++    }
++}
++#endif
++
++static int print_rkmpp_codec_info(AVTextFormatContext *tfc,
++                                  const char *device_tree, int print_encoder)
++{
++#if CONFIG_RKMPP
++    int header_printed = 0;
++    unsigned i, j;
++    const unsigned section_id  = print_encoder ? SECTION_ID_DEVICE_ENCODERS_RKMPP
++                                               : SECTION_ID_DEVICE_DECODERS_RKMPP;
++    const unsigned section_id2 = print_encoder ? SECTION_ID_DEVICE_ENCODER
++                                               : SECTION_ID_DEVICE_DECODER;
++    int no_h264_high10_422_dec = 0;
++    int no_vp9_profile2_dec = 0;
++    int no_4320p_dec = 0;
++    int no_2160p_dec = 0;
++    int no_4320p_enc = 0;
++    int no_2160p_enc = 0;
++    int no_8192p_jpegd = 0;
++    int no_ext_jpege_fmts = 0;
++    int no_ext_h26xe_fmts = 0;
++
++    if (!tfc || !device_tree)
++        return AVERROR(EINVAL);
++
++    if (strstr(device_tree, "rk35")) {
++        const int is_rk356x = !!strstr(device_tree, "rk356");
++        const int is_rk357x = !!strstr(device_tree, "rk357");
++        const int is_rk358x = !!strstr(device_tree, "rk358");
++        no_h264_high10_422_dec = 0;
++        no_vp9_profile2_dec = !!strstr(device_tree, "rk3562");
++        no_4320p_dec = !is_rk357x && !is_rk358x;
++        no_4320p_enc = !is_rk357x && !is_rk358x;
++        no_2160p_dec = !!strstr(device_tree, "rk3538");
++        no_2160p_enc = !is_rk357x && !is_rk358x;
++        no_8192p_jpegd = !is_rk356x && !is_rk357x && !is_rk358x;
++        no_ext_jpege_fmts = !is_rk357x;
++        no_ext_h26xe_fmts = !is_rk357x && !is_rk358x;
++    } else if (strstr(device_tree, "rk33")) {
++        no_h264_high10_422_dec = !strstr(device_tree, "rk3399");
++        no_vp9_profile2_dec = 1;
++        no_4320p_dec = 1;
++        no_4320p_enc = 1;
++        no_2160p_dec = !!strstr(device_tree, "rk3326");
++        no_2160p_enc = 1;
++        no_8192p_jpegd = 1;
++        no_ext_jpege_fmts = 1;
++        no_ext_h26xe_fmts = 1;
++    } else
++        return AVERROR(ENOSYS);
++
++    for (i = 0; (print_encoder ? rkmppenc_modes[i].name : rkmppdec_modes[i].name); i++) {
++        const RkmppCodecMode *mode = print_encoder ? &rkmppenc_modes[i] : &rkmppdec_modes[i];
++        const MppCtxType ctx_type = print_encoder ? MPP_CTX_ENC : MPP_CTX_DEC;
++        const MppCodingType coding_type = rkmpp_map_av_to_mpp_coding_type(mode->codec);
++        MppApi *mapi = NULL;
++        MppCtx  mctx = NULL;
++        unsigned max_width = 0, max_height = 0;
++        int header2_printed = 0;
++        int header3_printed = 0;
++
++        if (!mode->formats || coding_type == MPP_VIDEO_CodingUnused)
++            continue;
++
++        if (mpp_check_support_format(ctx_type, coding_type) != MPP_OK)
++            continue;
++
++        if (mpp_create(&mctx, &mapi) != MPP_OK)
++            goto next;
++
++        if (mpp_init(mctx, ctx_type, coding_type) != MPP_OK)
++            goto next;
++
++        if (!header_printed) {
++            mark_section_show_entries(section_id, 1, NULL);
++            avtext_print_section_header(tfc, NULL, section_id);
++            header_printed = 1;
++        }
++
++        mark_section_show_entries(section_id2, 1, NULL);
++        avtext_print_section_header(tfc, NULL, section_id2);
++        print_str("codec_name", avcodec_get_name(mode->codec));
++        print_int("codec_id", mode->codec);
++        print_str("codec_desc", mode->name);
++
++        switch (mode->codec) {
++        case AV_CODEC_ID_H264:
++        case AV_CODEC_ID_HEVC:
++        case AV_CODEC_ID_VP9:
++        case AV_CODEC_ID_AV1:
++            if (print_encoder) {
++                max_width  = no_2160p_enc ? 1920 : no_4320p_enc ? 4096 : 8192;
++                max_height = no_2160p_enc ? 1088 : no_4320p_enc ? 2304 : 4320;
++            } else {
++                max_width  = no_2160p_dec ? 1920 : no_4320p_dec ? 4096 : 8192;
++                max_height = no_2160p_dec ? 1088 : no_4320p_dec ? 2304 : 4320;
++            }
++            break;
++        case AV_CODEC_ID_MJPEG:
++            if (print_encoder) {
++                max_width  = 8192;
++                max_height = 8192;
++            } else {
++                max_width  = no_8192p_jpegd ? 8176 : 8192;
++                max_height = no_8192p_jpegd ? 8176 : 8192;
++            }
++            break;
++        default:
++            max_width  = 1920;
++            max_height = 1088;
++            break;
++        }
++        print_int("max_width", max_width);
++        print_int("max_height", max_height);
++
++        /* Formats */
++        for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++            const enum AVPixelFormat format = mode->formats[j];
++            const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(format);
++
++            if (!desc)
++                continue;
++
++            if (print_encoder) {
++                const int is_h26xe_base_fmt = format == AV_PIX_FMT_YUV420P ||
++                                              format == AV_PIX_FMT_NV12 ||
++                                              format == AV_PIX_FMT_YUYV422 ||
++                                              format == AV_PIX_FMT_UYVY422 ||
++                                              format == AV_PIX_FMT_BGRA;
++                const int is_jpege_base_fmt = is_h26xe_base_fmt ||
++                                              format == AV_PIX_FMT_RGBA ||
++                                              format == AV_PIX_FMT_ARGB ||
++                                              format == AV_PIX_FMT_ABGR;
++
++                if ((mode->codec == AV_CODEC_ID_H264 ||
++                     mode->codec == AV_CODEC_ID_HEVC) &&
++                    no_ext_h26xe_fmts && !is_h26xe_base_fmt)
++                    continue;
++
++                if (mode->codec == AV_CODEC_ID_MJPEG) {
++                    if (no_ext_jpege_fmts && !is_jpege_base_fmt)
++                        continue;
++                    if (!no_ext_jpege_fmts && (desc->flags & AV_PIX_FMT_FLAG_RGB))
++                        continue;
++                }
++            } else {
++                if (mode->codec == AV_CODEC_ID_H264 &&
++                    no_h264_high10_422_dec && format != AV_PIX_FMT_NV12)
++                    continue;
++
++                if (mode->codec == AV_CODEC_ID_VP9 &&
++                    no_vp9_profile2_dec && format != AV_PIX_FMT_NV12)
++                    continue;
++            }
++
++            if (!header2_printed) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                header2_printed = 1;
++            }
++            mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++            print_str("format_name", av_get_pix_fmt_name(format));
++            print_int("format_id", format);
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++        }
++        if (header2_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++        /* Profiles */
++        for (j = 0; mode->profiles && mode->profiles[j] != AV_PROFILE_UNKNOWN; j++) {
++            if (mode->codec == AV_CODEC_ID_H264 &&
++                (print_encoder || (!print_encoder && no_h264_high10_422_dec)) &&
++                mode->profiles[j] > AV_PROFILE_H264_HIGH)
++                continue;
++
++            if (mode->codec == AV_CODEC_ID_HEVC &&
++                print_encoder &&
++                mode->profiles[j] > AV_PROFILE_HEVC_MAIN)
++                continue;
++
++            if (mode->codec == AV_CODEC_ID_VP9 &&
++                (!print_encoder && no_vp9_profile2_dec) &&
++                mode->profiles[j] > AV_PROFILE_VP9_0)
++                continue;
++
++            if (!header3_printed) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PROFILES, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILES);
++                header3_printed = 1;
++            }
++            mark_section_show_entries(SECTION_ID_DEVICE_PROFILE, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILE);
++            print_str("profile_name", avcodec_profile_name(mode->codec, mode->profiles[j]));
++            print_int("profile_id", mode->profiles[j]);
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILE
++        }
++        if (header3_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILES
++
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_{DEC,ENC}ODER
++next:
++        if (mapi) {
++            mapi->reset(mctx);
++            mpp_destroy(mctx);
++        }
++    }
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_{DEC,ENC}ODERS_RKMPP
++
++    return 0;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++int print_rkmpp_decoder_info(AVTextFormatContext *tfc, const char *device_tree)
++{
++    return print_rkmpp_codec_info(tfc, device_tree, 0);
++}
++
++int print_rkmpp_encoder_info(AVTextFormatContext *tfc, const char *device_tree)
++{
++    return print_rkmpp_codec_info(tfc, device_tree, 1);
++}
++
++#if (CONFIG_RKMPP && CONFIG_RKRGA)
++static const char *rkrga_map_vpp_type_to_str(enum RkrgaVppType vpp)
++{
++    switch (vpp) {
++    case RKRGA_VPP_SCALE:   return "scale";
++    case RKRGA_VPP_OVERLAY: return "overlay";
++    case RKRGA_VPP_ROTATE:  return "rotate";
++    case RKRGA_VPP_FLIP:    return "flip";
++    default:                return "";
++    }
++}
++#endif
++
++int print_rkmpp_vpp_info(AVTextFormatContext *tfc, const char *device_tree)
++{
++#if (CONFIG_RKMPP && CONFIG_RKRGA)
++    int header_printed = 0;
++    unsigned i, j;
++    const char *rga_ver = NULL;
++    int has_rga2 = 0;
++    int has_rga2l = 0;
++    int has_rga2p = 0;
++    int has_rga3 = 0;
++
++    if (!tfc || !device_tree)
++        return AVERROR(EINVAL);
++
++    if (!strstr(device_tree, "rk35") && !strstr(device_tree, "rk33"))
++        return AVERROR(ENOSYS);
++
++    rga_ver = querystring(RGA_VERSION);
++    has_rga2  = !!strstr(rga_ver, "RGA_2");
++    has_rga2l = !!strstr(rga_ver, "RGA_2_lite");
++    has_rga2p = !!strstr(rga_ver, "RGA_2_PRO");
++    has_rga3  = !!strstr(rga_ver, "RGA_3");
++
++    if (!(has_rga2 || has_rga3))
++        return AVERROR(ENOSYS);
++
++    for (i = 0; rkrgavpp_modes[i].name; i++) {
++        const RkrgaVppMode *mode = &rkrgavpp_modes[i];
++        unsigned max_width = 0, max_height = 0;
++        unsigned min_width = 0, min_height = 0;
++        int header2_printed = 0;
++
++        if (!header_printed) {
++            mark_section_show_entries(SECTION_ID_DEVICE_FILTERS_RKMPP, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_FILTERS_RKMPP);
++            header_printed = 1;
++        }
++
++        mark_section_show_entries(SECTION_ID_DEVICE_FILTER, 1, NULL);
++        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_FILTER);
++        print_str("filter_name", rkrga_map_vpp_type_to_str(mode->vpp));
++        print_str("filter_desc", mode->name);
++
++        if (has_rga3) {
++            max_width = max_height = 8128;
++            min_width = 68; min_height = 2;
++        } else if (has_rga2p) {
++            max_width = max_height = 8192;
++            min_width = min_height = 2;
++        } else {
++            max_width = max_height = 4096;
++            min_width = min_height = 2;
++        }
++        print_int("min_width", min_width);
++        print_int("min_height", min_height);
++        print_int("max_width", max_width);
++        print_int("max_height", max_height);
++
++        switch (mode->vpp) {
++        case RKRGA_VPP_SCALE:
++            print_int("min_scale_ratio", (has_rga3 || has_rga2l) ? 8 : 16);
++            print_int("max_scale_ratio", (has_rga2 && !has_rga2l) ? 16 : 8);
++            print_int("support_10bit_crop", (has_rga3 || has_rga2p));
++            break;
++        case RKRGA_VPP_ROTATE:
++            print_int("support_e2e_fbc_422_wh_swap", 0);
++            break;
++        }
++        print_int("support_10bit_out", !!has_rga3);
++        print_int("support_8k_fully_planar_out", !!has_rga2p);
++
++        /* Formats */
++        for (j = 0; mode->formats[j] != AV_PIX_FMT_NONE; j++) {
++            const enum AVPixelFormat format = mode->formats[j];
++            const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(format);
++            int is_rgb = 0, is_yuv = 0, is_planar = 0, is_fully_planar = 0;
++
++            if (!desc)
++                continue;
++
++            is_rgb = desc->flags & AV_PIX_FMT_FLAG_RGB;
++            is_yuv = !is_rgb && desc->nb_components >= 2;
++            is_planar = desc->flags & AV_PIX_FMT_FLAG_PLANAR;
++            is_fully_planar = is_planar && desc->comp[1].plane != desc->comp[2].plane;
++
++            if (!has_rga2 && is_yuv && is_fully_planar)
++                continue;
++
++            if (!has_rga2p && is_yuv && (!desc->log2_chroma_w && !desc->log2_chroma_h))
++                continue;
++
++            if (!has_rga3 && (format == AV_PIX_FMT_P010 || format == AV_PIX_FMT_P210))
++                continue;
++
++            if (!header2_printed) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                header2_printed = 1;
++            }
++            mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++            avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++            print_str("format_name", av_get_pix_fmt_name(format));
++            print_int("format_id", format);
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++        }
++        if (header2_printed)
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_FILTER
++    }
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_FILTERS_RKMPP
++
++    return 0;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
+Index: FFmpeg/fftools/ffprobe_hw_vaapi.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_vaapi.c
+@@ -0,0 +1,1323 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "ffprobe_hw_internal.h"
++
++#if CONFIG_LIBDRM
++#   include <drm.h>
++#   include <xf86drm.h>
++#   include <dlfcn.h>
++#   include <fcntl.h>
++#   if HAVE_UNISTD_H
++#       include <unistd.h>
++#   endif
++#   include "libavutil/hwcontext_drm.h"
++#endif
++
++#if (CONFIG_VAAPI && HAVE_VAAPI_DRM)
++#   include <va/va.h>
++#   include <va/va_vpp.h>
++#   include <va/va_drm.h>
++#   include <va/va_drmcommon.h>
++#   include "libavutil/hwcontext_vaapi.h"
++#endif
++
++#if CONFIG_LIBDRM
++struct udev;
++struct udev_hwdb;
++struct udev_list_entry;
++
++typedef struct udev* (*udev_new_t)(void);
++typedef struct udev* (*udev_unref_t)(struct udev *udev);
++typedef struct udev_hwdb* (*udev_hwdb_new_t)(struct udev *udev);
++typedef struct udev_hwdb* (*udev_hwdb_unref_t)(struct udev_hwdb *hwdb);
++typedef struct udev_list_entry* (*udev_hwdb_get_properties_list_entry_t)(struct udev_hwdb *hwdb, const char *modalias, unsigned int flags);
++typedef const char* (*udev_list_entry_get_name_t)(struct udev_list_entry *list_entry);
++typedef const char* (*udev_list_entry_get_value_t)(struct udev_list_entry *list_entry);
++typedef struct udev_list_entry* (*udev_list_entry_get_next_t)(struct udev_list_entry *list_entry);
++
++typedef struct UdevFunctions {
++    void *handle;
++    udev_new_t udev_new;
++    udev_unref_t udev_unref;
++    udev_hwdb_new_t udev_hwdb_new;
++    udev_hwdb_unref_t udev_hwdb_unref;
++    udev_hwdb_get_properties_list_entry_t udev_hwdb_get_properties_list_entry;
++    udev_list_entry_get_name_t udev_list_entry_get_name;
++    udev_list_entry_get_value_t udev_list_entry_get_value;
++    udev_list_entry_get_next_t udev_list_entry_get_next;
++} UdevFunctions;
++
++static UdevFunctions udev_functions = { NULL };
++#endif
++
++int init_udev_functions(void)
++{
++#if CONFIG_LIBDRM
++    if (udev_functions.handle)
++        return 0;
++
++    udev_functions.handle = dlopen("libudev.so.1", RTLD_LAZY);
++    if (!udev_functions.handle)
++        udev_functions.handle = dlopen("libudev.so", RTLD_LAZY);
++
++    if (!udev_functions.handle) {
++        av_log(NULL, AV_LOG_DEBUG, "Failed to load libudev.so\n");
++        return AVERROR(ENOSYS);
++    }
++
++#   define LOAD_UDEV_FUNCTION(type, name) do { \
++    udev_functions.name = (type)dlsym(udev_functions.handle, #name); \
++    if (!udev_functions.name) { \
++        av_log(NULL, AV_LOG_DEBUG, "Missing symbol lookup reference: %s\n", #name); \
++        goto fail; \
++    } \
++} while (0)
++
++    LOAD_UDEV_FUNCTION(udev_new_t, udev_new);
++    LOAD_UDEV_FUNCTION(udev_unref_t, udev_unref);
++    LOAD_UDEV_FUNCTION(udev_hwdb_new_t, udev_hwdb_new);
++    LOAD_UDEV_FUNCTION(udev_hwdb_unref_t, udev_hwdb_unref);
++    LOAD_UDEV_FUNCTION(udev_hwdb_get_properties_list_entry_t, udev_hwdb_get_properties_list_entry);
++    LOAD_UDEV_FUNCTION(udev_list_entry_get_name_t, udev_list_entry_get_name);
++    LOAD_UDEV_FUNCTION(udev_list_entry_get_value_t, udev_list_entry_get_value);
++    LOAD_UDEV_FUNCTION(udev_list_entry_get_next_t, udev_list_entry_get_next);
++#   undef LOAD_UDEV_FUNCTION
++
++    return 0;
++
++fail:
++    uninit_udev_functions();
++    return AVERROR_UNKNOWN;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++void uninit_udev_functions(void)
++{
++#if CONFIG_LIBDRM
++    if (udev_functions.handle) {
++        dlclose(udev_functions.handle);
++        memset(&udev_functions, 0, sizeof(udev_functions));
++    }
++#endif
++}
++
++#if CONFIG_LIBDRM
++static int print_drm_pci_device_name(AVTextFormatContext *tfc, drmDevice *drm_dev)
++{
++    struct udev *udev_ctx = NULL;
++    struct udev_hwdb *hwdb_ctx = NULL;
++    struct udev_list_entry *entries = NULL;
++    struct udev_list_entry *entry = NULL;
++    char modalias[128];
++    const char *model = NULL;
++    int ret = 0;
++
++    if (!tfc || !drm_dev || drm_dev->bustype != DRM_BUS_PCI || !drm_dev->deviceinfo.pci)
++        return AVERROR(EINVAL);
++
++    if ((ret = init_udev_functions()) < 0)
++        return ret;
++
++    if (!udev_functions.handle)
++        return AVERROR(ENOSYS);
++
++    udev_ctx = udev_functions.udev_new();
++    if (!udev_ctx)
++        return AVERROR(ENOMEM);
++
++    hwdb_ctx = udev_functions.udev_hwdb_new(udev_ctx);
++    if (!hwdb_ctx) {
++        ret = AVERROR(ENOENT);
++        goto fail;
++    }
++
++    snprintf(modalias, sizeof(modalias), "pci:v0000%04Xd0000%04Xsv0000%04Xsd0000%04X*",
++             drm_dev->deviceinfo.pci->vendor_id,
++             drm_dev->deviceinfo.pci->device_id,
++             drm_dev->deviceinfo.pci->subvendor_id,
++             drm_dev->deviceinfo.pci->subdevice_id);
++    entries = udev_functions.udev_hwdb_get_properties_list_entry(hwdb_ctx, modalias, 0);
++
++    if (!entries) {
++        snprintf(modalias, sizeof(modalias), "pci:v0000%04Xd0000%04X*",
++                 drm_dev->deviceinfo.pci->vendor_id,
++                 drm_dev->deviceinfo.pci->device_id);
++        entries = udev_functions.udev_hwdb_get_properties_list_entry(hwdb_ctx, modalias, 0);
++    }
++    if (!entries) {
++        ret = AVERROR(ENOENT);
++        goto fail;
++    }
++
++    for (entry = entries; entry; entry = udev_functions.udev_list_entry_get_next(entry)) {
++        const char *name  = udev_functions.udev_list_entry_get_name(entry);
++        const char *value = udev_functions.udev_list_entry_get_value(entry);
++
++        if (!name || !value)
++            continue;
++
++        if (!strcmp(name, "ID_MODEL_FROM_DATABASE") ||
++            (!strcmp(name, "ID_MODEL_TEXT") && !model)) {
++            model = value;
++        }
++    }
++    if (!model) {
++        ret = AVERROR(ENODEV);
++        goto fail;
++    }
++
++    print_str("device_name", model);
++
++fail:
++    if (hwdb_ctx)
++        udev_functions.udev_hwdb_unref(hwdb_ctx);
++    if (udev_ctx)
++        udev_functions.udev_unref(udev_ctx);
++
++    return ret;
++}
++
++static int ff_drmDevicesEqual(drmDevice *a, drmDevice *b)
++{
++    if (!a || !b || a->bustype != b->bustype)
++        return 0;
++
++    switch (a->bustype) {
++    case DRM_BUS_PCI:
++        return !memcmp(a->businfo.pci, b->businfo.pci, sizeof(*a->businfo.pci));
++    case DRM_BUS_USB:
++        return !memcmp(a->businfo.usb, b->businfo.usb, sizeof(*a->businfo.usb));
++    case DRM_BUS_PLATFORM:
++        return !memcmp(a->businfo.platform, b->businfo.platform, sizeof(*a->businfo.platform));
++#   ifdef DRM_BUS_HOST1X
++    case DRM_BUS_HOST1X:
++        return !memcmp(a->businfo.host1x, b->businfo.host1x, sizeof(*a->businfo.host1x));
++#   endif
++#   ifdef DRM_BUS_FAUX
++    case DRM_BUS_FAUX:
++        return !memcmp(a->businfo.faux, b->businfo.faux, sizeof(*a->businfo.faux));
++#   endif
++    }
++
++    return 0;
++}
++#endif
++
++int create_drm_devices(HwDeviceRefs *refs, const char *device_path)
++{
++    return create_drm_devices_with_filter(refs, -1, device_path);
++}
++
++int create_drm_devices_with_filter(HwDeviceRefs *refs, int vendor_id, const char *device_path)
++{
++#if CONFIG_LIBDRM
++    int i, j, n = 0, ret = 0;
++    drmDevice *drm_devs[FFPROBE_HW_MAX_DEV_NUM];
++    drmDevice *in_drm_dev = NULL;
++    int in_path_fd = -1;
++
++#   ifdef DRM_DEVICE_GET_PCI_REVISION
++    n = drmGetDevices2(0, drm_devs, FF_ARRAY_ELEMS(drm_devs));
++#   else
++    n = drmGetDevices(drm_devs, FF_ARRAY_ELEMS(drm_devs));
++#   endif
++    if (n <= 0)
++        return AVERROR(ENOSYS);
++
++    if (device_path) {
++        in_path_fd = open(device_path, O_RDWR);
++        if (in_path_fd < 0) {
++            ret = AVERROR(EINVAL);
++            goto exit;
++        }
++#   ifdef DRM_DEVICE_GET_PCI_REVISION
++        ret = drmGetDevice2(in_path_fd, 0, &in_drm_dev);
++#   else
++        ret = drmGetDevice(in_path_fd, &in_drm_dev);
++#   endif
++        if (ret || !in_drm_dev) {
++            ret = AVERROR(EINVAL);
++            goto exit;
++        }
++    }
++
++    for (i = 0, j = 0; i < FFMIN(n, FFPROBE_HW_MAX_DEV_NUM) && refs; i++) {
++        drmDevice *drm_dev = drm_devs[i];
++        const char *node_path = NULL;
++        char *device_path_drm = refs[j].device_path_drm;
++        const size_t device_path_drm_sz = FF_ARRAY_ELEMS(refs[j].device_path_drm);
++
++        if (drm_dev->available_nodes & (1 << DRM_NODE_RENDER))
++            node_path = drm_dev->nodes[DRM_NODE_RENDER];
++        else if (drm_dev->available_nodes & (1 << DRM_NODE_PRIMARY))
++            node_path = drm_dev->nodes[DRM_NODE_PRIMARY];
++
++        if (!node_path)
++            continue;
++
++        /* Filter out by the requested device path */
++        if (in_drm_dev && !ff_drmDevicesEqual(in_drm_dev, drm_dev))
++            continue;
++
++        /* Filter out by the requested vendor id */
++        if (vendor_id > 0 &&
++            (drm_dev->bustype != DRM_BUS_PCI ||
++             vendor_id != drm_dev->deviceinfo.pci->vendor_id))
++            continue;
++
++        ret = av_hwdevice_ctx_create(&refs[j].drm_ref, AV_HWDEVICE_TYPE_DRM,
++                                     node_path, NULL, 0);
++        if (ret < 0)
++            continue;
++
++        av_strlcpy(device_path_drm, node_path, device_path_drm_sz);
++
++        refs[j].device_vendor_id = drm_dev->bustype == DRM_BUS_PCI
++                                   ? drm_dev->deviceinfo.pci->vendor_id : 0;
++        j++;
++    }
++
++exit:
++    if (in_drm_dev)
++        drmFreeDevice(&in_drm_dev);
++#   if HAVE_UNISTD_H
++    if (in_path_fd >= 0)
++        close(in_path_fd);
++#   endif
++    if (n > 0)
++        drmFreeDevices(drm_devs, n);
++    return ret;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++int print_drm_device_info(AVTextFormatContext *tfc, AVBufferRef *drm_ref)
++{
++#if CONFIG_LIBDRM
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVDRMDeviceContext  *hwctx = NULL;
++    drmVersion *drm_ver = NULL;
++    drmDevice *drm_dev = NULL;
++    int ret = 0;
++
++    if (!tfc || !drm_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)drm_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++    if (hwctx->fd < 0)
++        return AVERROR(ENOSYS);
++
++    drm_ver = drmGetVersion(hwctx->fd);
++    if (!drm_ver)
++        return AVERROR(ENOSYS);
++
++#   ifdef DRM_DEVICE_GET_PCI_REVISION
++    ret = drmGetDevice2(hwctx->fd, 0, &drm_dev);
++#   else
++    ret = drmGetDevice(hwctx->fd, &drm_dev);
++#   endif
++    if (ret || !drm_dev) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    init_udev_functions();
++
++    mark_section_show_entries(SECTION_ID_DEVICE_INFO_DRM, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_INFO_DRM);
++
++    print_drm_pci_device_name(tfc, drm_dev);
++
++    print_str("device_driver_name", drm_ver->name);
++    print_int("device_driver_version_major", drm_ver->version_major);
++    print_int("device_driver_version_minor", drm_ver->version_minor);
++    print_int("device_driver_version_patchlevel", drm_ver->version_patchlevel);
++
++    if (drm_dev->bustype == DRM_BUS_PCI) {
++        print_int("device_vid", drm_dev->deviceinfo.pci->vendor_id);
++        print_int("device_did", drm_dev->deviceinfo.pci->device_id);
++        print_int("device_sub_vid", drm_dev->deviceinfo.pci->subvendor_id);
++        print_int("device_sub_did", drm_dev->deviceinfo.pci->subdevice_id);
++        print_int("device_pci_domain", drm_dev->businfo.pci->domain);
++        print_int("device_pci_bus", drm_dev->businfo.pci->bus);
++        print_int("device_pci_dev", drm_dev->businfo.pci->dev);
++        print_int("device_pci_func", drm_dev->businfo.pci->func);
++    }
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_INFO_DRM
++
++    uninit_udev_functions();
++
++exit:
++    if (drm_ver)
++        drmFreeVersion(drm_ver);
++    if (drm_dev)
++        drmFreeDevice(&drm_dev);
++    return ret;
++#endif
++    return AVERROR(ENOSYS);
++}
++
++/* DRM -> VAAPI */
++void create_derive_vaapi_devices_from_drm(HwDeviceRefs *refs)
++{
++    for (unsigned i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs && refs[i].drm_ref; i++) {
++        av_hwdevice_ctx_create_derived(&refs[i].vaapi_ref, AV_HWDEVICE_TYPE_VAAPI,
++                                       refs[i].drm_ref, 0);
++    }
++}
++
++/* DRM -> VULKAN */
++void create_derive_vulkan_devices_from_drm(HwDeviceRefs *refs)
++{
++    for (unsigned i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs && refs[i].drm_ref; i++) {
++        av_hwdevice_ctx_create_derived(&refs[i].vulkan_ref, AV_HWDEVICE_TYPE_VULKAN,
++                                       refs[i].drm_ref, 0);
++    }
++}
++
++#if (CONFIG_VAAPI && HAVE_VAAPI_DRM)
++typedef struct VaapiCodecMode {
++    const char          *name;
++    const enum AVCodecID codec;
++    const int            profile;
++    const VAProfile      va_profile;
++} VaapiCodecMode;
++
++static const VaapiCodecMode vaapidec_modes[] = {
++#   define MAP(n, c, p, v) { n, AV_CODEC_ID_ ## c, AV_PROFILE_ ## p, v }
++    MAP("VAAPI MPEG-2 Decoder, Simple",             MPEG2VIDEO, MPEG2_SIMPLE,               0),  /* VAProfileMPEG2Simple */
++    MAP("VAAPI MPEG-2 Decoder, Main",               MPEG2VIDEO, MPEG2_MAIN,                 1),  /* VAProfileMPEG2Main */
++    MAP("VAAPI H.264 Decoder, ConstrainedBaseline", H264,       H264_CONSTRAINED_BASELINE,  13), /* VAProfileH264ConstrainedBaseline */
++    MAP("VAAPI H.264 Decoder, Main",                H264,       H264_MAIN,                  6),  /* VAProfileH264Main */
++    MAP("VAAPI H.264 Decoder, High",                H264,       H264_HIGH,                  7),  /* VAProfileH264High */
++    MAP("VAAPI H.264 Decoder, High10",              H264,       H264_HIGH_10,               36), /* VAProfileH264High10 */
++    MAP("VAAPI H.264 Decoder, High422",             H264,       H264_HIGH_422,              40), /* VAProfileH264High422 */
++    MAP("VAAPI VC-1 Decoder, Simple",               VC1,        VC1_SIMPLE,                 8),  /* VAProfileVC1Simple */
++    MAP("VAAPI VC-1 Decoder, Main",                 VC1,        VC1_MAIN,                   9),  /* VAProfileVC1Main */
++    MAP("VAAPI VC-1 Decoder, Advanced",             VC1,        VC1_ADVANCED,               10), /* VAProfileVC1Advanced */
++    MAP("VAAPI MJPEG Decoder, Baseline",            MJPEG,      MJPEG_HUFFMAN_BASELINE_DCT, 12), /* VAProfileJPEGBaseline */
++    MAP("VAAPI VP8 Decoder, Profile0_3",            VP8,        UNKNOWN,                    14), /* VAProfileVP8Version0_3 */
++    MAP("VAAPI HEVC Decoder, Main",                 HEVC,       HEVC_MAIN,                  17), /* VAProfileHEVCMain */
++    MAP("VAAPI HEVC Decoder, Main10",               HEVC,       HEVC_MAIN_10,               18), /* VAProfileHEVCMain10 */
++    MAP("VAAPI HEVC Decoder, Main12",               HEVC,       HEVC_REXT,                  23), /* VAProfileHEVCMain12 */
++    MAP("VAAPI HEVC Decoder, Main422_10",           HEVC,       HEVC_REXT,                  24), /* VAProfileHEVCMain422_10 */
++    MAP("VAAPI HEVC Decoder, Main422_12",           HEVC,       HEVC_REXT,                  25), /* VAProfileHEVCMain422_12 */
++    MAP("VAAPI HEVC Decoder, Main444",              HEVC,       HEVC_REXT,                  26), /* VAProfileHEVCMain444 */
++    MAP("VAAPI HEVC Decoder, Main444_10",           HEVC,       HEVC_REXT,                  27), /* VAProfileHEVCMain444_10 */
++    MAP("VAAPI HEVC Decoder, Main444_12",           HEVC,       HEVC_REXT,                  28), /* VAProfileHEVCMain444_12 */
++    MAP("VAAPI VP9 Decoder, Profile0",              VP9,        VP9_0,                      19), /* VAProfileVP9Profile0 */
++    MAP("VAAPI VP9 Decoder, Profile1",              VP9,        VP9_1,                      20), /* VAProfileVP9Profile1 */
++    MAP("VAAPI VP9 Decoder, Profile2",              VP9,        VP9_2,                      21), /* VAProfileVP9Profile2 */
++    MAP("VAAPI VP9 Decoder, Profile3",              VP9,        VP9_3,                      22), /* VAProfileVP9Profile3 */
++    MAP("VAAPI AV1 Decoder, Profile0",              AV1,        AV1_MAIN,                   32), /* VAProfileAV1Profile0 */
++    MAP("VAAPI VVC Decoder, Main10",                VVC,        VVC_MAIN_10,                37), /* VAProfileVVCMain10 */
++    MAP(NULL, NONE, UNKNOWN, -1), /* VAProfileNone */
++};
++
++static const VaapiCodecMode vaapienc_modes[] = {
++    MAP("VAAPI H.264 Encoder, ConstrainedBaseline", H264,       H264_CONSTRAINED_BASELINE,  13), /* VAProfileH264ConstrainedBaseline */
++    MAP("VAAPI H.264 Encoder, Main",                H264,       H264_MAIN,                  6),  /* VAProfileH264Main */
++    MAP("VAAPI H.264 Encoder, High",                H264,       H264_HIGH,                  7),  /* VAProfileH264High */
++    MAP("VAAPI MJPEG Encoder, Baseline",            MJPEG,      MJPEG_HUFFMAN_BASELINE_DCT, 12), /* VAProfileJPEGBaseline */
++    MAP("VAAPI HEVC Encoder, Main",                 HEVC,       HEVC_MAIN,                  17), /* VAProfileHEVCMain */
++    MAP("VAAPI HEVC Encoder, Main10",               HEVC,       HEVC_MAIN_10,               18), /* VAProfileHEVCMain10 */
++    MAP("VAAPI HEVC Encoder, Main422_10",           HEVC,       HEVC_REXT,                  24), /* VAProfileHEVCMain422_10 */
++    MAP("VAAPI HEVC Encoder, Main444",              HEVC,       HEVC_REXT,                  26), /* VAProfileHEVCMain444 */
++    MAP("VAAPI HEVC Encoder, Main444_10",           HEVC,       HEVC_REXT,                  27), /* VAProfileHEVCMain444_10 */
++    MAP("VAAPI VP9 Encoder, Profile0",              VP9,        VP9_0,                      19), /* VAProfileVP9Profile0 */
++    MAP("VAAPI VP9 Encoder, Profile1",              VP9,        VP9_1,                      20), /* VAProfileVP9Profile1 */
++    MAP("VAAPI VP9 Encoder, Profile2",              VP9,        VP9_2,                      21), /* VAProfileVP9Profile2 */
++    MAP("VAAPI VP9 Encoder, Profile3",              VP9,        VP9_3,                      22), /* VAProfileVP9Profile3 */
++    MAP("VAAPI AV1 Encoder, Profile0",              AV1,        AV1_MAIN,                   32), /* VAProfileAV1Profile0 */
++    MAP(NULL, NONE, UNKNOWN, -1), /* VAProfileNone */
++#   undef MAP
++};
++
++enum VaapiVppType {
++    VAAPI_VPP_SCALE,
++    VAAPI_VPP_DEINT,
++    VAAPI_VPP_OVERLAY,
++    VAAPI_VPP_ROTATE,
++    VAAPI_VPP_FLIP,
++    VAAPI_VPP_DENOISE,
++    VAAPI_VPP_DETAIL,
++    VAAPI_VPP_PROCAMP,
++    VAAPI_VPP_TONEMAP,
++    VAAPI_VPP_NONE,
++};
++
++typedef struct VaapiVppMode {
++    const char               *name;
++    const enum VaapiVppType   vpp;
++    const VAProcFilterType    va_proc;
++} VaapiVppMode;
++
++static const VaapiVppMode vaapivpp_modes[] = {
++    { "VAAPI VPP Scale Filter",       VAAPI_VPP_SCALE,   0 }, /* VAProcFilterNone */
++    { "VAAPI VPP Deinterlace Filter", VAAPI_VPP_DEINT,   2 }, /* VAProcFilterDeinterlacing */
++#   if VA_CHECK_VERSION(1, 1, 0)
++    { "VAAPI VPP Overlay Filter",     VAAPI_VPP_OVERLAY, 0 }, /* VAProcFilterNone */
++    { "VAAPI VPP Rotate Filter",      VAAPI_VPP_ROTATE,  0 }, /* VAProcFilterNone */
++    { "VAAPI VPP Flip Filter",        VAAPI_VPP_FLIP,    0 }, /* VAProcFilterNone */
++#   endif
++    { "VAAPI VPP Denoise Filter",     VAAPI_VPP_DENOISE, 1 }, /* VAProcFilterNoiseReduction */
++    { "VAAPI VPP Detail Filter",      VAAPI_VPP_DETAIL,  3 }, /* VAProcFilterSharpening */
++    { "VAAPI VPP Procamp Filter",     VAAPI_VPP_PROCAMP, 4 }, /* VAProcFilterColorBalance */
++#   if VA_CHECK_VERSION(1, 4, 0)
++    { "VAAPI VPP Tonemap Filter",     VAAPI_VPP_TONEMAP, 8 }, /* VAProcFilterHighDynamicRangeToneMapping */
++#   endif
++    { NULL, VAAPI_VPP_NONE, 0 },
++};
++#endif
++
++int print_vaapi_device_info(AVTextFormatContext *tfc, AVBufferRef *vaapi_ref, AVBufferRef *drm_ref)
++{
++#if (CONFIG_VAAPI && HAVE_VAAPI_DRM)
++    AVHWDeviceContext  *dev_ctx = NULL;
++    AVVAAPIDeviceContext *hwctx = NULL;
++    unsigned ver_major = 0;
++    unsigned ver_minor = 0;
++    const char *vendor_str = NULL;
++    unsigned short vendor_id = 0;
++    unsigned short device_id = 0;
++
++    if (!tfc || !vaapi_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)vaapi_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++
++    if (!vaDisplayIsValid(hwctx->display))
++        return AVERROR(ENOSYS);
++
++#   if CONFIG_LIBDRM
++    if (drm_ref) {
++        AVHWDeviceContext *dev_ctx_drm = (AVHWDeviceContext*)drm_ref->data;
++        AVDRMDeviceContext *hwctx_drm = dev_ctx_drm ? dev_ctx_drm->hwctx : NULL;
++        VADisplay display = hwctx_drm ? vaGetDisplayDRM(hwctx_drm->fd) : NULL;
++
++        if (display) {
++#       if VA_CHECK_VERSION(1, 0, 0)
++            vaSetErrorCallback(display, NULL, NULL);
++            vaSetInfoCallback(display, NULL, NULL);
++#       endif
++            vaInitialize(display, &ver_major, &ver_minor);
++            vaTerminate(display);
++        }
++    }
++#   endif
++
++    vendor_str = vaQueryVendorString(hwctx->display);
++
++#   if VA_CHECK_VERSION(1, 15, 0)
++    {
++        VADisplayAttribute pci_attr = { .type = VADisplayPCIID };
++        VAStatus sts = vaGetDisplayAttributes(hwctx->display, &pci_attr, 1);
++
++        if (sts == VA_STATUS_SUCCESS &&
++            pci_attr.flags != VA_DISPLAY_ATTRIB_NOT_SUPPORTED) {
++            vendor_id = (pci_attr.value >> 16) & 0xFFFF;
++            device_id = pci_attr.value & 0xFFFF;
++        }
++    }
++#   endif
++
++    mark_section_show_entries(SECTION_ID_DEVICE_INFO_VAAPI, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_INFO_VAAPI);
++
++    if (vendor_str) {
++        print_str("device_vendor_string", vendor_str);
++    }
++    if (vendor_id && device_id) {
++        print_int("device_vid", vendor_id);
++        print_int("device_did", device_id);
++    }
++    if (ver_major || ver_minor) {
++        print_int("device_vaapi_impl_version_major", ver_major);
++        print_int("device_vaapi_impl_version_minor", ver_minor);
++    }
++    print_int("device_vaapi_api_version_major", VA_MAJOR_VERSION);
++    print_int("device_vaapi_api_version_minor", VA_MINOR_VERSION);
++    print_int("device_vaapi_api_version_micro", VA_MICRO_VERSION);
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_INFO_VAAPI
++
++    return 0;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++#if (CONFIG_VAAPI && HAVE_VAAPI_DRM)
++static int vaapi_map_va_fourcc_to_av_pix_fmt(unsigned fourcc) {
++    switch (fourcc) {
++    case VA_FOURCC('N','V','1','2'): return AV_PIX_FMT_NV12;
++    case VA_FOURCC('P','0','1','0'): return AV_PIX_FMT_P010;
++    case VA_FOURCC('P','0','1','2'): return AV_PIX_FMT_P012;
++
++    case VA_FOURCC('Y','U','Y','2'): return AV_PIX_FMT_YUYV422;
++    case VA_FOURCC('U','Y','V','Y'): return AV_PIX_FMT_UYVY422;
++    case VA_FOURCC('Y','2','1','0'): return AV_PIX_FMT_Y210;
++    case VA_FOURCC('Y','2','1','2'): return AV_PIX_FMT_Y212;
++
++    case VA_FOURCC('X','Y','U','V'): return AV_PIX_FMT_VUYX;
++    case VA_FOURCC('Y','4','1','0'): return AV_PIX_FMT_XV30;
++    case VA_FOURCC('Y','4','1','2'): return AV_PIX_FMT_XV36;
++
++    case VA_FOURCC('Y','8','0','0'): return AV_PIX_FMT_GRAY8;
++    case VA_FOURCC('4','1','1','P'): return AV_PIX_FMT_YUV411P;
++    case VA_FOURCC('I','4','2','0'): return AV_PIX_FMT_YUV420P;
++    case VA_FOURCC('I','M','C','3'): return AV_PIX_FMT_YUV420P;
++    case VA_FOURCC('4','2','2','V'): return AV_PIX_FMT_YUV440P;
++    case VA_FOURCC('4','2','2','H'): return AV_PIX_FMT_YUV422P;
++    case VA_FOURCC('4','4','4','P'): return AV_PIX_FMT_YUV444P;
++
++    case VA_FOURCC('B','G','R','A'): return AV_PIX_FMT_BGRA;
++    case VA_FOURCC('B','G','R','X'): return AV_PIX_FMT_BGR0;
++    case VA_FOURCC('R','G','B','A'): return AV_PIX_FMT_RGBA;
++    case VA_FOURCC('R','G','B','X'): return AV_PIX_FMT_RGB0;
++    case VA_FOURCC('A','B','G','R'): return AV_PIX_FMT_ABGR;
++    case VA_FOURCC('X','B','G','R'): return AV_PIX_FMT_0BGR;
++    case VA_FOURCC('A','R','G','B'): return AV_PIX_FMT_ARGB;
++    case VA_FOURCC('X','R','G','B'): return AV_PIX_FMT_0RGB;
++
++    case VA_FOURCC('X','R','3','0'): return AV_PIX_FMT_X2RGB10;
++    case VA_FOURCC('X','B','3','0'): return AV_PIX_FMT_X2BGR10;
++    default:                         return AV_PIX_FMT_NONE;
++    }
++}
++#endif
++
++static int print_vaapi_codec_info(AVTextFormatContext *tfc, AVBufferRef *vaapi_ref, int print_encoder)
++{
++#if (CONFIG_VAAPI && HAVE_VAAPI_DRM)
++    AVHWDeviceContext  *dev_ctx = NULL;
++    AVVAAPIDeviceContext *hwctx = NULL;
++    VAStatus sts;
++    VAEntrypoint *va_entries = NULL;
++    unsigned nb_va_entries = 0;
++    VAImageFormat *va_images = NULL;
++    unsigned nb_va_images = 0;
++    const char *vendor_str = NULL;
++    int header_printed = 0;
++    unsigned i, j, k;
++    int ret = 0;
++    const unsigned section_id  = print_encoder ? SECTION_ID_DEVICE_ENCODERS_VAAPI
++                                               : SECTION_ID_DEVICE_DECODERS_VAAPI;
++    const unsigned section_id2 = print_encoder ? SECTION_ID_DEVICE_ENCODER
++                                               : SECTION_ID_DEVICE_DECODER;
++
++    if (!tfc || !vaapi_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)vaapi_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++
++    if (!vaDisplayIsValid(hwctx->display))
++        return AVERROR(ENOSYS);
++
++    nb_va_entries = vaMaxNumEntrypoints(hwctx->display);
++    if (!nb_va_entries)
++        return AVERROR(ENOSYS);
++
++    va_entries = av_malloc_array(nb_va_entries, sizeof(*va_entries));
++    if (!va_entries)
++        return AVERROR(ENOMEM);
++
++    nb_va_images = vaMaxNumImageFormats(hwctx->display);
++    if (!nb_va_images) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    va_images = av_malloc_array(nb_va_images, sizeof(*va_images));
++    if (!va_images) {
++        ret = AVERROR(ENOMEM);
++        goto exit;
++    }
++
++    sts = vaQueryImageFormats(hwctx->display, va_images, &nb_va_images);
++    if (sts != VA_STATUS_SUCCESS) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    vendor_str = vaQueryVendorString(hwctx->display);
++
++    for (i = 0; (print_encoder ? vaapienc_modes[i].name : vaapidec_modes[i].name); i++) {
++        const VaapiCodecMode *mode = print_encoder ? &vaapienc_modes[i] : &vaapidec_modes[i];
++
++        sts = vaQueryConfigEntrypoints(hwctx->display, mode->va_profile,
++                                       va_entries, &nb_va_entries);
++        if (sts != VA_STATUS_SUCCESS)
++            continue;
++
++        for (j = 0; j < nb_va_entries; j++) {
++            const VAEntrypoint e = va_entries[j];
++            const int is_dec_vid_entry = e == VAEntrypointVLD;
++            const int is_enc_pic_entry = e == VAEntrypointEncPicture;
++            const int is_enc_vid_entry_lp = e == 8; /* VAEntrypointEncSliceLP */
++            const int is_enc_vid_entry = is_enc_vid_entry_lp ||
++                                         e == VAEntrypointEncSlice;
++            VAConfigID config_id = VA_INVALID_ID;
++            VASurfaceAttrib *surf_attrs = NULL;
++            unsigned nb_surf_attrs = 0;
++            VAConfigAttrib max_sz_conf_attrs[] = {
++                { .type = 18 /* VAConfigAttribMaxPictureWidth  */ },
++                { .type = 19 /* VAConfigAttribMaxPictureHeight */ },
++            };
++            VAConfigAttrib vid_enc_conf_attrs[] = {
++                { .type =       VAConfigAttribRateControl         },
++                { .type = 21 /* VAConfigAttribEncQualityRange */  },
++                { .type =       VAConfigAttribEncMaxRefFrames     },
++            };
++            unsigned min_width = 0, min_height = 0;
++            unsigned max_width = 0, max_height = 0;
++            int header2_printed = 0;
++            char full_str[128] = { 0 };
++
++            if (print_encoder) {
++                if (!(is_enc_vid_entry || is_enc_pic_entry))
++                    continue;
++                if (mode->codec != AV_CODEC_ID_MJPEG && !is_enc_vid_entry)
++                    continue;
++                if (mode->codec == AV_CODEC_ID_MJPEG && !is_enc_pic_entry)
++                    continue;
++            } else if (!is_dec_vid_entry)
++                continue;
++
++            sts = vaCreateConfig(hwctx->display, mode->va_profile, e, NULL, 0, &config_id);
++            if (sts != VA_STATUS_SUCCESS)
++                continue;
++
++            sts = vaQuerySurfaceAttributes(hwctx->display, config_id, NULL, &nb_surf_attrs);
++            if (sts != VA_STATUS_SUCCESS)
++                goto next;
++
++            surf_attrs = av_malloc_array(nb_surf_attrs, sizeof(*surf_attrs));
++            if (!surf_attrs)
++                goto next;
++
++            sts = vaQuerySurfaceAttributes(hwctx->display, config_id, surf_attrs, &nb_surf_attrs);
++            if (sts != VA_STATUS_SUCCESS)
++                goto next;
++
++            for (k = 0; k < nb_surf_attrs; k++) {
++                switch (surf_attrs[k].type) {
++                case VASurfaceAttribMinWidth:  min_width  = surf_attrs[k].value.value.i; break;
++                case VASurfaceAttribMinHeight: min_height = surf_attrs[k].value.value.i; break;
++                case VASurfaceAttribMaxWidth:  max_width  = surf_attrs[k].value.value.i; break;
++                case VASurfaceAttribMaxHeight: max_height = surf_attrs[k].value.value.i; break;
++                }
++            }
++            sts = vaGetConfigAttributes(hwctx->display, mode->va_profile,
++                                        e, max_sz_conf_attrs,
++                                        FF_ARRAY_ELEMS(max_sz_conf_attrs));
++            if (sts == VA_STATUS_SUCCESS) {
++                const unsigned max_pic_width  = max_sz_conf_attrs[0].value;
++                const unsigned max_pic_height = max_sz_conf_attrs[1].value;
++
++                if (max_pic_width && max_pic_height &&
++                    max_pic_width  != VA_ATTRIB_NOT_SUPPORTED &&
++                    max_pic_height != VA_ATTRIB_NOT_SUPPORTED) {
++                    max_width  = FFMIN(max_width,  max_pic_width);
++                    max_height = FFMIN(max_height, max_pic_height);
++                }
++            }
++
++            snprintf(full_str, sizeof(full_str), "%s%s",
++                     mode->name, is_enc_vid_entry_lp ? " (Low-Power)" : "");
++
++            if (!header_printed) {
++                mark_section_show_entries(section_id, 1, NULL);
++                avtext_print_section_header(tfc, NULL, section_id);
++                header_printed = 1;
++            }
++
++            mark_section_show_entries(section_id2, 1, NULL);
++            avtext_print_section_header(tfc, NULL, section_id2);
++            print_str("codec_name", avcodec_get_name(mode->codec));
++            print_int("codec_id", mode->codec);
++            print_str("codec_desc", full_str);
++            if (min_width && min_height) {
++                print_int("min_width",  min_width);
++                print_int("min_height", min_height);
++            }
++            if (max_width && max_height) {
++                print_int("max_width",  max_width);
++                print_int("max_height", max_height);
++            }
++
++            if (print_encoder && mode->codec != AV_CODEC_ID_MJPEG) {
++                print_int("low_power", is_enc_vid_entry_lp);
++
++                sts = vaGetConfigAttributes(hwctx->display, mode->va_profile,
++                                            e, vid_enc_conf_attrs,
++                                            FF_ARRAY_ELEMS(vid_enc_conf_attrs));
++                if (sts == VA_STATUS_SUCCESS) {
++                    const unsigned rc   = vid_enc_conf_attrs[0].value;
++                    const unsigned q_lv = vid_enc_conf_attrs[1].value;
++                    const unsigned refs = vid_enc_conf_attrs[2].value;
++
++                    if (rc != VA_ATTRIB_NOT_SUPPORTED) {
++                        static const unsigned rc_cqp  = VA_RC_CQP;
++                        static const unsigned rc_cbr  = VA_RC_CBR;
++                        static const unsigned rc_vbr  = VA_RC_VBR;
++                        static const unsigned rc_qvbr = 0x00000400; /* VA_RC_QVBR */
++                        static const unsigned rc_icq  = 0x00000040; /* VA_RC_ICQ  */
++                        static const unsigned rc_mb   = 0x00000080; /* VA_RC_MB   */
++#   define CHECK_RC(x) ((rc & (x)) == (x))
++                        print_int("cqp_ratecontrol",  CHECK_RC(rc_cqp));
++                        print_int("cbr_ratecontrol",  CHECK_RC(rc_cbr));
++                        print_int("cbr_mbbrc",        CHECK_RC(rc_cbr  | rc_mb));
++                        print_int("vbr_ratecontrol",  CHECK_RC(rc_vbr));
++                        print_int("vbr_mbbrc",        CHECK_RC(rc_vbr  | rc_mb));
++                        print_int("qvbr_ratecontrol", CHECK_RC(rc_qvbr));
++                        print_int("qvbr_mbbrc",       CHECK_RC(rc_qvbr | rc_mb));
++                        print_int("icq_ratecontrol",  CHECK_RC(rc_icq));
++                        print_int("icq_mbbrc",        CHECK_RC(rc_icq  | rc_mb));
++#   undef CHECK_RC
++                    }
++                    if (q_lv != VA_ATTRIB_NOT_SUPPORTED) {
++                        print_int("max_quality_level", q_lv);
++                    }
++                    if (refs != VA_ATTRIB_NOT_SUPPORTED) {
++                        print_int("max_ref_frames_l0", refs & 0xFFFF);
++                        print_int("max_ref_frames_l1", (refs >> 16) & 0xFFFF);
++                    }
++                }
++            }
++
++            /* Profile */
++            if (mode->profile != AV_PROFILE_UNKNOWN) {
++                mark_section_show_entries(SECTION_ID_DEVICE_PROFILES, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILES);
++                mark_section_show_entries(SECTION_ID_DEVICE_PROFILE, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PROFILE);
++                print_str("profile_name", avcodec_profile_name(mode->codec, mode->profile));
++                print_int("profile_id", mode->profile);
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILE
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PROFILES
++            }
++
++            /* Formats */
++            for (k = 0; k < nb_surf_attrs; k++) {
++                int format = AV_PIX_FMT_NONE;
++                unsigned p = 0, surf_fourcc = 0;
++
++                if (surf_attrs[k].type != VASurfaceAttribPixelFormat)
++                    continue;
++
++                surf_fourcc = surf_attrs[k].value.value.i;
++                format = vaapi_map_va_fourcc_to_av_pix_fmt(surf_fourcc);
++                if (format == AV_PIX_FMT_NONE)
++                    continue;
++
++                /* Fixup Intel i965 driver false reporting */
++                if (e == VAEntrypointEncSlice &&
++                    format != AV_PIX_FMT_NV12 &&
++                    format != AV_PIX_FMT_P010 &&
++                    strstr(vendor_str, "Intel i965 driver"))
++                    continue;
++
++                for (p = 0; p < nb_va_images && format != vaapi_map_va_fourcc_to_av_pix_fmt(va_images[p].fourcc); p++);
++                if (p >= nb_va_images)
++                    continue;
++
++                if (!header2_printed) {
++                    mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                    header2_printed = 1;
++                }
++                mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++                print_str("format_name", av_get_pix_fmt_name(format));
++                print_int("format_id", format);
++                print_str("format_fourcc", av_fourcc2str(surf_fourcc));
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++            }
++            if (header2_printed)
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++            avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_{DEC,ENC}ODER
++next:
++            if (config_id != VA_INVALID_ID)
++                vaDestroyConfig(hwctx->display, config_id);
++
++            av_freep(&surf_attrs);
++        }
++    }
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_{DEC,ENC}ODERS_VAAPI
++
++exit:
++    av_freep(&va_images);
++    av_freep(&va_entries);
++
++    return ret;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++int print_vaapi_decoder_info(AVTextFormatContext *tfc, AVBufferRef *vaapi_ref)
++{
++    return print_vaapi_codec_info(tfc, vaapi_ref, 0);
++}
++
++int print_vaapi_encoder_info(AVTextFormatContext *tfc, AVBufferRef *vaapi_ref)
++{
++    return print_vaapi_codec_info(tfc, vaapi_ref, 1);
++}
++
++#if (CONFIG_VAAPI && HAVE_VAAPI_DRM)
++static const char *vaapi_map_vpp_type_to_str(enum VaapiVppType vpp)
++{
++    switch (vpp) {
++    case VAAPI_VPP_SCALE:   return "scale";
++    case VAAPI_VPP_DEINT:   return "deinterlace";
++    case VAAPI_VPP_OVERLAY: return "overlay";
++    case VAAPI_VPP_ROTATE:  return "rotate";
++    case VAAPI_VPP_FLIP:    return "flip";
++    case VAAPI_VPP_DENOISE: return "denoise";
++    case VAAPI_VPP_DETAIL:  return "detail";
++    case VAAPI_VPP_PROCAMP: return "procamp";
++    case VAAPI_VPP_TONEMAP: return "tonemap";
++    default:                return "";
++    }
++}
++#endif
++
++int print_vaapi_vpp_info(AVTextFormatContext *tfc, AVBufferRef *vaapi_ref)
++{
++#if (CONFIG_VAAPI && HAVE_VAAPI_DRM)
++    AVHWDeviceContext  *dev_ctx = NULL;
++    AVVAAPIDeviceContext *hwctx = NULL;
++    VAStatus sts;
++    VAEntrypoint *va_entries = NULL;
++    unsigned nb_va_entries = 0;
++    VAImageFormat *va_images = NULL;
++    unsigned nb_va_images = 0;
++    int header_printed = 0;
++    unsigned i, j, k;
++    int ret = 0;
++
++    if (!tfc || !vaapi_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)vaapi_ref->data;
++    if (!dev_ctx)
++        return AVERROR(ENOSYS);
++
++    hwctx = dev_ctx->hwctx;
++
++    if (!vaDisplayIsValid(hwctx->display))
++        return AVERROR(ENOSYS);
++
++    nb_va_entries = vaMaxNumEntrypoints(hwctx->display);
++    if (!nb_va_entries)
++        return AVERROR(ENOSYS);
++
++    va_entries = av_malloc_array(nb_va_entries, sizeof(*va_entries));
++    if (!va_entries)
++        return AVERROR(ENOMEM);
++
++    sts = vaQueryConfigEntrypoints(hwctx->display, VAProfileNone,
++                                   va_entries, &nb_va_entries);
++    if (sts != VA_STATUS_SUCCESS) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    nb_va_images = vaMaxNumImageFormats(hwctx->display);
++    if (!nb_va_images) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    va_images = av_malloc_array(nb_va_images, sizeof(*va_images));
++    if (!va_images) {
++        ret = AVERROR(ENOMEM);
++        goto exit;
++    }
++
++    sts = vaQueryImageFormats(hwctx->display, va_images, &nb_va_images);
++    if (sts != VA_STATUS_SUCCESS) {
++        ret = AVERROR(ENOSYS);
++        goto exit;
++    }
++
++    for (i = 0; i < nb_va_entries; i++) {
++        VAConfigID config_id = VA_INVALID_ID;
++        VAContextID vpp_ctx = VA_INVALID_ID;
++        VAProcFilterType va_filters[10] = { 0 }; /* VAProcFilterCount */
++        unsigned nb_va_filters = FF_ARRAY_ELEMS(va_filters);
++        VASurfaceAttrib *surf_attrs = NULL;
++        unsigned nb_surf_attrs = 0;
++        unsigned min_width = 0, min_height = 0;
++        unsigned max_width = 0, max_height = 0;
++
++        if (va_entries[i] != VAEntrypointVideoProc)
++            continue;
++
++        sts = vaCreateConfig(hwctx->display, VAProfileNone, VAEntrypointVideoProc, NULL, 0, &config_id);
++        if (sts != VA_STATUS_SUCCESS)
++            break;
++
++        sts = vaQuerySurfaceAttributes(hwctx->display, config_id, NULL, &nb_surf_attrs);
++        if (sts != VA_STATUS_SUCCESS)
++            goto next;
++
++        surf_attrs = av_malloc_array(nb_surf_attrs, sizeof(*surf_attrs));
++        if (!surf_attrs)
++            goto next;
++
++        sts = vaQuerySurfaceAttributes(hwctx->display, config_id, surf_attrs, &nb_surf_attrs);
++        if (sts != VA_STATUS_SUCCESS)
++            goto next;
++
++        for (j = 0; j < nb_surf_attrs; j++) {
++            switch (surf_attrs[j].type) {
++            case VASurfaceAttribMinWidth:  min_width  = surf_attrs[j].value.value.i; break;
++            case VASurfaceAttribMinHeight: min_height = surf_attrs[j].value.value.i; break;
++            case VASurfaceAttribMaxWidth:  max_width  = surf_attrs[j].value.value.i; break;
++            case VASurfaceAttribMaxHeight: max_height = surf_attrs[j].value.value.i; break;
++            }
++        }
++
++        sts = vaCreateContext(hwctx->display, config_id,
++                              FFMIN(FFMAX(min_width, 1280), max_width),
++                              FFMIN(FFMAX(min_height, 720), max_height),
++                              VA_PROGRESSIVE, NULL, 0, &vpp_ctx);
++        if (sts != VA_STATUS_SUCCESS)
++            goto next;
++
++        sts = vaQueryVideoProcFilters(hwctx->display, vpp_ctx, va_filters, &nb_va_filters);
++        if (sts != VA_STATUS_SUCCESS)
++            goto next;
++
++        for (j = 0; vaapivpp_modes[j].name; j++) {
++            const VaapiVppMode *mode = &vaapivpp_modes[j];
++
++            for (k = 0; k < nb_va_filters; k++) {
++                VABufferID filter_buf = VA_INVALID_ID;
++                VABufferID *p_filter_buf = NULL;
++                unsigned nb_filter_buf = 0;
++                VAProcFilterParameterBuffer               denoise_param_buf = { 0 };
++                VAProcFilterParameterBuffer               detail_param_buf = { 0 };
++                VAProcFilterParameterBufferDeinterlacing  deint_param_buf = { 0 };
++                VAProcFilterParameterBufferColorBalance   procamp_param_buf = { 0 };
++#   if VA_CHECK_VERSION(1, 4, 0)
++                VAProcFilterParameterBufferHDRToneMapping tonemap_param_buf = { 0 };
++#   endif
++                void *p_param_buf = NULL;
++                size_t sz_param_buf = 0;
++                unsigned nb_param_buf = 0;
++                VAProcPipelineCaps caps = { 0 };
++                unsigned mask_deint_caps = 0;
++                unsigned mask_procamp_caps = 0;
++                av_unused unsigned mask_tonemap_caps = 0;
++                int header2_printed = 0;
++
++                if (mode->va_proc != va_filters[k] &&
++                    mode->va_proc != VAProcFilterNone)
++                    continue;
++
++                switch (mode->vpp) {
++#   define VPP_PARAM_BUF(vpp, param_buf) \
++                case (vpp): {                             \
++                    (param_buf).type = mode->va_proc;     \
++                    p_param_buf      = &(param_buf);      \
++                    sz_param_buf     = sizeof(param_buf); \
++                    nb_param_buf++;                       \
++                    break;                                \
++                }
++                VPP_PARAM_BUF(VAAPI_VPP_DEINT,   deint_param_buf)
++                VPP_PARAM_BUF(VAAPI_VPP_DENOISE, denoise_param_buf)
++                VPP_PARAM_BUF(VAAPI_VPP_DETAIL,  detail_param_buf)
++                VPP_PARAM_BUF(VAAPI_VPP_PROCAMP, procamp_param_buf)
++#   if VA_CHECK_VERSION(1, 4, 0)
++                VPP_PARAM_BUF(VAAPI_VPP_TONEMAP, tonemap_param_buf)
++#   endif
++#   undef VPP_PARAM_BUF
++                }
++
++                if (p_filter_buf && sz_param_buf && nb_filter_buf) {
++                    sts = vaCreateBuffer(hwctx->display, vpp_ctx,
++                                         VAProcFilterParameterBufferType,
++                                         sz_param_buf, nb_param_buf, p_param_buf, &filter_buf);
++                    if (sts != VA_STATUS_SUCCESS)
++                        continue;
++
++                    p_filter_buf = &filter_buf;
++                    nb_filter_buf++;
++                }
++
++                sts = vaQueryVideoProcPipelineCaps(hwctx->display, vpp_ctx, p_filter_buf, nb_filter_buf, &caps);
++                if (sts != VA_STATUS_SUCCESS) {
++                    if (filter_buf != VA_INVALID_ID)
++                        vaDestroyBuffer(hwctx->display, filter_buf);
++                    continue;
++                }
++
++#   if VA_CHECK_VERSION(1, 1, 0)
++                {
++                    unsigned src_flags = 0, dst_flags = 0;
++
++                    switch (mode->vpp) {
++                    case VAAPI_VPP_OVERLAY:
++                        src_flags = caps.blend_flags;
++                        dst_flags = VA_BLEND_GLOBAL_ALPHA;
++                        break;
++                    case VAAPI_VPP_ROTATE:
++                        src_flags = caps.rotation_flags;
++                        dst_flags = (1 << VA_ROTATION_90) | (1 << VA_ROTATION_180) | (1 << VA_ROTATION_270);
++                        break;
++                    case VAAPI_VPP_FLIP:
++                        src_flags = caps.mirror_flags;
++                        dst_flags = VA_MIRROR_HORIZONTAL | VA_MIRROR_VERTICAL;
++                        break;
++                    }
++                    if (dst_flags && ((src_flags & dst_flags) != dst_flags)) {
++                        if (filter_buf != VA_INVALID_ID)
++                            vaDestroyBuffer(hwctx->display, filter_buf);
++                        continue;
++                    }
++                }
++#   endif
++
++                {
++                    VAProcFilterCapDeinterlacing    deint_caps[VAProcDeinterlacingCount] = { 0 };
++                    VAProcFilterCap                 denoise_caps = { 0 };
++                    VAProcFilterCap                 detail_caps = { 0 };
++                    VAProcFilterCapColorBalance     procamp_caps[VAProcColorBalanceCount] = { 0 };
++#   if VA_CHECK_VERSION(1, 4, 0)
++                    VAProcFilterCapHighDynamicRange tonemap_caps[VAProcHighDynamicRangeMetadataTypeCount] = { 0 };
++#   endif
++                    void *p_caps = NULL;
++                    unsigned nb_caps = 0;
++
++                    switch (mode->vpp) {
++                    case VAAPI_VPP_DEINT:
++                        p_caps = &deint_caps; nb_caps = FF_ARRAY_ELEMS(deint_caps); break;
++                    case VAAPI_VPP_DENOISE:
++                        p_caps = &denoise_caps; nb_caps = 1; break;
++                    case VAAPI_VPP_DETAIL:
++                        p_caps = &detail_caps; nb_caps = 1; break;
++                    case VAAPI_VPP_PROCAMP:
++                        p_caps = &procamp_caps; nb_caps = FF_ARRAY_ELEMS(procamp_caps); break;
++#   if VA_CHECK_VERSION(1, 4, 0)
++                    case VAAPI_VPP_TONEMAP:
++                        p_caps = &tonemap_caps; nb_caps = FF_ARRAY_ELEMS(tonemap_caps); break;
++#   endif
++                    }
++                    if (p_caps && nb_caps) {
++                        unsigned c = 0, mask_caps = 0;
++                        const unsigned is_caps_arr = nb_caps > 1;
++
++                        sts = vaQueryVideoProcFilterCaps(hwctx->display, vpp_ctx, mode->va_proc, p_caps, &nb_caps);
++                        if (sts == VA_STATUS_SUCCESS && is_caps_arr) {
++                            switch (mode->vpp) {
++                            case VAAPI_VPP_DEINT:
++                                for (c = 0; c < nb_caps; c++)
++                                    mask_caps |= (deint_caps[c].type > 0) ? (1 << deint_caps[c].type) : 0;
++                                mask_deint_caps = mask_caps;
++                                break;
++                            case VAAPI_VPP_PROCAMP:
++                                for (c = 0; c < nb_caps; c++)
++                                    mask_caps |= (procamp_caps[c].type > 0) ? (1 << procamp_caps[c].type) : 0;
++                                mask_procamp_caps = mask_caps;
++                                break;
++#   if VA_CHECK_VERSION(1, 4, 0)
++                            case VAAPI_VPP_TONEMAP:
++                                for (c = 0; c < nb_caps; c++)
++                                    mask_caps |= (tonemap_caps[c].metadata_type == 1) ? tonemap_caps[c].caps_flag : 0;
++                                mask_tonemap_caps = mask_caps;
++                                break;
++#   endif
++                            }
++                        }
++                        if (sts != VA_STATUS_SUCCESS || !nb_caps || (is_caps_arr && !mask_caps)) {
++                            if (filter_buf != VA_INVALID_ID)
++                                vaDestroyBuffer(hwctx->display, filter_buf);
++                            continue;
++                        }
++                    }
++                }
++
++#   if VA_CHECK_VERSION(1, 1, 0)
++                {
++                    unsigned min_vpp_width = 0, min_vpp_height = 0;
++                    unsigned max_vpp_width = 0, max_vpp_height = 0;
++#       define INTERSECT_MIN(a, b) (((a) && (b)) ? ((a) > (b) ? (a) : (b)) : ((a) ? (a) : (b)))
++#       define INTERSECT_MAX(a, b) (((a) && (b)) ? ((a) < (b) ? (a) : (b)) : ((a) ? (a) : (b)))
++                    min_vpp_width  = INTERSECT_MIN(caps.min_input_width,  caps.min_output_width);
++                    min_vpp_height = INTERSECT_MIN(caps.min_input_height, caps.min_output_height);
++                    max_vpp_width  = INTERSECT_MAX(caps.max_input_width,  caps.max_output_width);
++                    max_vpp_height = INTERSECT_MAX(caps.max_input_height, caps.max_output_height);
++                    min_width      = INTERSECT_MIN(min_width,  min_vpp_width);
++                    min_height     = INTERSECT_MIN(min_height, min_vpp_height);
++                    max_width      = INTERSECT_MAX(max_width,  max_vpp_width);
++                    max_height     = INTERSECT_MAX(max_height, max_vpp_height);
++#       undef INTERSECT_MIN
++#       undef INTERSECT_MAX
++                }
++#   endif
++
++                if (!header_printed) {
++                    mark_section_show_entries(SECTION_ID_DEVICE_FILTERS_VAAPI, 1, NULL);
++                    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_FILTERS_VAAPI);
++                    header_printed = 1;
++                }
++
++                mark_section_show_entries(SECTION_ID_DEVICE_FILTER, 1, NULL);
++                avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_FILTER);
++                print_str("filter_name", vaapi_map_vpp_type_to_str(mode->vpp));
++                print_str("filter_desc", mode->name);
++                if (min_width && min_height) {
++                    print_int("min_width",  min_width);
++                    print_int("min_height", min_height);
++                }
++                if (max_width && max_height) {
++                    print_int("max_width",  max_width);
++                    print_int("max_height", max_height);
++                }
++
++                switch (mode->vpp) {
++                case VAAPI_VPP_DEINT:
++                    print_int("deint_mode_bob",                !!(mask_deint_caps & (1 << VAProcDeinterlacingBob)));
++                    print_int("deint_mode_weave",              !!(mask_deint_caps & (1 << VAProcDeinterlacingWeave)));
++                    print_int("deint_mode_motion_adaptive",    !!(mask_deint_caps & (1 << VAProcDeinterlacingMotionAdaptive)));
++                    print_int("deint_mode_motion_compensated", !!(mask_deint_caps & (1 << VAProcDeinterlacingMotionCompensated)));
++                    break;
++                case VAAPI_VPP_PROCAMP:
++                    print_int("procamp_mode_hue",              !!(mask_procamp_caps & (1 << VAProcColorBalanceHue)));
++                    print_int("procamp_mode_saturation",       !!(mask_procamp_caps & (1 << VAProcColorBalanceSaturation)));
++                    print_int("procamp_mode_brightness",       !!(mask_procamp_caps & (1 << VAProcColorBalanceBrightness)));
++                    print_int("procamp_mode_contrast",         !!(mask_procamp_caps & (1 << VAProcColorBalanceContrast)));
++                    break;
++#   if VA_CHECK_VERSION(1, 4, 0)
++                case VAAPI_VPP_TONEMAP:
++                    print_int("tonemap_mode_hdr10_to_sdr",     !!(mask_tonemap_caps & VA_TONE_MAPPING_HDR_TO_SDR));
++                    print_int("tonemap_mode_hdr10_to_hdr10",   !!(mask_tonemap_caps & VA_TONE_MAPPING_HDR_TO_HDR));
++                    break;
++#   endif
++                }
++
++                /* Formats */
++                for (k = 0; k < nb_surf_attrs; k++) {
++                    int format = AV_PIX_FMT_NONE;
++                    unsigned p = 0, surf_fourcc = 0;
++
++                    if (surf_attrs[k].type != VASurfaceAttribPixelFormat)
++                        continue;
++
++                    surf_fourcc = surf_attrs[k].value.value.i;
++                    format = vaapi_map_va_fourcc_to_av_pix_fmt(surf_fourcc);
++                    if (format == AV_PIX_FMT_NONE)
++                        continue;
++
++                    for (p = 0; p < nb_va_images && format != vaapi_map_va_fourcc_to_av_pix_fmt(va_images[p].fourcc); p++);
++                    if (p >= nb_va_images)
++                        continue;
++
++                    if (!header2_printed) {
++                        mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMTS, 1, NULL);
++                        avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMTS);
++                        header2_printed = 1;
++                    }
++                    mark_section_show_entries(SECTION_ID_DEVICE_PIX_FMT, 1, NULL);
++                    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_PIX_FMT);
++                    print_str("format_name", av_get_pix_fmt_name(format));
++                    print_int("format_id", format);
++                    print_str("format_fourcc", av_fourcc2str(surf_fourcc));
++                    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMT
++                }
++                if (header2_printed)
++                    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_PIX_FMTS
++
++                avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_FILTER
++
++                if (filter_buf != VA_INVALID_ID)
++                    vaDestroyBuffer(hwctx->display, filter_buf);
++
++                break;
++            }
++        }
++next:
++        if (vpp_ctx != VA_INVALID_ID)
++            vaDestroyContext(hwctx->display, vpp_ctx);
++
++        if (config_id != VA_INVALID_ID)
++            vaDestroyConfig(hwctx->display, config_id);
++
++        av_freep(&surf_attrs);
++
++        break;
++    }
++    if (header_printed)
++        avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_FILTERS_VAAPI
++
++exit:
++    av_freep(&va_images);
++    av_freep(&va_entries);
++
++    return ret;
++#else
++    return AVERROR(ENOSYS);
++#endif
++}
++
++/* VAAPI -> QSV */
++void create_derive_qsv_devices_from_vaapi(HwDeviceRefs *refs)
++{
++    for (unsigned i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs && refs[i].vaapi_ref; i++) {
++        if (refs[i].device_vendor_id != FFPROBE_HW_VENDOR_ID_INTEL)
++            continue;
++        av_hwdevice_ctx_create_derived(&refs[i].qsv_ref, AV_HWDEVICE_TYPE_QSV,
++                                       refs[i].vaapi_ref, 0);
++    }
++}
++
++/* VAAPI -> OPENCL */
++void create_derive_opencl_devices_from_vaapi(HwDeviceRefs *refs)
++{
++    for (unsigned i = 0; i < FFPROBE_HW_MAX_DEV_NUM && refs && refs[i].vaapi_ref; i++) {
++        if (refs[i].device_vendor_id != FFPROBE_HW_VENDOR_ID_INTEL)
++            continue;
++        av_hwdevice_ctx_create_derived(&refs[i].opencl_ref, AV_HWDEVICE_TYPE_OPENCL,
++                                       refs[i].vaapi_ref, 0);
++    }
++}
+Index: FFmpeg/fftools/ffprobe_hw_vulkan.c
+===================================================================
+--- /dev/null
++++ FFmpeg/fftools/ffprobe_hw_vulkan.c
+@@ -0,0 +1,178 @@
++/*
++ * Copyright (C) 2026 NyanMisaka
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++#include "ffprobe_hw_internal.h"
++
++#if CONFIG_VULKAN
++#   include "libavutil/hwcontext_vulkan.h"
++#   include "libavutil/vulkan_loader.h"
++#   include "libavutil/vulkan.h"
++#   include "libavutil/bprint.h"
++#endif
++
++#if CONFIG_VULKAN
++typedef enum {
++    TYPE_STR,
++    TYPE_UINT,
++    TYPE_DEVTYPE,
++    TYPE_VERSION
++} VulkanAttrType;
++
++typedef struct {
++    const char          *attr_str;
++    const size_t         offset;
++    const int            is_limits;
++    const VulkanAttrType attr_type;
++} VulkanAttr;
++
++static const VulkanAttr vulkan_compute_attrs[] = {
++#   define OFF_P(x) offsetof(VkPhysicalDeviceProperties, x)
++#   define OFF_L(x) offsetof(VkPhysicalDeviceLimits, x)
++    { "device_name",                               OFF_P(deviceName),                     0, TYPE_STR     },
++    { "device_type",                               OFF_P(deviceType),                     0, TYPE_DEVTYPE },
++    { "device_vid",                                OFF_P(vendorID),                       0, TYPE_UINT    },
++    { "device_did",                                OFF_P(deviceID),                       0, TYPE_UINT    },
++    { "device_api_version",                        OFF_P(apiVersion),                     0, TYPE_VERSION },
++    { "device_max_compute_shared_mem",             OFF_L(maxComputeSharedMemorySize),     1, TYPE_UINT    },
++    { "device_max_compute_work_group_invocations", OFF_L(maxComputeWorkGroupInvocations), 1, TYPE_UINT    },
++    { "device_max_compute_work_group_x",           OFF_L(maxComputeWorkGroupSize[0]),     1, TYPE_UINT    },
++    { "device_max_compute_work_group_y",           OFF_L(maxComputeWorkGroupSize[1]),     1, TYPE_UINT    },
++    { "device_max_compute_work_group_z",           OFF_L(maxComputeWorkGroupSize[2]),     1, TYPE_UINT    },
++    { "device_max_uniform_buffer_range",           OFF_L(maxUniformBufferRange),          1, TYPE_UINT    },
++    { "device_max_storage_buffer_range",           OFF_L(maxStorageBufferRange),          1, TYPE_UINT    },
++    { "device_max_push_constants_size",            OFF_L(maxPushConstantsSize),           1, TYPE_UINT    },
++#   undef OFF_P
++#   undef OFF_L
++};
++#endif
++
++int print_vulkan_device_info(AVTextFormatContext *tfc, AVBufferRef *vulkan_ref)
++{
++#if CONFIG_VULKAN
++    AVHWDeviceContext *dev_ctx = NULL;
++    AVVulkanDeviceContext *hwctx = NULL;
++    VkPhysicalDevice phys_dev = NULL;
++    FFVulkanFunctions vkfn;
++    uint64_t exts = 0;
++
++    if (!tfc || !vulkan_ref)
++        return AVERROR(EINVAL);
++
++    dev_ctx = (AVHWDeviceContext*)vulkan_ref->data;
++    hwctx = dev_ctx->hwctx;
++
++    phys_dev = hwctx->phys_dev;
++    if (!phys_dev)
++        return AVERROR(ENOSYS);
++
++    exts = ff_vk_extensions_to_mask(hwctx->enabled_dev_extensions,
++                                    hwctx->nb_enabled_dev_extensions);
++    if (ff_vk_load_functions(dev_ctx, &vkfn, exts, 1, 1) < 0)
++        return AVERROR(ENOSYS);
++
++    mark_section_show_entries(SECTION_ID_DEVICE_INFO_VULKAN, 1, NULL);
++    avtext_print_section_header(tfc, NULL, SECTION_ID_DEVICE_INFO_VULKAN);
++
++    {
++        VkPhysicalDeviceProperties props;
++        VkPhysicalDeviceMemoryProperties mem_props;
++
++        vkfn.GetPhysicalDeviceProperties(phys_dev, &props);
++        vkfn.GetPhysicalDeviceMemoryProperties(phys_dev, &mem_props);
++
++        for (unsigned i = 0; i < FF_ARRAY_ELEMS(vulkan_compute_attrs); i++) {
++            const VulkanAttr *a = &vulkan_compute_attrs[i];
++            void *base = a->is_limits ? (void*)&props.limits : (void*)&props;
++            void *val  = (uint8_t*)base + a->offset;
++
++            switch (a->attr_type) {
++            case TYPE_STR:     print_str(a->attr_str, (char*)val);      break;
++            case TYPE_UINT:    print_int(a->attr_str, *(uint32_t*)val); break;
++            case TYPE_DEVTYPE: print_int(a->attr_str, *(uint32_t*)val); break;
++            case TYPE_VERSION: print_int("device_api_version_major", VK_VERSION_MAJOR(*(uint32_t*)val));
++                               print_int("device_api_version_minor", VK_VERSION_MINOR(*(uint32_t*)val));
++                               print_int("device_api_version_patch", VK_VERSION_PATCH(*(uint32_t*)val)); break;
++            }
++        }
++
++        if (props.apiVersion >= VK_MAKE_VERSION(1, 2, 0)) {
++            VkPhysicalDeviceDriverProperties driver_props = {
++                .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES,
++                .pNext = NULL
++            };
++            VkPhysicalDeviceProperties2 props2 = {
++                .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2,
++                .pNext = &driver_props
++            };
++
++            vkfn.GetPhysicalDeviceProperties2(phys_dev, &props2);
++
++            print_str("device_driver_name", driver_props.driverName);
++            print_str("device_driver_info", driver_props.driverInfo);
++            print_int("device_driver_conformance_version_major",    (int64_t)driver_props.conformanceVersion.major);
++            print_int("device_driver_conformance_version_minor",    (int64_t)driver_props.conformanceVersion.minor);
++            print_int("device_driver_conformance_version_subminor", (int64_t)driver_props.conformanceVersion.subminor);
++            print_int("device_driver_conformance_version_patch",    (int64_t)driver_props.conformanceVersion.patch);
++        }
++
++        {
++            uint64_t total_local = 0;
++            uint64_t total_host = 0;
++
++            for (unsigned i = 0; i < mem_props.memoryHeapCount; i++) {
++                if (mem_props.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
++                    total_local += mem_props.memoryHeaps[i].size;
++                else
++                    total_host += mem_props.memoryHeaps[i].size;
++            }
++            print_int("device_local_memory_size", (int64_t)total_local);
++            print_int("device_host_memory_size", (int64_t)total_host);
++        }
++    }
++
++    {
++        unsigned dev_ext_count = 0;
++
++        vkfn.EnumerateDeviceExtensionProperties(phys_dev, NULL, &dev_ext_count, NULL);
++        if (dev_ext_count > 0) {
++            VkExtensionProperties *dev_exts = av_malloc_array(dev_ext_count, sizeof(VkExtensionProperties));
++
++            if (dev_exts) {
++                AVBPrint bp;
++
++                av_bprint_init(&bp, 0, AV_BPRINT_SIZE_UNLIMITED);
++
++                vkfn.EnumerateDeviceExtensionProperties(phys_dev, NULL, &dev_ext_count, dev_exts);
++                for (unsigned i = 0; i < dev_ext_count; i++)
++                    av_bprintf(&bp, "%s%s", i > 0 ? " " : "", dev_exts[i].extensionName);
++
++                if (av_bprint_is_complete(&bp))
++                    print_str("device_extensions", bp.str);
++
++                av_bprint_finalize(&bp, NULL);
++                av_free(dev_exts);
++            }
++        }
++    }
++
++    avtext_print_section_footer(tfc); // SECTION_ID_DEVICE_INFO_VULKAN
++#endif
++    return 0;
++}
+Index: FFmpeg/fftools/textformat/avtextformat.h
+===================================================================
+--- FFmpeg.orig/fftools/textformat/avtextformat.h
++++ FFmpeg/fftools/textformat/avtextformat.h
+@@ -29,7 +29,7 @@
+ #include "libavutil/hash.h"
+ #include "avtextwriters.h"
+ 
+-#define SECTION_MAX_NB_CHILDREN 11
++#define SECTION_MAX_NB_CHILDREN (11+17)
+ 
+ typedef struct AVTextFormatSectionContext {
+     char *context_id;
+@@ -110,7 +110,7 @@ typedef struct AVTextFormatter {
+ } AVTextFormatter;
+ 
+ #define SECTION_MAX_NB_LEVELS    12
+-#define SECTION_MAX_NB_SECTIONS 100
++#define SECTION_MAX_NB_SECTIONS (100+5)
+ 
+ typedef struct AVTextFormatOptions {
+     /**
+Index: FFmpeg/libavutil/cuda_check.h
+===================================================================
+--- FFmpeg.orig/libavutil/cuda_check.h
++++ FFmpeg/libavutil/cuda_check.h
+@@ -64,4 +64,36 @@ static inline int ff_cuda_check(void *av
+ 
+ #define FF_CUDA_CHECK_DL(avclass, cudl, x) ff_cuda_check(avclass, cudl->cuGetErrorName, cudl->cuGetErrorString, (x), #x)
+ 
++typedef const char* NVML_API_CALL nvml_check_ErrorString(nvmlReturn_t result);
++
++/**
++ * Wrap a NVML function call and print error information if it fails.
++ */
++static inline int ff_nvml_check(void *avctx,
++                                void *nvmlErrorString_fn,
++                                nvmlReturn_t err, const char *func)
++{
++    const char *err_string;
++
++    av_log(avctx, AV_LOG_TRACE, "Calling %s\n", func);
++
++    if (err == NVML_SUCCESS)
++        return 0;
++
++    err_string = ((nvml_check_ErrorString *)nvmlErrorString_fn)(err);
++
++    av_log(avctx, AV_LOG_ERROR, "%s failed", func);
++    if (err_string)
++        av_log(avctx, AV_LOG_ERROR, " -> %d: %s", (int)err, err_string);
++    av_log(avctx, AV_LOG_ERROR, "\n");
++
++    return AVERROR_EXTERNAL;
++}
++
++/**
++ * Convenience wrapper for ff_nvml_check when dynamically loading nvml symbols.
++ */
++
++#define FF_NVML_CHECK_DL(avclass, nvmldl, x) ff_nvml_check(avclass, nvmldl->nvmlErrorString, (x), #x)
++
+ #endif /* AVUTIL_CUDA_CHECK_H */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -95,3 +95,4 @@
 0095-add-scale-d3d11-p010-shader-fallback.patch
 0096-fix-full-range-input-for-mjpeg-vaapi-encoder.patch
 0097-add-misc-enhancements-to-mfenc-hw-encoder.patch
+0098-add-hw-caps-detection-and-usage-monitoring-to-ffprobe.patch


### PR DESCRIPTION
DONE:
* vaapi/drm (linux)
  - dev+dec+enc+vpp caps
  - opencl dev caps (intel only)
  - vulkan dev caps
* d3d11va/mft (win)
  - dev+dec+enc caps
  - monitoring (dxgi-pdh)
* cuda (win+linux)
  - dev+dec+enc caps
  - monitoring (nvml/dxgi-pdh)
* qsv (win+linux)
  - dev+dec+enc+vpp caps
  - opencl dev caps
  - monitoring (dxgi-pdh)
* amf (win)
  - dev+dec+enc caps
  - opencl dev caps
  - monitoring (dxgi-pdh)
* rkmpp (linux)
  - dev+dec+enc+vpp caps
  - opencl dev caps
* videotoolbox (macos)
  - dev+dec+enc caps

TODO:
* drm i915/xe/amdgpu usage monitoring
  - https://dri.freedesktop.org/docs/drm/gpu/drm-usage-stats.html#drm-client-usage-stats
  - https://dri.freedesktop.org/docs/drm/gpu/i915.html#i915-drm-client-usage-stats-implementation
  - https://dri.freedesktop.org/docs/drm/gpu/xe/xe-drm-usage-stats.html#xe-usage-stats
  - https://github.com/torvalds/linux/blob/master/drivers/gpu/drm/amd/amdgpu/amdgpu_fdinfo.c
* ~vulkan dev caps (linux vaapi amd)~
* ~adapt videotoolbox/metal probe to AVTextFormatter?~
* ~rockchip rkmpp/rkrga?~
  - ~cannot probe details without rawvideo/bitstream, better to check devicetree models and hardcode caps~

TESTING:
```
-show_hwaccel       show details of the given hwaccel type (available types are: vaapi, d3d11va, cuda, qsv, amf, rkmpp, videotoolbox)
-hwaccel_flags      set hwaccel flags for showing (available flags are: all, dev, dec, enc, vpp, ocl, vk, dx11, subdev, util)
-hwaccel_device     set a hwaccel device for showing

ffprobe -v quiet -hide_banner -print_format json -show_hwaccel vaapi
ffprobe -v quiet -hide_banner -print_format json -show_hwaccel vaapi -o /path/to/vaapi.json
ffprobe -v quiet -hide_banner -print_format json -show_hwaccel vaapi -hwaccel_device /dev/dri/renderD128
ffprobe -v quiet -hide_banner -print_format json -show_hwaccel vaapi -hwaccel_flags dev+ocl

ffprobe -v quiet -hide_banner -print_format json -show_hwaccel cuda
ffprobe -v quiet -hide_banner -print_format json -show_hwaccel cuda -o /path/to/cuda.json
ffprobe -v quiet -hide_banner -print_format json -show_hwaccel cuda -hwaccel_device 0
ffprobe -v quiet -hide_banner -print_format json -show_hwaccel cuda -hwaccel_flags util
```