### PR TITLE
fix(frame): correct operator precedence in av_frame_copy_side_data check

### DIFF
--- a/debian/patches/0020-add-new-frame-sidedata-func.patch
+++ b/debian/patches/0020-add-new-frame-sidedata-func.patch
@@ -72,8 +72,8 @@ Index: jellyfin-ffmpeg/libavutil/frame.c
 -        }
 -        av_dict_copy(&sd_dst->metadata, sd_src->metadata, 0);
 -    }
-+    if (ret = av_frame_copy_side_data(dst, src,
-+        force_copy ? AV_FRAME_COPY_PROPS_FORCECOPY : 0) < 0)
++    if ((ret = av_frame_copy_side_data(dst, src,
++        force_copy ? AV_FRAME_COPY_PROPS_FORCECOPY : 0)) < 0)
 +        return ret;
  
      ret = av_buffer_replace(&dst->opaque_ref, src->opaque_ref);


### PR DESCRIPTION
### Summary

`0020-add-new-frame-sidedata-func.patch` introduces a `frame_copy_props()` call with an operator-precedence bug:

```c
if (ret = av_frame_copy_side_data(dst, src,
    force_copy ? AV_FRAME_COPY_PROPS_FORCECOPY : 0) < 0)
    return ret;
```

In C, `<` has higher precedence than `=`, so this parses as:

```c
if (ret = (av_frame_copy_side_data(...) < 0))
```

`ret` is therefore assigned the **boolean** result of the comparison (`0` on success, `1` on failure), not the function's return value.

### Impact

`av_frame_copy_side_data()` returns `0` on success or a negative `AVERROR` on failure.

- On success: `ret = (0 < 0) = 0`, the `if` is false — happens to work.
- On failure: the helper returns e.g. `AVERROR(ENOMEM)`, but `ret = (AVERROR(ENOMEM) < 0) = 1`, the `if` is true and the function `return`s **`1`** — a bogus positive value instead of the real error code. Callers of `frame_copy_props()` / `av_frame_copy_props()` / `av_frame_ref()` that test `ret < 0` then **silently miss the failure** and propagate a wrong positive return.

### Fix

Add the missing parentheses so the return value is assigned first, then compared:

```c
if ((ret = av_frame_copy_side_data(dst, src,
    force_copy ? AV_FRAME_COPY_PROPS_FORCECOPY : 0)) < 0)
    return ret;
```

Found while porting this patch series to ffmpeg 6.1.

### Note

The `jellyfin-5.1` branch carries the same bug in `0021-add-new-frame-sidedata-func.patch`. Happy to open a matching PR against that branch if you'd like it fixed there too.
