### PR TITLE
fix(frame): correct operator precedence in av_frame_copy_side_data check (5.x)

### DIFF
--- a/debian/patches/0021-add-new-frame-sidedata-func.patch
+++ b/debian/patches/0021-add-new-frame-sidedata-func.patch
@@ -68,8 +68,8 @@ Index: jellyfin-ffmpeg/libavutil/frame.c
 -        }
 -        av_dict_copy(&sd_dst->metadata, sd_src->metadata, 0);
 -    }
-+    if (ret = av_frame_copy_side_data(dst, src,
-+        force_copy ? AV_FRAME_COPY_PROPS_FORCECOPY : 0) < 0)
++    if ((ret = av_frame_copy_side_data(dst, src,
++        force_copy ? AV_FRAME_COPY_PROPS_FORCECOPY : 0)) < 0)
 +        return ret;
  
      ret = av_buffer_replace(&dst->opaque_ref, src->opaque_ref);


### PR DESCRIPTION
## Same operator-precedence fix as #735, for the 5.x trunk

The maintainer approved carrying the #735 fix over to the 5.x branch.
This applies the identical one-character-per-line correction to
`0021-add-new-frame-sidedata-func.patch`.

The check in `av_frame_copy_side_data`:

```c
if (ret = av_frame_copy_side_data(dst, src, ...) < 0)
```

binds as `ret = (av_frame_copy_side_data(...) < 0)`, so `ret` receives the
boolean of the comparison (0/1) instead of the function's return value, and
the intended error path is never taken (the raw negative `AVERROR` is not
propagated). Parenthesised correctly:

```c
if ((ret = av_frame_copy_side_data(dst, src, ...)) < 0)
```

### Related
- #735 — same fix, `jellyfin-6.0` (merged)
- #736 — `jellyfin-6.1` port (closed; kept on the fork for reference)
- Sibling: the identical bug is also present on `jellyfin-4.4` (in
  `0032-add-async-support-for-qsv-vpp.patch`), fixed in #738.
  `jellyfin-7.1` and `jellyfin` (8.x) are unaffected — `av_frame_copy_side_data`
  is upstream there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
