### PR TITLE
fix(frame): correct operator precedence in av_frame_copy_side_data check (4.4)

### DIFF
--- a/debian/patches/0032-add-async-support-for-qsv-vpp.patch
+++ b/debian/patches/0032-add-async-support-for-qsv-vpp.patch
@@ -2720,8 +2720,8 @@ Index: jellyfin-ffmpeg/libavutil/frame.c
 -        }
 -        av_dict_copy(&sd_dst->metadata, sd_src->metadata, 0);
 -    }
-+    if (ret = av_frame_copy_side_data(dst, src,
-+        force_copy ? AV_FRAME_COPY_PROPS_FORCECOPY : 0) < 0)
++    if ((ret = av_frame_copy_side_data(dst, src,
++        force_copy ? AV_FRAME_COPY_PROPS_FORCECOPY : 0)) < 0)
 +        return ret;
  
  #if FF_API_FRAME_QP


### PR DESCRIPTION
## Same operator-precedence fix as #735, for the 4.4 trunk

While verifying the other 6.x branches for the #735 defect, the identical
bug turned up on `jellyfin-4.4` as well. Here `av_frame_copy_side_data` is
defined inside `0032-add-async-support-for-qsv-vpp.patch` (rather than a
dedicated patch), but the buggy check is the same:

```c
if (ret = av_frame_copy_side_data(dst, src, ...) < 0)
```

binds as `ret = (av_frame_copy_side_data(...) < 0)`, so `ret` receives the
boolean of the comparison (0/1) instead of the function's return value, and
the intended error path is never taken (the raw negative `AVERROR` is not
propagated). Fixed by parenthesising the assignment:

```c
if ((ret = av_frame_copy_side_data(dst, src, ...)) < 0)
```

### Related
- #735 — same fix, `jellyfin-6.0` (merged)
- #737 — same fix, `jellyfin-5.1` (companion PR)
- #736 — `jellyfin-6.1` port (closed; kept on the fork for reference)
- `jellyfin-7.1` and `jellyfin` (8.x) are unaffected — `av_frame_copy_side_data`
  is upstream there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
