### PR TITLE
Fix rotated HDR10 mastering-display primaries in nvenc HEVC

### DIFF
--- a/debian/patches/0032-add-hdr-metadata-for-nvenc-hevc-encoder.patch
+++ b/debian/patches/0032-add-hdr-metadata-for-nvenc-hevc-encoder.patch
@@ -23,7 +23,7 @@ Index: FFmpeg/libavcodec/nvenc.c
 +        if (sd) {
 +            AVMasteringDisplayMetadata *mdm = (AVMasteringDisplayMetadata *)sd->data;
 +            // HEVC uses a g,b,r ordering, which we convert from a more natural r,g,b
-+            const int mapping[3] = {2, 0, 1};
++            const int mapping[3] = {1, 2, 0};
 +            const int chroma_den = 50000;
 +            const int luma_den = 10000;
 +


### PR DESCRIPTION
Hello!

I ran into an issue with HDR10 movies: after encoding with hevc_nvenc, the picture came out washed-out / too bright.

I used AI to help me (I'm not an ffmpeg pro) and managed to diagnose that the mastering-display color primaries were getting rotated (red shifted to green, green shifted to blue, blue shifted to red).

I found that 0032-add-hdr-metadata-for-nvenc-hevc-encoder.patch uses {2, 0, 1} for the mapping, but HEVC stores the primaries in green, blue, red order. Since FFmpeg's display_primaries array is in RGB order (R=0, G=1, B=2), the mapping that produces G, B, R should be {1, 2, 0}, not {2, 0, 1} (the comment right above the line even says "HEVC uses a g,b,r ordering, which we convert from a more natural r,g,b").

After this change, it seems to fix the issue, but again, I'm not an ffmpeg pro, so I may be mistaken.

Thank you :)