### PR TITLE
Fix D3D11 Dolby Vision conversion on Qualcomm

### DIFF
--- a/debian/patches/0091-add-d3d11-deinterlace-filter.patch
+++ b/debian/patches/0091-add-d3d11-deinterlace-filter.patch
@@ -1192,7 +1192,7 @@ Index: FFmpeg/libavfilter/d3d11_filter.c
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/d3d11_filter.c
-@@ -0,0 +1,284 @@
+@@ -0,0 +1,285 @@
 +/*
 + * Common D3D11 filter helpers
 + *
@@ -1256,7 +1256,8 @@ Index: FFmpeg/libavfilter/d3d11_filter.c
 +    HRESULT hr;
 +
 +    hr = compile(source, strlen(source), NULL, macros, NULL, entry, target,
-+                 D3DCOMPILE_OPTIMIZATION_LEVEL3, 0, &cs_blob, &err_blob);
++                 D3DCOMPILE_OPTIMIZATION_LEVEL3 |
++                 D3DCOMPILE_IEEE_STRICTNESS, 0, &cs_blob, &err_blob);
 +    if (FAILED(hr)) {
 +        if (err_blob) {
 +            av_log(ctx, AV_LOG_ERROR, "Failed compiling %s shader %s: %.*s\n",
@@ -1481,7 +1482,7 @@ Index: FFmpeg/libavfilter/d3d11_filter.h
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/d3d11_filter.h
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,84 @@
 +/*
 + * Common D3D11 filter helpers
 + *
@@ -1511,6 +1512,9 @@ Index: FFmpeg/libavfilter/d3d11_filter.h
 +
 +#ifndef D3DCOMPILE_OPTIMIZATION_LEVEL3
 +#define D3DCOMPILE_OPTIMIZATION_LEVEL3 (1 << 15)
++#endif
++#ifndef D3DCOMPILE_IEEE_STRICTNESS
++#define D3DCOMPILE_IEEE_STRICTNESS (1 << 13)
 +#endif
 +
 +typedef HRESULT (WINAPI *FFD3DCompileProc)(LPCVOID, SIZE_T, LPCSTR,

--- a/debian/patches/0094-add-d3d11-tonemap-filter.patch
+++ b/debian/patches/0094-add-d3d11-tonemap-filter.patch
@@ -1171,7 +1171,7 @@ Index: FFmpeg/libavfilter/d3d11/tonemap.hlsl
 ===================================================================
 --- /dev/null
 +++ FFmpeg/libavfilter/d3d11/tonemap.hlsl
-@@ -0,0 +1,629 @@
+@@ -0,0 +1,626 @@
 +/*
 + * D3D11 tonemap
 + *
@@ -1628,15 +1628,13 @@ Index: FFmpeg/libavfilter/d3d11/tonemap.hlsl
 +    return mul(dovi_rgb_matrix, yuv) + dovi_ycc2rgb_offset;
 +}
 +
-+float3 dovi_lms2rgb(float3 c)
++float3 dovi_lms2linear_rgb(float3 c)
 +{
 +    c = float3(eotf_st2084_common(c.x),
 +               eotf_st2084_common(c.y),
 +               eotf_st2084_common(c.z));
-+    c = mul(dovi_lms2rgb_matrix, c);
-+    return float3(inverse_eotf_st2084_common(c.x),
-+                  inverse_eotf_st2084_common(c.y),
-+                  inverse_eotf_st2084_common(c.z));
++    c = max(mul(dovi_lms2rgb_matrix, c), float3(0.0, 0.0, 0.0));
++    return c * (ST2084_MAX_LUMINANCE / REFERENCE_WHITE_ALT);
 +}
 +
 +float dovi_poly(float s, float4 coeffs)
@@ -1693,7 +1691,7 @@ Index: FFmpeg/libavfilter/d3d11/tonemap.hlsl
 +    float s = clamp(sig[ch], 0.0, 1.0);
 +
 +    int ci = 0;
-+    if (num > 2) {
++    if (ch == 0 && num > 2) {
 +        [unroll] for (int i = 0; i < 7; i++)
 +            ci += s >= dovi_pivots[po + (i >> 2)][i & 3] ? 1 : 0;
 +    }
@@ -1722,8 +1720,7 @@ Index: FFmpeg/libavfilter/d3d11/tonemap.hlsl
 +    float3 c;
 +    if (APPLY_DOVI_VAL != 0) {
 +        c = dovi_ycc2rgb(yuv);
-+        c = dovi_lms2rgb(c);
-+        c = linearize(c);
++        c = dovi_lms2linear_rgb(c);
 +    } else {
 +        c = yuv2rgb(yuv.x, yuv.y, yuv.z);
 +        c = linearize(c);


### PR DESCRIPTION
<!--
Ensure your title is short, descriptive, and in the imperative mood (Fix X, Change Y, instead of Fixed X, Changed Y).
For a good inspiration of what to write in commit messages and PRs please review https://chris.beams.io/posts/git-commit/ and our https://docs.jellyfin.org/general/contributing/issues.html page.
-->

**Changes**
<!-- Describe your changes here in 1-5 sentences. -->

Qualcomm GPU's platform native `pow()` implementation might have some correctness bug which caused the round-trip of PQ linearization/delinerization for values close to epsilon might overflow/underflow that make a value should be very close to 0 becomes very large.

Fortunately this round trip can be skipped by fusing operations in our kernel and that is mathematically equivalent, and by removing this round trip X1 GPU no longer produces broken color.

**Issues**
<!-- Tag any issues that this PR solves here.
ex. Fixes # -->