### PR TITLE
Fix over release in yadif_videotoolbox filter

### DIFF
--- a/debian/patches/0056-add-bwdif-videotoolbox-filter.patch
+++ b/debian/patches/0056-add-bwdif-videotoolbox-filter.patch
@@ -804,7 +804,17 @@ Index: FFmpeg/libavfilter/vf_yadif_videotoolbox.m
 ===================================================================
 --- FFmpeg.orig/libavfilter/vf_yadif_videotoolbox.m
 +++ FFmpeg/libavfilter/vf_yadif_videotoolbox.m
-@@ -436,7 +436,8 @@ const FFFilter ff_vf_yadif_videotoolbox
+@@ -95,9 +95,6 @@ static void call_kernel(AVFilterContext
+ 
+     [buffer commit];
+     [buffer waitUntilCompleted];
+-
+-    ff_objc_release(&encoder);
+-    ff_objc_release(&buffer);
+ }
+ 
+ static void filter(AVFilterContext *ctx, AVFrame *dst,
+@@ -436,7 +433,8 @@ const FFFilter ff_vf_yadif_videotoolbox
      .p.name         = "yadif_videotoolbox",
      .p.description  = NULL_IF_CONFIG_SMALL("YADIF for VideoToolbox frames using Metal compute"),
      .p.priv_class   = &yadif_videotoolbox_class,

--- a/debian/patches/0078-backport-fixes-for-vulkan-from-upstream.patch
+++ b/debian/patches/0078-backport-fixes-for-vulkan-from-upstream.patch
@@ -152,6 +152,79 @@ Index: FFmpeg/libavcodec/vulkan_encode_av1.c
 ===================================================================
 --- FFmpeg.orig/libavcodec/vulkan_encode_av1.c
 +++ FFmpeg/libavcodec/vulkan_encode_av1.c
+@@ -593,7 +593,6 @@ static int init_profile(AVCodecContext *
+     FFVulkanEncodeContext *ctx = &enc->common;
+     FFVulkanContext *s = &ctx->s;
+     FFVulkanFunctions *vk = &ctx->s.vkfn;
+-    FFHWBaseEncodeContext *base_ctx = &ctx->base;
+ 
+     VkVideoEncodeAV1CapabilitiesKHR av1_caps = {
+         .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_CAPABILITIES_KHR,
+@@ -631,31 +630,6 @@ static int init_profile(AVCodecContext *
+     };
+     profile->pNext = &enc->profile;
+ 
+-    /* Set level */
+-    if (avctx->level == AV_LEVEL_UNKNOWN) {
+-        const AV1LevelDescriptor *level;
+-        float framerate = 0.0;
+-
+-        if (avctx->framerate.num > 0 && avctx->framerate.den > 0)
+-            framerate = av_q2d(avctx->framerate);
+-
+-        level = ff_av1_guess_level(avctx->bit_rate, enc->seq_tier,
+-                                   base_ctx->surface_width, base_ctx->surface_height,
+-                                   enc->tile_rows * enc->tile_cols,
+-                                   enc->tile_cols, framerate);
+-        if (level) {
+-            av_log(avctx, AV_LOG_VERBOSE, "Using level %s.\n", level->name);
+-            enc->seq_level_idx = level->level_idx;
+-        } else {
+-            av_log(avctx, AV_LOG_VERBOSE, "Stream will not conform to "
+-                   "any normal level, using level 7.3 by default.\n");
+-            enc->seq_level_idx = STD_VIDEO_AV1_LEVEL_7_3;
+-            enc->seq_tier = 1;
+-        }
+-    } else {
+-        enc->seq_level_idx = ff_vk_av1_level_to_vk(avctx->level);
+-    }
+-
+     /* User has explicitly specified a profile. */
+     if (avctx->profile != AV_PROFILE_UNKNOWN)
+         return 0;
+@@ -750,6 +724,32 @@ static av_cold int init_sequence_headers
+     if (!desc)
+         return AVERROR(EINVAL);
+ 
++    enc->seq_tier = enc->common.opts.tier;
++
++    if (avctx->level == AV_LEVEL_UNKNOWN) {
++        const AV1LevelDescriptor *level;
++        float framerate = 0.0;
++
++        if (avctx->framerate.num > 0 && avctx->framerate.den > 0)
++            framerate = av_q2d(avctx->framerate);
++
++        level = ff_av1_guess_level(avctx->bit_rate, enc->seq_tier,
++                                   base_ctx->surface_width, base_ctx->surface_height,
++                                   enc->tile_rows * enc->tile_cols,
++                                   enc->tile_cols, framerate);
++        if (level) {
++            av_log(avctx, AV_LOG_VERBOSE, "Using level %s.\n", level->name);
++            enc->seq_level_idx = level->level_idx;
++        } else {
++            av_log(avctx, AV_LOG_VERBOSE, "Stream will not conform to "
++                   "any normal level, using level 7.3 by default.\n");
++            enc->seq_level_idx = STD_VIDEO_AV1_LEVEL_7_3;
++            enc->seq_tier = 1;
++        }
++    } else {
++        enc->seq_level_idx = avctx->level;
++    }
++
+     seq_obu->header.obu_type = AV1_OBU_SEQUENCE_HEADER;
+     *seq = (AV1RawSequenceHeader) {
+         .seq_profile = avctx->profile,
 @@ -1023,7 +1023,7 @@ static int init_base_units(AVCodecContex
      } else {
          av_log(avctx, AV_LOG_ERROR, "Unable to get feedback for AV1 sequence header = %zu\n",
@@ -198,7 +271,16 @@ Index: FFmpeg/libavcodec/vulkan_encode_av1.c
  }
  
  static int vulkan_encode_av1_add_obu(AVCodecContext *avctx,
-@@ -1359,6 +1361,10 @@ static av_cold int vulkan_encode_av1_ini
+@@ -1229,6 +1231,8 @@ static av_cold int vulkan_encode_av1_ini
+ 
+     if (avctx->profile == AV_PROFILE_UNKNOWN)
+         avctx->profile = enc->common.opts.profile;
++    if (avctx->level == AV_LEVEL_UNKNOWN)
++        avctx->level = enc->common.opts.level;
+ 
+     enc->caps = (VkVideoEncodeAV1CapabilitiesKHR) {
+         .sType = VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_CAPABILITIES_KHR,
+@@ -1359,6 +1363,10 @@ static av_cold int vulkan_encode_av1_ini
  static av_cold int vulkan_encode_av1_close(AVCodecContext *avctx)
  {
      VulkanEncodeAV1Context *enc = avctx->priv_data;

--- a/debian/rules
+++ b/debian/rules
@@ -52,6 +52,7 @@ CONFIG := --prefix=${TARGET_DIR} \
 	--enable-libshaderc \
 	--enable-libplacebo \
 	--enable-vulkan \
+	--enable-vulkan-static \
 	--enable-vaapi \
 	--enable-ffnvcodec \
 	--enable-cuda \


### PR DESCRIPTION
**Changes**
- Fix over release in yadif_videotoolbox filter
- Update more backported vulkan fixes from upstream
- Enable vulkan-static for DEB builds

**Issues**
- https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/23850