### PR TITLE
Drop support for EOL Debian Bullseye (old old stable)

### DIFF
--- a/.github/workflows/_meta.yaml
+++ b/.github/workflows/_meta.yaml
@@ -8,7 +8,7 @@ on:
       codenames:
         description: 'Stringified JSON object listing target distro codenames'
         required: true
-        default: '["bullseye"]'
+        default: '["trixie"]'
         type: string
       architectures:
         description: 'Stringified JSON object listing target architectures'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'debian'
-      codenames: '["bullseye", "bookworm", "trixie"]'
+      codenames: '["bookworm", "trixie"]'
       architectures: '["amd64", "arm64"]'
       release: false
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/_meta.yaml
     with:
       distro: 'debian'
-      codenames: '["bullseye", "bookworm", "trixie"]'
+      codenames: '["bookworm", "trixie"]'
       architectures: '["amd64", "arm64"]'
       release: true
     secrets:
@@ -83,7 +83,6 @@ jobs:
       max-parallel: 1
       matrix:
         arrays: [
-          {distro: 'debian', codename: 'bullseye'},
           {distro: 'debian', codename: 'bookworm'},
           {distro: 'debian', codename: 'trixie'},
           {distro: 'ubuntu', codename: 'jammy'},

--- a/build
+++ b/build
@@ -4,9 +4,8 @@ usage() {
     echo -e "Build Jellyfin FFMPEG deb packages"
     echo -e " $0 <release> <arch>"
     echo -e "Releases:          Arches:"
-    echo -e " * bullseye         * amd64"
-    echo -e " * bookworm         * arm64"
-    echo -e " * trixie"
+    echo -e " * bookworm         * amd64"
+    echo -e " * trixie           * arm64"
     echo -e " * jammy"
     echo -e " * noble"
     echo -e " * resolute"
@@ -19,12 +18,6 @@ fi
 
 cli_release="${1}"
 case ${cli_release} in
-    'bullseye')
-        release="debian:bullseye"
-        gcc_ver="10"
-        llvm_ver="16"
-        llvmspirvlib_ver="11"
-    ;;
     'bookworm')
         release="debian:bookworm"
         gcc_ver="12"

--- a/build.yaml
+++ b/build.yaml
@@ -3,8 +3,6 @@
 name: "jellyfin-ffmpeg"
 version: "8.1.2-4"
 packages:
-  - bullseye-amd64
-  - bullseye-arm64
   - bookworm-amd64
   - bookworm-arm64
   - trixie-amd64

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 jellyfin-ffmpeg (8.1.2-4) unstable; urgency=medium
 
   * Fix AMD hevc_vaapi encoder extradata with overrides
+  * Drop support for EOL Debian Bullseye (old old stable)
 
  -- nyanmisaka <nst799610810@gmail.com>  Thu, 3 Sep 2026 12:38:02 +0800
 


### PR DESCRIPTION
The dependencies required to build it are no longer available.

**Changes**
- Drop support for EOL Debian Bullseye (old old stable)