### PR TITLE
Bump version to 8.1.2-5

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 # We just wrap `build` so this is really it
 name: "jellyfin-ffmpeg"
-version: "8.1.2-4"
+version: "8.1.2-5"
 packages:
   - bookworm-amd64
   - bookworm-arm64

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+jellyfin-ffmpeg (8.1.2-5) unstable; urgency=medium
+
+  * Make HDR10+ removal more precise
+  * Sync some fixes for ac4dec
+  * Fix QSV AV1 decoder exporting HDR side data
+
+ -- nyanmisaka <nst799610810@gmail.com>  Wed, 9 Sep 2026 17:31:57 +0800
+
 jellyfin-ffmpeg (8.1.2-4) unstable; urgency=medium
 
   * Fix AMD hevc_vaapi encoder extradata with overrides

--- a/debian/patches/0042-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
+++ b/debian/patches/0042-add-full-hwa-pipeline-for-rockchip-rk3588-platform.patch
@@ -266,7 +266,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
   *
   * This file is part of FFmpeg.
   *
-@@ -19,564 +20,1487 @@
+@@ -19,564 +20,1494 @@
   * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
   */
  
@@ -566,7 +566,8 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    RK_S64 paramS64;
 -    RK_S32 paramS32;
 +    RKMPPDecContext *r = avctx->priv_data;
-+
+ 
+-    avctx->pix_fmt = AV_PIX_FMT_DRM_PRIME;
 +    r->last_pts = AV_NOPTS_VALUE;
 +    r->eof = 0;
 +    r->draining = 0;
@@ -585,7 +586,12 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    }
 +#endif
  
--    avctx->pix_fmt = AV_PIX_FMT_DRM_PRIME;
+-    // create a decoder and a ref to it
+-    decoder = av_refstruct_alloc_ext(sizeof(*decoder), 0,
+-                                     NULL, rkmpp_release_decoder);
+-    if (!decoder) {
+-        ret = AVERROR(ENOMEM);
+-        goto fail;
 +    if (r->mapi) {
 +        r->mapi->reset(r->mctx);
 +        mpp_destroy(r->mctx);
@@ -605,13 +611,7 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        av_buffer_unref(&r->hwframe);
 +    if (r->hwdevice)
 +        av_buffer_unref(&r->hwdevice);
- 
--    // create a decoder and a ref to it
--    decoder = av_refstruct_alloc_ext(sizeof(*decoder), 0,
--                                     NULL, rkmpp_release_decoder);
--    if (!decoder) {
--        ret = AVERROR(ENOMEM);
--        goto fail;
++
 +    return 0;
 +}
 +
@@ -990,17 +990,70 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -static int rkmpp_send_packet(AVCodecContext *avctx, const AVPacket *avpkt)
 +static int rkmpp_export_mastering_display(AVCodecContext *avctx, AVFrame *frame,
 +                                          MppFrameMasteringDisplayMetadata mpp_mastering)
++{
++    AVMasteringDisplayMetadata *mastering = NULL;
++    static const MppFrameMasteringDisplayMetadata zero_meta = { 0 };
++    int mapping[3] = { 0, 1, 2 };
++    int chroma_den;
++    int max_luma_den;
++    int min_luma_den;
++    int ret;
++
++    if (!memcmp(&mpp_mastering, &zero_meta, sizeof(zero_meta)))
++        return 0;
++
++    switch (avctx->codec_id) {
++    case AV_CODEC_ID_HEVC:
++        // HEVC uses a g,b,r ordering, which we convert to a more natural r,g,b
++        mapping[0] = 2;
++        mapping[1] = 0;
++        mapping[2] = 1;
++        chroma_den = 50000;
++        max_luma_den = 10000;
++        min_luma_den = 10000;
++        break;
++    case AV_CODEC_ID_AV1:
++        chroma_den = 1 << 16;
++        max_luma_den = 1 << 8;
++        min_luma_den = 1 << 14;
++        break;
++    default:
++        return 0;
++    }
++
++    ret = ff_decode_mastering_display_new(avctx, frame, &mastering);
++    if (ret < 0)
++        return ret;
++
++    if (mastering) {
++        for (int i = 0; i < 3; i++) {
++            const int j = mapping[i];
++            mastering->display_primaries[i][0] =
++                av_make_q(mpp_mastering.display_primaries[j][0], chroma_den);
++            mastering->display_primaries[i][1] =
++                av_make_q(mpp_mastering.display_primaries[j][1], chroma_den);
++        }
++        mastering->white_point[0] = av_make_q(mpp_mastering.white_point[0], chroma_den);
++        mastering->white_point[1] = av_make_q(mpp_mastering.white_point[1], chroma_den);
++
++        mastering->max_luminance = av_make_q(mpp_mastering.max_luminance, max_luma_den);
++        mastering->min_luminance = av_make_q(mpp_mastering.min_luminance, min_luma_den);
++
++        mastering->has_luminance = 1;
++        mastering->has_primaries = 1;
++    }
++
++    return 0;
++}
++
++static int rkmpp_export_content_light(AVCodecContext *avctx, AVFrame *frame,
++                                      MppFrameContentLightMetadata mpp_light)
  {
 -    RKMPPDecodeContext *rk_context = avctx->priv_data;
 -    RKMPPDecoder *decoder = rk_context->decoder;
--    int ret;
-+    AVMasteringDisplayMetadata *mastering = NULL;
-+    AVFrameSideData *sd = NULL;
-+    int mapping[3] = { 0, 1, 2 };
-+    int chroma_den = 0;
-+    int max_luma_den = 0;
-+    int min_luma_den = 0;
-+    int i;
++    AVContentLightMetadata *light = NULL;
++    static const MppFrameContentLightMetadata zero_meta = { 0 };
+     int ret;
  
 -    // handle EOF
 -    if (!avpkt->size) {
@@ -1009,41 +1062,17 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -        ret = rkmpp_write_data(avctx, NULL, 0, 0);
 -        if (ret)
 -            av_log(avctx, AV_LOG_ERROR, "Failed to send EOS to decoder (code = %d)\n", ret);
--        return ret;
-+    switch (avctx->codec_id) {
-+        case AV_CODEC_ID_HEVC:
-+            // HEVC uses a g,b,r ordering, which we convert to a more natural r,g,b
-+            mapping[0] = 2;
-+            mapping[1] = 0;
-+            mapping[2] = 1;
-+            chroma_den = 50000;
-+            max_luma_den = 10000;
-+            min_luma_den = 10000;
-+            break;
-+        case AV_CODEC_ID_AV1:
-+            chroma_den = 1 << 16;
-+            max_luma_den = 1 << 8;
-+            min_luma_den = 1 << 14;
-+            break;
-+        default:
-+            return 0;
-+    }
++    if (!memcmp(&mpp_light, &zero_meta, sizeof(zero_meta)))
++        return 0;
 +
-+    sd = av_frame_get_side_data(frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
-+    if (sd)
-+        mastering = (AVMasteringDisplayMetadata *)sd->data;
-+    else
-+        mastering = av_mastering_display_metadata_create_side_data(frame);
-+    if (!mastering)
-+        return AVERROR(ENOMEM);
++    ret = ff_decode_content_light_new(avctx, frame, &light);
++    if (ret < 0)
+         return ret;
 +
-+    for (i = 0; i < 3; i++) {
-+        const int j = mapping[i];
-+        mastering->display_primaries[i][0] = av_make_q(mpp_mastering.display_primaries[j][0], chroma_den);
-+        mastering->display_primaries[i][1] = av_make_q(mpp_mastering.display_primaries[j][1], chroma_den);
++    if (light) {
++        light->MaxCLL  = mpp_light.MaxCLL;
++        light->MaxFALL = mpp_light.MaxFALL;
      }
-+    mastering->white_point[0] = av_make_q(mpp_mastering.white_point[0], chroma_den);
-+    mastering->white_point[1] = av_make_q(mpp_mastering.white_point[1], chroma_den);
  
 -    // on first packet, send extradata
 -    if (decoder->first_packet) {
@@ -1065,66 +1094,35 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -    ret = rkmpp_write_data(avctx, avpkt->data, avpkt->size, avpkt->pts);
 -    if (ret && ret!=AVERROR(EAGAIN))
 -        av_log(avctx, AV_LOG_ERROR, "Failed to write data to decoder (code = %d)\n", ret);
-+    mastering->max_luminance = av_make_q(mpp_mastering.max_luminance, max_luma_den);
-+    mastering->min_luminance = av_make_q(mpp_mastering.min_luminance, min_luma_den);
++    return 0;
++}
  
 -    return ret;
-+    mastering->has_luminance = 1;
-+    mastering->has_primaries = 1;
-+
-+    return 0;
++static void rkmpp_free_mpp_frame(void *opaque, uint8_t *data)
++{
++    MppFrame mpp_frame = (MppFrame)opaque;
++    mpp_frame_deinit(&mpp_frame);
  }
  
 -static void rkmpp_release_frame(void *opaque, uint8_t *data)
-+static int rkmpp_export_content_light(AVFrame *frame,
-+                                      MppFrameContentLightMetadata mpp_light)
++static void rkmpp_free_drm_desc(void *opaque, uint8_t *data)
  {
 -    AVDRMFrameDescriptor *desc = (AVDRMFrameDescriptor *)data;
 -    RKMPPFrameContext *framecontext = opaque;
-+    AVContentLightMetadata *light = NULL;
- 
--    mpp_frame_deinit(&framecontext->frame);
--    av_refstruct_unref(&framecontext->decoder_ref);
-+    AVFrameSideData *sd = av_frame_get_side_data(frame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
-+    if (sd)
-+        light = (AVContentLightMetadata *)sd->data;
-+    else
-+        light = av_content_light_metadata_create_side_data(frame);
-+    if (!light)
-+        return AVERROR(ENOMEM);
- 
--    av_free(desc);
-+    light->MaxCLL  = mpp_light.MaxCLL;
-+    light->MaxFALL = mpp_light.MaxFALL;
-+
-+    return 0;
- }
- 
--static int rkmpp_retrieve_frame(AVCodecContext *avctx, AVFrame *frame)
-+static void rkmpp_free_mpp_frame(void *opaque, uint8_t *data)
- {
--    RKMPPDecodeContext *rk_context = avctx->priv_data;
--    RKMPPDecoder *decoder = rk_context->decoder;
--    int ret;
--    MppFrame mppframe = NULL;
--    MppBuffer buffer = NULL;
-+    MppFrame mpp_frame = (MppFrame)opaque;
-+    mpp_frame_deinit(&mpp_frame);
-+}
-+
-+static void rkmpp_free_drm_desc(void *opaque, uint8_t *data)
-+{
 +    AVRKMPPDRMFrameDescriptor *drm_desc = (AVRKMPPDRMFrameDescriptor *)opaque;
 +    av_free(drm_desc);
 +}
-+
+ 
+-    mpp_frame_deinit(&framecontext->frame);
+-    av_refstruct_unref(&framecontext->decoder_ref);
 +static int frame_create_buf(AVFrame *frame,
 +                            uint8_t* data, int size,
 +                            void (*free)(void *opaque, uint8_t *data),
 +                            void *opaque, int flags)
 +{
 +    int i;
-+
+ 
+-    av_free(desc);
 +    for (i = 0; i < AV_NUM_DATA_POINTERS; i++) {
 +        if (!frame->buf[i]) {
 +            frame->buf[i] = av_buffer_create(data, size, free, opaque, flags);
@@ -1132,10 +1130,16 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        }
 +    }
 +    return AVERROR(EINVAL);
-+}
-+
+ }
+ 
+-static int rkmpp_retrieve_frame(AVCodecContext *avctx, AVFrame *frame)
 +static int rkmpp_export_frame(AVCodecContext *avctx, AVFrame *frame, MppFrame mpp_frame)
-+{
+ {
+-    RKMPPDecodeContext *rk_context = avctx->priv_data;
+-    RKMPPDecoder *decoder = rk_context->decoder;
+-    int ret;
+-    MppFrame mppframe = NULL;
+-    MppBuffer buffer = NULL;
 +    RKMPPDecContext *r = avctx->priv_data;
 +    AVRKMPPDRMFrameDescriptor *desc = NULL;
      AVDRMLayerDescriptor *layer = NULL;
@@ -1218,33 +1222,33 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +    if ((ret = frame_create_buf(frame, (uint8_t *)desc, sizeof(*desc),
 +                                rkmpp_free_drm_desc, desc, AV_BUFFER_FLAG_READONLY)) < 0)
 +        return ret;
++
++    frame->data[0] = (uint8_t *)desc;
  
 -            av_log(avctx, AV_LOG_INFO, "Decoder noticed an info change (%dx%d), format=%d\n",
 -                                        (int)mpp_frame_get_width(mppframe), (int)mpp_frame_get_height(mppframe),
 -                                        (int)mpp_frame_get_fmt(mppframe));
-+    frame->data[0] = (uint8_t *)desc;
- 
--            avctx->width = mpp_frame_get_width(mppframe);
--            avctx->height = mpp_frame_get_height(mppframe);
 +    frame->hw_frames_ctx = av_buffer_ref(r->hwframe);
 +    if (!frame->hw_frames_ctx)
 +        return AVERROR(ENOMEM);
  
--            decoder->mpi->control(decoder->ctx, MPP_DEC_SET_INFO_CHANGE_READY, NULL);
+-            avctx->width = mpp_frame_get_width(mppframe);
+-            avctx->height = mpp_frame_get_height(mppframe);
 +    if ((ret = ff_decode_frame_props(avctx, frame)) < 0)
 +        return ret;
  
--            av_buffer_unref(&decoder->frames_ref);
+-            decoder->mpi->control(decoder->ctx, MPP_DEC_SET_INFO_CHANGE_READY, NULL);
 +    frame->width  = avctx->width;
 +    frame->height = avctx->height;
+ 
+-            av_buffer_unref(&decoder->frames_ref);
++    mpp_frame_pts = mpp_frame_get_pts(mpp_frame);
++    frame->pts    = MPP_PTS_TO_PTS(mpp_frame_pts, avctx->pkt_timebase);
  
 -            decoder->frames_ref = av_hwframe_ctx_alloc(decoder->device_ref);
 -            if (!decoder->frames_ref) {
 -                ret = AVERROR(ENOMEM);
 -                goto fail;
-+    mpp_frame_pts = mpp_frame_get_pts(mpp_frame);
-+    frame->pts    = MPP_PTS_TO_PTS(mpp_frame_pts, avctx->pkt_timebase);
-+
 +    mpp_frame_mode = mpp_frame_get_mode(mpp_frame);
 +    if ((mpp_frame_mode & MPP_FRAME_FLAG_FIELD_ORDER_MASK) == MPP_FRAME_FLAG_DEINTERLACED)
 +        frame->flags |= AV_FRAME_FLAG_INTERLACED;
@@ -1258,13 +1262,14 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +                                              (AVRational) { frame->width, frame->height });
 +    }
 +
-+    if (avctx->codec_id == AV_CODEC_ID_HEVC &&
++    if ((avctx->codec_id == AV_CODEC_ID_HEVC ||
++         avctx->codec_id == AV_CODEC_ID_AV1) &&
 +        (frame->color_trc == AVCOL_TRC_SMPTE2084 ||
 +         frame->color_trc == AVCOL_TRC_ARIB_STD_B67)) {
 +        ret = rkmpp_export_mastering_display(avctx, frame, mpp_frame_get_mastering_display(mpp_frame));
 +        if (ret < 0)
 +            return ret;
-+        ret = rkmpp_export_content_light(frame, mpp_frame_get_content_light(mpp_frame));
++        ret = rkmpp_export_content_light(avctx, frame, mpp_frame_get_content_light(mpp_frame));
 +        if (ret < 0)
 +            return ret;
 +    }
@@ -1291,15 +1296,11 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        clear_unused_sd_frames(r->sd_frame_list, r->last_pts_dovi, mpp_frame_pts); /* display order */
 +    }
 +#endif
-+
-+    return 0;
-+}
  
 -            mppformat = mpp_frame_get_fmt(mppframe);
 -            drmformat = rkmpp_get_frameformat(mppformat);
-+static void rkmpp_export_avctx_color_props(AVCodecContext *avctx, MppFrame mpp_frame)
-+{
-+    int val;
++    return 0;
++}
  
 -            hwframes = (AVHWFramesContext*)decoder->frames_ref->data;
 -            hwframes->format    = AV_PIX_FMT_DRM_PRIME;
@@ -1309,8 +1310,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -            ret = av_hwframe_ctx_init(decoder->frames_ref);
 -            if (ret < 0)
 -                goto fail;
-+    if (!avctx || !mpp_frame)
-+        return;
++static void rkmpp_export_avctx_color_props(AVCodecContext *avctx, MppFrame mpp_frame)
++{
++    int val;
  
 -            // here decoder is fully initialized, we need to feed it again with data
 -            ret = AVERROR(EAGAIN);
@@ -1318,6 +1320,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -        } else if (mpp_frame_get_eos(mppframe)) {
 -            av_log(avctx, AV_LOG_DEBUG, "Received a EOS frame.\n");
 -            decoder->eos_reached = 1;
++    if (!avctx || !mpp_frame)
++        return;
++
 +    if (avctx->color_primaries == AVCOL_PRI_RESERVED0)
 +        avctx->color_primaries = AVCOL_PRI_UNSPECIFIED;
 +    if ((val = mpp_frame_get_color_primaries(mpp_frame)) &&
@@ -1573,17 +1578,17 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +            ret = AVERROR_EXTERNAL;
 +            goto exit;
 +        }
- 
--            frame->hw_frames_ctx = av_buffer_ref(decoder->frames_ref);
--            if (!frame->hw_frames_ctx) {
--                av_frame_unref(frame);
--                return AVERROR(ENOMEM);
++
 +        if ((ret = r->mapi->control(r->mctx, MPP_DEC_SET_INFO_CHANGE_READY, NULL)) != MPP_OK) {
 +            av_log(avctx, AV_LOG_ERROR, "Failed to set info change ready: %d\n", ret);
 +            ret = AVERROR_EXTERNAL;
 +            goto exit;
 +        }
-+
+ 
+-            frame->hw_frames_ctx = av_buffer_ref(decoder->frames_ref);
+-            if (!frame->hw_frames_ctx) {
+-                av_frame_unref(frame);
+-                return AVERROR(ENOMEM);
 +        /* there's no real info change, export the frame directly */
 +        if (avctx->codec_id == AV_CODEC_ID_MJPEG)
 +            goto export;
@@ -1742,9 +1747,9 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        av_log(avctx, AV_LOG_TRACE, "Failed to put packet: %d\n", ret);
 +        goto fail;
 +    }
-+
-+    return MPP_OK;
  
++    return MPP_OK;
++
 +fail:
 +    if (mpp_frame)
 +        mpp_frame_deinit(&mpp_frame);
@@ -1813,9 +1818,17 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 +        if ((ret = mpp_buffer_get(r->buf_group_misc, &mpp_buf, pkt->size)) != MPP_OK) {
 +            av_log(avctx, AV_LOG_ERROR, "Failed to get buffer for packet: %d\n", ret);
 +            return AVERROR_EXTERNAL;
-         }
++        }
 +        if (!mpp_buf)
 +            return AVERROR(ENOMEM);
++
++        if ((ret = mpp_buffer_write(mpp_buf, 0, pkt->data, pkt->size)) != MPP_OK) {
++            av_log(avctx, AV_LOG_ERROR, "Failed to write buffer: %d\n", ret);
++            mpp_buffer_put(mpp_buf);
++            return AVERROR_EXTERNAL;
+         }
++        if ((ret = mpp_buffer_sync_partial_end(mpp_buf, 0, pkt->size)) != MPP_OK)
++            av_log(avctx, AV_LOG_DEBUG, "Failed to sync buffer write: %d\n", ret);
  
 -        freeslots = INPUT_MAX_PACKETS - usedslots;
 -        if (freeslots > 0) {
@@ -1825,14 +1838,6 @@ Index: FFmpeg/libavcodec/rkmppdec.c
 -                ret = ff_decode_get_packet(avctx, pkt);
 -                if (ret < 0 && ret != AVERROR_EOF) {
 -                    return ret;
-+        if ((ret = mpp_buffer_write(mpp_buf, 0, pkt->data, pkt->size)) != MPP_OK) {
-+            av_log(avctx, AV_LOG_ERROR, "Failed to write buffer: %d\n", ret);
-+            mpp_buffer_put(mpp_buf);
-+            return AVERROR_EXTERNAL;
-+        }
-+        if ((ret = mpp_buffer_sync_partial_end(mpp_buf, 0, pkt->size)) != MPP_OK)
-+            av_log(avctx, AV_LOG_DEBUG, "Failed to sync buffer write: %d\n", ret);
-+
 +        if ((ret = mpp_packet_init_with_buffer(&mpp_pkt, mpp_buf)) != MPP_OK) {
 +            av_log(avctx, AV_LOG_ERROR, "Failed to init packet with buffer: %d\n", ret);
 +            mpp_buffer_put(mpp_buf);

--- a/debian/patches/0054-add-ac4-decoder-for-atsc-3-0.patch
+++ b/debian/patches/0054-add-ac4-decoder-for-atsc-3-0.patch
@@ -921,7 +921,7 @@ Index: FFmpeg/libavcodec/ac4dec.c
 +        for (int i = 0; i < 5; i++) {
 +            int N_w = transf_lengths[i];
 +            float alpha = kbd_window_alpha[j][i];
-+            float scale = 1.f / N_w;
++            float scale = -1.f / N_w;
 +
 +            if ((ret = av_tx_init(&s->tx_ctx[j][i], &s->tx_fn[j][i],
 +                                  AV_TX_FLOAT_MDCT, 1, N_w, &scale, AV_TX_FULL_IMDCT)))
@@ -8212,7 +8212,7 @@ Index: FFmpeg/libavcodec/ac4dec_data.h
 +    0x031e10,
 +};
 +
-+DECLARE_ASM_CONST(16, float, qwin)[640] = {
++DECLARE_ASM_CONST(32, float, qwin)[640] = {
 +    0,
 +    1.990318758627504e-004,  2.494762615491542e-004,  3.021769445225078e-004,
 +    3.548460080857985e-004,  4.058915811480806e-004,  4.546408052001889e-004,

--- a/debian/patches/0099-fix-qsv-av1-decoder-exporting-hdr-side-data.patch
+++ b/debian/patches/0099-fix-qsv-av1-decoder-exporting-hdr-side-data.patch
@@ -1,0 +1,132 @@
+Index: FFmpeg/libavcodec/qsvdec.c
+===================================================================
+--- FFmpeg.orig/libavcodec/qsvdec.c
++++ FFmpeg/libavcodec/qsvdec.c
+@@ -707,18 +707,36 @@ static int qsv_export_hdr_side_data(AVCo
+ 
+     // The SDK reuses this flag for HDR SEI parsing
+     if (mdcv->InsertPayloadToggle) {
+-        AVMasteringDisplayMetadata *mastering;
+-        const int mapping[3] = {2, 0, 1};
+-        const int chroma_den = 50000;
+-        const int luma_den = 10000;
+-        int i;
++        AVMasteringDisplayMetadata *mastering = NULL;
++        int mapping[3] = { 0, 1, 2 };
++        int chroma_den;
++        int max_luma_den;
++        int min_luma_den;
++
++        switch (avctx->codec_id) {
++        case AV_CODEC_ID_HEVC:
++            mapping[0] = 2;
++            mapping[1] = 0;
++            mapping[2] = 1;
++            chroma_den = 50000;
++            max_luma_den = 10000;
++            min_luma_den = 10000;
++            break;
++        case AV_CODEC_ID_AV1:
++            chroma_den = 1 << 16;
++            max_luma_den = 1 << 8;
++            min_luma_den = 1 << 14;
++            break;
++        default:
++            return AVERROR(ENOSYS);
++        }
+ 
+         ret = ff_decode_mastering_display_new(avctx, frame, &mastering);
+         if (ret < 0)
+             return ret;
+ 
+         if (mastering) {
+-            for (i = 0; i < 3; i++) {
++            for (int i = 0; i < 3; i++) {
+                 const int j = mapping[i];
+                 mastering->display_primaries[i][0] = av_make_q(mdcv->DisplayPrimariesX[j], chroma_den);
+                 mastering->display_primaries[i][1] = av_make_q(mdcv->DisplayPrimariesY[j], chroma_den);
+@@ -727,8 +745,8 @@ static int qsv_export_hdr_side_data(AVCo
+             mastering->white_point[0] = av_make_q(mdcv->WhitePointX, chroma_den);
+             mastering->white_point[1] = av_make_q(mdcv->WhitePointY, chroma_den);
+ 
+-            mastering->max_luminance = av_make_q(mdcv->MaxDisplayMasteringLuminance, luma_den);
+-            mastering->min_luminance = av_make_q(mdcv->MinDisplayMasteringLuminance, luma_den);
++            mastering->max_luminance = av_make_q(mdcv->MaxDisplayMasteringLuminance, max_luma_den);
++            mastering->min_luminance = av_make_q(mdcv->MinDisplayMasteringLuminance, min_luma_den);
+ 
+             mastering->has_luminance = 1;
+             mastering->has_primaries = 1;
+@@ -737,7 +755,7 @@ static int qsv_export_hdr_side_data(AVCo
+ 
+     // The SDK reuses this flag for HDR SEI parsing
+     if (clli->InsertPayloadToggle) {
+-        AVContentLightMetadata *light;
++        AVContentLightMetadata *light = NULL;
+ 
+         ret = ff_decode_content_light_new(avctx, frame, &light);
+         if (ret < 0)
+@@ -751,46 +769,6 @@ static int qsv_export_hdr_side_data(AVCo
+ 
+     return 0;
+ }
+-
+-static int qsv_export_hdr_side_data_av1(AVCodecContext *avctx, mfxExtMasteringDisplayColourVolume *mdcv,
+-                                        mfxExtContentLightLevelInfo *clli, AVFrame *frame)
+-{
+-    if (mdcv->InsertPayloadToggle) {
+-        AVMasteringDisplayMetadata *mastering = av_mastering_display_metadata_create_side_data(frame);
+-        const int chroma_den   = 1 << 16;
+-        const int max_luma_den = 1 << 8;
+-        const int min_luma_den = 1 << 14;
+-
+-        if (!mastering)
+-            return AVERROR(ENOMEM);
+-
+-        for (int i = 0; i < 3; i++) {
+-            mastering->display_primaries[i][0] = av_make_q(mdcv->DisplayPrimariesX[i], chroma_den);
+-            mastering->display_primaries[i][1] = av_make_q(mdcv->DisplayPrimariesY[i], chroma_den);
+-        }
+-
+-        mastering->white_point[0] = av_make_q(mdcv->WhitePointX, chroma_den);
+-        mastering->white_point[1] = av_make_q(mdcv->WhitePointY, chroma_den);
+-
+-        mastering->max_luminance = av_make_q(mdcv->MaxDisplayMasteringLuminance, max_luma_den);
+-        mastering->min_luminance = av_make_q(mdcv->MinDisplayMasteringLuminance, min_luma_den);
+-
+-        mastering->has_luminance = 1;
+-        mastering->has_primaries = 1;
+-    }
+-
+-    if (clli->InsertPayloadToggle) {
+-        AVContentLightMetadata *light = av_content_light_metadata_create_side_data(frame);
+-        if (!light)
+-            return AVERROR(ENOMEM);
+-
+-        light->MaxCLL  = clli->MaxContentLightLevel;
+-        light->MaxFALL = clli->MaxPicAverageLightLevel;
+-    }
+-
+-    return 0;
+-}
+-
+ #endif
+ 
+ static int h264_decode_fpa(H2645SEIFramePacking *fpa, AVFrame *frame)
+@@ -1062,15 +1040,9 @@ static int qsv_decode(AVCodecContext *av
+ #endif
+ 
+ #if QSV_VERSION_ATLEAST(1, 35)
+-        if (QSV_RUNTIME_VERSION_ATLEAST(q->ver, 1, 35) && avctx->codec_id == AV_CODEC_ID_HEVC) {
++        if ((QSV_RUNTIME_VERSION_ATLEAST(q->ver, 1, 35) && avctx->codec_id == AV_CODEC_ID_HEVC) ||
++            (QSV_RUNTIME_VERSION_ATLEAST(q->ver, 2, 9)  && avctx->codec_id == AV_CODEC_ID_AV1)) {
+             ret = qsv_export_hdr_side_data(avctx, &aframe.frame->mdcv, &aframe.frame->clli, frame);
+-
+-            if (ret < 0)
+-                return ret;
+-        }
+-
+-        if (QSV_RUNTIME_VERSION_ATLEAST(q->ver, 2, 9) && avctx->codec_id == AV_CODEC_ID_AV1) {
+-            ret = qsv_export_hdr_side_data_av1(avctx, &aframe.frame->mdcv, &aframe.frame->clli, frame);
+             if (ret < 0)
+                 return ret;
+         }

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -96,3 +96,4 @@
 0096-fix-full-range-input-for-mjpeg-vaapi-encoder.patch
 0097-add-misc-enhancements-to-mfenc-hw-encoder.patch
 0098-backport-a-fix-to-not-stall-sub2video-on-stream-eof.patch
+0099-fix-qsv-av1-decoder-exporting-hdr-side-data.patch


### PR DESCRIPTION
**Changes**
- Sync some fixes for ac4dec
- Fix QSV AV1 decoder exporting HDR side data
- Update RKMPP decoder to use ff_decode_{mastering_display,content_light}_new
- Bump version to 8.1.2-5

**Issues**
- Fixes #761