### PR TITLE
Fix using hwmap with swscale unstable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ jellyfin-ffmpeg (8.1.2-5) unstable; urgency=medium
   * Make HDR10+ removal more precise
   * Sync some fixes for ac4dec
   * Fix QSV AV1 decoder exporting HDR side data
+  * Fix using hwmap with swscale unstable
 
  -- nyanmisaka <nst799610810@gmail.com>  Wed, 9 Sep 2026 17:31:57 +0800
 

--- a/debian/patches/0074-fix-mapped-hwframe-to-swframe-swscale-conversion.patch
+++ b/debian/patches/0074-fix-mapped-hwframe-to-swframe-swscale-conversion.patch
@@ -1,18 +1,51 @@
+Index: FFmpeg/libswscale/format.c
+===================================================================
+--- FFmpeg.orig/libswscale/format.c
++++ FFmpeg/libswscale/format.c
+@@ -320,7 +320,12 @@ SwsFormat ff_fmt_from_frame(const AVFram
+     enum AVPixelFormat hw_format = AV_PIX_FMT_NONE;
+ 
+ #if CONFIG_UNSTABLE
+-    if (frame->hw_frames_ctx) {
++    const AVPixFmtDescriptor *hw_desc = av_pix_fmt_desc_get(frame->format);
++    av_assert0(hw_desc);
++
++    if (hw_desc->flags & AV_PIX_FMT_FLAG_HWACCEL) {
++        av_assert0(frame->hw_frames_ctx);
++
+         AVHWFramesContext *hwfc = (AVHWFramesContext *)frame->hw_frames_ctx->data;
+         hw_format = frame->format;
+         format = hwfc->sw_format;
 Index: FFmpeg/libswscale/swscale.c
 ===================================================================
 --- FFmpeg.orig/libswscale/swscale.c
 +++ FFmpeg/libswscale/swscale.c
-@@ -1430,7 +1430,12 @@ int sws_frame_setup(SwsContext *ctx, con
+@@ -1440,10 +1440,27 @@ int sws_frame_setup(SwsContext *ctx, con
+     if ((ret = validate_params(ctx)) < 0)
+         return ret;
  
++    const AVPixFmtDescriptor *src_desc = av_pix_fmt_desc_get(src->format);
++    const AVPixFmtDescriptor *dst_desc = av_pix_fmt_desc_get(dst->format);
++    av_assert0(src_desc);
++    av_assert0(dst_desc);
++
++    const int src_is_hwaccel = !!(src_desc->flags & AV_PIX_FMT_FLAG_HWACCEL);
++    const int dst_is_hwaccel = !!(dst_desc->flags & AV_PIX_FMT_FLAG_HWACCEL);
++    if (src_is_hwaccel && !src->hw_frames_ctx)
++        return AVERROR(EINVAL);
++    if (dst_is_hwaccel && !dst->hw_frames_ctx)
++        return AVERROR(EINVAL);
++
      /* For now, if a single frame has a context, then both need a context */
      if (!!src->hw_frames_ctx != !!dst->hw_frames_ctx) {
 -        return AVERROR(ENOTSUP);
-+        const AVPixFmtDescriptor *src_desc = av_pix_fmt_desc_get(src->format);
-+        const AVPixFmtDescriptor *dst_desc = av_pix_fmt_desc_get(dst->format);
-+        const int is_mapped_hwframe_to_sw = !(src_desc->flags & AV_PIX_FMT_FLAG_HWACCEL) &&
-+                                            !(dst_desc->flags & AV_PIX_FMT_FLAG_HWACCEL);
-+        if (!is_mapped_hwframe_to_sw)
++        if (src_is_hwaccel ^ dst_is_hwaccel)
 +            return AVERROR(ENOTSUP);
++
      } else if (!!src->hw_frames_ctx) {
++        if (!src_is_hwaccel || !dst_is_hwaccel)
++            return AVERROR(EINVAL);
++
          /* Both hardware frames must already be allocated */
          if (!src->data[0] || !dst->data[0])
+             return AVERROR(EINVAL);

--- a/debian/patches/0099-fix-qsv-av1-decoder-exporting-hdr-side-data.patch
+++ b/debian/patches/0099-fix-qsv-av1-decoder-exporting-hdr-side-data.patch
@@ -2,16 +2,14 @@ Index: FFmpeg/libavcodec/qsvdec.c
 ===================================================================
 --- FFmpeg.orig/libavcodec/qsvdec.c
 +++ FFmpeg/libavcodec/qsvdec.c
-@@ -707,18 +707,36 @@ static int qsv_export_hdr_side_data(AVCo
- 
+@@ -708,17 +708,35 @@ static int qsv_export_hdr_side_data(AVCo
      // The SDK reuses this flag for HDR SEI parsing
      if (mdcv->InsertPayloadToggle) {
--        AVMasteringDisplayMetadata *mastering;
+         AVMasteringDisplayMetadata *mastering;
 -        const int mapping[3] = {2, 0, 1};
 -        const int chroma_den = 50000;
 -        const int luma_den = 10000;
 -        int i;
-+        AVMasteringDisplayMetadata *mastering = NULL;
 +        int mapping[3] = { 0, 1, 2 };
 +        int chroma_den;
 +        int max_luma_den;
@@ -56,15 +54,6 @@ Index: FFmpeg/libavcodec/qsvdec.c
  
              mastering->has_luminance = 1;
              mastering->has_primaries = 1;
-@@ -737,7 +755,7 @@ static int qsv_export_hdr_side_data(AVCo
- 
-     // The SDK reuses this flag for HDR SEI parsing
-     if (clli->InsertPayloadToggle) {
--        AVContentLightMetadata *light;
-+        AVContentLightMetadata *light = NULL;
- 
-         ret = ff_decode_content_light_new(avctx, frame, &light);
-         if (ret < 0)
 @@ -751,46 +769,6 @@ static int qsv_export_hdr_side_data(AVCo
  
      return 0;


### PR DESCRIPTION
The `jellyfin-ffmpeg` package on Arch Linux did not enable `--disable-unstable`, thereby triggering this error.

**Changes**
- Fix using hwmap with swscale unstable
- Polish the QSV AV1 decoder patch

**Issues**
- Fixes https://github.com/jellyfin/jellyfin-ffmpeg/issues/763